### PR TITLE
Fixes csv and xlsx input errors in deep_chem.scripts.process_datasets

### DIFF
--- a/deep_chem/scripts/process_dataset.py
+++ b/deep_chem/scripts/process_dataset.py
@@ -174,8 +174,8 @@ def generate_targets(input_file, input_type, fields, field_types, out_pkl,
     print row_index
     print raw_row
     # Skip row labels.
-    #if row_index == 0 or raw_row is None:  #but if data has no rows, then this will skip 1st compound 
-      #continue
+    if row_index == 0 or raw_row is None:  
+      continue
     row, row_data = {}, get_row_data(raw_row, input_type, fields, field_types)
     for ind, (field, field_type) in enumerate(zip(fields, field_types)):
       row[field] = process_field(row_data[ind], field_type)


### PR DESCRIPTION
1. Adds a --delimiter flag for csv input. Fixes #8 
2. For xlsx input, assumes the first sheet is the active sheet, regardless of its name. Fixes #9 
3. Adds a check that ensures the length of  --fields is equal to the length of --field-types
