### PR TITLE
fix link for keras

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Requirements
 * [rdkit](http://www.rdkit.org/docs/Install.html)
 * [sklearn](https://github.com/scikit-learn/scikit-learn.git)
 * [numpy](https://store.continuum.io/cshop/anaconda/)
-* [keras](keras.io)
+* [keras](http://keras.io)
 
 Linux (64-bit) Installation 
 ------------------


### PR DESCRIPTION
the current link: https://github.com/deepchem/deepchem/blob/master/keras.io