### PR TITLE
Added metrics class

### DIFF
--- a/deepchem/models/test/__init__.py
+++ b/deepchem/models/test/__init__.py
@@ -48,35 +48,31 @@ class TestAPI(unittest.TestCase):
     shutil.rmtree(self.samples_dir)
     shutil.rmtree(self.train_dir)
     shutil.rmtree(self.test_dir)
+    # TODO(rbharath): Removing this causes crashes for some reason. Need to
+    # debug.
     #shutil.rmtree(self.model_dir)
 
   def _create_model(self, train_dataset, test_dataset, model, transformers,
-                    test_model_creator=None):
+                    metrics):
     """Helper method to create model for test."""
 
     # Fit trained model
     model.fit(train_dataset)
     model.save(self.model_dir)
 
-    # Now create test model
-    if test_model_creator is not None:
-      test_model = test_model_creator()
-      test_model.load(self.model_dir)
-      model = test_model
-
     # Eval model on train
     evaluator = Evaluator(model, train_dataset, transformers, verbose=True)
     with tempfile.NamedTemporaryFile() as train_csv_out:
       with tempfile.NamedTemporaryFile() as train_stats_out:
         _, _ = evaluator.compute_model_performance(
-            train_csv_out, train_stats_out)
+            metrics, train_csv_out, train_stats_out)
 
     # Eval model on test
     evaluator = Evaluator(model, test_dataset, transformers, verbose=True)
     with tempfile.NamedTemporaryFile() as test_csv_out:
       with tempfile.NamedTemporaryFile() as test_stats_out:
         _, _ = evaluator.compute_model_performance(
-            test_csv_out, test_stats_out)
+            metrics, test_csv_out, test_stats_out)
 
   def _featurize_train_test_split(self, splittype, compound_featurizers, 
                                   complex_featurizers,

--- a/deepchem/models/test/test_api.py
+++ b/deepchem/models/test/test_api.py
@@ -26,8 +26,10 @@ from deepchem.models.sklearn_models import SklearnModel
 from deepchem.transformers import NormalizationTransformer
 from deepchem.transformers import LogTransformer
 from deepchem.transformers import ClippingTransformer
-from sklearn.ensemble import RandomForestRegressor
 from deepchem.models.test import TestAPI
+from deepchem import metrics
+from deepchem.metrics import Metric
+from sklearn.ensemble import RandomForestRegressor
 
 class TestKerasSklearnAPI(TestAPI):
   """
@@ -48,9 +50,14 @@ class TestKerasSklearnAPI(TestAPI):
         complex_featurizers, input_transformers,
         output_transformers, input_file, task_types.keys())
     model_params["data_shape"] = train_dataset.get_data_shape()
+    regression_metrics = [Metric(metrics.r2_score),
+                          Metric(metrics.mean_squared_error),
+                          Metric(metrics.mean_absolute_error)]
 
-    model = SklearnModel(task_types, model_params, model_instance=RandomForestRegressor())
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    model = SklearnModel(task_types, model_params,
+                         model_instance=RandomForestRegressor())
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       regression_metrics)
 
   def test_singletask_sklearn_rf_user_specified_regression_API(self):
     """Test of singletask RF ECFP regression API."""
@@ -71,9 +78,14 @@ class TestKerasSklearnAPI(TestAPI):
         user_specified_features=user_specified_features,
         split_field=split_field)
     model_params["data_shape"] = train_dataset.get_data_shape()
+    regression_metrics = [Metric(metrics.r2_score),
+                          Metric(metrics.mean_squared_error),
+                          Metric(metrics.mean_absolute_error)]
 
-    model = SklearnModel(task_types, model_params, model_instance=RandomForestRegressor())
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    model = SklearnModel(task_types, model_params,
+                         model_instance=RandomForestRegressor())
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       regression_metrics)
 
   def test_singletask_sklearn_rf_ECFP_regression_sharded_API(self):
     """Test of singletask RF ECFP regression API: sharded edition."""
@@ -92,11 +104,15 @@ class TestKerasSklearnAPI(TestAPI):
         shard_size=50)
     # We set shard size above to force the creation of multiple shards of the data.
     # pdbbind_core has ~200 examples.
-
     model_params["data_shape"] = train_dataset.get_data_shape()
+    regression_metrics = [Metric(metrics.r2_score),
+                          Metric(metrics.mean_squared_error),
+                          Metric(metrics.mean_absolute_error)]
 
-    model = SklearnModel(task_types, model_params, model_instance=RandomForestRegressor())
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    model = SklearnModel(task_types, model_params,
+                         model_instance=RandomForestRegressor())
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       regression_metrics)
 
   def test_singletask_sklearn_rf_RDKIT_descriptor_regression_API(self):
     """Test of singletask RF RDKIT-descriptor regression API."""
@@ -113,9 +129,14 @@ class TestKerasSklearnAPI(TestAPI):
         complex_featurizers, input_transformers,
         output_transformers, input_file, task_types.keys())
     model_params["data_shape"] = train_dataset.get_data_shape()
+    regression_metrics = [Metric(metrics.r2_score),
+                          Metric(metrics.mean_squared_error),
+                          Metric(metrics.mean_absolute_error)]
 
-    model = SklearnModel(task_types, model_params, model_instance=RandomForestRegressor())
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    model = SklearnModel(task_types, model_params,
+                         model_instance=RandomForestRegressor())
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       regression_metrics)
 
   '''
   # TODO(rbharath): This fails on many systems with an Illegal Instruction
@@ -181,12 +202,18 @@ class TestKerasSklearnAPI(TestAPI):
         ligand_pdb_field=ligand_pdb_field,
         user_specified_features=user_specified_features)
     model_params["data_shape"] = train_dataset.get_data_shape()
+    regression_metrics = [Metric(metrics.r2_score),
+                          Metric(metrics.mean_squared_error),
+                          Metric(metrics.mean_absolute_error)]
 
     model = SingleTaskDNN(task_types, model_params)
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       regression_metrics)
 
 
-    #TODO(enf/rbharath): 3D CNN's are broken and must be fixed.
+    #TODO(enf/rbharath): This should be uncommented now that 3D CNNs are in
+    #                    keras. Need to upgrade the base version of keras for
+    #                    deepchem.
     '''
   def test_singletask_cnn_GridFeaturizer_regression_API(self):
     """Test of singletask 3D ConvNet regression API."""
@@ -249,6 +276,11 @@ class TestKerasSklearnAPI(TestAPI):
         complex_featurizers, input_transformers,
         output_transformers, input_file, task_types.keys())
     model_params["data_shape"] = train_dataset.get_data_shape()
+    classification_metrics = [Metric(metrics.roc_auc_score),
+                              Metric(metrics.matthews_corrcoef),
+                              Metric(metrics.recall_score),
+                              Metric(metrics.accuracy_score)]
     
     model = MultiTaskDNN(task_types, model_params)
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       classification_metrics)

--- a/deepchem/models/test/test_tf_api.py
+++ b/deepchem/models/test/test_tf_api.py
@@ -28,8 +28,10 @@ from deepchem.models.tensorflow_models.fcnet import TensorflowMultiTaskClassifie
 from deepchem.transformers import NormalizationTransformer
 from deepchem.transformers import LogTransformer
 from deepchem.transformers import ClippingTransformer
-from sklearn.ensemble import RandomForestRegressor
 from deepchem.models.test import TestAPI
+from deepchem import metrics
+from deepchem.metrics import Metric
+from sklearn.ensemble import RandomForestRegressor
 
 class TestTensorflowAPI(TestAPI):
   """
@@ -72,7 +74,13 @@ class TestTensorflowAPI(TestAPI):
       "learning_rate": .001,
       "data_shape": train_dataset.get_data_shape()
     }
+    classification_metrics = [Metric(metrics.roc_auc_score),
+                              Metric(metrics.matthews_corrcoef),
+                              Metric(metrics.recall_score),
+                              Metric(metrics.accuracy_score)]
+
     model = TensorflowModel(
         task_types, model_params, self.model_dir,
         tf_class=TensorflowMultiTaskClassifier)
-    self._create_model(train_dataset, test_dataset, model, transformers)
+    self._create_model(train_dataset, test_dataset, model, transformers,
+                       classification_metrics)


### PR DESCRIPTION
Adds a straightforward implementation of a `Metric` class. Users are now allowed to add custom metrics at will rather than depending on pre-defined metrics. This satisfies issues #98 

Note that this PR does not add support for multitask metrics (median ROC-AUC for example). Support for these metrics will be added in a follow-up PR.