### PR TITLE
Safe normalization for CoulombBinarizationTransformer

### DIFF
--- a/deepchem/transformers/__init__.py
+++ b/deepchem/transformers/__init__.py
@@ -50,7 +50,6 @@ class Transformer(object):
 
     Adds X-transform, y-transform columns to metadata.
     """
-    dataset.update_moments()
     df = dataset.metadata_df
     indices = range(0, df.shape[0])
     transform_row_partial = partial(_transform_row, df=df, transformer=self)

--- a/deepchem/transformers/__init__.py
+++ b/deepchem/transformers/__init__.py
@@ -265,7 +265,6 @@ class CoulombBinarizationTransformer(Transformer):
       Xt.append(np.array(X_t))
 
     X = np.vstack(Xt)
-    print(X.shape)
     X_means = X.mean(axis=0)
     X_stds = (X-X_means).std()
 

--- a/deepchem/transformers/__init__.py
+++ b/deepchem/transformers/__init__.py
@@ -235,7 +235,7 @@ class CoulombRandomizationTransformer(Transformer):
   def untransform(self, z):
     print("Cannot undo CoulombRandomizationTransformer.")
 
-class CoulombBinarizationTransformer(CoulombRandomizationTransformer):
+class CoulombBinarizationTransformer(Transformer):
 
   def __init__(self, transform_X=False, transform_y=False, dataset=None,
                theta=1):
@@ -251,6 +251,27 @@ class CoulombBinarizationTransformer(CoulombRandomizationTransformer):
     for _, row in df.iterrows(): # Iterate over entire df by rows
       X = load_from_disk(row['X-transformed'])
       self.feature_max = np.maximum(self.feature_max,X.max(axis=0))
+
+  def transform(self, dataset, parallel=False):
+
+    super(CoulombBinarizationTransformer, self).transform(dataset,
+          parallel=parallel)
+
+    df = dataset.metadata_df
+    Xt = []
+
+    for _, row in df.iterrows():
+      X_t = load_from_disk(row['X-transformed'])
+      Xt.append(np.array(X_t))
+
+    X = np.vstack(Xt)
+    print(X.shape)
+    X_means = X.mean(axis=0)
+    X_stds = (X-X_means).std()
+
+    for i, row in df.iterrows():
+      X_t = (Xt[i]-X_means)/X_stds
+      save_to_disk(X_t, row['X-transformed'])
 
   def transform_row(self, i, df):
     """


### PR DESCRIPTION
This PR adds:
- A safe normalization routine for the `CoulombBinarizationTransformer` that is automatically performed after binarization.

The existing `NormalizationTransformer` (and related stats code) contains a divide by zero bug if there exists a column within X where X[:,i] = mean(X[:,i]) and std(X[:,i]) = 0.  We first found this bug when stacking normalization following `CoulombBinarizationTransformer`.  Switching to the np mean and std functions give the correct normalization.

@rbharath Instead of merging right away, we could use this PR to discuss whether to change the statistics functions in `Dataset` to something similar to what I've done in `transform`.  It could make sense to combine `get_statistics` and `update_moments` into one function that loads X-transformed from disk and computes the stats, as well as get rid of X_sums and X_squares from the metadata df (I think this is the only time when these are calculated or used).