### PR TITLE
Fix regressor cost

### DIFF
--- a/deepchem/models/tensorflow_models/__init__.py
+++ b/deepchem/models/tensorflow_models/__init__.py
@@ -655,7 +655,7 @@ class TensorflowRegressor(TensorflowGraph):
       A tensor with shape batch_size containing the weighted cost for each
       example.
     """
-    return tf.mul(tf.nn.l2_loss(output - labels), weights)
+    return tf.mul(0.5 * tf.square(output - labels), weights)
 
   def example_counts(self, y_true):
     """Get counts of examples in each class.


### PR DESCRIPTION
The regression loss function is wrong in tfvs. `tf.nn.l2_loss` returns a scalar (the unweighted sum of the per-example losses), which obviously gives the wrong values for the per-example losses. This PR calculates per-example losses which are then weighted appropriately.