### PR TITLE
Molecular Weight Splitter Class

### DIFF
--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -95,6 +95,39 @@ class Splitter(object):
     """
     raise NotImplementedError
 
+class MolecularWeightSplitter(Splitter):
+  """
+  Class for doing data splits by molecular weight.
+  """
+  def split(self, samples, seed=None, frac_train=.8, frac_valid=.1,
+            frac_test=.1, log_every_n=None):
+    """
+    Splits internal compounds into train/validation/test using the MW calculated
+    by SMILES string.
+    """
+    np.testing.assert_almost_equal(frac_train + frac_valid + frac_test, 1.)
+    np.random.seed(seed)
+
+    smiles_df = samples.compounds_df['smiles']
+    mw = []
+    for idx, row in smiles_df.iterrows():
+        smiles = Chem.Mol
+
+    # create new array that contains IDs sorted by MW
+
+    # split based on frac_train/frac_valid+frac_test
+
+    # random split frac_valid/frac_test
+
+    train_cutoff = frac_train * len(samples.compounds_df)
+    valid_cutoff = (frac_train+frac_valid) * len(samples.compounds_df)
+    shuffled = np.random.permutation(range(len(samples.compounds_df)))
+
+    # log stats on MW in each dataset
+
+    return (shuffled[:train_cutoff], shuffled[train_cutoff:valid_cutoff],
+            shuffled[valid_cutoff:])
+
 class RandomSplitter(Splitter):
   """
   Class for doing random data splits.

--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -111,7 +111,7 @@ class MolecularWeightSplitter(Splitter):
 
     df = samples.compounds_df
     mws = []
-    for _, row in smiles_df.iterrows():
+    for _, row in df.iterrows():
         mol = Chem.MolFromSmiles(row['smiles'])
         mw = Chem.rdMolDescriptors.CalcExactMolWt(mol)
         mws.append(mw)


### PR DESCRIPTION
This PR adds:
- A new `Splitter` object for splitting by molecular weight.  The splitter calculates the MW of each sample by converting the SMILES string from the `samples.compounds_df` in RDKit, sorts the samples by MW, and returns the sample indices needed to create the train/valid/test datasets.

This adds the ability to train on small molecules and predict on larger ones.

The current MW split class will split the indices up based on `frac_train`, `frac_valid`, and `frac_test` values passed to the `split` function.  The way that the splitting occurs, training dataset will always contain the lowest MW samples, test dataset will always contain the highest MW samples, and valid dataset will contain intermediates MW samples.

In the future, it would be good to:
- Add an option to specify the split MW's directly (in dalton units)
- Add an option to split the valid/test datasets randomly rather than by MW
- Calculate MW statistics within each dataset (mean, var)