### PR TITLE
AtomicCoordinates featurizer with variadic molecule size

### DIFF
--- a/deepchem/datasets/__init__.py
+++ b/deepchem/datasets/__init__.py
@@ -887,7 +887,11 @@ def convert_df_to_numpy(df, feature_type, tasks, mol_id_field, dtype,
   x_list = list(df[feature_type].values)
   valid_inds = np.array([1 if elt.size > 0 else 0 for elt in x_list], dtype=bool)
   x_list = [elt for (is_valid, elt) in zip(valid_inds, x_list) if is_valid]
-  x = np.squeeze(np.array(x_list))
+  if dtype == object:
+    # JSG hack until I can figure out a better way to do this
+    x = df[feature_type].values
+  else:
+    x = np.squeeze(np.array(x_list))
   ############################################################## TIMING
   time2 = time.time()
   log("TIMING: convert_df_to_numpy x computation took %0.3f s" % (time2-time1),

--- a/deepchem/datasets/__init__.py
+++ b/deepchem/datasets/__init__.py
@@ -887,11 +887,7 @@ def convert_df_to_numpy(df, feature_type, tasks, mol_id_field, dtype,
   x_list = list(df[feature_type].values)
   valid_inds = np.array([1 if elt.size > 0 else 0 for elt in x_list], dtype=bool)
   x_list = [elt for (is_valid, elt) in zip(valid_inds, x_list) if is_valid]
-  if dtype == object:
-    # JSG hack until I can figure out a better way to do this
-    x = df[feature_type].values
-  else:
-    x = np.squeeze(np.array(x_list))
+  x = np.squeeze(np.array(x_list))
   ############################################################## TIMING
   time2 = time.time()
   log("TIMING: convert_df_to_numpy x computation took %0.3f s" % (time2-time1),

--- a/deepchem/featurizers/atomic_coordinates.py
+++ b/deepchem/featurizers/atomic_coordinates.py
@@ -14,13 +14,16 @@ from deepchem.featurizers import Featurizer
 
 class AtomicCoordinates(Featurizer):
   """
-  Nx3 matrix of Cartesian coordinates [Angstrom]
+  1x3 Header (num_atoms, 0, 0)
+  Nx3 matrix of Cartesian coordinates [Bohr]
   """
   name = ['atomic_coordinates']
 
-  def __init__(self):
+  def __init__(self, max_atoms=None):
     # Type of data created by this featurizer
     self.dtype = object
+    self.max_atoms = max_atoms
+    
 
   def _featurize(self, mol):
     """
@@ -33,7 +36,8 @@ class AtomicCoordinates(Featurizer):
     """
 
     N = mol.GetNumAtoms()
-    coords = np.zeros((N,3))
+    Nmax = self.max_atoms
+    coords = np.zeros((Nmax+1,3))
 
     # RDKit stores atomic coordinates in Angstrom. Atomic unit of length is the
     # bohr (1 bohr = 0.529177 Angstrom). Converting units makes gradient calculation
@@ -41,10 +45,11 @@ class AtomicCoordinates(Featurizer):
     coords_in_bohr = [mol.GetConformer(0).GetAtomPosition(i).__div__(0.52917721092)
                       for i in xrange(N)]
 
+    coords[0,0] = N
     for atom in xrange(N):
-      coords[atom,0] = coords_in_bohr[atom].x
-      coords[atom,1] = coords_in_bohr[atom].y
-      coords[atom,2] = coords_in_bohr[atom].z
+      coords[atom+1,0] = coords_in_bohr[atom].x
+      coords[atom+1,1] = coords_in_bohr[atom].y
+      coords[atom+1,2] = coords_in_bohr[atom].z
 
     coords = [coords]
     return coords

--- a/deepchem/featurizers/atomic_coordinates.py
+++ b/deepchem/featurizers/atomic_coordinates.py
@@ -18,6 +18,10 @@ class AtomicCoordinates(Featurizer):
   """
   name = ['atomic_coordinates']
 
+  def __init__(self):
+    # Type of data created by this featurizer
+    self.dtype = object
+
   def _featurize(self, mol):
     """
     Calculate atomic coodinates.

--- a/deepchem/featurizers/atomic_coordinates.py
+++ b/deepchem/featurizers/atomic_coordinates.py
@@ -14,6 +14,43 @@ from deepchem.featurizers import Featurizer
 
 class AtomicCoordinates(Featurizer):
   """
+  Nx3 matrix of Cartesian coordinates [Bohr]
+  """
+  name = ['atomic_coordinates']
+
+  def __init__(self, max_atoms=None):
+    # Type of data created by this featurizer
+    self.dtype = object
+
+  def _featurize(self, mol):
+    """
+    Calculate atomic coodinates.
+
+    Parameters
+    ----------
+    mol : RDKit Mol
+          Molecule.
+    """
+
+    N = mol.GetNumAtoms()
+    coords = np.zeros((N,3))
+
+    # RDKit stores atomic coordinates in Angstrom. Atomic unit of length is the
+    # bohr (1 bohr = 0.529177 Angstrom). Converting units makes gradient calculation
+    # consistent with most QM software packages.
+    coords_in_bohr = [mol.GetConformer(0).GetAtomPosition(i).__div__(0.52917721092)
+                      for i in xrange(N)]
+
+    for atom in xrange(N):
+      coords[atom,0] = coords_in_bohr[atom].x
+      coords[atom,1] = coords_in_bohr[atom].y
+      coords[atom,2] = coords_in_bohr[atom].z
+
+    coords = [coords]
+    return coords
+
+class FixedSizeAtomicCoordinates(Featurizer):
+  """
   1x3 Header (num_atoms, 0, 0)
   Nx3 matrix of Cartesian coordinates [Bohr]
   """

--- a/deepchem/featurizers/tests/test_atomic_coordinates.py
+++ b/deepchem/featurizers/tests/test_atomic_coordinates.py
@@ -31,7 +31,7 @@ class TestAtomicCoordinates(unittest.TestCase):
     Simple test that atomic coordinates returns ndarray of right shape.
     """
     N = self.mol.GetNumAtoms()
-    atomic_coords_featurizer = AtomicCoordinates()
+    atomic_coords_featurizer = AtomicCoordinates(max_atoms=N)
     # TODO(rbharath, joegomes): Why does AtomicCoordinates return a list? Is
     # this expected behavior? Need to think about API.
     coords = atomic_coords_featurizer._featurize(self.mol)[0]

--- a/deepchem/featurizers/tests/test_atomic_coordinates.py
+++ b/deepchem/featurizers/tests/test_atomic_coordinates.py
@@ -10,6 +10,7 @@ from deepchem.featurizers.atomic_coordinates import get_coords
 from deepchem.featurizers.atomic_coordinates import put_atoms_in_cells
 from deepchem.featurizers.atomic_coordinates import compute_neighbor_cell_map
 from deepchem.featurizers.atomic_coordinates import AtomicCoordinates
+from deepchem.featurizers.atomic_coordinates import FixedSizeAtomicCoordinates
 from deepchem.featurizers.atomic_coordinates import NeighborListAtomicCoordinates
 
 class TestAtomicCoordinates(unittest.TestCase):
@@ -31,12 +32,24 @@ class TestAtomicCoordinates(unittest.TestCase):
     Simple test that atomic coordinates returns ndarray of right shape.
     """
     N = self.mol.GetNumAtoms()
-    atomic_coords_featurizer = AtomicCoordinates(max_atoms=N)
+    atomic_coords_featurizer = AtomicCoordinates()
     # TODO(rbharath, joegomes): Why does AtomicCoordinates return a list? Is
     # this expected behavior? Need to think about API.
     coords = atomic_coords_featurizer._featurize(self.mol)[0]
     assert isinstance(coords, np.ndarray)
     assert coords.shape == (N, 3)
+
+  def test_fixed_size_atomic_coordinates(self):
+    """
+    Simple test that atomic coordinates returns ndarray of right shape.
+    """
+    N = self.mol.GetNumAtoms()
+    atomic_coords_featurizer = FixedSizeAtomicCoordinates(max_atoms=N)
+    # TODO(rbharath, joegomes): Why does AtomicCoordinates return a list? Is
+    # this expected behavior? Need to think about API.
+    coords = atomic_coords_featurizer._featurize(self.mol)[0]
+    assert isinstance(coords, np.ndarray)
+    assert coords.shape == (N+1, 3)
 
   def test_get_cells(self):
     """


### PR DESCRIPTION
This PR adds:
- Small change to `AtomicCoordinates` featurizer to return objects

@rbharath With this change added, I'm still unable to load the GDB7 dataset (neatly).  Here's the error I receive after calling `DataLoader.featurize()`:
[ERROR/PoolWorker-14] Traceback (most recent call last):
  File "/home/joegomes/deepchem/deepchem/featurizers/featurize.py", line 56, in __call__
    result = self.__callable(*args, **kwargs)
  File "/home/joegomes/deepchem/deepchem/featurizers/featurize.py", line 93, in featurize_map_function
    raw_df_shard, write_fn, shard_num, input_type)
  File "/home/joegomes/deepchem/deepchem/featurizers/featurize.py", line 240, in _featurize_shard
    metadata_row = write_fn((basename, df_shard))
  File "/home/joegomes/deepchem/deepchem/datasets/__init__.py", line 154, in write_dataframe
    dtype, verbosity)
  File "/home/joegomes/deepchem/deepchem/datasets/__init__.py", line 890, in convert_df_to_numpy
    x = np.squeeze(np.array(x_list))
ValueError: could not broadcast input array from shape (5,3) into shape (1,1)

The problem pops up when trying to cast a list of numpy arrays (from AtomicCoordinates, after data validation in `convert_df_to_numpy`) into a numpy array.  I've played around with removing this np.array call in `Dataset` and I run into problems doing the `select` call during dataset splitting (trying to index a multi-dim list).  I've also tried making `AtomicCoordinates` return a list rather than a np.array, but run into a similar broadcasting issue (5,3 -> 1).  I was able to bypass all np.array calls and ended up with a data_shape of (1,1,5,3).  I suspect there is a better way to handle this, but for now I'm modifying my local atomicnet code to expect a data shape like this.  Thoughts?

Here is code for reproducing this error:
```
from __future__ import print_function
from __future__ import division
from __future__ import unicode_literals
import os
import tempfile

import numpy as np
import numpy.random

from deepchem.featurizers.featurize import DataLoader
from deepchem.hyperparameters import HyperparamOpt
from deepchem import metrics
from deepchem.metrics import Metric
from deepchem.models.tensorflow_models import TensorflowModel
from deepchem.transformers import NormalizationTransformer
from deepchem.utils.evaluate import Evaluator
from deepchem.splits import RandomSplitter
from deepchem.featurizers.atomic_coordinates import AtomicCoordinates

feature_dir = tempfile.mkdtemp()
train_dir = tempfile.mkdtemp()
valid_dir = tempfile.mkdtemp()
test_dir = tempfile.mkdtemp()
model_dir = tempfile.mkdtemp()
init_dir = tempfile.mkdtemp()

featurizers = AtomicCoordinates()
input_file = "/home/joegomes/deepchem/datasets/gdb1k.sdf"
task_file = input_file+".csv"
with open(task_file, 'rb') as f:
    tasks = [x.strip() for x in f.readline().split(',')]
task_type = "regression"
task_types = {task: task_type for task in tasks}
smiles_field = "smiles"
mol_field = "mol"

featurizer = DataLoader(tasks=tasks,
                            smiles_field=smiles_field,
                            mol_field=mol_field,
                            featurizer=featurizers,
                            verbosity="high")

featurized_dataset = featurizer.featurize(input_file, feature_dir, shard_size=1000)

from deepchem.splits import RandomSplitter
random_splitter = RandomSplitter()
train_dataset, valid_dataset, test_dataset = random_splitter.train_valid_test_split(featurized_dataset,
    train_dir, valid_dir, test_dir, compute_feature_statistics=False)

input_transformers = []
output_transformers = [NormalizationTransformer(transform_y=True, dataset=train_dataset)]
transformers = input_transformers + output_transformers

for transformer in transformers:
    transformer.transform(train_dataset)
for transformer in transformers:
    transformer.transform(valid_dataset)
for transformer in transformers:
    transformer.transform(test_dataset)
```
Before merging, hopefully we can use this PR to fix any outstanding variadic molecule issues.