### PR TITLE
Support Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
 - '2.7'
+- '3.5'
 sudo: required
 dist: trusty
 install:

--- a/deepchem/datasets/__init__.py
+++ b/deepchem/datasets/__init__.py
@@ -257,7 +257,7 @@ class Dataset(object):
     """
     if not len(self.metadata_df):
       raise ValueError("No data in dataset.")
-    return self.metadata_df.iterrows().next()[1]['task_names']
+    return next(self.metadata_df.iterrows())[1]['task_names']
 
   def get_data_shape(self):
     """
@@ -268,7 +268,7 @@ class Dataset(object):
     sample_X = load_from_disk(
         os.path.join(
             self.data_dir,
-            self.metadata_df.iterrows().next()[1]['X-transformed']))[0]
+            next(self.metadata_df.iterrows())[1]['X-transformed']))[0]
     return np.shape(sample_X)
 
   def get_shard_size(self):
@@ -278,7 +278,7 @@ class Dataset(object):
     sample_y = load_from_disk(
         os.path.join(
             self.data_dir,
-            self.metadata_df.iterrows().next()[1]['y-transformed']))
+            next(self.metadata_df.iterrows())[1]['y-transformed']))
     return len(sample_y)
 
   def _get_metadata_filename(self):
@@ -891,7 +891,7 @@ class Dataset(object):
 
     energy = y[:,0]
     grad = y[:,1:]
-    for i in xrange(energy.size):
+    for i in range(energy.size):
       grad[i] *= energy[i]
 
     ydely_means = np.sum(grad, axis=0)/y_n[1:]

--- a/deepchem/datasets/pdbbind_datasets.py
+++ b/deepchem/datasets/pdbbind_datasets.py
@@ -39,7 +39,7 @@ def compute_pdbbind_grid_feature(compound_featurizers, complex_featurizers,
   """Compute features for a given complex"""
   protein_file = os.path.join(pdb_subdir, "%s_protein.pdb" % pdb_code)
   ligand_file = os.path.join(pdb_subdir, "%s_ligand.sdf" % pdb_code)
-  rdkit_mol = Chem.SDMolSupplier(str(ligand_file)).next()
+  rdkit_mol = next(Chem.SDMolSupplier(str(ligand_file)))
 
   all_features = []
   for complex_featurizer in complex_featurizers:

--- a/deepchem/datasets/tests/test_datasets.py
+++ b/deepchem/datasets/tests/test_datasets.py
@@ -29,7 +29,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
   Test basic top-level API for dataset objects.
   """
 
-  def test_sparsify_and_densify(self):
+  def notest_sparsify_and_densify(self):
     """Test that sparsify and densify work as inverses."""
     # Test on identity matrix
     num_samples = 10
@@ -53,7 +53,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     X_reconstructed = densify_features(X_sparse, num_features)
     np.testing.assert_array_equal(X, X_reconstructed)
 
-  def test_pad_features(self):
+  def notest_pad_features(self):
     """Test that pad_features pads features correctly."""
     batch_size = 100
     num_features = 10
@@ -99,7 +99,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert len(X_out) == batch_size
   
 
-  def test_pad_batches(self):
+  def notest_pad_batches(self):
     """Test that pad_batch pads batches correctly."""
     batch_size = 100
     num_features = 10
@@ -171,7 +171,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
         batch_size, X_b, y_b, w_b, ids_b)
     assert len(X_out) == len(y_out) == len(w_out) == len(ids_out) == batch_size
     
-  def test_get_task_names(self):
+  def notest_get_task_names(self):
     """Test that get_task_names returns correct task_names"""
     solubility_dataset = self.load_solubility_data()
     assert solubility_dataset.get_task_names() == ["log-solubility"]
@@ -182,7 +182,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
         "task9", "task10", "task11", "task12", "task13", "task14", "task15",
         "task16"])
 
-  def test_get_data_shape(self):
+  def notest_get_data_shape(self):
     """Test that get_data_shape returns currect data shape"""
     solubility_dataset = self.load_solubility_data()
     assert solubility_dataset.get_data_shape() == (1024,) 
@@ -190,12 +190,12 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     multitask_dataset = self.load_multitask_data()
     assert multitask_dataset.get_data_shape() == (1024,)
 
-  def test_len(self):
+  def notest_len(self):
     """Test that len(dataset) works."""
     solubility_dataset = self.load_solubility_data()
     assert len(solubility_dataset) == 10
 
-  def test_reshard(self):
+  def notest_reshard(self):
     """Test that resharding the dataset works."""
     solubility_dataset = self.load_solubility_data()
     X, y, w, ids = solubility_dataset.to_numpy()
@@ -220,7 +220,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     np.testing.assert_array_equal(w, w_rr)
     np.testing.assert_array_equal(ids, ids_rr)
 
-  def test_select(self):
+  def notest_select(self):
     """Test that dataset select works."""
     num_datapoints = 10
     num_features = 10
@@ -241,7 +241,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     np.testing.assert_array_equal(ids[indices], ids_sel)
     shutil.rmtree(select_dir)
 
-  def test_get_shape(self):
+  def notest_get_shape(self):
     """Test that get_shape works."""
     num_datapoints = 100
     num_features = 10
@@ -261,7 +261,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert ids_shape == ids.shape
 
 
-  def test_to_singletask(self):
+  def notest_to_singletask(self):
     """Test that to_singletask works."""
     num_datapoints = 100
     num_features = 10
@@ -292,7 +292,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
       for task_dir in task_dirs:
         shutil.rmtree(task_dir)
   
-  def test_iterbatches(self):
+  def notest_iterbatches(self):
     """Test that iterating over batches of data works."""
     solubility_dataset = self.load_solubility_data()
     batch_size = 2
@@ -304,7 +304,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
       assert w_b.shape == (batch_size,) + (len(tasks),)
       assert ids_b.shape == (batch_size,)
 
-  def test_to_numpy(self):
+  def notest_to_numpy(self):
     """Test that transformation to numpy arrays is sensible."""
     solubility_dataset = self.load_solubility_data()
     data_shape = solubility_dataset.get_data_shape()
@@ -318,7 +318,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert w.shape == (N_samples, N_tasks)
     assert ids.shape == (N_samples,)
 
-  def test_consistent_ordering(self):
+  def notest_consistent_ordering(self):
     """Test that ordering of labels is consistent over time."""
     solubility_dataset = self.load_solubility_data()
 
@@ -327,7 +327,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
 
     assert np.array_equal(ids1, ids2)
 
-  def test_get_statistics(self):
+  def notest_get_statistics(self):
     """Test statistics computation of this dataset."""
     solubility_dataset = self.load_solubility_data()
     X, y, _, _ = solubility_dataset.to_numpy()

--- a/deepchem/datasets/tests/test_datasets.py
+++ b/deepchem/datasets/tests/test_datasets.py
@@ -29,7 +29,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
   Test basic top-level API for dataset objects.
   """
 
-  def notest_sparsify_and_densify(self):
+  def test_sparsify_and_densify(self):
     """Test that sparsify and densify work as inverses."""
     # Test on identity matrix
     num_samples = 10
@@ -53,7 +53,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     X_reconstructed = densify_features(X_sparse, num_features)
     np.testing.assert_array_equal(X, X_reconstructed)
 
-  def notest_pad_features(self):
+  def test_pad_features(self):
     """Test that pad_features pads features correctly."""
     batch_size = 100
     num_features = 10
@@ -99,7 +99,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert len(X_out) == batch_size
   
 
-  def notest_pad_batches(self):
+  def test_pad_batches(self):
     """Test that pad_batch pads batches correctly."""
     batch_size = 100
     num_features = 10
@@ -171,7 +171,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
         batch_size, X_b, y_b, w_b, ids_b)
     assert len(X_out) == len(y_out) == len(w_out) == len(ids_out) == batch_size
     
-  def notest_get_task_names(self):
+  def test_get_task_names(self):
     """Test that get_task_names returns correct task_names"""
     solubility_dataset = self.load_solubility_data()
     assert solubility_dataset.get_task_names() == ["log-solubility"]
@@ -182,7 +182,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
         "task9", "task10", "task11", "task12", "task13", "task14", "task15",
         "task16"])
 
-  def notest_get_data_shape(self):
+  def test_get_data_shape(self):
     """Test that get_data_shape returns currect data shape"""
     solubility_dataset = self.load_solubility_data()
     assert solubility_dataset.get_data_shape() == (1024,) 
@@ -190,12 +190,12 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     multitask_dataset = self.load_multitask_data()
     assert multitask_dataset.get_data_shape() == (1024,)
 
-  def notest_len(self):
+  def test_len(self):
     """Test that len(dataset) works."""
     solubility_dataset = self.load_solubility_data()
     assert len(solubility_dataset) == 10
 
-  def notest_reshard(self):
+  def test_reshard(self):
     """Test that resharding the dataset works."""
     solubility_dataset = self.load_solubility_data()
     X, y, w, ids = solubility_dataset.to_numpy()
@@ -220,7 +220,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     np.testing.assert_array_equal(w, w_rr)
     np.testing.assert_array_equal(ids, ids_rr)
 
-  def notest_select(self):
+  def test_select(self):
     """Test that dataset select works."""
     num_datapoints = 10
     num_features = 10
@@ -241,7 +241,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     np.testing.assert_array_equal(ids[indices], ids_sel)
     shutil.rmtree(select_dir)
 
-  def notest_get_shape(self):
+  def test_get_shape(self):
     """Test that get_shape works."""
     num_datapoints = 100
     num_features = 10
@@ -261,7 +261,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert ids_shape == ids.shape
 
 
-  def notest_to_singletask(self):
+  def test_to_singletask(self):
     """Test that to_singletask works."""
     num_datapoints = 100
     num_features = 10
@@ -292,7 +292,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
       for task_dir in task_dirs:
         shutil.rmtree(task_dir)
   
-  def notest_iterbatches(self):
+  def test_iterbatches(self):
     """Test that iterating over batches of data works."""
     solubility_dataset = self.load_solubility_data()
     batch_size = 2
@@ -304,7 +304,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
       assert w_b.shape == (batch_size,) + (len(tasks),)
       assert ids_b.shape == (batch_size,)
 
-  def notest_to_numpy(self):
+  def test_to_numpy(self):
     """Test that transformation to numpy arrays is sensible."""
     solubility_dataset = self.load_solubility_data()
     data_shape = solubility_dataset.get_data_shape()
@@ -318,7 +318,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert w.shape == (N_samples, N_tasks)
     assert ids.shape == (N_samples,)
 
-  def notest_consistent_ordering(self):
+  def test_consistent_ordering(self):
     """Test that ordering of labels is consistent over time."""
     solubility_dataset = self.load_solubility_data()
 
@@ -327,7 +327,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
 
     assert np.array_equal(ids1, ids2)
 
-  def notest_get_statistics(self):
+  def test_get_statistics(self):
     """Test statistics computation of this dataset."""
     solubility_dataset = self.load_solubility_data()
     X, y, _, _ = solubility_dataset.to_numpy()

--- a/deepchem/datasets/tests/test_load.py
+++ b/deepchem/datasets/tests/test_load.py
@@ -47,7 +47,7 @@ class TestLoad(TestAPI):
     shutil.move(data_dir, moved_data_dir)
 
     moved_dataset = Dataset(
-        moved_data_dir, reload=reload)
+        moved_data_dir, reload=True)
 
     X_moved, y_moved, w_moved, ids_moved = moved_dataset.to_numpy()
 

--- a/deepchem/featurizers/__init__.py
+++ b/deepchem/featurizers/__init__.py
@@ -212,8 +212,8 @@ class Featurizer(object):
     # - second axis = max # conformers
     # - remaining axes = determined by feature shape
     features_shape = None
-    for i in xrange(len(features)):
-      for j in xrange(len(features[i])):
+    for i in range(len(features)):
+      for j in range(len(features[i])):
         if features[i][j] is not None:
           features_shape = features[i][0].shape
           break
@@ -230,7 +230,7 @@ class Featurizer(object):
       try:
         x[i, :n_confs] = mol_features
       except ValueError:  # handle None conformer values
-        for j in xrange(n_confs):
+        for j in range(n_confs):
           x[i, j] = mol_features[j]
     return x
 

--- a/deepchem/featurizers/atomic_coordinates.py
+++ b/deepchem/featurizers/atomic_coordinates.py
@@ -37,10 +37,10 @@ class AtomicCoordinates(Featurizer):
     # RDKit stores atomic coordinates in Angstrom. Atomic unit of length is the
     # bohr (1 bohr = 0.529177 Angstrom). Converting units makes gradient calculation
     # consistent with most QM software packages.
-    coords_in_bohr = [mol.GetConformer(0).GetAtomPosition(i).__div__(0.52917721092)
-                      for i in xrange(N)]
+    coords_in_bohr = [mol.GetConformer(0).GetAtomPosition(i).__idiv__(0.52917721092)
+                      for i in range(N)]
 
-    for atom in xrange(N):
+    for atom in range(N):
       coords[atom,0] = coords_in_bohr[atom].x
       coords[atom,1] = coords_in_bohr[atom].y
       coords[atom,2] = coords_in_bohr[atom].z

--- a/deepchem/featurizers/coulomb_matrices.py
+++ b/deepchem/featurizers/coulomb_matrices.py
@@ -85,8 +85,8 @@ class CoulombMatrix(Featurizer):
     for conf in mol.GetConformers():
       d = self.get_interatomic_distances(conf)
       m = np.zeros((n_atoms, n_atoms))
-      for i in xrange(mol.GetNumAtoms()):
-        for j in xrange(mol.GetNumAtoms()):
+      for i in range(mol.GetNumAtoms()):
+        for j in range(mol.GetNumAtoms()):
           if i == j:
             m[i, j] = 0.5 * z[i] ** 2.4
           elif i < j:
@@ -127,7 +127,7 @@ class CoulombMatrix(Featurizer):
     rval = []
     row_norms = np.asarray([np.linalg.norm(row) for row in m], dtype=float)
     rng = np.random.RandomState(self.seed)
-    for i in xrange(self.n_samples):
+    for i in range(self.n_samples):
       e = rng.normal(size=row_norms.size)
       p = np.argsort(row_norms + e)
       new = m[p][:, p]  # permute rows first, then columns
@@ -145,10 +145,10 @@ class CoulombMatrix(Featurizer):
         Molecule conformer.
     """
     n_atoms = conf.GetNumAtoms()
-    coords = [conf.GetAtomPosition(i).__div__(0.52917721092) for i in xrange(n_atoms)]  # Convert AtomPositions from Angstrom to bohr (atomic units)
+    coords = [conf.GetAtomPosition(i).__idiv__(0.52917721092) for i in range(n_atoms)]  # Convert AtomPositions from Angstrom to bohr (atomic units)
     d = np.zeros((n_atoms, n_atoms), dtype=float)
-    for i in xrange(n_atoms):
-      for j in xrange(n_atoms):
+    for i in range(n_atoms):
+      for j in range(n_atoms):
         if i < j:
           d[i, j] = coords[i].Distance(coords[j])
           d[j, i] = d[i, j]

--- a/deepchem/featurizers/featurize.py
+++ b/deepchem/featurizers/featurize.py
@@ -167,7 +167,7 @@ class DataLoader(object):
         worker_pool = mp.Pool(processes=1)
     log("Spawning workers now.", self.verbosity)
     metadata_rows = []
-    data_iterator = it.izip(
+    data_iterator = zip(
         it.repeat((self, shard_size, input_type, data_dir)),
         enumerate(load_data(input_files, shard_size, self.verbosity)))
     # Turns out python map is terrible and exhausts the generator as given.
@@ -212,7 +212,7 @@ class DataLoader(object):
     # creating a Dataset. Is there a more elegant solutions?
     dataset = Dataset(data_dir=data_dir,
                       metadata_rows=metadata_rows,
-                      reload=reload, verbosity=self.verbosity)
+                      reload=True, verbosity=self.verbosity)
     ############################################################## TIMING
     time2 = time.time()
     print("TIMING: dataset construction took %0.3f s" % (time2-time1),

--- a/deepchem/featurizers/featurize.py
+++ b/deepchem/featurizers/featurize.py
@@ -167,8 +167,10 @@ class DataLoader(object):
         worker_pool = mp.Pool(processes=1)
     log("Spawning workers now.", self.verbosity)
     metadata_rows = []
-    data_iterator = zip(
-        it.repeat((self, shard_size, input_type, data_dir)),
+    def wrap_with_shard_metadata(iterator):
+      for item in iterator:
+        yield ((self, shard_size, input_type, data_dir), item)
+    data_iterator = wrap_with_shard_metadata(
         enumerate(load_data(input_files, shard_size, self.verbosity)))
     # Turns out python map is terrible and exhausts the generator as given.
     # Solution seems to be to to manually pull out N elements from iterator,

--- a/deepchem/featurizers/grid_featurizer.py
+++ b/deepchem/featurizers/grid_featurizer.py
@@ -398,7 +398,7 @@ def _compute_ecfp_features(system_ob, ecfp_degree, ecfp_power):
 
   ecfp_dict = _compute_all_ecfp(system_ob, degree=ecfp_degree)
   ecfp_vec = [_hash_ecfp(ecfp, ecfp_power)
-        for index, ecfp in ecfp_dict.iteritems()]
+        for index, ecfp in ecfp_dict.items()]
   ecfp_array = np.zeros(2 ** ecfp_power)
   ecfp_array[sorted(ecfp_vec)] = 1.0
   return(ecfp_array)
@@ -1126,7 +1126,7 @@ class GridFeaturizer(ComplexFeaturizer):
 
     if "voxel_combined" in self.feature_types:
       features = {}
-      for system_id, system in transformed_systems.iteritems():
+      for system_id, system in transformed_systems.items():
         protein_xyz = system[0]
         ligand_xyz = system[1]
         feature_tensors = []
@@ -1256,7 +1256,7 @@ class GridFeaturizer(ComplexFeaturizer):
          nb_channel),
         dtype=np.float16)      
     if feature_dict is not None:
-      for key, features in feature_dict.iteritems():
+      for key, features in feature_dict.items():
         voxels = get_voxels(
           coordinates, key, self.box_width, self.voxel_width)
         for voxel in voxels:  
@@ -1290,7 +1290,7 @@ class GridFeaturizer(ComplexFeaturizer):
         hash_function(
           feature,
           channel_power) for key,
-        feature in feature_dict.iteritems()]
+        feature in feature_dict.items()]
       feature_vector[on_channels] += 1
     elif feature_list is not None:
       feature_vector[0] += len(feature_list)

--- a/deepchem/featurizers/nnscore.py
+++ b/deepchem/featurizers/nnscore.py
@@ -64,7 +64,7 @@ PI_PADDING = 0.75
 def hashtable_entry_add_one(hashtable, key, toadd=1):
   """Increments hashtable entry if exists, else creates entry."""
   # note that dictionaries (hashtables) are passed by reference in python
-  if hashtable.has_key(key):
+  if key in hashtable:
     hashtable[key] = hashtable[key] + toadd
   else:
     hashtable[key] = toadd

--- a/deepchem/featurizers/nnscore_pdb.py
+++ b/deepchem/featurizers/nnscore_pdb.py
@@ -509,7 +509,7 @@ class PDB(object):
 
     Helper function called when loading PDB from file.
     """
-    for key, residue in self.get_residues().iteritems():
+    for key, residue in self.get_residues().items():
       residue_names = [self.all_atoms[ind].atomname.strip() for ind in residue]
       self.check_protein_format_process_residue(residue_names, key)
 
@@ -967,7 +967,7 @@ class PDB(object):
       List of Aromatic objects.
     """
     charges = []
-    for key, res in residues.iteritems():
+    for key, res in residues.items():
       resname, _, _ = key.strip().split("_")
       real_resname = resname[-3:]
       if real_resname in resnames:
@@ -1287,7 +1287,7 @@ class PDB(object):
       List of Aromatic objects.
     """
     aromatics = []
-    for key, res in residues.iteritems():
+    for key, res in residues.items():
       real_resname, _, _ = key.strip().split("_")
       indices_of_ring = []
       if real_resname in resname:

--- a/deepchem/featurizers/tests/test_binana.py
+++ b/deepchem/featurizers/tests/test_binana.py
@@ -72,7 +72,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       hydrophobics_dict[name] = compute_hydrophobic_contacts(
           ligand, protein)
-    for name, hydrophobics in hydrophobics_dict.iteritems():
+    for name, hydrophobics in hydrophobics_dict.items():
       print("Processing hydrohobics for %s" % name)
       assert len(hydrophobics) == 6
       assert "BACKBONE_ALPHA" in hydrophobics
@@ -90,7 +90,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       electrostatics_dict[name] = compute_electrostatic_energy(
           ligand, protein)
-    for name, electrostatics in electrostatics_dict.iteritems():
+    for name, electrostatics in electrostatics_dict.items():
       print("Processing electrostatics for %s" % name)
       # The keys of these dicts are pairs of atomtypes, but the keys are
       # sorted so that ("C", "O") is always written as "C_O". Thus, for N
@@ -109,7 +109,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       active_site_dict[name] = compute_active_site_flexibility(
           ligand, protein)
-    for name, active_site_flexibility in active_site_dict.iteritems():
+    for name, active_site_flexibility in active_site_dict.items():
       print("Processing active site flexibility for %s" % name)
       assert len(active_site_flexibility.keys()) == 6
       assert "BACKBONE_ALPHA" in active_site_flexibility
@@ -137,7 +137,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       hbonds_dict[name] = compute_hydrogen_bonds(
           ligand, protein)
-    for name, hbonds in hbonds_dict.iteritems():
+    for name, hbonds in hbonds_dict.items():
       print("Processing hydrogen bonds for %s" % name)
       assert len(hbonds) == 12
       assert "HDONOR-LIGAND_BACKBONE_ALPHA" in hbonds
@@ -161,7 +161,7 @@ class TestBinana(unittest.TestCase):
     for name, _, ligand in self.test_cases:
       counts_dict[name] = compute_ligand_atom_counts(
           ligand)
-    for name, counts in counts_dict.iteritems():
+    for name, counts in counts_dict.items():
       print("Processing ligand atom counts for %s" % name)
       #print counts
       assert len(counts) == len(Binana.atom_types)
@@ -175,15 +175,15 @@ class TestBinana(unittest.TestCase):
       contacts_dict[name] = compute_contacts(
           ligand, protein)
     num_atoms = len(Binana.atom_types)
-    for name, (close_contacts, contacts) in contacts_dict.iteritems():
+    for name, (close_contacts, contacts) in contacts_dict.items():
       print("Processing contacts for %s" % name)
       print("close_contacts")
-      for key, val in close_contacts.iteritems():
+      for key, val in close_contacts.items():
         if val != 0:
           print (key, val)
       print("len(close_contacts): " + str(len(close_contacts)))
       print("contacts")
-      for key, val in contacts.iteritems():
+      for key, val in contacts.items():
         if val != 0:
           print (key, val)
       print("len(contacts): " + str(len(contacts)))
@@ -200,7 +200,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       pi_stacking_dict[name] = compute_pi_pi_stacking(
           ligand, protein)
-    for name, pi_stacking in pi_stacking_dict.iteritems():
+    for name, pi_stacking in pi_stacking_dict.items():
       print("Processing pi-stacking for %s" % name)
       assert len(pi_stacking) == 3
       print(pi_stacking)
@@ -221,7 +221,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       pi_t_dict[name] = compute_pi_t(
           ligand, protein)
-    for name, pi_t in pi_t_dict.iteritems():
+    for name, pi_t in pi_t_dict.items():
       print("Processing pi-T for %s" % name)
       assert len(pi_t) == 3
       assert "T-SHAPED_ALPHA" in pi_t
@@ -236,7 +236,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       pi_cation_dict[name] = compute_pi_cation(
           ligand, protein)
-    for name, pi_cation in pi_cation_dict.iteritems():
+    for name, pi_cation in pi_cation_dict.items():
       print("Processing pi-cation for %s" % name)
       assert len(pi_cation) == 6
       assert 'PI-CATION_LIGAND-CHARGED_ALPHA' in pi_cation
@@ -257,7 +257,7 @@ class TestBinana(unittest.TestCase):
     for name, protein, ligand in self.test_cases:
       salt_bridges_dict[name] = compute_salt_bridges(
           ligand, protein)
-    for name, salt_bridges in salt_bridges_dict.iteritems():
+    for name, salt_bridges in salt_bridges_dict.items():
       print("Processing salt-bridges for %s" % name)
       assert len(salt_bridges) == 3
       print(salt_bridges)
@@ -289,6 +289,6 @@ class TestBinana(unittest.TestCase):
     # rotatable_boonds_count: 1
     total_len = (3*num_atoms*(num_atoms+1)/2 + num_atoms
                  + 12 + 6 + 3 + 6 + 3 + 6 + 3 + 1)
-    for name, input_vector in features_dict.iteritems():
+    for name, input_vector in features_dict.items():
       print("Processing input-vector for %s" % name)
       assert len(input_vector) == total_len

--- a/deepchem/hyperparameters/__init__.py
+++ b/deepchem/hyperparameters/__init__.py
@@ -7,6 +7,7 @@ import itertools
 import tempfile
 import shutil
 import collections
+from functools import reduce
 from operator import mul
 from deepchem.utils.evaluate import Evaluator
 from deepchem.utils.save import log
@@ -35,7 +36,7 @@ class HyperparamOpt(object):
     """ 
     hyperparams = params_dict.keys()
     hyperparam_vals = params_dict.values() 
-    for hyperparam_list in params_dict.itervalues():
+    for hyperparam_list in params_dict.values():
       assert isinstance(hyperparam_list, collections.Iterable)
 
     number_combinations = reduce(mul, [len(vals) for vals in hyperparam_vals])

--- a/deepchem/metrics/__init__.py
+++ b/deepchem/metrics/__init__.py
@@ -123,13 +123,14 @@ class Metric(object):
         self.name = self.task_averager.__name__ + "-" + self.metric.__name__
     else:
       self.name = name
+    print(self.name)
     self.verbosity = verbosity
     self.threshold = threshold
     if mode is None:
-      if self.name in ["roc_auc_score", "matthews_corrcoef", "recall_score",
+      if self.metric.__name__ in ["roc_auc_score", "matthews_corrcoef", "recall_score",
                        "accuracy_score", "kappa_score", "precision_score"]:
         mode = "classification"
-      elif self.name in ["pearson_r2_score", "r2_score", "mean_squared_error",
+      elif self.metric.__name__ in ["pearson_r2_score", "r2_score", "mean_squared_error",
                          "mean_absolute_error", "rms_score",
                          "mae_score"]:
         mode = "regression"
@@ -167,7 +168,7 @@ class Metric(object):
       w = np.ones_like(y_true)
     assert y_true.shape[0] == y_pred.shape[0] == w.shape[0]
     computed_metrics = []
-    for task in xrange(n_tasks):
+    for task in range(n_tasks):
       y_task = y_true[:, task]
       if self.mode == "regression":
         y_pred_task = y_pred[:, task]

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -301,8 +301,8 @@ class Model(object):
         h = 0.001
         fd_batch = []
         # Filling a new batch with displaced geometries
-        for i in xrange(num_atoms):
-          for j in xrange(coords):
+        for i in range(num_atoms):
+          for j in range(coords):
             displace = np.zeros((num_atoms, coords))
             displace[i][j] += h/2
             fd_batch.append(xb+displace)

--- a/deepchem/models/keras_models/__init__.py
+++ b/deepchem/models/keras_models/__init__.py
@@ -36,7 +36,7 @@ class KerasModel(Model):
     self.model_instance.save(h5_filename)
     # Save architecture
     json_string = model.to_json()
-    with open(json_filename, "wb") as file_obj:
+    with open(json_filename, "w") as file_obj:
       file_obj.write(json_string)
     model.save_weights(h5_filename, overwrite=True)
 

--- a/deepchem/models/tensorflow_models/__init__.py
+++ b/deepchem/models/tensorflow_models/__init__.py
@@ -5,7 +5,7 @@ from __future__ import division
 from __future__ import unicode_literals
 
 import collections
-import cPickle as pickle
+import pickle
 import os
 import time
 import warnings
@@ -80,7 +80,7 @@ class TensorflowGraph(object):
   def get_feed_dict(named_values):
     feed_dict = {}
     placeholder_root = "placeholders"
-    for name, value in named_values.iteritems():
+    for name, value in named_values.items():
       feed_dict['{}/{}:0'.format(placeholder_root, name)] = value
     return feed_dict
 
@@ -187,7 +187,7 @@ class TensorflowGraphModel(object):
       gradient_costs = []  # costs used for gradient calculation
 
       with TensorflowGraph.shared_name_scope('costs', graph, name_scopes):
-        for task in xrange(self.n_tasks):
+        for task in range(self.n_tasks):
           task_str = str(task).zfill(len(str(self.n_tasks)))
           with TensorflowGraph.shared_name_scope(
               'cost_{}'.format(task_str), graph, name_scopes):
@@ -381,7 +381,7 @@ class TensorflowGraphModel(object):
     weights = []
     placeholder_scope = TensorflowGraph.get_placeholder_scope(graph, name_scopes)
     with placeholder_scope:
-      for task in xrange(self.n_tasks):
+      for task in range(self.n_tasks):
         weights.append(tf.identity(
             tf.placeholder(tf.float32, shape=[None],
                            name='weights_%d' % task)))
@@ -508,7 +508,7 @@ class TensorflowClassifier(TensorflowGraphModel):
       n_classes = self.n_classes
       labels = []
       with placeholder_scope:
-        for task in xrange(self.n_tasks):
+        for task in range(self.n_tasks):
           labels.append(tf.identity(
               tf.placeholder(tf.float32, shape=[None, n_classes],
                              name='labels_%d' % task)))
@@ -608,7 +608,7 @@ class TensorflowRegressor(TensorflowGraphModel):
       batch_size = self.batch_size
       labels = []
       with placeholder_scope:
-        for task in xrange(self.n_tasks):
+        for task in range(self.n_tasks):
           labels.append(tf.identity(
               tf.placeholder(tf.float32, shape=[None],
                              name='labels_%d' % task)))

--- a/deepchem/models/tensorflow_models/fcnet.py
+++ b/deepchem/models/tensorflow_models/fcnet.py
@@ -51,7 +51,7 @@ class TensorflowMultiTaskClassifier(TensorflowClassifier):
 
       prev_layer = self.mol_features
       prev_layer_size = n_features 
-      for i in xrange(n_layers):
+      for i in range(n_layers):
         layer = tf.nn.relu(model_ops.fully_connected_layer(
             tensor=prev_layer,
             size=layer_sizes[i],
@@ -81,7 +81,7 @@ class TensorflowMultiTaskClassifier(TensorflowClassifier):
     """ 
     orig_dict = {}
     orig_dict["mol_features"] = X_b
-    for task in xrange(self.n_tasks):
+    for task in range(self.n_tasks):
       if y_b is not None:
         orig_dict["labels_%d" % task] = to_one_hot(y_b[:, task])
       else:
@@ -133,7 +133,7 @@ class TensorflowMultiTaskRegressor(TensorflowRegressor):
 
       prev_layer = self.mol_features
       prev_layer_size = n_features 
-      for i in xrange(n_layers):
+      for i in range(n_layers):
         layer = tf.nn.relu(model_ops.fully_connected_layer(
             tensor=prev_layer,
             size=layer_sizes[i],
@@ -172,7 +172,7 @@ class TensorflowMultiTaskRegressor(TensorflowRegressor):
     """ 
     orig_dict = {}
     orig_dict["mol_features"] = X_b
-    for task in xrange(self.n_tasks):
+    for task in range(self.n_tasks):
       if y_b is not None:
         orig_dict["labels_%d" % task] = y_b[:, task]
       else:

--- a/deepchem/models/tensorflow_models/tests/test_utils.py
+++ b/deepchem/models/tensorflow_models/tests/test_utils.py
@@ -42,14 +42,14 @@ class UtilsTest(test_util.TensorFlowTestCase):
 
   def testParseCheckpoint(self):
     # parse CheckpointState proto
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(mode='w+') as f:
       cp = checkpoint_state_pb2.CheckpointState()
       cp.model_checkpoint_path = 'my-checkpoint'
       f.write(text_format.MessageToString(cp))
       f.file.flush()
       self.assertEqual(utils.ParseCheckpoint(f.name), 'my-checkpoint')
     # parse path to actual checkpoint
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(mode='w+') as f:
       f.write('This is not a CheckpointState proto.')
       f.file.flush()
       self.assertEqual(utils.ParseCheckpoint(f.name), f.name)

--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -39,8 +39,9 @@ class TestGeneralization(TestAPI):
     X, y = dataset.data, dataset.target
     frac_train = .7
     n_samples = len(X)
-    X_train, y_train = X[:frac_train*n_samples], y[:frac_train*n_samples]
-    X_test, y_test = X[frac_train*n_samples:], y[frac_train*n_samples:]
+    n_train = int(frac_train*n_samples)
+    X_train, y_train = X[:n_train], y[:n_train]
+    X_test, y_test = X[n_train:], y[n_train:]
     train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
     test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
 
@@ -73,8 +74,9 @@ class TestGeneralization(TestAPI):
 
     frac_train = .7
     n_samples = len(X)
-    X_train, y_train = X[:frac_train*n_samples], y[:frac_train*n_samples]
-    X_test, y_test = X[frac_train*n_samples:], y[frac_train*n_samples:]
+    n_train = int(frac_train*n_samples)
+    X_train, y_train = X[:n_train], y[:n_train]
+    X_test, y_test = X[n_train:], y[n_train:]
     train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
     test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
 
@@ -117,8 +119,9 @@ class TestGeneralization(TestAPI):
     
     frac_train = .7
     n_samples = len(X)
-    X_train, y_train = X[:frac_train*n_samples], y[:frac_train*n_samples]
-    X_test, y_test = X[frac_train*n_samples:], y[frac_train*n_samples:]
+    n_train = int(frac_train*n_samples)
+    X_train, y_train = X[:n_train], y[:n_train]
+    X_test, y_test = X[n_train:], y[n_train:]
     train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
     test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
 
@@ -154,8 +157,9 @@ class TestGeneralization(TestAPI):
 
     frac_train = .7
     n_samples = len(X)
-    X_train, y_train = X[:frac_train*n_samples], y[:frac_train*n_samples]
-    X_test, y_test = X[frac_train*n_samples:], y[frac_train*n_samples:]
+    n_train = int(frac_train*n_samples)
+    X_train, y_train = X[:n_train], y[:n_train]
+    X_test, y_test = X[n_train:], y[n_train:]
     train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
     test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
 
@@ -191,8 +195,9 @@ class TestGeneralization(TestAPI):
     
     frac_train = .7
     n_samples = len(X)
-    X_train, y_train = X[:frac_train*n_samples], y[:frac_train*n_samples]
-    X_test, y_test = X[frac_train*n_samples:], y[frac_train*n_samples:]
+    n_train = int(frac_train*n_samples)
+    X_train, y_train = X[:n_train], y[:n_train]
+    X_test, y_test = X[n_train:], y[n_train:]
     train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
     test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
 

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -406,7 +406,7 @@ class TestOverfitAPI(TestAPI):
     dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
 
     verbosity = "high"
-    classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
+    classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity, task_averager=np.mean)
     def model_builder(model_dir):
       sklearn_model = RandomForestClassifier()
       return SklearnModel(sklearn_model, model_dir)
@@ -476,7 +476,7 @@ class TestOverfitAPI(TestAPI):
     dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
 
     verbosity = "high"
-    classification_metric = Metric(metrics.accuracy_score, verbosity=verbosity)
+    classification_metric = Metric(metrics.accuracy_score, verbosity=verbosity, task_averager=np.mean)
     tensorflow_model = TensorflowMultiTaskClassifier(
         n_tasks, n_features, self.model_dir, dropouts=[0.],
         learning_rate=0.0003, weight_init_stddevs=[.1],
@@ -511,7 +511,7 @@ class TestOverfitAPI(TestAPI):
     dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
 
     verbosity = "high"
-    regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
+    regression_metric = Metric(metrics.r2_score, verbosity=verbosity, task_averager=np.mean)
     def model_builder(model_dir):
       sklearn_model = RandomForestRegressor()
       return SklearnModel(sklearn_model, model_dir)

--- a/deepchem/scripts/dock_dude.py
+++ b/deepchem/scripts/dock_dude.py
@@ -177,8 +177,8 @@ def dock_ligand_to_receptor(ligand_file, receptor_filename, protein_centroid,
   out_filename = os.path.join(subdir, "%s_docked.pdbqt" % ligand_name)
   if os.path.exists(out_filename):
     try:
-      receptor_pybel = pybel.readfile("pdbqt", 
-        out_filename).next()
+      receptor_pybel = next(pybel.readfile("pdbqt", 
+        out_filename))
       return out_filename
     except:
       pass
@@ -217,8 +217,8 @@ def dock_ligands_to_receptors(docking_dir, worker_pool=False, exhaustiveness=Non
 
     print("Examining %s" % receptor_filename)
 
-    receptor_pybel = pybel.readfile("pdb", 
-        os.path.join(subdir, "%s.pdb" % receptor_name)).next()
+    receptor_pybel = next(pybel.readfile("pdb", 
+        os.path.join(subdir, "%s.pdb" % receptor_name)))
     protein_centroid, protein_range = get_molecule_data(receptor_pybel)
 
     box_dims = protein_range + 5.0
@@ -241,8 +241,8 @@ def dock_ligands_to_receptors(docking_dir, worker_pool=False, exhaustiveness=Non
       print("Docking to %s first to ascertain centroid and box dimensions" % active_ligand)
 
       out_pdb_qt = dock_ligand_to_receptor_partial(active_ligand)
-      ligand_pybel = pybel.readfile("pdbqt", 
-                                    out_pdb_qt).next()
+      ligand_pybel = next(pybel.readfile("pdbqt", 
+                                    out_pdb_qt))
       ligand_centroid, _ = get_molecule_data(ligand_pybel)
       print("Protein centroid = %s" %(str(protein_centroid)))
       print("Ligand centroid = %s" %(str(ligand_centroid)))

--- a/deepchem/scripts/process_vs_datasets.py
+++ b/deepchem/scripts/process_vs_datasets.py
@@ -11,7 +11,7 @@ import argparse
 import os
 import csv
 from rdkit import Chem
-import cPickle as pickle
+import pickle
 import warnings
 from multiprocessing import Pool
 import itertools

--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -361,7 +361,7 @@ class SpecifiedSplitter(Splitter):
 
   def __init__(self, input_file, split_field, verbosity=None):
     """Provide input information for splits."""
-    raw_df = load_data([input_file], shard_size=None).next()
+    raw_df = next(load_data([input_file], shard_size=None))
     self.splits = raw_df[split_field].values
     self.verbosity = verbosity
 

--- a/deepchem/transformers/__init__.py
+++ b/deepchem/transformers/__init__.py
@@ -164,7 +164,7 @@ class NormalizationTransformer(Transformer):
       energy = tasks[:,0]
       transformed_grad = []
 
-      for i in xrange(energy.size):
+      for i in range(energy.size):
         Etf = energy[i]
         grad_Etf = grad[i].flatten()
         grad_E = Etf*grad_var+energy_var*grad_Etf+grad_means
@@ -225,7 +225,7 @@ class AtomicNormalizationTransformer(Transformer):
 
       # add 2nd order correction term to gradients
       grad_var = 1/self.y_stds[0]*(self.ydely_means-self.y_means[0]*self.y_means[1:])
-      for i in xrange(y.shape[0]):
+      for i in range(y.shape[0]):
         y[i,1:] = y[i,1:] - grad_var*y[i,0]/self.y_stds[0]
 
       save_to_disk(y, os.path.join(data_dir, row['y-transformed']))
@@ -240,7 +240,7 @@ class AtomicNormalizationTransformer(Transformer):
 
       # untransform grad
       grad_var = 1/self.y_stds[0]*(self.ydely_means-self.y_means[0]*self.y_means[1:])
-      for i in xrange(z.shape[0]):
+      for i in range(z.shape[0]):
         z[i,1:] = z[i,0]*grad_var + self.y_stds[0]*z[i,1:] + self.y_means[1:] 
       # untransform energy
       z[:,0] = z[:,0] * self.y_stds[0] + self.y_means[0]
@@ -259,7 +259,7 @@ class AtomicNormalizationTransformer(Transformer):
       energy = tasks[:,0]
       transformed_grad = []
 
-      for i in xrange(energy.size):
+      for i in range(energy.size):
         Etf = energy[i]
         grad_Etf = grad[i].flatten()
         grad_E = Etf*grad_var+energy_var*grad_Etf+grad_means
@@ -323,7 +323,7 @@ class LogTransformer(Transformer):
       if self.features is None:
         X = np.log(X+1)
       else:
-        for j in xrange(num_features):
+        for j in range(num_features):
           if j in self.features:
             X[:,j] = np.log(X[:,j]+1)
           else:
@@ -336,7 +336,7 @@ class LogTransformer(Transformer):
       if self.tasks is None:
         y = np.log(y+1)
       else:
-        for j in xrange(num_tasks):
+        for j in range(num_tasks):
           if j in self.tasks:
             y[:,j] = np.log(y[:,j]+1)
           else:
@@ -352,7 +352,7 @@ class LogTransformer(Transformer):
       if self.features is None:
         return np.exp(z)-1
       else:
-        for j in xrange(num_features):
+        for j in range(num_features):
           if j in self.features:
             z[:,j] = np.exp(z[:,j])-1
           else:
@@ -363,7 +363,7 @@ class LogTransformer(Transformer):
       if self.tasks is None:
         return np.exp(z)-1
       else:
-        for j in xrange(num_tasks):
+        for j in range(num_tasks):
           if j in self.tasks:
             z[:,j] = np.exp(z[:,j])-1
           else:
@@ -435,8 +435,8 @@ class CoulombRandomizationTransformer(Transformer):
     d = int((np.sqrt(8*len(x)+1)-1)/2)
     cm = np.zeros([d,d])
     cm[np.triu_indices_from(cm)] = x
-    for i in xrange(len(cm)):
-      for j in xrange(i+1,len(cm)):
+    for i in range(len(cm)):
+      for j in range(i+1,len(cm)):
         cm[j,i] = cm[i,j]
     return cm
 
@@ -475,7 +475,7 @@ class CoulombRandomizationTransformer(Transformer):
     row = df.iloc[i]
     if self.transform_X:
       X = load_from_disk(os.path.join(data_dir, row['X-transformed']))
-      for j in xrange(len(X)):
+      for j in range(len(X)):
         cm = self.construct_cm_from_triu(X[j])
         X[j] = self.unpad_randomize_and_flatten(cm)
       save_to_disk(X, os.path.join(data_dir, row['X-transformed']))
@@ -489,7 +489,7 @@ class CoulombRandomizationTransformer(Transformer):
     Randomly permute a Coulomb Matrix passed as an array
     """
     if self.transform_X:
-      for j in xrange(len(X)):
+      for j in range(len(X)):
         cm = self.construct_cm_from_triu(X[j])
         X[j] = self.unpad_randomize_and_flatten(cm)
 

--- a/deepchem/utils/__init__.py
+++ b/deepchem/utils/__init__.py
@@ -32,9 +32,9 @@ def pad_array(x, shape, fill=0, both=False):
   """
   x = np.asarray(x)
   if not isinstance(shape, tuple):
-    shape = tuple(shape for _ in xrange(x.ndim))
+    shape = tuple(shape for _ in range(x.ndim))
   pad = []
-  for i in xrange(x.ndim):
+  for i in range(x.ndim):
     diff = shape[i] - x.shape[i]
     assert diff >= 0
     if both:

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -44,7 +44,7 @@ class Evaluator(object):
     """
     Write computed stats to file.
     """
-    with open(stats_out, "wb") as statsfile:
+    with open(stats_out, "w") as statsfile:
       statsfile.write(str(scores) + "\n")
 
   def output_predictions(self, y_preds, csv_out):
@@ -59,7 +59,7 @@ class Evaluator(object):
     n_tasks = len(self.task_names)
     y_preds = np.reshape(y_preds, (len(y_preds), n_tasks))
     assert len(y_preds) == len(mol_ids)
-    with open(csv_out, "wb") as csvfile:
+    with open(csv_out, "w") as csvfile:
       csvwriter = csv.writer(csvfile)
       csvwriter.writerow(["Compound"] + self.dataset.get_task_names())
       for mol_id, y_pred in zip(mol_ids, y_preds):

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -68,7 +68,7 @@ def load_sdf_files(input_files):
   dataframes = []
   for input_file in input_files:
     # Tasks are stored in .sdf.csv file
-    raw_df = load_csv_files([input_file+".csv"], shard_size=None).next()
+    raw_df = next(load_csv_files([input_file+".csv"], shard_size=None))
     # Structures are stored in .sdf file
     print("Reading structures from %s." % input_file)
     suppl = Chem.SDMolSupplier(str(input_file), removeHs=False)


### PR DESCRIPTION
I also fixed some bugs in the process.

I discussed this with @rbharath and we agreed to do the conversion in the way that would produce the cleanest, simplest Python 3 code, even if that means it's now less efficient under Python 2 than it used to be.  For example, I just replaced `xrange` (which returns an iterator, but only exists in Python 2) with `range` (which returns a list in Python 2 but an iterator in Python 3).  Consider this an incentive to switch to Python 3. :)