### PR TITLE
Refactoring of Dataset

### DIFF
--- a/deepchem/datasets/muv_datasets.py
+++ b/deepchem/datasets/muv_datasets.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 import shutil
 from deepchem.utils.save import load_from_disk
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.featurizers.featurize import DataLoader
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.transformers import BalancingTransformer
@@ -59,7 +59,7 @@ def load_muv(base_dir, reload=True, frac_train=.8):
     dataset = loader.featurize(dataset_file, data_dir)
     regen = True
   else:
-    dataset = Dataset(data_dir, reload=True)
+    dataset = DiskDataset(data_dir, reload=True)
 
   # Initialize transformers 
   transformers = [
@@ -69,7 +69,7 @@ def load_muv(base_dir, reload=True, frac_train=.8):
     for transformer in transformers:
         transformer.transform(dataset)
 
-  X, y, w, ids = dataset.to_numpy()
+  X, y, w, ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
   num_tasks = 17
   num_train = frac_train * len(dataset)
   MUV_tasks = MUV_tasks[:num_tasks]
@@ -80,9 +80,9 @@ def load_muv(base_dir, reload=True, frac_train=.8):
   w_train, w_valid = w[:num_train, :num_tasks], w[num_train:, :num_tasks]
   ids_train, ids_valid = ids[:num_train], ids[num_train:]
 
-  train_dataset = Dataset.from_numpy(train_dir, X_train, y_train,
+  train_dataset = DiskDataset.from_numpy(train_dir, X_train, y_train,
                                      w_train, ids_train, MUV_tasks)
-  valid_dataset = Dataset.from_numpy(valid_dir, X_valid, y_valid,
+  valid_dataset = DiskDataset.from_numpy(valid_dir, X_valid, y_valid,
                                      w_valid, ids_valid, MUV_tasks)
   
   return MUV_tasks, (train_dataset, valid_dataset), transformers

--- a/deepchem/datasets/pcba_datasets.py
+++ b/deepchem/datasets/pcba_datasets.py
@@ -9,7 +9,7 @@ import os
 import numpy as np
 import shutil
 from deepchem.utils.save import load_from_disk
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.featurizers.featurize import DataLoader
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.transformers import BalancingTransformer
@@ -80,7 +80,7 @@ def load_pcba(base_dir, reload=True, frac_train=.8):
     dataset = loader.featurize(dataset_file, data_dir)
     regen = True
   else:
-    dataset = Dataset(data_dir, reload=True)
+    dataset = DiskDataset(data_dir, reload=True)
 
   # Initialize transformers 
   transformers = [
@@ -93,7 +93,7 @@ def load_pcba(base_dir, reload=True, frac_train=.8):
 
   print("About to perform train/valid/test split.")
   num_train = frac_train * len(dataset)
-  X, y, w, ids = dataset.to_numpy()
+  X, y, w, ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
   num_tasks = 120
   PCBA_tasks = PCBA_tasks[:num_tasks]
   print("Using following tasks")
@@ -103,9 +103,9 @@ def load_pcba(base_dir, reload=True, frac_train=.8):
   w_train, w_valid = w[:num_train, :num_tasks], w[num_train:, :num_tasks]
   ids_train, ids_valid = ids[:num_train], ids[num_train:]
 
-  train_dataset = Dataset.from_numpy(train_dir, X_train, y_train,
+  train_dataset = DiskDataset.from_numpy(train_dir, X_train, y_train,
                                      w_train, ids_train, PCBA_tasks)
-  valid_dataset = Dataset.from_numpy(valid_dir, X_valid, y_valid,
+  valid_dataset = DiskDataset.from_numpy(valid_dir, X_valid, y_valid,
                                      w_valid, ids_valid, PCBA_tasks)
 
   

--- a/deepchem/datasets/pdbbind_datasets.py
+++ b/deepchem/datasets/pdbbind_datasets.py
@@ -12,7 +12,7 @@ import pandas as pd
 import shutil
 from rdkit import Chem
 from deepchem.utils.save import load_from_disk
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.transformers import BalancingTransformer
 from deepchem.featurizers.nnscore import NNScoreComplexFeaturizer
@@ -109,7 +109,7 @@ def load_core_pdbbind_coordinates(pdbbind_dir, base_dir, reload=True):
   X = np.array(features, dtype-object)
   w = np.ones_like(y)
    
-  dataset = Dataset.from_numpy(data_dir, X, y, w, ids)
+  dataset = DiskDataset.from_numpy(data_dir, X, y, w, ids)
   transformers = []
   
   return tasks, dataset, transformers
@@ -176,7 +176,7 @@ def load_core_pdbbind_grid(pdbbind_dir, base_dir, reload=True):
   X = np.vstack(features)
   w = np.ones_like(y)
    
-  dataset = Dataset.from_numpy(data_dir, X, y, w, ids)
+  dataset = DiskDataset.from_numpy(data_dir, X, y, w, ids)
   transformers = []
   
   return tasks, dataset, transformers

--- a/deepchem/datasets/tests/test_datasets.py
+++ b/deepchem/datasets/tests/test_datasets.py
@@ -322,8 +322,8 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     """Test that ordering of labels is consistent over time."""
     solubility_dataset = self.load_solubility_data()
 
-    ids1 = solubility_dataset.get_ids()
-    ids2 = solubility_dataset.get_ids()
+    ids1 = solubility_dataset.ids
+    ids2 = solubility_dataset.ids
 
     assert np.array_equal(ids1, ids2)
 

--- a/deepchem/datasets/tests/test_datasets.py
+++ b/deepchem/datasets/tests/test_datasets.py
@@ -259,38 +259,6 @@ class TestBasicDatasetAPI(TestDatasetAPI):
     assert y_shape == y.shape
     assert w_shape == w.shape
     assert ids_shape == ids.shape
-
-
-  def test_to_singletask(self):
-    """Test that to_singletask works."""
-    num_datapoints = 100
-    num_features = 10
-    num_tasks = 10
-    # Generate data
-    X = np.random.rand(num_datapoints, num_features)
-    y = np.random.randint(2, size=(num_datapoints, num_tasks))
-    w = np.random.randint(2, size=(num_datapoints, num_tasks))
-    ids = np.array(["id"] * num_datapoints)
-    
-    dataset = NumpyDataset(X, y, w, ids)
-
-    task_dirs = []
-    try:
-      for task in range(num_tasks):
-        task_dirs.append(tempfile.mkdtemp())
-      singletask_datasets = dataset.to_singletask(task_dirs)
-      for task in range(num_tasks):
-        singletask_dataset = singletask_datasets[task]
-        X_task, y_task, w_task, ids_task = (singletask_dataset.X, singletask_dataset.y, singletask_dataset.w, singletask_dataset.ids)
-        w_nonzero = w[:, task] != 0
-        np.testing.assert_array_equal(X_task, X[w_nonzero != 0])
-        np.testing.assert_array_equal(y_task.flatten(), y[:, task][w_nonzero != 0])
-        np.testing.assert_array_equal(w_task.flatten(), w[:, task][w_nonzero != 0])
-        np.testing.assert_array_equal(ids_task, ids[w_nonzero != 0])
-    finally:
-      # Cleanup
-      for task_dir in task_dirs:
-        shutil.rmtree(task_dir)
   
   def test_iterbatches(self):
     """Test that iterating over batches of data works."""
@@ -303,6 +271,36 @@ class TestBasicDatasetAPI(TestDatasetAPI):
       assert y_b.shape == (batch_size,) + (len(tasks),)
       assert w_b.shape == (batch_size,) + (len(tasks),)
       assert ids_b.shape == (batch_size,)
+
+  def test_itersamples_numpy(self):
+    """Test that iterating over samples in a NumpyDataset works."""
+    num_datapoints = 100
+    num_features = 10
+    num_tasks = 10
+    # Generate data
+    X = np.random.rand(num_datapoints, num_features)
+    y = np.random.randint(2, size=(num_datapoints, num_tasks))
+    w = np.random.randint(2, size=(num_datapoints, num_tasks))
+    ids = np.array(["id"] * num_datapoints)
+    dataset = NumpyDataset(X, y, w, ids)
+    for i, (sx, sy, sw, sid) in enumerate(dataset.itersamples()):
+        np.testing.assert_array_equal(sx, X[i])
+        np.testing.assert_array_equal(sy, y[i])
+        np.testing.assert_array_equal(sw, w[i])
+        np.testing.assert_array_equal(sid, ids[i])
+
+  def test_itersamples_dist(self):
+    """Test that iterating over samples in a DiskDataset works."""
+    solubility_dataset = self.load_solubility_data()
+    X = solubility_dataset.X
+    y = solubility_dataset.y
+    w = solubility_dataset.w
+    ids = solubility_dataset.ids
+    for i, (sx, sy, sw, sid) in enumerate(solubility_dataset.itersamples()):
+        np.testing.assert_array_equal(sx, X[i])
+        np.testing.assert_array_equal(sy, y[i])
+        np.testing.assert_array_equal(sw, w[i])
+        np.testing.assert_array_equal(sid, ids[i])
 
   def test_to_numpy(self):
     """Test that transformation to numpy arrays is sensible."""

--- a/deepchem/datasets/tests/test_drop.py
+++ b/deepchem/datasets/tests/test_drop.py
@@ -43,7 +43,7 @@ class TestDrop(TestAPI):
                         verbosity=verbosity)
     dataset = loader.featurize(dataset_file, data_dir, debug=True, logging=False)
 
-    X, y, w, ids = dataset.to_numpy()
+    X, y, w, ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     print("ids.shape, X.shape, y.shape, w.shape")
     print(ids.shape, X.shape, y.shape, w.shape)
     assert len(X) == len(y) == len(w) == len(ids)

--- a/deepchem/datasets/tests/test_load.py
+++ b/deepchem/datasets/tests/test_load.py
@@ -43,13 +43,13 @@ class TestLoad(TestAPI):
                         verbosity=verbosity)
     dataset = loader.featurize(dataset_file, data_dir)
 
-    X, y, w, ids = dataset.to_numpy()
+    X, y, w, ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     shutil.move(data_dir, moved_data_dir)
 
     moved_dataset = DiskDataset(
         moved_data_dir, reload=True)
 
-    X_moved, y_moved, w_moved, ids_moved = moved_dataset.to_numpy()
+    X_moved, y_moved, w_moved, ids_moved = (moved_dataset.X, moved_dataset.y, moved_dataset.w, moved_dataset.ids)
 
     np.testing.assert_allclose(X, X_moved)
     np.testing.assert_allclose(y, y_moved)
@@ -100,7 +100,7 @@ class TestLoad(TestAPI):
         dataset_file, data_dir)
 
     # Do train/valid split.
-    X_multi, y_multi, w_multi, ids_multi = dataset.to_numpy()
+    X_multi, y_multi, w_multi, ids_multi = (dataset.X, dataset.y, dataset.w, dataset.ids)
 
 
     ####### Do singletask load
@@ -109,7 +109,7 @@ class TestLoad(TestAPI):
       print("Processing task %s" % task)
       dataset = DiskDataset(data_dir, verbosity=verbosity, reload=reload)
 
-      X_task, y_task, w_task, ids_task = dataset.to_numpy()
+      X_task, y_task, w_task, ids_task = (dataset.X, dataset.y, dataset.w, dataset.ids)
       y_tasks.append(y_task[:, ind])
       w_tasks.append(w_task[:, ind])
 
@@ -167,7 +167,7 @@ class TestLoad(TestAPI):
     dataset = loader.featurize(dataset_file, data_dir)
 
     # Do train/valid split.
-    X_multi, y_multi, w_multi, ids_multi = dataset.to_numpy()
+    X_multi, y_multi, w_multi, ids_multi = (dataset.X, dataset.y, dataset.w, dataset.ids)
 
 
     ####### Do singletask load
@@ -182,7 +182,7 @@ class TestLoad(TestAPI):
                           verbosity=verbosity)
       dataset = loader.featurize(dataset_file, data_dir)
 
-      X_task, y_task, w_task, ids_task = dataset.to_numpy()
+      X_task, y_task, w_task, ids_task = (dataset.X, dataset.y, dataset.w, dataset.ids)
       y_tasks.append(y_task)
       w_tasks.append(w_task)
       ids_tasks.append(ids_task)

--- a/deepchem/datasets/tests/test_load.py
+++ b/deepchem/datasets/tests/test_load.py
@@ -17,7 +17,7 @@ from deepchem.models.tests import TestAPI
 from deepchem.utils.save import load_from_disk
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.featurizers.featurize import DataLoader
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 
 ## task0: 1,1,0,-,0,-,1,-,-,1
 
@@ -46,7 +46,7 @@ class TestLoad(TestAPI):
     X, y, w, ids = dataset.to_numpy()
     shutil.move(data_dir, moved_data_dir)
 
-    moved_dataset = Dataset(
+    moved_dataset = DiskDataset(
         moved_data_dir, reload=True)
 
     X_moved, y_moved, w_moved, ids_moved = moved_dataset.to_numpy()
@@ -107,7 +107,7 @@ class TestLoad(TestAPI):
     y_tasks, w_tasks, = [], []
     for ind, task in enumerate(all_tasks):
       print("Processing task %s" % task)
-      dataset = Dataset(data_dir, verbosity=verbosity, reload=reload)
+      dataset = DiskDataset(data_dir, verbosity=verbosity, reload=reload)
 
       X_task, y_task, w_task, ids_task = dataset.to_numpy()
       y_tasks.append(y_task[:, ind])

--- a/deepchem/datasets/tests/test_merge.py
+++ b/deepchem/datasets/tests/test_merge.py
@@ -71,13 +71,13 @@ class TestMerge(TestAPI):
 
     shard_nums = [1, 2]
 
-    orig_ids = dataset.get_ids()
+    orig_ids = dataset.ids
     _, _, _, ids_1 = dataset.get_shard(1)
     _, _, _, ids_2 = dataset.get_shard(2)
 
     subset = dataset.subset(subset_dir, shard_nums)
-    after_ids = dataset.get_ids()
+    after_ids = dataset.ids
 
     assert len(subset) == 4
-    assert sorted(subset.get_ids()) == sorted(np.concatenate([ids_1, ids_2]))
+    assert sorted(subset.ids) == sorted(np.concatenate([ids_1, ids_2]))
     assert list(orig_ids) == list(after_ids)

--- a/deepchem/datasets/tests/test_merge.py
+++ b/deepchem/datasets/tests/test_merge.py
@@ -17,7 +17,7 @@ from deepchem.models.tests import TestAPI
 from deepchem.utils.save import load_from_disk
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.featurizers.featurize import DataLoader
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 
 class TestMerge(TestAPI):
   """
@@ -45,7 +45,7 @@ class TestMerge(TestAPI):
     second_dataset = loader.featurize(
         dataset_file, second_data_dir)
 
-    merged_dataset = Dataset.merge(
+    merged_dataset = DiskDataset.merge(
         merged_data_dir, [first_dataset, second_dataset])
 
     assert len(merged_dataset) == len(first_dataset) + len(second_dataset)

--- a/deepchem/datasets/tests/test_shuffle.py
+++ b/deepchem/datasets/tests/test_shuffle.py
@@ -17,7 +17,7 @@ from deepchem.models.tests import TestAPI
 from deepchem.utils.save import load_from_disk
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.featurizers.featurize import DataLoader
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 
 class TestShuffle(TestAPI):
   """
@@ -41,11 +41,11 @@ class TestShuffle(TestAPI):
     dataset = loader.featurize(
         dataset_file, data_dir, shard_size=2)
 
-    X_orig, y_orig, w_orig, orig_ids = dataset.to_numpy()
+    X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     orig_len = len(dataset)
 
     dataset.shuffle(iterations=5)
-    X_new, y_new, w_new, new_ids = dataset.to_numpy()
+    X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     
     assert len(dataset) == orig_len
     # The shuffling should have switched up the ordering
@@ -75,11 +75,11 @@ class TestShuffle(TestAPI):
     dataset = loader.featurize(
         dataset_file, data_dir, shard_size=2)
 
-    X_orig, y_orig, w_orig, orig_ids = dataset.to_numpy()
+    X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     orig_len = len(dataset)
 
     dataset.sparse_shuffle()
-    X_new, y_new, w_new, new_ids = dataset.to_numpy()
+    X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     
     assert len(dataset) == orig_len
     # The shuffling should have switched up the ordering
@@ -109,11 +109,11 @@ class TestShuffle(TestAPI):
     dataset = loader.featurize(
         dataset_file, data_dir, shard_size=2)
 
-    X_orig, y_orig, w_orig, orig_ids = dataset.to_numpy()
+    X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     orig_len = len(dataset)
 
     dataset.reshard_shuffle(reshard_size=1)
-    X_new, y_new, w_new, new_ids = dataset.to_numpy()
+    X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
     
     assert len(dataset) == orig_len
     # The shuffling should have switched up the ordering
@@ -135,11 +135,11 @@ class TestShuffle(TestAPI):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.random.randint(2, size=(n_samples, n_tasks))
     ids = np.arange(n_samples)
-    dataset = Dataset.from_numpy(self.data_dir, X, y, w, ids)
+    dataset = DiskDataset.from_numpy(self.data_dir, X, y, w, ids)
     dataset.reshard(shard_size=10)
 
     dataset.shuffle_each_shard()
-    X_s, y_s, w_s, ids_s = dataset.to_numpy()
+    X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
     assert X_s.shape == X.shape
     assert y_s.shape == y.shape
     assert ids_s.shape == ids.shape
@@ -163,11 +163,11 @@ class TestShuffle(TestAPI):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.random.randint(2, size=(n_samples, n_tasks))
     ids = np.arange(n_samples)
-    dataset = Dataset.from_numpy(self.data_dir, X, y, w, ids)
+    dataset = DiskDataset.from_numpy(self.data_dir, X, y, w, ids)
     dataset.reshard(shard_size=10)
     dataset.shuffle_shards()
 
-    X_s, y_s, w_s, ids_s = dataset.to_numpy()
+    X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
 
     assert X_s.shape == X.shape
     assert y_s.shape == y.shape

--- a/deepchem/datasets/tox21_datasets.py
+++ b/deepchem/datasets/tox21_datasets.py
@@ -11,7 +11,7 @@ import shutil
 from deepchem.utils.save import load_from_disk
 from deepchem.featurizers.featurize import DataLoader
 from deepchem.featurizers.fingerprints import CircularFingerprint
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.transformers import BalancingTransformer
 
 def load_tox21(base_dir, reload=True, num_train=7200):
@@ -56,7 +56,7 @@ def load_tox21(base_dir, reload=True, num_train=7200):
     dataset = loader.featurize(
         dataset_file, data_dir, shard_size=8192)
   else:
-    dataset = Dataset(data_dir, tox21_tasks, reload=True)
+    dataset = DiskDataset(data_dir, tox21_tasks, reload=True)
 
   # Initialize transformers 
   transformers = [
@@ -66,15 +66,15 @@ def load_tox21(base_dir, reload=True, num_train=7200):
     for transformer in transformers:
         transformer.transform(dataset)
 
-  X, y, w, ids = dataset.to_numpy()
+  X, y, w, ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
   X_train, X_valid = X[:num_train], X[num_train:]
   y_train, y_valid = y[:num_train], y[num_train:]
   w_train, w_valid = w[:num_train], w[num_train:]
   ids_train, ids_valid = ids[:num_train], ids[num_train:]
 
-  train_dataset = Dataset.from_numpy(train_dir, X_train, y_train,
+  train_dataset = DiskDataset.from_numpy(train_dir, X_train, y_train,
                                      w_train, ids_train, tox21_tasks)
-  valid_dataset = Dataset.from_numpy(valid_dir, X_valid, y_valid,
+  valid_dataset = DiskDataset.from_numpy(valid_dir, X_valid, y_valid,
                                      w_valid, ids_valid, tox21_tasks)
   
   return tox21_tasks, (train_dataset, valid_dataset), transformers

--- a/deepchem/featurizers/featurize.py
+++ b/deepchem/featurizers/featurize.py
@@ -23,7 +23,7 @@ from deepchem.utils.save import save_to_disk
 from deepchem.utils.save import load_pickle_from_disk
 from deepchem.featurizers import Featurizer, ComplexFeaturizer
 from deepchem.featurizers import UserDefinedFeaturizer
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.utils.save import load_data
 from deepchem.utils.save import get_input_type
 ############################################################## DEBUG
@@ -83,7 +83,7 @@ def featurize_map_function(args):
       loader.verbosity)
   log("About to featurize shard.", loader.verbosity)
   write_fn = partial(
-      Dataset.write_dataframe, data_dir=data_dir,
+      DiskDataset.write_dataframe, data_dir=data_dir,
       featurizer=loader.featurizer, tasks=loader.tasks,
       mol_id_field=loader.id_field, verbosity=loader.verbosity)
   ############################################################## TIMING
@@ -212,7 +212,7 @@ class DataLoader(object):
 
     # TODO(rbharath): This whole bit with metadata_rows is an awkward way of
     # creating a Dataset. Is there a more elegant solutions?
-    dataset = Dataset(data_dir=data_dir,
+    dataset = DiskDataset(data_dir=data_dir,
                       metadata_rows=metadata_rows,
                       reload=True, verbosity=self.verbosity)
     ############################################################## TIMING

--- a/deepchem/featurizers/grid_featurizer.py
+++ b/deepchem/featurizers/grid_featurizer.py
@@ -12,7 +12,7 @@ import time
 from collections import deque
 import hashlib
 import sys
-#import openbabel as ob
+import openbabel as ob
 from functools import partial
 from deepchem.featurizers import ComplexFeaturizer
 from deepchem.utils.save import log

--- a/deepchem/featurizers/grid_featurizer.py
+++ b/deepchem/featurizers/grid_featurizer.py
@@ -12,7 +12,7 @@ import time
 from collections import deque
 import hashlib
 import sys
-import openbabel as ob
+#import openbabel as ob
 from functools import partial
 from deepchem.featurizers import ComplexFeaturizer
 from deepchem.utils.save import log

--- a/deepchem/featurizers/nnscore_utils.py
+++ b/deepchem/featurizers/nnscore_utils.py
@@ -11,7 +11,7 @@ __license__ = "GNU General Public License"
 import math
 import os
 import subprocess
-#import openbabel
+import openbabel
 import numpy as np
 
 

--- a/deepchem/featurizers/nnscore_utils.py
+++ b/deepchem/featurizers/nnscore_utils.py
@@ -11,7 +11,7 @@ __license__ = "GNU General Public License"
 import math
 import os
 import subprocess
-import openbabel
+#import openbabel
 import numpy as np
 
 

--- a/deepchem/featurizers/tests/test_featurized_samples.py
+++ b/deepchem/featurizers/tests/test_featurized_samples.py
@@ -13,7 +13,7 @@ import os
 import unittest
 import tempfile
 import shutil
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.models.tests import TestAPI
 from deepchem.splits import RandomSplitter
 from deepchem.splits import ScaffoldSplitter
@@ -153,7 +153,7 @@ class TestFeaturizedSamples(TestAPI):
     # Now perform move
     shutil.move(data_dir, moved_data_dir)
 
-    moved_featurized_dataset = Dataset(
+    moved_featurized_dataset = DiskDataset(
         data_dir=moved_data_dir, reload=True)
 
     assert len(moved_featurized_dataset) == n_dataset

--- a/deepchem/hyperparameters/tests/test_hyperparam_opt.py
+++ b/deepchem/hyperparameters/tests/test_hyperparam_opt.py
@@ -24,7 +24,7 @@ from deepchem.metrics import Metric
 from deepchem.models.multitask import SingletaskToMultitask 
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble import RandomForestRegressor
-from deepchem.datasets import Dataset
+from deepchem.datasets import NumpyDataset
 from deepchem.hyperparameters import HyperparamOpt
 from deepchem.models.keras_models.fcnet import MultiTaskDNN
 from deepchem.models.keras_models import KerasModel
@@ -85,9 +85,7 @@ class TestHyperparamOptAPI(TestAPI):
     y_train = np.random.randint(2, size=(n_train, n_tasks))
     w_train = np.ones_like(y_train)
     ids_train = ["C"] * n_train
-    train_dataset = Dataset.from_numpy(self.train_dir,
-                                       X_train, y_train, w_train, ids_train,
-                                       tasks)
+    train_dataset = NumpyDataset(X_train, y_train, w_train, ids_train)
 
     # Define validation dataset
     n_valid = 10
@@ -95,9 +93,7 @@ class TestHyperparamOptAPI(TestAPI):
     y_valid = np.random.randint(2, size=(n_valid, n_tasks))
     w_valid = np.ones_like(y_valid)
     ids_valid = ["C"] * n_valid
-    valid_dataset = Dataset.from_numpy(self.valid_dir,
-                                       X_valid, y_valid, w_valid, ids_valid,
-                                       tasks)
+    valid_dataset = NumpyDataset(X_valid, y_valid, w_valid, ids_valid)
 
     transformers = []
     classification_metric = Metric(metrics.matthews_corrcoef, np.mean,

--- a/deepchem/hyperparameters/tests/test_hyperparam_opt.py
+++ b/deepchem/hyperparameters/tests/test_hyperparam_opt.py
@@ -24,7 +24,7 @@ from deepchem.metrics import Metric
 from deepchem.models.multitask import SingletaskToMultitask 
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble import RandomForestRegressor
-from deepchem.datasets import NumpyDataset
+from deepchem.datasets import DiskDataset, NumpyDataset
 from deepchem.hyperparameters import HyperparamOpt
 from deepchem.models.keras_models.fcnet import MultiTaskDNN
 from deepchem.models.keras_models import KerasModel
@@ -85,7 +85,10 @@ class TestHyperparamOptAPI(TestAPI):
     y_train = np.random.randint(2, size=(n_train, n_tasks))
     w_train = np.ones_like(y_train)
     ids_train = ["C"] * n_train
-    train_dataset = NumpyDataset(X_train, y_train, w_train, ids_train)
+
+    train_dataset = DiskDataset.from_numpy(self.train_dir,
+                                           X_train, y_train, w_train, ids_train,
+                                           tasks) 
 
     # Define validation dataset
     n_valid = 10
@@ -93,7 +96,9 @@ class TestHyperparamOptAPI(TestAPI):
     y_valid = np.random.randint(2, size=(n_valid, n_tasks))
     w_valid = np.ones_like(y_valid)
     ids_valid = ["C"] * n_valid
-    valid_dataset = NumpyDataset(X_valid, y_valid, w_valid, ids_valid)
+    valid_dataset = DiskDataset.from_numpy(self.valid_dir,
+                                           X_valid, y_valid, w_valid, ids_valid,
+                                           tasks)
 
     transformers = []
     classification_metric = Metric(metrics.matthews_corrcoef, np.mean,

--- a/deepchem/models/multitask.py
+++ b/deepchem/models/multitask.py
@@ -9,6 +9,7 @@ import os
 import numpy as np
 from deepchem.utils.save import log
 from deepchem.models import Model
+from deepchem.datasets import DiskDataset
 import sklearn
 from deepchem.transformers import undo_transforms
 
@@ -36,7 +37,6 @@ class SingletaskToMultitask(Model):
           self.verbosity, "high")
       self.task_model_dirs[task] = task_model_dir
 
-  
   def _create_task_datasets(self, dataset):
     """Make directories to hold data for tasks"""
     task_data_dirs = []
@@ -46,20 +46,56 @@ class SingletaskToMultitask(Model):
         shutil.rmtree(task_data_dir)
       os.makedirs(task_data_dir)
       task_data_dirs.append(task_data_dir)
-    task_datasets = dataset.to_singletask(task_data_dirs)
+    task_datasets = self._to_singletask(dataset, task_data_dirs)
     if self.verbosity is not None:
       for task, task_dataset in zip(self.tasks, task_datasets):
         log("Dataset for task %s has shape %s"
             % (task, str(task_dataset.get_shape())), self.verbosity)
     return task_datasets
-   
-      
+
+  def _to_singletask(self, dataset, task_dirs):
+    """Transforms a multitask dataset to a collection of singletask datasets."""
+    tasks = dataset.get_task_names()
+    assert len(tasks) == len(task_dirs)
+    log("Splitting multitask dataset into singletask datasets", dataset.verbosity)
+    task_metadata_rows = {task: [] for task in tasks}
+    for shard_num, (X, y, w, ids) in enumerate(dataset.itershards()):
+      log("Processing shard %d" % shard_num, dataset.verbosity)
+      basename = "dataset-%d" % shard_num
+      for task_num, task in enumerate(tasks):
+        log("\tTask %s" % task, dataset.verbosity)
+        w_task = w[:, task_num]
+        y_task = y[:, task_num]
+
+        # Extract those datapoints which are present for this task
+        X_nonzero = X[w_task != 0]
+        num_datapoints = X_nonzero.shape[0]
+        y_nonzero = np.reshape(y_task[w_task != 0], (num_datapoints, 1))
+        w_nonzero = np.reshape(w_task[w_task != 0], (num_datapoints, 1))
+        ids_nonzero = ids[w_task != 0]
+
+        if X_nonzero.size > 0: 
+          task_metadata_rows[task].append(
+            DiskDataset.write_data_to_disk(
+                task_dirs[task_num], basename, [task],
+                X_nonzero, y_nonzero, w_nonzero, ids_nonzero))
+    
+    task_datasets = [
+        DiskDataset(data_dir=task_dirs[task_num],
+                metadata_rows=task_metadata_rows[task],
+                verbosity=dataset.verbosity)
+        for (task_num, task) in enumerate(tasks)]
+    return task_datasets
+
+
   def fit(self, dataset, **kwargs):
     """
     Updates all singletask models with new information.
 
     Warning: This current implementation is only functional for sklearn models. 
     """
+    if not isinstance(dataset, DiskDataset):
+      raise ValueError('SingletaskToMultitask only works with DiskDatasets')
     log("About to create task-specific datasets", self.verbosity, "high")
     task_datasets = self._create_task_datasets(dataset)
     for ind, task in enumerate(self.tasks):

--- a/deepchem/models/multitask.py
+++ b/deepchem/models/multitask.py
@@ -53,7 +53,8 @@ class SingletaskToMultitask(Model):
             % (task, str(task_dataset.get_shape())), self.verbosity)
     return task_datasets
 
-  def _to_singletask(self, dataset, task_dirs):
+  @staticmethod
+  def _to_singletask(dataset, task_dirs):
     """Transforms a multitask dataset to a collection of singletask datasets."""
     tasks = dataset.get_task_names()
     assert len(tasks) == len(task_dirs)

--- a/deepchem/models/sklearn_models/__init__.py
+++ b/deepchem/models/sklearn_models/__init__.py
@@ -23,8 +23,9 @@ class SklearnModel(Model):
     """
     Fits SKLearn model to data.
     """
-    X, y, w, _ = dataset.to_numpy()
-    y, w = np.squeeze(y), np.squeeze(w)
+    X = dataset.X
+    y = np.squeeze(dataset.y)
+    w = np.squeeze(dataset.w)
     # Logistic regression doesn't support weights
     if not isinstance(self.model_instance, LogisticRegression):
       self.model_instance.fit(X, y, w)

--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -16,7 +16,7 @@ import numpy as np
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression 
 from sklearn.linear_model import LogisticRegression
-from deepchem.datasets import NumpyDataset
+from deepchem.datasets import DiskDataset
 from deepchem.metrics import Metric
 from deepchem.models.tests import TestAPI
 from deepchem.models.sklearn_models import SklearnModel
@@ -42,8 +42,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = NumpyDataset(X_train, y_train)
-    test_dataset = NumpyDataset(X_test, y_test)
+    train_dataset = DiskDataset.from_numpy(self.train_dir, X_train, y_train)
+    test_dataset = DiskDataset.from_numpy(self.test_dir, X_test, y_test)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
@@ -77,8 +77,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = NumpyDataset(X_train, y_train)
-    test_dataset = NumpyDataset(X_test, y_test)
+    train_dataset = DiskDataset.from_numpy(self.train_dir, X_train, y_train)
+    test_dataset = DiskDataset.from_numpy(self.test_dir, X_test, y_test)
 
     # Eval model on train
     transformers = [
@@ -122,8 +122,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = NumpyDataset(X_train, y_train)
-    test_dataset = NumpyDataset(X_test, y_test)
+    train_dataset = DiskDataset.from_numpy(self.train_dir, X_train, y_train)
+    test_dataset = DiskDataset.from_numpy(self.test_dir, X_test, y_test)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
@@ -160,8 +160,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = NumpyDataset(X_train, y_train)
-    test_dataset = NumpyDataset(X_test, y_test)
+    train_dataset = DiskDataset.from_numpy(self.train_dir, X_train, y_train)
+    test_dataset = DiskDataset.from_numpy(self.test_dir, X_test, y_test)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -198,8 +198,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = NumpyDataset(X_train, y_train)
-    test_dataset = NumpyDataset(X_test, y_test)
+    train_dataset = DiskDataset.from_numpy(self.train_dir, X_train, y_train)
+    test_dataset = DiskDataset.from_numpy(self.test_dir, X_test, y_test)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)

--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -16,7 +16,7 @@ import numpy as np
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression 
 from sklearn.linear_model import LogisticRegression
-from deepchem.datasets import Dataset
+from deepchem.datasets import NumpyDataset
 from deepchem.metrics import Metric
 from deepchem.models.tests import TestAPI
 from deepchem.models.sklearn_models import SklearnModel
@@ -42,8 +42,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
-    test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
+    train_dataset = NumpyDataset(X_train, y_train)
+    test_dataset = NumpyDataset(X_test, y_test)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
@@ -77,8 +77,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
-    test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
+    train_dataset = NumpyDataset(X_train, y_train)
+    test_dataset = NumpyDataset(X_test, y_test)
 
     # Eval model on train
     transformers = [
@@ -122,8 +122,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
-    test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
+    train_dataset = NumpyDataset(X_train, y_train)
+    test_dataset = NumpyDataset(X_test, y_test)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
@@ -160,8 +160,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
-    test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
+    train_dataset = NumpyDataset(X_train, y_train)
+    test_dataset = NumpyDataset(X_test, y_test)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -198,8 +198,8 @@ class TestGeneralization(TestAPI):
     n_train = int(frac_train*n_samples)
     X_train, y_train = X[:n_train], y[:n_train]
     X_test, y_test = X[n_train:], y[n_train:]
-    train_dataset = Dataset.from_numpy(self.train_dir, X_train, y_train)
-    test_dataset = Dataset.from_numpy(self.test_dir, X_test, y_test)
+    train_dataset = NumpyDataset(X_train, y_train)
+    test_dataset = NumpyDataset(X_test, y_test)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)

--- a/deepchem/models/tests/test_multitask.py
+++ b/deepchem/models/tests/test_multitask.py
@@ -15,7 +15,7 @@ import tempfile
 import shutil
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.featurizers.featurize import DataLoader
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.models.tests import TestAPI
 from deepchem.splits import ScaffoldSplitter
 
@@ -58,8 +58,7 @@ class TestMultitaskData(TestAPI):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids, tasks)
-    X_out, y_out, w_out, _ = dataset.to_numpy()
-    np.testing.assert_allclose(X, X_out)
-    np.testing.assert_allclose(y, y_out)
-    np.testing.assert_allclose(w, w_out)
+    dataset = DiskDataset.from_numpy(self.train_dir, X, y, w, ids, tasks)
+    np.testing.assert_allclose(X, dataset.X)
+    np.testing.assert_allclose(y, dataset.y)
+    np.testing.assert_allclose(w, dataset.w)

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -16,7 +16,7 @@ import sklearn
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble import RandomForestRegressor
 from deepchem import metrics
-from deepchem.datasets import Dataset
+from deepchem.datasets import NumpyDataset
 from deepchem.metrics import Metric
 from deepchem.models.tests import TestAPI
 from deepchem.utils.evaluate import Evaluator
@@ -47,7 +47,7 @@ class TestOverfitAPI(TestAPI):
     X = np.random.rand(n_samples, n_features)
     y = np.random.rand(n_samples, n_tasks)
     w = np.ones((n_samples, n_tasks))
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
@@ -77,7 +77,7 @@ class TestOverfitAPI(TestAPI):
     X = np.random.rand(n_samples, n_features)
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -109,7 +109,7 @@ class TestOverfitAPI(TestAPI):
     y = np.random.binomial(1, p, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -144,7 +144,7 @@ class TestOverfitAPI(TestAPI):
       y = np.random.rand(n_samples, n_tasks)
       w = np.ones((n_samples, n_tasks))
 
-      dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+      dataset = NumpyDataset(X, y, w, ids)
 
       verbosity = "high"
       regression_metric = Metric(metrics.r2_score, verbosity=verbosity)
@@ -175,7 +175,7 @@ class TestOverfitAPI(TestAPI):
     X = np.random.rand(n_samples, n_features)
     y = np.zeros((n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     regression_metric = Metric(metrics.mean_squared_error, verbosity=verbosity)
@@ -214,7 +214,7 @@ class TestOverfitAPI(TestAPI):
       y = np.random.randint(2, size=(n_samples, n_tasks))
       w = np.ones((n_samples, n_tasks))
     
-      dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+      dataset = NumpyDataset(X, y, w, ids)
 
       verbosity = "high"
       classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -252,7 +252,7 @@ class TestOverfitAPI(TestAPI):
       y = np.random.binomial(1, p, size=(n_samples, n_tasks))
       w = np.ones((n_samples, n_tasks))
     
-      dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+      dataset = NumpyDataset(X, y, w, ids)
 
       verbosity = "high"
       classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -284,7 +284,7 @@ class TestOverfitAPI(TestAPI):
     X = np.random.rand(n_samples, n_features)
     y = np.zeros((n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.accuracy_score, verbosity=verbosity)
@@ -321,7 +321,7 @@ class TestOverfitAPI(TestAPI):
     y = np.random.binomial(1, p, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -368,7 +368,7 @@ class TestOverfitAPI(TestAPI):
     w_flat[y_flat != 0] = weight_nonzero
     w = np.reshape(w_flat, (n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -403,7 +403,7 @@ class TestOverfitAPI(TestAPI):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity, task_averager=np.mean)
@@ -439,7 +439,7 @@ class TestOverfitAPI(TestAPI):
       X = np.random.rand(n_samples, n_features)
       y = np.random.randint(2, size=(n_samples, n_tasks))
       w = np.ones((n_samples, n_tasks))
-      dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+      dataset = NumpyDataset(X, y, w, ids)
 
       verbosity = "high"
       classification_metric = Metric(
@@ -473,7 +473,7 @@ class TestOverfitAPI(TestAPI):
     y = np.zeros((n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.accuracy_score, verbosity=verbosity, task_averager=np.mean)
@@ -508,7 +508,7 @@ class TestOverfitAPI(TestAPI):
     y = np.random.rand(n_samples, n_tasks)
     w = np.ones((n_samples, n_tasks))
 
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity, task_averager=np.mean)
@@ -544,7 +544,7 @@ class TestOverfitAPI(TestAPI):
       X = np.random.rand(n_samples, n_features)
       y = np.random.randint(2, size=(n_samples, n_tasks))
       w = np.ones((n_samples, n_tasks))
-      dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+      dataset = NumpyDataset(X, y, w, ids)
 
       verbosity = "high"
       regression_metric = Metric(metrics.r2_score, verbosity=verbosity,
@@ -578,7 +578,7 @@ class TestOverfitAPI(TestAPI):
     y = np.zeros((n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     model_params = {
       "layer_sizes": [1000],
@@ -593,8 +593,7 @@ class TestOverfitAPI(TestAPI):
       "bias_init_consts": [1.],
       "nb_epoch": 100,
       "penalty": 0.0,
-      "optimizer": "adam",
-      "data_shape": dataset.get_data_shape()
+      "optimizer": "adam"
     }
 
     verbosity = "high"

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -16,7 +16,7 @@ import sklearn
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble import RandomForestRegressor
 from deepchem import metrics
-from deepchem.datasets import NumpyDataset
+from deepchem.datasets import DiskDataset, NumpyDataset
 from deepchem.metrics import Metric
 from deepchem.models.tests import TestAPI
 from deepchem.utils.evaluate import Evaluator
@@ -403,7 +403,7 @@ class TestOverfitAPI(TestAPI):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = NumpyDataset(X, y, w, ids)
+    dataset = DiskDataset.from_numpy(self.train_dir, X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity, task_averager=np.mean)
@@ -508,7 +508,7 @@ class TestOverfitAPI(TestAPI):
     y = np.random.rand(n_samples, n_tasks)
     w = np.ones((n_samples, n_tasks))
 
-    dataset = NumpyDataset(X, y, w, ids)
+    dataset = DiskDataset.from_numpy(self.train_dir, X, y, w, ids)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity, task_averager=np.mean)

--- a/deepchem/models/tests/test_reload.py
+++ b/deepchem/models/tests/test_reload.py
@@ -14,7 +14,7 @@ from sklearn.ensemble import RandomForestClassifier
 from deepchem.models.tests import TestAPI
 from deepchem import metrics
 from deepchem.metrics import Metric
-from deepchem.datasets import Dataset
+from deepchem.datasets import NumpyDataset
 from deepchem.utils.evaluate import Evaluator
 from deepchem.models.sklearn_models import SklearnModel
 from deepchem.models.keras_models import KerasModel
@@ -41,7 +41,7 @@ class TestModelReload(TestAPI):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids, tasks)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -83,7 +83,7 @@ class TestModelReload(TestAPI):
       y = np.random.randint(2, size=(n_samples, n_tasks))
       w = np.ones((n_samples, n_tasks))
     
-      dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids, tasks)
+      dataset = NumpyDataset(X, y, w, ids)
 
       verbosity = "high"
       classification_metric = Metric(metrics.roc_auc_score, verbosity=verbosity)
@@ -124,7 +124,7 @@ class TestModelReload(TestAPI):
     y = np.random.randint(n_classes, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
   
-    dataset = Dataset.from_numpy(self.train_dir, X, y, w, ids)
+    dataset = NumpyDataset(X, y, w, ids)
 
     verbosity = "high"
     classification_metric = Metric(metrics.accuracy_score, verbosity=verbosity)

--- a/deepchem/models/tests/test_singletask_to_multitask.py
+++ b/deepchem/models/tests/test_singletask_to_multitask.py
@@ -13,7 +13,7 @@ import numpy as np
 from deepchem.models.tests import TestAPI
 from deepchem import metrics
 from deepchem.metrics import Metric
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.featurizers.fingerprints import CircularFingerprint
 from deepchem.models.multitask import SingletaskToMultitask 
 from deepchem.models.sklearn_models import SklearnModel
@@ -34,7 +34,7 @@ class TestSingletasktoMultitaskAPI(TestAPI):
     y_train = np.random.randint(2, size=(n_train, n_tasks))
     w_train = np.ones_like(y_train)
     ids_train = ["C"] * n_train
-    train_dataset = Dataset.from_numpy(
+    train_dataset = DiskDataset.from_numpy(
         self.train_dir, X_train, y_train, w_train, ids_train)
 
     # Define test dataset
@@ -43,7 +43,7 @@ class TestSingletasktoMultitaskAPI(TestAPI):
     y_test = np.random.randint(2, size=(n_test, n_tasks))
     w_test = np.ones_like(y_test)
     ids_test = ["C"] * n_test
-    test_dataset = Dataset.from_numpy(
+    test_dataset = DiskDataset.from_numpy(
         self.test_dir, X_test, y_test, w_test, ids_test)
 
     transformers = []

--- a/deepchem/models/tests/test_singletask_to_multitask.py
+++ b/deepchem/models/tests/test_singletask_to_multitask.py
@@ -10,6 +10,8 @@ __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "GPL"
 
 import numpy as np
+import tempfile
+import shutil
 from deepchem.models.tests import TestAPI
 from deepchem import metrics
 from deepchem.metrics import Metric
@@ -67,3 +69,35 @@ class TestSingletasktoMultitaskAPI(TestAPI):
     evaluator = Evaluator(multitask_model, test_dataset, transformers,
                           verbosity=True)
     _ = evaluator.compute_model_performance(classification_metrics)
+
+
+  def test_to_singletask(self):
+    """Test that to_singletask works."""
+    num_datapoints = 100
+    num_features = 10
+    num_tasks = 10
+    # Generate data
+    X = np.random.rand(num_datapoints, num_features)
+    y = np.random.randint(2, size=(num_datapoints, num_tasks))
+    w = np.random.randint(2, size=(num_datapoints, num_tasks))
+    ids = np.array(["id"] * num_datapoints)
+    
+    dataset = DiskDataset.from_numpy(self.train_dir, X, y, w, ids)
+
+    task_dirs = []
+    try:
+      for task in range(num_tasks):
+        task_dirs.append(tempfile.mkdtemp())
+      singletask_datasets = SingletaskToMultitask._to_singletask(None, dataset, task_dirs)
+      for task in range(num_tasks):
+        singletask_dataset = singletask_datasets[task]
+        X_task, y_task, w_task, ids_task = (singletask_dataset.X, singletask_dataset.y, singletask_dataset.w, singletask_dataset.ids)
+        w_nonzero = w[:, task] != 0
+        np.testing.assert_array_equal(X_task, X[w_nonzero != 0])
+        np.testing.assert_array_equal(y_task.flatten(), y[:, task][w_nonzero != 0])
+        np.testing.assert_array_equal(w_task.flatten(), w[:, task][w_nonzero != 0])
+        np.testing.assert_array_equal(ids_task, ids[w_nonzero != 0])
+    finally:
+      # Cleanup
+      for task_dir in task_dirs:
+        shutil.rmtree(task_dir)

--- a/deepchem/models/tests/test_singletask_to_multitask.py
+++ b/deepchem/models/tests/test_singletask_to_multitask.py
@@ -88,7 +88,7 @@ class TestSingletasktoMultitaskAPI(TestAPI):
     try:
       for task in range(num_tasks):
         task_dirs.append(tempfile.mkdtemp())
-      singletask_datasets = SingletaskToMultitask._to_singletask(None, dataset, task_dirs)
+      singletask_datasets = SingletaskToMultitask._to_singletask(dataset, task_dirs)
       for task in range(num_tasks):
         singletask_dataset = singletask_datasets[task]
         X_task, y_task, w_task, ids_task = (singletask_dataset.X, singletask_dataset.y, singletask_dataset.w, singletask_dataset.ids)

--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -260,7 +260,7 @@ class MolecularWeightSplitter(Splitter):
     np.random.seed(seed)
 
     mws = []
-    for smiles in dataset.get_ids():
+    for smiles in dataset.ids:
       mol = Chem.MolFromSmiles(smiles)
       mw = Chem.rdMolDescriptors.CalcExactMolWt(mol)
       mws.append(mw)
@@ -328,7 +328,7 @@ class ScaffoldSplitter(Splitter):
     scaffolds = {}
     log("About to generate scaffolds", self.verbosity)
     data_len = len(dataset)
-    for ind, smiles in enumerate(dataset.get_ids()):
+    for ind, smiles in enumerate(dataset.ids):
       if ind % log_every_n == 0:
         log("Generating scaffold %d/%d" % (ind, data_len), self.verbosity)
       scaffold = generate_scaffold(smiles)

--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -14,7 +14,7 @@ import numpy as np
 from rdkit import Chem
 from deepchem.utils import ScaffoldGenerator
 from deepchem.utils.save import log
-from deepchem.datasets import Dataset
+from deepchem.datasets import NumpyDataset
 from deepchem.featurizers.featurize import load_data
 
 def generate_scaffold(smiles, include_chirality=False):
@@ -176,11 +176,10 @@ class RandomStratifiedSplitter(Splitter):
     assert len(split_dirs) == 2
     # Handle edge case where frac_split is 1
     if frac_split == 1:
-      X, y, w, ids = dataset.to_numpy()
-      dataset_1 = Dataset.from_numpy(split_dirs[0], X, y, w, ids)
+      dataset_1 = NumpyDataset(dataset.X, dataset.y, dataset.w, dataset.ids)
       dataset_2 = None 
       return dataset_1, dataset_2
-    X, y, w, ids = randomize_arrays(dataset.to_numpy())
+    X, y, w, ids = randomize_arrays((dataset.X, dataset.y, dataset.w, dataset.ids))
     split_indices = self.get_task_split_indices(y, w, frac_split)
 
     # Create weight matrices fpor two haves. 
@@ -193,11 +192,11 @@ class RandomStratifiedSplitter(Splitter):
     # check out if any rows in either w_1 or w_2 are just zeros
     rows_1 = w_1.any(axis=1)
     X_1, y_1, w_1, ids_1 = X[rows_1], y[rows_1], w_1[rows_1], ids[rows_1]
-    dataset_1 = Dataset.from_numpy(split_dirs[0], X_1, y_1, w_1, ids_1)
+    dataset_1 = NumpyDataset(X_1, y_1, w_1, ids_1)
 
     rows_2 = w_2.any(axis=1)
     X_2, y_2, w_2, ids_2 = X[rows_2], y[rows_2], w_2[rows_2], ids[rows_2]
-    dataset_2 = Dataset.from_numpy(split_dirs[1], X_2, y_2, w_2, ids_2)
+    dataset_2 = NumpyDataset(X_2, y_2, w_2, ids_2)
 
     return dataset_1, dataset_2 
 
@@ -208,7 +207,7 @@ class RandomStratifiedSplitter(Splitter):
     """Custom split due to raggedness in original split.
     """
     # Obtain original x, y, and w arrays and shuffle
-    X, y, w, ids = randomize_arrays(dataset.to_numpy())
+    X, y, w, ids = randomize_arrays((dataset.X, dataset.y, dataset.w, dataset.ids))
     rem_dir = tempfile.mkdtemp()
     train_dataset, rem_dataset = self.split(
         dataset, [train_dir, rem_dir], frac_train)

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -11,7 +11,7 @@ __license__ = "GPL"
 
 import tempfile
 import numpy as np
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 from deepchem.splits import RandomSplitter
 from deepchem.splits import IndexSplitter
 from deepchem.splits import ScaffoldSplitter
@@ -40,7 +40,7 @@ class TestSplitters(TestDatasetAPI):
     assert len(test_data) == 1
 
     merge_dir = tempfile.mkdtemp()
-    merged_dataset = Dataset.merge(
+    merged_dataset = DiskDataset.merge(
         merge_dir, [train_data, valid_data, test_data])
     assert sorted(merged_dataset.ids) == (
            sorted(solubility_dataset.ids))
@@ -61,7 +61,7 @@ class TestSplitters(TestDatasetAPI):
     assert len(test_data) == 1
 
     merge_dir = tempfile.mkdtemp()
-    merged_dataset = Dataset.merge(
+    merged_dataset = DiskDataset.merge(
         merge_dir, [train_data, valid_data, test_data])
     assert sorted(merged_dataset.ids) == (
            sorted(solubility_dataset.ids))
@@ -108,7 +108,7 @@ class TestSplitters(TestDatasetAPI):
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
-    merged_dataset = Dataset.merge(merge_dir, fold_datasets)
+    merged_dataset = DiskDataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(solubility_dataset)
     assert sorted(merged_dataset.ids) == (
            sorted(solubility_dataset.ids))
@@ -141,7 +141,7 @@ class TestSplitters(TestDatasetAPI):
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
-    merged_dataset = Dataset.merge(merge_dir, fold_datasets)
+    merged_dataset = DiskDataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(solubility_dataset)
     assert sorted(merged_dataset.ids) == (
            sorted(solubility_dataset.ids))
@@ -175,7 +175,7 @@ class TestSplitters(TestDatasetAPI):
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
-    merged_dataset = Dataset.merge(merge_dir, fold_datasets)
+    merged_dataset = DiskDataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(solubility_dataset)
     assert sorted(merged_dataset.ids) == (
            sorted(solubility_dataset.ids))
@@ -298,7 +298,7 @@ class TestSplitters(TestDatasetAPI):
     w = np.ones((n_samples, n_tasks))
     ids = np.arange(n_samples)
     data_dir = tempfile.mkdtemp()
-    dataset = Dataset.from_numpy(data_dir, X, y, w, ids)
+    dataset = DiskDataset.from_numpy(data_dir, X, y, w, ids)
 
     stratified_splitter = RandomStratifiedSplitter()
     split_dirs = [tempfile.mkdtemp(), tempfile.mkdtemp()]
@@ -332,7 +332,7 @@ class TestSplitters(TestDatasetAPI):
     ids = np.arange(n_samples)
 
     data_dir = tempfile.mkdtemp()
-    dataset = Dataset.from_numpy(data_dir, X, y, w, ids)
+    dataset = DiskDataset.from_numpy(data_dir, X, y, w, ids)
     
     stratified_splitter = RandomStratifiedSplitter()
     ids_set = set(dataset.ids)
@@ -362,7 +362,7 @@ class TestSplitters(TestDatasetAPI):
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
-    merged_dataset = Dataset.merge(merge_dir, fold_datasets)
+    merged_dataset = DiskDataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(dataset)
     assert sorted(merged_dataset.ids) == (
            sorted(dataset.ids))
@@ -421,7 +421,6 @@ class TestSplitters(TestDatasetAPI):
     # task structure of w np array is such that each row corresponds to a
     # sample. The loaded sparse dataset has many rows with only zeros
     sparse_dataset = self.load_sparse_multitask_dataset()
-    X, y, w, ids = sparse_dataset.to_numpy()
     
     stratified_splitter = RandomStratifiedSplitter()
     datasets = stratified_splitter.train_valid_test_split(
@@ -431,7 +430,7 @@ class TestSplitters(TestDatasetAPI):
     train_data, valid_data, test_data = datasets
 
     for dataset_index, dataset in enumerate(datasets):
-      X, y, w, ids = dataset.to_numpy()
+      w = dataset.w
       # verify that there are no rows (samples) in weights matrix w
       # that have no hits.
       assert len(np.where(~w.any(axis=1))[0]) == 0

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -42,8 +42,8 @@ class TestSplitters(TestDatasetAPI):
     merge_dir = tempfile.mkdtemp()
     merged_dataset = Dataset.merge(
         merge_dir, [train_data, valid_data, test_data])
-    assert sorted(merged_dataset.get_ids()) == (
-           sorted(solubility_dataset.get_ids()))
+    assert sorted(merged_dataset.ids) == (
+           sorted(solubility_dataset.ids))
 
   def test_singletask_index_split(self):
     """
@@ -63,8 +63,8 @@ class TestSplitters(TestDatasetAPI):
     merge_dir = tempfile.mkdtemp()
     merged_dataset = Dataset.merge(
         merge_dir, [train_data, valid_data, test_data])
-    assert sorted(merged_dataset.get_ids()) == (
-           sorted(solubility_dataset.get_ids()))
+    assert sorted(merged_dataset.ids) == (
+           sorted(solubility_dataset.ids))
 
   def test_singletask_scaffold_split(self):
     """
@@ -87,7 +87,7 @@ class TestSplitters(TestDatasetAPI):
     """
     solubility_dataset = self.load_solubility_data()
     random_splitter = RandomSplitter()
-    ids_set = set(solubility_dataset.get_ids())
+    ids_set = set(solubility_dataset.ids)
 
     K = 5
     fold_dirs = [tempfile.mkdtemp() for i in range(K)]
@@ -97,21 +97,21 @@ class TestSplitters(TestDatasetAPI):
       # Verify lengths is 10/k == 2
       assert len(fold_dataset) == 2
       # Verify that compounds in this fold are subset of original compounds
-      fold_ids_set = set(fold_dataset.get_ids())
+      fold_ids_set = set(fold_dataset.ids)
       assert fold_ids_set.issubset(ids_set)
       # Verify that no two folds have overlapping compounds.
       for other_fold in range(K):
         if fold == other_fold:
           continue
         other_fold_dataset = fold_datasets[other_fold]
-        other_fold_ids_set = set(other_fold_dataset.get_ids())
+        other_fold_ids_set = set(other_fold_dataset.ids)
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
     merged_dataset = Dataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(solubility_dataset)
-    assert sorted(merged_dataset.get_ids()) == (
-           sorted(solubility_dataset.get_ids()))
+    assert sorted(merged_dataset.ids) == (
+           sorted(solubility_dataset.ids))
 
   def test_singletask_index_k_fold_split(self):
     """
@@ -119,7 +119,7 @@ class TestSplitters(TestDatasetAPI):
     """
     solubility_dataset = self.load_solubility_data()
     index_splitter = IndexSplitter()
-    ids_set = set(solubility_dataset.get_ids())
+    ids_set = set(solubility_dataset.ids)
 
     K = 5
     fold_dirs = [tempfile.mkdtemp() for i in range(K)]
@@ -130,21 +130,21 @@ class TestSplitters(TestDatasetAPI):
       # Verify lengths is 10/k == 2
       assert len(fold_dataset) == 2
       # Verify that compounds in this fold are subset of original compounds
-      fold_ids_set = set(fold_dataset.get_ids())
+      fold_ids_set = set(fold_dataset.ids)
       assert fold_ids_set.issubset(ids_set)
       # Verify that no two folds have overlapping compounds.
       for other_fold in range(K):
         if fold == other_fold:
           continue
         other_fold_dataset = fold_datasets[other_fold]
-        other_fold_ids_set = set(other_fold_dataset.get_ids())
+        other_fold_ids_set = set(other_fold_dataset.ids)
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
     merged_dataset = Dataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(solubility_dataset)
-    assert sorted(merged_dataset.get_ids()) == (
-           sorted(solubility_dataset.get_ids()))
+    assert sorted(merged_dataset.ids) == (
+           sorted(solubility_dataset.ids))
     
   def test_singletask_scaffold_k_fold_split(self):
     """
@@ -152,7 +152,7 @@ class TestSplitters(TestDatasetAPI):
     """
     solubility_dataset = self.load_solubility_data()
     scaffold_splitter = ScaffoldSplitter()
-    ids_set = set(solubility_dataset.get_ids())
+    ids_set = set(solubility_dataset.ids)
 
     K = 5
     fold_dirs = [tempfile.mkdtemp() for i in range(K)]
@@ -164,21 +164,21 @@ class TestSplitters(TestDatasetAPI):
       # Verify lengths is 10/k == 2
       assert len(fold_dataset) == 2
       # Verify that compounds in this fold are subset of original compounds
-      fold_ids_set = set(fold_dataset.get_ids())
+      fold_ids_set = set(fold_dataset.ids)
       assert fold_ids_set.issubset(ids_set)
       # Verify that no two folds have overlapping compounds.
       for other_fold in range(K):
         if fold == other_fold:
           continue
         other_fold_dataset = fold_datasets[other_fold]
-        other_fold_ids_set = set(other_fold_dataset.get_ids())
+        other_fold_ids_set = set(other_fold_dataset.ids)
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
     merged_dataset = Dataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(solubility_dataset)
-    assert sorted(merged_dataset.get_ids()) == (
-           sorted(solubility_dataset.get_ids()))
+    assert sorted(merged_dataset.ids) == (
+           sorted(solubility_dataset.ids))
 
   def test_singletask_stratified_column_indices(self):
     """
@@ -310,10 +310,10 @@ class TestSplitters(TestDatasetAPI):
     assert len(dataset_2) == 10
 
     # Check positives are correctly distributed
-    y_1 = dataset_1.get_labels()
+    y_1 = dataset_1.y
     assert np.count_nonzero(y_1) == n_positives/2
 
-    y_2 = dataset_2.get_labels()
+    y_2 = dataset_2.y
     assert np.count_nonzero(y_2) == n_positives/2
 
   def test_singletask_stratified_k_fold_split(self):
@@ -335,7 +335,7 @@ class TestSplitters(TestDatasetAPI):
     dataset = Dataset.from_numpy(data_dir, X, y, w, ids)
     
     stratified_splitter = RandomStratifiedSplitter()
-    ids_set = set(dataset.get_ids())
+    ids_set = set(dataset.ids)
 
     K = 5
     fold_dirs = [tempfile.mkdtemp() for i in range(K)]
@@ -347,25 +347,25 @@ class TestSplitters(TestDatasetAPI):
       # Verify lengths is 100/k == 20
       # Note: This wouldn't work for multitask str
       # assert len(fold_dataset) == n_samples/K
-      fold_labels = fold_dataset.get_labels()
+      fold_labels = fold_dataset.y
       # Verify that each fold has n_positives/K = 4 positive examples.
       assert np.count_nonzero(fold_labels == 1) == n_positives/K
       # Verify that compounds in this fold are subset of original compounds
-      fold_ids_set = set(fold_dataset.get_ids())
+      fold_ids_set = set(fold_dataset.ids)
       assert fold_ids_set.issubset(ids_set)
       # Verify that no two folds have overlapping compounds.
       for other_fold in range(K):
         if fold == other_fold:
           continue
         other_fold_dataset = fold_datasets[other_fold]
-        other_fold_ids_set = set(other_fold_dataset.get_ids())
+        other_fold_ids_set = set(other_fold_dataset.ids)
         assert fold_ids_set.isdisjoint(other_fold_ids_set)
 
     merge_dir = tempfile.mkdtemp()
     merged_dataset = Dataset.merge(merge_dir, fold_datasets)
     assert len(merged_dataset) == len(dataset)
-    assert sorted(merged_dataset.get_ids()) == (
-           sorted(dataset.get_ids()))
+    assert sorted(merged_dataset.ids) == (
+           sorted(dataset.ids))
 
 
   def test_multitask_random_split(self):

--- a/deepchem/transformers/__init__.py
+++ b/deepchem/transformers/__init__.py
@@ -383,8 +383,8 @@ class BalancingTransformer(Transformer):
     assert transform_w
 
     # Compute weighting factors from dataset.
-    y = self.dataset.get_labels()
-    w = self.dataset.get_weights()
+    y = self.dataset.y
+    w = self.dataset.w
     # Ensure dataset is binary
     np.testing.assert_allclose(sorted(np.unique(y)), np.array([0., 1.]))
     weights = []

--- a/deepchem/transformers/tests/test_transformers.py
+++ b/deepchem/transformers/tests/test_transformers.py
@@ -26,9 +26,9 @@ class TestTransformerAPI(TestDatasetAPI):
     solubility_dataset = self.load_solubility_data()
     log_transformer = LogTransformer(
         transform_y=True, dataset=solubility_dataset)
-    X, y, w, ids = solubility_dataset.to_numpy()
+    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     log_transformer.transform(solubility_dataset)
-    X_t, y_t, w_t, ids_t = solubility_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -48,9 +48,9 @@ class TestTransformerAPI(TestDatasetAPI):
     solubility_dataset = self.load_solubility_data()
     log_transformer = LogTransformer(
         transform_X=True, dataset=solubility_dataset)
-    X, y, w, ids = solubility_dataset.to_numpy()
+    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     log_transformer.transform(solubility_dataset)
-    X_t, y_t, w_t, ids_t = solubility_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -80,9 +80,9 @@ class TestTransformerAPI(TestDatasetAPI):
     log_transformer = LogTransformer(
         transform_y=True, tasks=tasks,
         dataset=multitask_dataset)
-    X, y, w, ids = multitask_dataset.to_numpy()
+    X, y, w, ids = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
     log_transformer.transform(multitask_dataset)
-    X_t, y_t, w_t, ids_t = multitask_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
 
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -112,9 +112,9 @@ class TestTransformerAPI(TestDatasetAPI):
     log_transformer = LogTransformer(
         transform_X=True, features=features,
         dataset=multitask_dataset)
-    X, y, w, ids = multitask_dataset.to_numpy()
+    X, y, w, ids = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
     log_transformer.transform(multitask_dataset)
-    X_t, y_t, w_t, ids_t = multitask_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
 
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -134,9 +134,9 @@ class TestTransformerAPI(TestDatasetAPI):
     solubility_dataset = self.load_solubility_data()
     normalization_transformer = NormalizationTransformer(
         transform_y=True, dataset=solubility_dataset)
-    X, y, w, ids = solubility_dataset.to_numpy()
+    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     normalization_transformer.transform(solubility_dataset)
-    X_t, y_t, w_t, ids_t = solubility_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
       assert id_elt == id_t_elt
@@ -156,9 +156,9 @@ class TestTransformerAPI(TestDatasetAPI):
     solubility_dataset = self.load_solubility_data()
     normalization_transformer = NormalizationTransformer(
         transform_X=True, dataset=solubility_dataset)
-    X, y, w, ids = solubility_dataset.to_numpy()
+    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     normalization_transformer.transform(solubility_dataset)
-    X_t, y_t, w_t, ids_t = solubility_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
       assert id_elt == id_t_elt
@@ -188,9 +188,9 @@ class TestTransformerAPI(TestDatasetAPI):
     classification_dataset = self.load_classification_data()
     balancing_transformer = BalancingTransformer(
       transform_w=True, dataset=classification_dataset)
-    X, y, w, ids = classification_dataset.to_numpy()
+    X, y, w, ids = (classification_dataset.X, classification_dataset.y, classification_dataset.w, classification_dataset.ids)
     balancing_transformer.transform(classification_dataset)
-    X_t, y_t, w_t, ids_t = classification_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (classification_dataset.X, classification_dataset.y, classification_dataset.w, classification_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
       assert id_elt == id_t_elt
@@ -214,9 +214,9 @@ class TestTransformerAPI(TestDatasetAPI):
     multitask_dataset = self.load_multitask_data()
     balancing_transformer = BalancingTransformer(
       transform_w=True, dataset=multitask_dataset)
-    X, y, w, ids = multitask_dataset.to_numpy()
+    X, y, w, ids = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
     balancing_transformer.transform(multitask_dataset)
-    X_t, y_t, w_t, ids_t = multitask_dataset.to_numpy()
+    X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
       assert id_elt == id_t_elt

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -55,7 +55,7 @@ class Evaluator(object):
       y_preds: np.ndarray
       csvfile: Open file object.
     """
-    mol_ids = self.dataset.get_ids()
+    mol_ids = self.dataset.ids
     n_tasks = len(self.task_names)
     y_preds = np.reshape(y_preds, (len(y_preds), n_tasks))
     assert len(y_preds) == len(mol_ids)
@@ -70,9 +70,9 @@ class Evaluator(object):
     """
     Computes statistics of model on test data and saves results to csv.
     """
-    y = self.dataset.get_labels()
+    y = self.dataset.y
     y = undo_transforms(y, self.output_transformers)
-    w = self.dataset.get_weights()
+    w = self.dataset.w
 
     if not len(metrics):
       return {}

--- a/examples/pdbbind/pdbbind_tf.py
+++ b/examples/pdbbind/pdbbind_tf.py
@@ -28,7 +28,7 @@ from deepchem.utils.evaluate import Evaluator
 from deepchem.splits import RandomSplitter
 from deepchem.featurizers.atomic_coordinates import AtomicCoordinates
 from deepchem.datasets.pdbbind_datasets import load_core_pdbbind_grid
-from deepchem.datasets import Dataset
+from deepchem.datasets import DiskDataset
 
 verbosity = "high"
 base_dir = "/scratch/users/rbharath/PDBBIND-ATOMICNET"
@@ -49,16 +49,16 @@ pdbbind_tasks, dataset, transformers = load_core_pdbbind_grid(
 
 print("About to perform train/valid/test split.")
 num_train = .8 * len(dataset)
-X, y, w, ids = dataset.to_numpy()
+X, y, w, ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
 
 X_train, X_valid = X[:num_train], X[num_train:]
 y_train, y_valid = y[:num_train], y[num_train:]
 w_train, w_valid = w[:num_train], w[num_train:]
 ids_train, ids_valid = ids[:num_train], ids[num_train:]
 
-train_dataset = Dataset.from_numpy(train_dir, X_train, y_train,
+train_dataset = DiskDataset.from_numpy(train_dir, X_train, y_train,
                                    w_train, ids_train, pdbbind_tasks)
-valid_dataset = Dataset.from_numpy(valid_dir, X_valid, y_valid,
+valid_dataset = DiskDataset.from_numpy(valid_dir, X_valid, y_valid,
                                    w_valid, ids_valid, pdbbind_tasks)
 
 classification_metric = Metric(metrics.pearson_r2_score, verbosity=verbosity,


### PR DESCRIPTION
This is a major refactoring of the Dataset class.  It's now an abstract class with two concrete subclasses: NumpyDataset stores its data in memory as a set of Numpy arrays, and DiskDataset stores its data on disk.

Along the way I made a lot of changes, both to the public API and to the implementation.  One of the more notable ones is that I changed the `get_labels()`, `get_weights()`, and `get_ids()` methods to properties called `y`, `w`, and `ids`.  Then for completeness I added an `X` property as well.  That made the `to_numpy()` method redundant, so I got rid of it.

I also added an `itersamples()` method for iterating over all samples stored in the dataset.  And all methods for iterating like `iterbatches()` and `itershards()` now return an iterator object rather than doing the iteration themselves.  That means they can be called multiple times, and the different iterations won't interfere with each other.