### PR TITLE
Transformers work with NumpyDataset

### DIFF
--- a/deepchem/datasets/__init__.py
+++ b/deepchem/datasets/__init__.py
@@ -639,7 +639,7 @@ class DiskDataset(Dataset):
       newx, newy, neww = fn(X, y, w)
       basename = "dataset-%d" % shard_num
       metadata_rows.append(DiskDataset.write_data_to_disk(
-          out_dir, basename, tasks, newx, newy, neww, ids))
+          out_dir, basename, tasks, newx, newy, neww, ids, False))
     return DiskDataset(data_dir=out_dir,
                    metadata_rows=metadata_rows,
                    verbosity=self.verbosity)

--- a/deepchem/datasets/tests/test_datasets.py
+++ b/deepchem/datasets/tests/test_datasets.py
@@ -289,7 +289,7 @@ class TestBasicDatasetAPI(TestDatasetAPI):
         np.testing.assert_array_equal(sw, w[i])
         np.testing.assert_array_equal(sid, ids[i])
 
-  def test_itersamples_dist(self):
+  def test_itersamples_disk(self):
     """Test that iterating over samples in a DiskDataset works."""
     solubility_dataset = self.load_solubility_data()
     X = solubility_dataset.X
@@ -301,6 +301,56 @@ class TestBasicDatasetAPI(TestDatasetAPI):
         np.testing.assert_array_equal(sy, y[i])
         np.testing.assert_array_equal(sw, w[i])
         np.testing.assert_array_equal(sid, ids[i])
+
+  def test_transform_numpy(self):
+    """Test that the transform() method works for NumpyDatasets."""
+    num_datapoints = 100
+    num_features = 10
+    num_tasks = 10
+
+    # Generate data
+
+    X = np.random.rand(num_datapoints, num_features)
+    y = np.random.randint(2, size=(num_datapoints, num_tasks))
+    w = np.random.randint(2, size=(num_datapoints, num_tasks))
+    ids = np.array(["id"] * num_datapoints)
+    dataset = NumpyDataset(X, y, w, ids)
+
+    # Transform it
+
+    def fn(x, y, w):
+      return (2*x, 1.5*y, w)
+    transformed = dataset.transform(fn)
+    np.testing.assert_array_equal(X, dataset.X)
+    np.testing.assert_array_equal(y, dataset.y)
+    np.testing.assert_array_equal(w, dataset.w)
+    np.testing.assert_array_equal(ids, dataset.ids)
+    np.testing.assert_array_equal(2*X, transformed.X)
+    np.testing.assert_array_equal(1.5*y, transformed.y)
+    np.testing.assert_array_equal(w, transformed.w)
+    np.testing.assert_array_equal(ids, transformed.ids)
+
+  def test_transform_disk(self):
+    """Test that the transform() method works for DiskDatasets."""
+    dataset = self.load_solubility_data()
+    X = dataset.X
+    y = dataset.y
+    w = dataset.w
+    ids = dataset.ids
+
+    # Transform it
+
+    def fn(x, y, w):
+      return (2*x, 1.5*y, w)
+    transformed = dataset.transform(fn)
+    np.testing.assert_array_equal(X, dataset.X)
+    np.testing.assert_array_equal(y, dataset.y)
+    np.testing.assert_array_equal(w, dataset.w)
+    np.testing.assert_array_equal(ids, dataset.ids)
+    np.testing.assert_array_equal(2*X, transformed.X)
+    np.testing.assert_array_equal(1.5*y, transformed.y)
+    np.testing.assert_array_equal(w, transformed.w)
+    np.testing.assert_array_equal(ids, transformed.ids)
 
   def test_to_numpy(self):
     """Test that transformation to numpy arrays is sensible."""

--- a/deepchem/datasets/tests/test_reload.py
+++ b/deepchem/datasets/tests/test_reload.py
@@ -77,7 +77,7 @@ class TestReload(TestAPI):
     print("Transforming datasets")
     for dataset in [train_dataset, valid_dataset, test_dataset]:
       for transformer in transformers:
-          transformer.transform(dataset)
+          dataset = transformer.transform(dataset)
 
     return (len(train_dataset), len(valid_dataset), len(test_dataset))
     

--- a/deepchem/hyperparameters/tests/test_hyperparam_opt.py
+++ b/deepchem/hyperparameters/tests/test_hyperparam_opt.py
@@ -57,7 +57,7 @@ class TestHyperparamOptAPI(TestAPI):
         NormalizationTransformer(transform_y=True, dataset=train_dataset)]
     for dataset in [train_dataset, test_dataset]:
       for transformer in transformers:
-        transformer.transform(dataset)
+        dataset = transformer.transform(dataset)
 
     params_dict = {"n_estimators": [10, 100]}
     metric = Metric(metrics.r2_score)

--- a/deepchem/models/tests/test_api.py
+++ b/deepchem/models/tests/test_api.py
@@ -108,7 +108,7 @@ class TestModelAPI(TestAPI):
     transformers = input_transformers + output_transformers
     for dataset in [train_dataset, test_dataset]:
       for transformer in transformers:
-        transformer.transform(dataset)
+        dataset = transformer.transform(dataset)
 
     regression_metrics = [Metric(metrics.r2_score),
                           Metric(metrics.mean_squared_error),
@@ -157,7 +157,7 @@ class TestModelAPI(TestAPI):
     transformers = input_transformers + output_transformers
     for dataset in [train_dataset, test_dataset]:
       for transformer in transformers:
-        transformer.transform(dataset)
+        dataset = transformer.transform(dataset)
 
     regression_metrics = [Metric(metrics.r2_score),
                           Metric(metrics.mean_squared_error),
@@ -246,7 +246,7 @@ class TestModelAPI(TestAPI):
 
     for dataset in [train_dataset, test_dataset]:
       for transformer in transformers:
-        transformer.transform(dataset)
+        dataset = transformer.transform(dataset)
 
     classification_metrics = [Metric(metrics.roc_auc_score),
                               Metric(metrics.matthews_corrcoef),

--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -87,7 +87,7 @@ class TestGeneralization(TestAPI):
         NormalizationTransformer(transform_y=True, dataset=train_dataset)]
     for data in [train_dataset, test_dataset]:
       for transformer in transformers:
-          transformer.transform(data)
+          data = transformer.transform(data)
 
     verbosity = "high"
     regression_metric = Metric(metrics.r2_score, verbosity=verbosity)

--- a/deepchem/transformers/__init__.py
+++ b/deepchem/transformers/__init__.py
@@ -12,7 +12,7 @@ from deepchem.utils.save import save_to_disk
 from deepchem.utils.save import load_from_disk
 from deepchem.utils import pad_array
 import shutil
-from deepchem.datasets import DiskDataset
+from deepchem.datasets import DiskDataset, NumpyDataset
 
 def undo_transforms(y, transformers):
   """Undoes all transformations applied."""
@@ -64,14 +64,8 @@ class Transformer(object):
     # Use fact that bools add as ints in python
     assert (transform_X + transform_y + transform_w) == 1 
 
-  def transform_row(self, i, df, data_dir):
-    """
-    Transforms the data (X, y, w, ...) in a single row).
-    """
-    raise NotImplementedError(
-      "Each Transformer is responsible for its own transform_row method.")
-
   def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
     raise NotImplementedError(
       "Each Transformer is responsible for its own transform_array method.")
 
@@ -80,25 +74,12 @@ class Transformer(object):
     raise NotImplementedError(
       "Each Transformer is responsible for its own untransfomr method.")
 
-  # TODO(rbharath): Change this function to behave like the featurization
-  # (accept IPyparallel pool objects to allow for multi-node parallelism)
   def transform(self, dataset, parallel=False):
     """
     Transforms all internally stored data.
     Adds X-transform, y-transform columns to metadata.
     """
-    df = dataset.metadata_df
-    indices = range(0, df.shape[0])
-    transform_row_partial = partial(
-        _transform_row, df=df, transformer=self, data_dir=dataset.data_dir)
-    if parallel:
-      pool = mp.Pool(int(mp.cpu_count()/4))
-      pool.map(transform_row_partial, indices)
-      pool.terminate()
-    else:
-      for index in indices:
-        transform_row_partial(index)
-    dataset.save_to_disk()
+    return dataset.transform(lambda X, y, w: self.transform_array(X, y, w))
 
   def transform_on_array(self, X, y, w):
     """
@@ -106,13 +87,6 @@ class Transformer(object):
     """
     X, y, w = self.transform_array(X, y, w)    
     return X, y, w
-
-def _transform_row(i, df, transformer, data_dir):
-  """
-  Transforms the data (X, y, w,...) in a single row.
-  Writes X-transformed, y-transformed to disk.
-  """
-  transformer.transform_row(i, df, data_dir)
 
 class NormalizationTransformer(Transformer):
 
@@ -139,26 +113,16 @@ class NormalizationTransformer(Transformer):
       self.ydely_means = ydely_means
 
   def transform(self, dataset, parallel=False):
-    super(NormalizationTransformer, self).transform(
+    return super(NormalizationTransformer, self).transform(
         dataset, parallel=parallel)
-    
 
-  def transform_row(self, i, df, data_dir):
-    """
-    Normalizes the data (X, y, w, ...) in a single row).
-    """
-    row = df.iloc[i]
-
+  def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
     if self.transform_X:
-      X = load_from_disk(
-          os.path.join(data_dir, row['X-transformed']))
       X = np.nan_to_num((X - self.X_means) / self.X_stds)
-      save_to_disk(X, os.path.join(data_dir, row['X-transformed']))
-
     if self.transform_y:
-      y = load_from_disk(os.path.join(data_dir, row['y-transformed']))
       y = np.nan_to_num((y - self.y_means) / self.y_stds)
-      save_to_disk(y, os.path.join(data_dir, row['y-transformed']))
+    return (X, y, w)
 
   def untransform(self, z):
     """
@@ -217,7 +181,7 @@ class AtomicNormalizationTransformer(Transformer):
     self.ydely_means = ydely_means
 
   def transform(self, dataset, parallel=False):
-    super(AtomicNormalizationTransformer, self).transform(
+    return super(AtomicNormalizationTransformer, self).transform(
         dataset, parallel=parallel)
     
 
@@ -246,6 +210,19 @@ class AtomicNormalizationTransformer(Transformer):
         y[i,1:] = y[i,1:] - grad_var*y[i,0]/self.y_stds[0]
 
       save_to_disk(y, os.path.join(data_dir, row['y-transformed']))
+
+  def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
+    if self.transform_X:
+      X = np.nan_to_num((X - self.X_means) / self.X_stds)
+    if self.transform_y:
+      # transform tasks as normal
+      y = np.nan_to_num((y - self.y_means) / self.y_stds)
+      # add 2nd order correction term to gradients
+      grad_var = 1/self.y_stds[0]*(self.ydely_means-self.y_means[0]*self.y_means[1:])
+      for i in range(y.shape[0]):
+        y[i,1:] = y[i,1:] - grad_var*y[i,0]/self.y_stds[0]
+    return (X, y, w)
 
   def untransform(self, z):
     """
@@ -298,21 +275,15 @@ class ClippingTransformer(Transformer):
                                               dataset=dataset)
     self.max_val = max_val
 
-  def transform_row(self, i, df, data_dir):
-    """
-    Clips outliers for the data (X, y, w, ...) in a single row).
-    """
-    row = df.iloc[i]
+  def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
     if self.transform_X:
-      X = load_from_disk(os.path.join(data_dir, row['X-transformed']))
       X[X > self.max_val] = self.max_val
       X[X < (-1.0*self.max_val)] = -1.0 * self.max_val
-      save_to_disk(X, os.path.join(data_dir, row['X-transformed']))
     if self.transform_y:
-      y = load_from_disk(os.path.join(data_dir, row['y-transformed']))
       y[y > trunc] = trunc
       y[y < (-1.0*trunc)] = -1.0 * trunc
-      save_to_disk(y, os.path.join(data_dir, row['y-transformed']))
+    return (X, y, w)
 
   def untransform(self, z):
     warnings.warn("Clipping cannot be undone.")
@@ -330,12 +301,9 @@ class LogTransformer(Transformer):
         transform_X=transform_X, transform_y=transform_y,
         dataset=dataset)
 
-  def transform_row(self, i, df, data_dir):
-    """Logarithmically transforms data in dataset."""
-    """Select features and tasks of interest for transformation."""
-    row = df.iloc[i]
+  def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
     if self.transform_X:
-      X = load_from_disk(os.path.join(data_dir, row['X-transformed']))
       num_features=len(X[0])
       if self.features is None:
         X = np.log(X+1)
@@ -345,10 +313,7 @@ class LogTransformer(Transformer):
             X[:,j] = np.log(X[:,j]+1)
           else:
             X[:,j] = X[:,j]
-      save_to_disk(X, os.path.join(data_dir, row['X-transformed']))
-
     if self.transform_y:
-      y = load_from_disk(os.path.join(data_dir, row['y-transformed']))
       num_tasks=len(y[0])
       if self.tasks is None:
         y = np.log(y+1)
@@ -358,7 +323,7 @@ class LogTransformer(Transformer):
             y[:,j] = np.log(y[:,j]+1)
           else:
             y[:,j] = y[:,j]
-      save_to_disk(y, os.path.join(data_dir, row['y-transformed']))
+    return (X, y, w)
 
   def untransform(self, z):
     """
@@ -420,11 +385,8 @@ class BalancingTransformer(Transformer):
       weights.append((neg_weight, pos_weight))
     self.weights = weights
 
-  def transform_row(self, i, df, data_dir):
-    """Reweight the labels for this data."""
-    row = df.iloc[i]
-    y = load_from_disk(os.path.join(data_dir, row['y-transformed']))
-    w = load_from_disk(os.path.join(data_dir, row['w-transformed']))
+  def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
     w_balanced = np.zeros_like(w)
     for ind, task in enumerate(self.dataset.get_task_names()):
       task_y = y[:, ind]
@@ -433,7 +395,7 @@ class BalancingTransformer(Transformer):
       one_indices = np.logical_and(task_y==1, task_w != 0)
       w_balanced[zero_indices, ind] = self.weights[ind][0]
       w_balanced[one_indices, ind] = self.weights[ind][1]
-    save_to_disk(w_balanced, os.path.join(data_dir, row['w-transformed']))
+    return (X, y, w_balanced)
 
 class CoulombRandomizationTransformer(Transformer):
 
@@ -484,22 +446,6 @@ class CoulombRandomizationTransformer(Transformer):
 
     return rcm
 
-  def transform_row(self, i, df, data_dir):
-    """
-    Randomly permute a Coulomb Matrix in a dataset
-    """
-    row = df.iloc[i]
-    if self.transform_X:
-      X = load_from_disk(os.path.join(data_dir, row['X-transformed']))
-      for j in range(len(X)):
-        cm = self.construct_cm_from_triu(X[j])
-        X[j] = self.unpad_randomize_and_flatten(cm)
-      save_to_disk(X, os.path.join(data_dir, row['X-transformed']))
-
-    if self.transform_y:
-      print("y will not be transformed by "
-            "CoulombRandomizationTransformer.")
-
   def transform_array(self, X, y, w):
     """
     Randomly permute a Coulomb Matrix passed as an array
@@ -537,7 +483,7 @@ class CoulombBinarizationTransformer(Transformer):
 
   def transform(self, dataset, parallel=False):
 
-    super(CoulombBinarizationTransformer, self).transform(dataset,
+    dataset = super(CoulombBinarizationTransformer, self).transform(dataset,
           parallel=parallel)
 
     df = dataset.metadata_df
@@ -554,28 +500,7 @@ class CoulombBinarizationTransformer(Transformer):
     for i, row in df.iterrows():
       X_t = (Xt[i]-X_means)/X_stds
       save_to_disk(X_t, os.path.join(dataset.data_dir, row['X-transformed']))
-
-  def transform_row(self, i, df, data_dir):
-    """
-    Binarizes data in dataset with sigmoid function
-    """
-    row = df.iloc[i]
-    X_bin = []
-    if self.update_state: 
-      self.set_max(df, data_dir)
-      self.update_state = False
-    if self.transform_X:
-      X = load_from_disk(os.path.join(data_dir, row['X-transformed']))
-      for i in range(X.shape[1]):
-        for k in np.arange(0,self.feature_max[i]+self.theta,self.theta):
-          X_bin += [np.tanh((X[:,i]-k)/self.theta)]
-
-      X_bin = np.array(X_bin).T
-      save_to_disk(X_bin, os.path.join(data_dir, row['X-transformed']))
-
-    if self.transform_y:
-      print("y will not be transformed by "
-            "CoulombBinarizationTransformer.")
+    return dataset
 
   def transform_array(self, X, y, w):
     """
@@ -629,10 +554,7 @@ class CDFTransformer(Transformer):
       y_t = get_cdf_values(y,self.bins)
       X_t = X
       """
-    # TODO (rbharath): Find a more elegant solution to saving the data?
-    shutil.rmtree(dataset.data_dir)
-    os.makedirs(dataset.data_dir)
-    DiskDataset.from_numpy(dataset.data_dir, X_t, y_t, w_t, ids_t)
+    return NumpyDataset(X_t, y_t, w_t, ids_t)
 
   def untransform(self, z):
     print("Cannot undo CDF Transformer, for now.")
@@ -691,6 +613,7 @@ class PowerTransformer(Transformer):
     shutil.rmtree(dataset.data_dir)
     os.makedirs(dataset.data_dir)
     DiskDataset.from_numpy(dataset.data_dir, X_t, y_t, w_t, ids_t)
+    return dataset
 
   def untransform(self, z):
     print("Cannot undo Power Transformer, for now.")    

--- a/deepchem/transformers/tests/test_transformers.py
+++ b/deepchem/transformers/tests/test_transformers.py
@@ -31,7 +31,7 @@ class TestTransformerAPI(TestDatasetAPI):
     log_transformer = LogTransformer(
         transform_y=True, dataset=solubility_dataset)
     X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
-    log_transformer.transform(solubility_dataset)
+    solubility_dataset = log_transformer.transform(solubility_dataset)
     X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     
     # Check ids are unchanged.
@@ -53,7 +53,7 @@ class TestTransformerAPI(TestDatasetAPI):
     log_transformer = LogTransformer(
         transform_X=True, dataset=solubility_dataset)
     X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
-    log_transformer.transform(solubility_dataset)
+    solubility_dataset = log_transformer.transform(solubility_dataset)
     X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     
     # Check ids are unchanged.
@@ -85,7 +85,7 @@ class TestTransformerAPI(TestDatasetAPI):
         transform_y=True, tasks=tasks,
         dataset=multitask_dataset)
     X, y, w, ids = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
-    log_transformer.transform(multitask_dataset)
+    multitask_dataset = log_transformer.transform(multitask_dataset)
     X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
 
     # Check ids are unchanged.
@@ -117,7 +117,7 @@ class TestTransformerAPI(TestDatasetAPI):
         transform_X=True, features=features,
         dataset=multitask_dataset)
     X, y, w, ids = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
-    log_transformer.transform(multitask_dataset)
+    multitask_dataset = log_transformer.transform(multitask_dataset)
     X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
 
     # Check ids are unchanged.
@@ -139,7 +139,7 @@ class TestTransformerAPI(TestDatasetAPI):
     normalization_transformer = NormalizationTransformer(
         transform_y=True, dataset=solubility_dataset)
     X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
-    normalization_transformer.transform(solubility_dataset)
+    solubility_dataset = normalization_transformer.transform(solubility_dataset)
     X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -161,7 +161,7 @@ class TestTransformerAPI(TestDatasetAPI):
     normalization_transformer = NormalizationTransformer(
         transform_X=True, dataset=solubility_dataset)
     X, y, w, ids = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
-    normalization_transformer.transform(solubility_dataset)
+    solubility_dataset = normalization_transformer.transform(solubility_dataset)
     X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y, solubility_dataset.w, solubility_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -194,8 +194,7 @@ class TestTransformerAPI(TestDatasetAPI):
     bins=1001
     cdf_transformer = CDFTransformer(transform_X=True, bins=bins)
     X, y, w, ids = (gaussian_dataset.X,gaussian_dataset.y,gaussian_dataset.w,gaussian_dataset.ids)
-    cdf_transformer.transform(gaussian_dataset, bins=bins)
-    gaussian_dataset = DiskDataset(data_dir=gaussian_dataset.data_dir,reload=True)
+    gaussian_dataset = cdf_transformer.transform(gaussian_dataset, bins=bins)
     X_t, y_t, w_t, ids_t = (gaussian_dataset.X,gaussian_dataset.y,gaussian_dataset.w,gaussian_dataset.ids)
 
     # Check ids are unchanged.
@@ -218,7 +217,7 @@ class TestTransformerAPI(TestDatasetAPI):
     bins=1001
     cdf_transformer = CDFTransformer(transform_y=True, bins=bins)
     X, y, w, ids = (gaussian_dataset.X,gaussian_dataset.y,gaussian_dataset.w,gaussian_dataset.ids)
-    cdf_transformer.transform(gaussian_dataset, bins=bins)
+    gaussian_dataset = cdf_transformer.transform(gaussian_dataset, bins=bins)
     gaussian_dataset = DiskDataset(data_dir=gaussian_dataset.data_dir,reload=True)
     X_t, y_t, w_t, ids_t = (gaussian_dataset.X,gaussian_dataset.y,gaussian_dataset.w,gaussian_dataset.ids)
 
@@ -240,7 +239,7 @@ class TestTransformerAPI(TestDatasetAPI):
     powers=[1,2,0.5]
     power_transformer = PowerTransformer(transform_X=True, powers=powers)
     X, y, w, ids = (gaussian_dataset.X,gaussian_dataset.y,gaussian_dataset.w,gaussian_dataset.ids)
-    power_transformer.transform(gaussian_dataset)
+    gaussian_dataset = power_transformer.transform(gaussian_dataset)
     gaussian_dataset = DiskDataset(data_dir=gaussian_dataset.data_dir,reload=True)
     X_t, y_t, w_t, ids_t = (gaussian_dataset.X,gaussian_dataset.y,gaussian_dataset.w,gaussian_dataset.ids)
 
@@ -263,7 +262,7 @@ class TestTransformerAPI(TestDatasetAPI):
     balancing_transformer = BalancingTransformer(
       transform_w=True, dataset=classification_dataset)
     X, y, w, ids = (classification_dataset.X, classification_dataset.y, classification_dataset.w, classification_dataset.ids)
-    balancing_transformer.transform(classification_dataset)
+    classification_dataset = balancing_transformer.transform(classification_dataset)
     X_t, y_t, w_t, ids_t = (classification_dataset.X, classification_dataset.y, classification_dataset.w, classification_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):
@@ -289,7 +288,7 @@ class TestTransformerAPI(TestDatasetAPI):
     balancing_transformer = BalancingTransformer(
       transform_w=True, dataset=multitask_dataset)
     X, y, w, ids = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
-    balancing_transformer.transform(multitask_dataset)
+    multitask_dataset = balancing_transformer.transform(multitask_dataset)
     X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y, multitask_dataset.w, multitask_dataset.ids)
     # Check ids are unchanged.
     for id_elt, id_t_elt in zip(ids, ids_t):


### PR DESCRIPTION
Fixes #250.  The one class that still only works on DiskDataset is CoulombBinarizationTransformer.  There aren't any test cases for that one, so I didn't feel comfortable modifying it.

The behavior of Transformers has changed slightly.  They now create a new dataset instead of modifying the existing one.  This means that wherever you have code like

```Python
transformer.transform(dataset)
```

you should change it to

```Python
dataset = transformer.transform(dataset)
```
