### PR TITLE
Simplifying Tensorflow API

### DIFF
--- a/deepchem/hyper/__init__.py
+++ b/deepchem/hyper/__init__.py
@@ -17,7 +17,7 @@ class HyperparamOpt(object):
   Provides simple hyperparameter search capabilities.
   """
 
-  def __init__(self, model_class, verbosity=None):
+  def __init__(self, model_class, verbosity="high"):
     self.model_class = model_class
     assert verbosity in [None, "low", "high"]
     self.verbosity = verbosity

--- a/deepchem/hyper/tests/test_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_hyperparam_opt.py
@@ -165,9 +165,8 @@ class TestHyperparamOptAPI(unittest.TestCase):
     params_dict = {"layer_sizes": [(10,), (100,)]}
 
     def model_builder(model_params, model_dir):
-        tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
-            len(tasks), n_features, model_dir, **model_params)
-        return dc.models.TensorflowModel(tensorflow_model)
+      return dc.models.TensorflowMultiTaskClassifier(
+          len(tasks), n_features, model_dir, **model_params)
     optimizer = dc.hyper.HyperparamOpt(model_builder)
     best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
       params_dict, train_dataset, valid_dataset, transformers, metric,

--- a/deepchem/metrics/__init__.py
+++ b/deepchem/metrics/__init__.py
@@ -104,7 +104,7 @@ class Metric(object):
   """Wrapper class for computing user-defined metrics."""
 
   def __init__(self, metric, task_averager=None, name=None, threshold=None,
-               verbosity=None, mode=None, compute_energy_metric=False):
+               verbosity="high", mode=None, compute_energy_metric=False):
     """
     Args:
       metric: function that takes args y_true, y_pred (in that order) and
@@ -127,12 +127,14 @@ class Metric(object):
     self.verbosity = verbosity
     self.threshold = threshold
     if mode is None:
-      if self.metric.__name__ in ["roc_auc_score", "matthews_corrcoef", "recall_score",
-                       "accuracy_score", "kappa_score", "precision_score"]:
+      if self.metric.__name__ in ["roc_auc_score", "matthews_corrcoef",
+                                  "recall_score", "accuracy_score",
+                                  "kappa_score", "precision_score"]:
         mode = "classification"
-      elif self.metric.__name__ in ["pearson_r2_score", "r2_score", "mean_squared_error",
-                         "mean_absolute_error", "rms_score",
-                         "mae_score"]:
+      elif self.metric.__name__ in ["pearson_r2_score", "r2_score",
+                                    "mean_squared_error",
+                                    "mean_absolute_error", "rms_score",
+                                    "mae_score"]:
         mode = "regression"
       else:
         raise ValueError("Must specify mode for new metric.")

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -10,7 +10,6 @@ from deepchem.models.sklearn_models import SklearnModel
 from deepchem.models.keras_models import KerasModel
 from deepchem.models.tf_keras_models.multitask_classifier import MultitaskGraphClassifier
 from deepchem.models.tf_keras_models.support_classifier import SupportGraphClassifier
-#from deepchem.models.tensorflow_models import TensorflowModel
 from deepchem.models.multitask import SingletaskToMultitask
 
 from deepchem.models.tensorflow_models.fcnet import TensorflowMultiTaskRegressor

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -10,15 +10,15 @@ from deepchem.models.sklearn_models import SklearnModel
 from deepchem.models.keras_models import KerasModel
 from deepchem.models.tf_keras_models.multitask_classifier import MultitaskGraphClassifier
 from deepchem.models.tf_keras_models.support_classifier import SupportGraphClassifier
-from deepchem.models.tensorflow_models import TensorflowModel
+#from deepchem.models.tensorflow_models import TensorflowModel
 from deepchem.models.multitask import SingletaskToMultitask
 
-# TODO(rbharath): I'm not sure if these belong here or in deepchem.nn
-# The issue is that these are not valid deepchem models. The solution might be
-# to make inherit from Model class
-from deepchem.models.keras_models.fcnet import MultiTaskDNN
 from deepchem.models.tensorflow_models.fcnet import TensorflowMultiTaskRegressor
 from deepchem.models.tensorflow_models.fcnet import TensorflowMultiTaskClassifier
 from deepchem.models.tensorflow_models.robust_multitask import RobustMultitaskRegressor
 from deepchem.models.tensorflow_models.robust_multitask import RobustMultitaskClassifier
 from deepchem.models.tensorflow_models.lr import TensorflowLogisticRegression
+
+# TODO(rbharath): I'm not sure if this model should be exposed. Not in
+# benchmark suite for example.
+from deepchem.models.keras_models.fcnet import MultiTaskDNN

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -162,8 +162,18 @@ class Model(object):
     """
     y_preds = []
     n_tasks = self.get_num_tasks()
-    for (X_batch, y_batch, w_batch, ids_batch) in dataset.iterbatches(
+    #################################################################### DEBUG
+    #for (X_batch, y_batch, w_batch, ids_batch) in dataset.iterbatches(
+    ind = 0
+    for (X_batch, _, _, ids_batch) in dataset.iterbatches(
+    #################################################################### DEBUG
         batch_size, deterministic=True):
+      #################################################################### DEBUG
+      if ind == 0:
+        print("ids_batch[0]")
+        print(ids_batch[0])
+      ind += 1
+      #################################################################### DEBUG
       n_samples = len(X_batch)
       y_pred_batch = self.predict_on_batch(X_batch, pad_batch=pad_batches)
       # Discard any padded predictions

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -162,18 +162,9 @@ class Model(object):
     """
     y_preds = []
     n_tasks = self.get_num_tasks()
-    #################################################################### DEBUG
-    #for (X_batch, y_batch, w_batch, ids_batch) in dataset.iterbatches(
     ind = 0
     for (X_batch, _, _, ids_batch) in dataset.iterbatches(
-    #################################################################### DEBUG
         batch_size, deterministic=True):
-      #################################################################### DEBUG
-      if ind == 0:
-        print("ids_batch[0]")
-        print(ids_batch[0])
-      ind += 1
-      #################################################################### DEBUG
       n_samples = len(X_batch)
       y_pred_batch = self.predict_on_batch(X_batch, pad_batch=pad_batches)
       # Discard any padded predictions

--- a/deepchem/models/multitask.py
+++ b/deepchem/models/multitask.py
@@ -20,7 +20,7 @@ class SingletaskToMultitask(Model):
 
   Warning: This current implementation is only functional for sklearn models. 
   """
-  def __init__(self, tasks, model_builder, model_dir=None, verbosity=None):
+  def __init__(self, tasks, model_builder, model_dir=None, verbosity="high"):
     self.tasks = tasks
     if model_dir is not None:
       if not os.path.exists(model_dir):

--- a/deepchem/models/tensorflow_models/__init__.py
+++ b/deepchem/models/tensorflow_models/__init__.py
@@ -270,12 +270,10 @@ class TensorflowGraphModel(Model):
         for epoch in range(nb_epoch):
           avg_loss, n_batches = 0., 0
           for ind, (X_b, y_b, w_b, ids_b) in enumerate(
-              ############################################################ DEBUG
-              ## hardcode pad_batches=True to work around limitations in Tensorflow
+              # Turns out there are valid cases where we don't want pad-batches
+              # on by default.
               #dataset.iterbatches(batch_size, pad_batches=True)):
               dataset.iterbatches(self.batch_size, pad_batches=pad_batches)):
-              #dataset.iterbatches(batch_size, pad_batches=pad_batches)):
-              ############################################################ DEBUG
             if ind % log_every_N_batches == 0:
               log("On batch %d" % ind, self.verbosity)
             # Run training op.

--- a/deepchem/models/tensorflow_models/__init__.py
+++ b/deepchem/models/tensorflow_models/__init__.py
@@ -160,8 +160,6 @@ class TensorflowGraphModel(Model):
     self.train_graph = self.construct_graph(training=True)
     self.eval_graph = self.construct_graph(training=False)
 
-  ################################################################ DEBUG
-
   def save(self):
     """
     No-op since tf models save themselves during fit()
@@ -172,12 +170,10 @@ class TensorflowGraphModel(Model):
     """
     Loads model from disk. Thin wrapper around restore() for consistency.
     """
-    self.model_instance.restore()
+    self.restore()
 
   def get_num_tasks(self):
     return self.n_tasks
-  ################################################################ DEBUG
-
 
   def construct_graph(self, training):
     """Returns a TensorflowGraph object."""
@@ -281,8 +277,8 @@ class TensorflowGraphModel(Model):
           for ind, (X_b, y_b, w_b, ids_b) in enumerate(
               ############################################################ DEBUG
               ## hardcode pad_batches=True to work around limitations in Tensorflow
-              #dataset.iterbatches(batch_size, pad_batches=True)):
-              dataset.iterbatches(batch_size, pad_batches=False)):
+              dataset.iterbatches(batch_size, pad_batches=True)):
+              #dataset.iterbatches(batch_size, pad_batches=False)):
               #dataset.iterbatches(batch_size, pad_batches=pad_batches)):
               ############################################################ DEBUG
             if ind % log_every_N_batches == 0:
@@ -684,8 +680,6 @@ class TensorflowRegressor(TensorflowGraphModel):
       outputs = []
       with self._get_shared_session(train=False).as_default():
         n_samples = len(X)
-        # TODO(rbharath): Should this be padding there? Shouldn't padding be
-        # turned on in predict?
         feed_dict = self.construct_feed_dict(X)
         data = self._get_shared_session(train=False).run(
             self.eval_graph.output, feed_dict=feed_dict)

--- a/deepchem/models/tensorflow_models/fcnet.py
+++ b/deepchem/models/tensorflow_models/fcnet.py
@@ -142,7 +142,7 @@ class TensorflowMultiTaskRegressor(TensorflowRegressor):
                 stddev=weight_init_stddevs[i]),
             bias_init=tf.constant(value=bias_init_consts[i],
                                   shape=[layer_sizes[i]])))
-        layer = model_ops.dropout(layer, dropouts[i])
+        layer = model_ops.dropout(layer, dropouts[i], training)
         prev_layer = layer
         prev_layer_size = layer_sizes[i]
 

--- a/deepchem/models/tests/test_api.py
+++ b/deepchem/models/tests/test_api.py
@@ -203,9 +203,8 @@ class TestAPI(unittest.TestCase):
                               dc.metrics.Metric(dc.metrics.recall_score),
                               dc.metrics.Metric(dc.metrics.accuracy_score)]
 
-    tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    model = dc.models.TensorflowMultiTaskClassifier(
         len(tasks), n_features)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(train_dataset)

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -169,11 +169,10 @@ class TestOverfit(test_util.TensorFlowTestCase):
     regression_metric = dc.metrics.Metric(
         dc.metrics.mean_squared_error, verbosity=verbosity)
     # TODO(rbharath): This breaks with optimizer="momentum". Why?
-    tensorflow_model = dc.models.TensorflowMultiTaskRegressor(
+    model = dc.models.TensorflowMultiTaskRegressor(
         n_tasks, n_features, dropouts=[0.],
         learning_rate=0.003, weight_init_stddevs=[np.sqrt(6)/np.sqrt(1000)],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=100)
@@ -272,11 +271,10 @@ class TestOverfit(test_util.TensorFlowTestCase):
     verbosity = "high"
     classification_metric = dc.metrics.Metric(
         dc.metrics.accuracy_score, verbosity=verbosity)
-    tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    model = dc.models.TensorflowMultiTaskClassifier(
         n_tasks, n_features, dropouts=[0.],
         learning_rate=0.0003, weight_init_stddevs=[.1],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=100)
@@ -307,11 +305,10 @@ class TestOverfit(test_util.TensorFlowTestCase):
     verbosity = "high"
     classification_metric = dc.metrics.Metric(
         dc.metrics.roc_auc_score, verbosity=verbosity)
-    tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    model = dc.models.TensorflowMultiTaskClassifier(
         n_tasks, n_features, dropouts=[0.],
         learning_rate=0.003, weight_init_stddevs=[.1],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=100)
@@ -352,11 +349,10 @@ class TestOverfit(test_util.TensorFlowTestCase):
     verbosity = "high"
     classification_metric = dc.metrics.Metric(
         dc.metrics.roc_auc_score, verbosity=verbosity)
-    tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    model = dc.models.TensorflowMultiTaskClassifier(
         n_tasks, n_features, dropouts=[0.],
         learning_rate=0.003, weight_init_stddevs=[1.],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=50)
@@ -449,11 +445,10 @@ class TestOverfit(test_util.TensorFlowTestCase):
     verbosity = "high"
     classification_metric = dc.metrics.Metric(
       dc.metrics.accuracy_score, verbosity=verbosity, task_averager=np.mean)
-    tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    model = dc.models.TensorflowMultiTaskClassifier(
         n_tasks, n_features, dropouts=[0.],
         learning_rate=0.0003, weight_init_stddevs=[.1],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset)
@@ -481,12 +476,11 @@ class TestOverfit(test_util.TensorFlowTestCase):
     verbosity = "high"
     classification_metric = dc.metrics.Metric(
       dc.metrics.accuracy_score, verbosity=verbosity, task_averager=np.mean)
-    tensorflow_model = dc.models.RobustMultitaskClassifier(
+    model = dc.models.RobustMultitaskClassifier(
         n_tasks, n_features, layer_sizes=[50],
         bypass_layer_sizes=[10], dropouts=[0.],
         learning_rate=0.003, weight_init_stddevs=[.1],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=25)
@@ -514,10 +508,9 @@ class TestOverfit(test_util.TensorFlowTestCase):
     verbosity = "high"
     classification_metric = dc.metrics.Metric(
       dc.metrics.accuracy_score, verbosity=verbosity, task_averager=np.mean)
-    tensorflow_model = dc.models.TensorflowLogisticRegression(
+    model = dc.models.TensorflowLogisticRegression(
         n_tasks, n_features, learning_rate=0.5, weight_init_stddevs=[.01],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset)
@@ -613,11 +606,10 @@ class TestOverfit(test_util.TensorFlowTestCase):
     regression_metric = dc.metrics.Metric(
         dc.metrics.mean_squared_error, verbosity=verbosity,
         task_averager=np.mean, mode="regression")
-    tensorflow_model = dc.models.TensorflowMultiTaskRegressor(
+    model = dc.models.TensorflowMultiTaskRegressor(
         n_tasks, n_features, dropouts=[0.],
         learning_rate=0.0003, weight_init_stddevs=[.1],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=50)
@@ -649,12 +641,11 @@ class TestOverfit(test_util.TensorFlowTestCase):
     regression_metric = dc.metrics.Metric(
         dc.metrics.mean_squared_error, verbosity=verbosity,
         task_averager=np.mean, mode="regression")
-    tensorflow_model = dc.models.RobustMultitaskRegressor(
+    model = dc.models.RobustMultitaskRegressor(
         n_tasks, n_features, layer_sizes=[50],
         bypass_layer_sizes=[10], dropouts=[0.],
         learning_rate=0.003, weight_init_stddevs=[.1],
         batch_size=n_samples, verbosity=verbosity)
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset, nb_epoch=25)

--- a/deepchem/models/tests/test_reload.py
+++ b/deepchem/models/tests/test_reload.py
@@ -110,20 +110,17 @@ class TestReload(unittest.TestCase):
     classification_metric = dc.metrics.Metric(dc.metrics.accuracy_score)
 
     model_dir = tempfile.mkdtemp()
-    tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    model = dc.models.TensorflowMultiTaskClassifier(
           n_tasks, n_features, model_dir, dropouts=[0.], verbosity="high")
-    model = dc.models.TensorflowModel(tensorflow_model)
 
     # Fit trained model
     model.fit(dataset)
     model.save()
 
     # Load trained model
-    reloaded_tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+    reloaded_model = dc.models.TensorflowMultiTaskClassifier(
         n_tasks, n_features, model_dir, dropouts=[0.],
         verbosity="high")
-    reloaded_model = dc.models.TensorflowModel(
-        reloaded_tensorflow_model)
     reloaded_model.reload()
 
     # Eval model on train

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -35,11 +35,8 @@ class Evaluator(object):
   def __init__(self, model, dataset, transformers, verbosity=False):
     self.model = model
     self.dataset = dataset
-    ########################################################## DEBUG
-    #self.output_transformers = [
-    #    transformer for transformer in transformers if transformer.transform_y]
-    self.transformers = transformers
-    ########################################################## DEBUG
+    self.output_transformers = [
+        transformer for transformer in transformers if transformer.transform_y]
     self.task_names = dataset.get_task_names()
     self.verbosity = verbosity
 
@@ -74,50 +71,19 @@ class Evaluator(object):
     Computes statistics of model on test data and saves results to csv.
     """
     y = self.dataset.y
-    ################################################################ DEBUG
-    #print("self.output_transformers")
-    #print(self.output_transformers)
-    ################################################################ DEBUG
-    ################################################################ DEBUG
-    #y = undo_transforms(y, self.output_transformers)
-    y = undo_transforms(y, self.transformers)
-    ################################################################ DEBUG
+    y = undo_transforms(y, self.output_transformers)
     w = self.dataset.w
 
     if not len(metrics):
       return {}
     else:
       mode = metrics[0].mode
-    ################################################################ DEBUG
-    print("mode")
-    print(mode)
-    ################################################################ DEBUG
     if mode == "classification":
-      ################################################################ DEBUG
-      #y_pred = self.model.predict_proba(self.dataset, self.output_transformers)
-      #y_pred_print = self.model.predict(
-      #    self.dataset, self.output_transformers).astype(int)
-      y_pred = self.model.predict_proba(self.dataset, self.transformers)
+      y_pred = self.model.predict_proba(self.dataset, self.output_transformers)
       y_pred_print = self.model.predict(
-          self.dataset, self.transformers).astype(int)
-      ################################################################ DEBUG
+          self.dataset, self.output_transformers).astype(int)
     else:
-      ################################################################ DEBUG
-      #y_pred = self.model.predict(self.dataset, self.output_transformers)
-      y_pred = self.model.predict(self.dataset, self.transformers)
-      ################################################################ DEBUG
-      ################################################################ DEBUG
-      print("y_pred.shape")
-      print(y_pred.shape)
-      print("y_pred[:1]")
-      print(y_pred[:1])
-      print("y[:1]")
-      print(y[:1])
-      raw_y = self.model.predict_on_batch(self.dataset.X[:1])
-      raw_y = undo_transforms(raw_y, self.transformers)
-      print("raw_y")
-      print(raw_y)
-      ################################################################ DEBUG
+      y_pred = self.model.predict(self.dataset, self.output_transformers)
       y_pred_print = y_pred
     multitask_scores = {}
 

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -35,8 +35,11 @@ class Evaluator(object):
   def __init__(self, model, dataset, transformers, verbosity=False):
     self.model = model
     self.dataset = dataset
-    self.output_transformers = [
-        transformer for transformer in transformers if transformer.transform_y]
+    ########################################################## DEBUG
+    #self.output_transformers = [
+    #    transformer for transformer in transformers if transformer.transform_y]
+    self.transformers = transformers
+    ########################################################## DEBUG
     self.task_names = dataset.get_task_names()
     self.verbosity = verbosity
 
@@ -71,19 +74,50 @@ class Evaluator(object):
     Computes statistics of model on test data and saves results to csv.
     """
     y = self.dataset.y
-    y = undo_transforms(y, self.output_transformers)
+    ################################################################ DEBUG
+    #print("self.output_transformers")
+    #print(self.output_transformers)
+    ################################################################ DEBUG
+    ################################################################ DEBUG
+    #y = undo_transforms(y, self.output_transformers)
+    y = undo_transforms(y, self.transformers)
+    ################################################################ DEBUG
     w = self.dataset.w
 
     if not len(metrics):
       return {}
     else:
       mode = metrics[0].mode
+    ################################################################ DEBUG
+    print("mode")
+    print(mode)
+    ################################################################ DEBUG
     if mode == "classification":
-      y_pred = self.model.predict_proba(self.dataset, self.output_transformers)
+      ################################################################ DEBUG
+      #y_pred = self.model.predict_proba(self.dataset, self.output_transformers)
+      #y_pred_print = self.model.predict(
+      #    self.dataset, self.output_transformers).astype(int)
+      y_pred = self.model.predict_proba(self.dataset, self.transformers)
       y_pred_print = self.model.predict(
-          self.dataset, self.output_transformers).astype(int)
+          self.dataset, self.transformers).astype(int)
+      ################################################################ DEBUG
     else:
-      y_pred = self.model.predict(self.dataset, self.output_transformers)
+      ################################################################ DEBUG
+      #y_pred = self.model.predict(self.dataset, self.output_transformers)
+      y_pred = self.model.predict(self.dataset, self.transformers)
+      ################################################################ DEBUG
+      ################################################################ DEBUG
+      print("y_pred.shape")
+      print(y_pred.shape)
+      print("y_pred[:1]")
+      print(y_pred[:1])
+      print("y[:1]")
+      print(y[:1])
+      raw_y = self.model.predict_on_batch(self.dataset.X[:1])
+      raw_y = undo_transforms(raw_y, self.transformers)
+      print("raw_y")
+      print(raw_y)
+      ################################################################ DEBUG
       y_pred_print = y_pred
     multitask_scores = {}
 

--- a/examples/muv/muv_tf.py
+++ b/examples/muv/muv_tf.py
@@ -21,11 +21,10 @@ train_dataset, valid_dataset, test_dataset = muv_datasets
 metric = dc.metrics.Metric(dc.metrics.roc_auc_score, np.mean,
                            mode="classification")
 
-tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
+model = dc.models.TensorflowMultiTaskClassifier(
     len(muv_tasks), n_features=1024, dropouts=[.25],
     learning_rate=0.001, weight_init_stddevs=[.1],
     batch_size=64, verbosity="high")
-model = dc.models.TensorflowModel(tensorflow_model)
 
 # Fit trained model
 model.fit(train_dataset)

--- a/examples/pcba/pcba_tf.py
+++ b/examples/pcba/pcba_tf.py
@@ -20,44 +20,30 @@ from deepchem.models.tensorflow_models import TensorflowModel
 
 np.random.seed(123)
 
-# Set some global variables up top
-
-reload = True
-verbosity = "high"
-
-base_dir = "/tmp/pcba_tf"
-model_dir = os.path.join(base_dir, "model")
-if os.path.exists(base_dir):
-  shutil.rmtree(base_dir)
-os.makedirs(base_dir)
-
-pcba_tasks, pcba_datasets, transformers = load_pcba(
-    base_dir, reload=reload)
+pcba_tasks, pcba_datasets, transformers = load_pcba()
 (train_dataset, valid_dataset) = pcba_datasets
 
 
-classification_metric = Metric(metrics.roc_auc_score, np.mean,
-                               verbosity=verbosity,
+metric = Metric(metrics.roc_auc_score, np.mean,
                                mode="classification")
 
-tensorflow_model = TensorflowMultiTaskClassifier(
+model = TensorflowMultiTaskClassifier(
     len(pcba_tasks), n_features, model_dir, dropouts=[.25],
     learning_rate=0.001, weight_init_stddevs=[.1],
-    batch_size=64, verbosity=verbosity)
-model = TensorflowModel(tensorflow_model, model_dir)
+    batch_size=64, verbosity="high")
 
 # Fit trained model
 model.fit(train_dataset)
 model.save()
 
 train_evaluator = Evaluator(model, train_dataset, transformers, verbosity=verbosity)
-train_scores = train_evaluator.compute_model_performance([classification_metric])
+train_scores = train_evaluator.compute_model_performance([metric])
 
 print("Train scores")
 print(train_scores)
 
 valid_evaluator = Evaluator(model, valid_dataset, transformers, verbosity=verbosity)
-valid_scores = valid_evaluator.compute_model_performance([classification_metric])
+valid_scores = valid_evaluator.compute_model_performance([metric])
 
 print("Validation scores")
 print(valid_scores)

--- a/examples/run_all_benchmarks.py
+++ b/examples/run_all_benchmarks.py
@@ -15,7 +15,7 @@ base_dir = tempfile.mkdtemp()
 out_path='.'
 models = ['tf', 'tf_robust', 'logreg', 'graphconv']
 #datasets = ['muv', 'nci', 'tox21', 'sider', 'toxcast']
-datasets = ['tox21']
+datasets = ['tox21', 'muv']
 
 hps = {}
 hps['tf'] = [{'dropouts': [0.25], 'learning_rate': 0.001,

--- a/examples/run_all_benchmarks.py
+++ b/examples/run_all_benchmarks.py
@@ -1,0 +1,41 @@
+"""
+@author: Bharath Ramsundar 
+"""
+import os
+import time
+import sys
+import pandas as pd
+import numpy as np
+import tempfile
+from scipy.stats import truncnorm
+from benchmark import benchmark_loading_datasets
+
+np.random.seed(123)
+base_dir = tempfile.mkdtemp()
+out_path='.'
+models = ['tf', 'tf_robust', 'logreg', 'graphconv']
+#datasets = ['muv', 'nci', 'tox21', 'sider', 'toxcast']
+datasets = ['tox21']
+
+hps = {}
+hps['tf'] = [{'dropouts': [0.25], 'learning_rate': 0.001,
+              'layer_sizes': [1000], 'batch_size': 50, 'nb_epoch': 10}]
+
+hps['tf_robust'] = [{'dropouts': [0.5], 'bypass_dropouts': [0.5],
+                     'learning_rate': 0.001,
+                     'layer_sizes': [500], 'bypass_layer_sizes': [100],
+                     'batch_size': 50, 'nb_epoch': 10}]
+              
+hps['logreg'] = [{'learning_rate': 0.001, 'penalty': 0.05, 
+                  'penalty_type': 'l1', 'batch_size': 50, 'nb_epoch': 10}]
+              
+hps['graphconv'] = [{'learning_rate': 0.001, 'n_filters': 64,
+                     'n_fully_connected_nodes': 128, 'batch_size': 50,
+                     'nb_epoch': 10}]
+
+for model in models:
+  for dataset in datasets:
+    print("Benchmarking %s on dataset %s" % (model, dataset))
+    benchmark_loading_datasets(base_dir, hps, dataset_name=dataset,
+                               model=model, reload=True,
+                               verbosity='high', out_path=out_path)

--- a/examples/run_benchmark.py
+++ b/examples/run_benchmark.py
@@ -23,18 +23,19 @@ n_filters = [64,96,128]
 n_fully_connected_nodes = [100,120,140,160,200,240,300]
 n_estimators = [500]
 
-out_path='/home/zqwu/deepchem/examples'
+out_path='.'
 base_dir_o="/tmp/benchmark_test_"+time.strftime("%Y_%m_%d", time.localtime())
 dname = sys.argv[1]
 model = sys.argv[2]
 
-parameters_printed = {'tf':['dropouts','learning_rate','layer_sizes',
-                            'batch_size','nb_epoch'],
-                      'logreg':['learning_rate','penalty','penalty_type',
-                                'batch_size','nb_epoch'],
-                      'graphconv':['learning_rate','n_filters','n_fully_connected_nodes',
-                                   'batch_size','nb_epoch'],
-                      'rf':['n_estimators']}
+parameters_printed = {'tf': ['dropouts', 'learning_rate', 'layer_sizes',
+                             'batch_size', 'nb_epoch'],
+                      'logreg': ['learning_rate', 'penalty', 'penalty_type',
+                                 'batch_size', 'nb_epoch'],
+                      'graphconv': ['learning_rate', 'n_filters',
+                                    'n_fully_connected_nodes',
+                                    'batch_size', 'nb_epoch'],
+                      'rf': ['n_estimators']}
 hps = {}
 hps[model] = []
 for i in range(int(sys.argv[3])):
@@ -53,9 +54,11 @@ for i in range(int(sys.argv[3])):
 
 
 
-  hps[model].append({'dropouts':[dp],'learning_rate':lr,'layer_sizes':[int(ls)],
-                'penalty':pn, 'penalty_type':pt, 'batch_size':int(bs),'nb_epoch':int(ne),
-		'n_filters': 64, 'n_fully_connected_nodes':128, 'n_estimators':500})
+  hps[model].append({'dropouts': [dp], 'learning_rate': lr,
+                     'layer_sizes': [int(ls)], 'penalty': pn,
+                     'penalty_type': pt, 'batch_size': int(bs),
+                     'nb_epoch': int(ne), 'n_filters': 64,
+                     'n_fully_connected_nodes': 128, 'n_estimators': 500})
   with open(os.path.join(out_path,'hps.csv'),'a') as f:        
     f.write('\n\n'+str(i))
     for item in hps[model][i]:
@@ -66,8 +69,3 @@ for i in range(int(sys.argv[3])):
 benchmark_loading_datasets(base_dir_o, hps, dataset_name=dname,
                            model=model,reload = True,
                            verbosity='high', out_path=out_path)
-
-
-
-    
-             

--- a/examples/tox21/tox21_logreg.py
+++ b/examples/tox21/tox21_logreg.py
@@ -23,10 +23,9 @@ train_dataset, valid_dataset, test_dataset = tox21_datasets
 metric = dc.metrics.Metric(dc.metrics.roc_auc_score, np.mean,
                            mode="classification")
 
-tensorflow_model = dc.models.TensorflowLogisticRegression(
+model = dc.models.TensorflowLogisticRegression(
     len(tox21_tasks), n_features, learning_rate=0.006, penalty = 0.05,
     weight_init_stddevs=[0.002],batch_size=32, verbosity="high")
-model = dc.models.TensorflowModel(tensorflow_model)
 
 # Fit trained model
 model.fit(train_dataset,nb_epoch = 50)

--- a/examples/tox21/tox21_robustMT_models.py
+++ b/examples/tox21/tox21_robustMT_models.py
@@ -23,18 +23,21 @@ train_dataset, valid_dataset, test_dataset = tox21_datasets
 metric = dc.metrics.Metric(dc.metrics.roc_auc_score, np.mean,
                            mode="classification")
 
-robust_classifier_model = dc.models.RobustMultitaskClassifier(
-    len(tox21_tasks), n_features, bypass_layer_sizes=[30],
-    bypass_weight_init_stddevs=[.02],
-    bypass_bias_init_consts=[1.],
-    bypass_dropouts=[.5],
-    dropouts=[.4],
-    learning_rate=0.002, weight_init_stddevs=[1.],
-    batch_size=50, verbosity="high")
-model = dc.models.TensorflowModel(robust_classifier_model)
+n_layers = 1
+n_bypass_layers = 1
+nb_epoch = 10
+model = dc.models.RobustMultitaskClassifier(
+    len(tox21_tasks), train_dataset.get_data_shape()[0],
+    layer_sizes=[500]*n_layers, bypass_layer_sizes=[50]*n_bypass_layers,
+    dropouts=[.25]*n_layers, bypass_dropouts=[.25]*n_bypass_layers, 
+    weight_init_stddevs=[.02]*n_layers, bias_init_consts=[.5]*n_layers,
+    bypass_weight_init_stddevs=[.02]*n_bypass_layers,
+    bypass_bias_init_consts=[.5]*n_bypass_layers,
+    learning_rate=.0003, penalty=.0001, penalty_type="l2",
+    optimizer="adam", batch_size=100, verbosity="high")
 
 # Fit trained model
-model.fit(train_dataset)
+model.fit(train_dataset, nb_epoch=nb_epoch)
 model.save()
 
 print("Evaluating model")

--- a/examples/tox21/tox21_tf_models.py
+++ b/examples/tox21/tox21_tf_models.py
@@ -23,11 +23,9 @@ train_dataset, valid_dataset, test_dataset = tox21_datasets
 metric = dc.metrics.Metric(dc.metrics.roc_auc_score, np.mean,
                            mode="classification")
 
-tensorflow_model = dc.models.TensorflowMultiTaskClassifier(
-    len(tox21_tasks), n_features, dropouts=[.25],
-    learning_rate=0.0003, weight_init_stddevs=[1.],
-    batch_size=32, verbosity="high")
-model = dc.models.TensorflowModel(tensorflow_model)
+model = dc.models.TensorflowMultiTaskClassifier(
+    len(tox21_tasks), n_features, layer_sizes=[1000], dropouts=[.25],
+    learning_rate=0.001, batch_size=50, verbosity="high")
 
 # Fit trained model
 model.fit(train_dataset)


### PR DESCRIPTION
Simplifies tensorflow models to remove some cruft (No need to use wrapper `dc.models.TensorflowModel`). Since this changes the API, I'd like to run the full benchmark suite as a regression before merging this change in. Need to add in the machinery to enable such a run.

Edit: Changes in this PR:

- Removes `TensorflowModel` as a wrapper. Simplifies the use of tensorflow models as a results. Updates tests and examples for consistency.
- Fixes serious bug in `TensorflowMultiTaskRegressor` where dropout was turned on at test time. #291 issue raised for adding more tests.
- Adds `seed` option to `TensorflowGraphModel` to allow for deterministic training of tensorflow models.
- Adds `examples/run_all_benchmarks.py` to move closer to an automated benchmarking suite.