### PR TITLE
Add batch padding option for compute_model_performance

### DIFF
--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -66,7 +66,7 @@ class Evaluator(object):
         csvwriter.writerow([mol_id] + list(y_pred))
 
   def compute_model_performance(self, metrics, csv_out=None, stats_out=None,
-                                threshold=None):
+                                threshold=None, pad_batches=False):
     """
     Computes statistics of model on test data and saves results to csv.
     """
@@ -79,11 +79,11 @@ class Evaluator(object):
     else:
       mode = metrics[0].mode
     if mode == "classification":
-      y_pred = self.model.predict_proba(self.dataset, self.output_transformers)
+      y_pred = self.model.predict_proba(self.dataset, self.output_transformers, pad_batches=pad_batches)
       y_pred_print = self.model.predict(
           self.dataset, self.output_transformers).astype(int)
     else:
-      y_pred = self.model.predict(self.dataset, self.output_transformers)
+      y_pred = self.model.predict(self.dataset, self.output_transformers, pad_batches=pad_batches)
       y_pred_print = y_pred
     multitask_scores = {}
 

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -71,7 +71,7 @@ def load_sdf_files(input_files):
     raw_df = next(load_csv_files([input_file+".csv"], shard_size=None))
     # Structures are stored in .sdf file
     print("Reading structures from %s." % input_file)
-    suppl = Chem.SDMolSupplier(str(input_file), removeHs=False)
+    suppl = Chem.SDMolSupplier(str(input_file), sanitize=False, removeHs=False, strictParsing=False)
     df_rows = []
     for ind, mol in enumerate(suppl):
       if mol is not None:


### PR DESCRIPTION
This PR adds:
- An option to pad batches when calling `model.predict()` from `Evaluator.compute_model_performance()`.  This is needed for dataset evaluation by `TensorflowModel`s that require padded batches.  Default option is False.
- A small change to the rdkit SDF reader.  This is needed to successfully load up the GDB7 data set. rdkit will throw an exception for molecules containing 4-coordinate nitrogen, etc which is a bit too strict.