### PR TITLE
NormalizationTransformer on single task datasets

### DIFF
--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -104,6 +104,7 @@ class NormalizationTransformer(Transformer):
       y_means, y_stds = dataset.get_statistics(X_stats=False, y_stats=True)
       self.y_means = y_means 
       # Control for pathological case with no variance.
+      y_stds = np.array(y_stds)
       y_stds[y_stds == 0] = 1.
       self.y_stds = y_stds
     self.transform_gradients = transform_gradients

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -105,7 +105,7 @@ def load_from_disk(filename):
   elif os.path.splitext(name)[1] == ".joblib":
     try:
       return joblib.load(filename)
-    except KeyError:
+    except KeyError, ValueError:
       # Try older joblib version for legacy files.
       return old_joblib.load(filename)
   elif os.path.splitext(name)[1] == ".csv":

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -105,8 +105,10 @@ def load_from_disk(filename):
   elif os.path.splitext(name)[1] == ".joblib":
     try:
       return joblib.load(filename)
-    except KeyError, ValueError:
+    except KeyError:
       # Try older joblib version for legacy files.
+      return old_joblib.load(filename)
+    except ValueError:
       return old_joblib.load(filename)
   elif os.path.splitext(name)[1] == ".csv":
     # First line of user-specified CSV *must* be header.


### PR DESCRIPTION
This PR includes:
- A bug fix for `NormalizationTransformer` on single task datasets
- A ValueError exception when attempting to load old joblib files