### PR TITLE
Use Absolute References in Example Code

### DIFF
--- a/examples/chembl/chembl_datasets.py
+++ b/examples/chembl/chembl_datasets.py
@@ -6,10 +6,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import sys
 import time
 
 import deepchem as dc
-from chembl.chembl_tasks import chembl_tasks
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from chembl_tasks import chembl_tasks
 
 
 # Set shard size low to avoid memory problems.

--- a/examples/chembl/chembl_datasets.py
+++ b/examples/chembl/chembl_datasets.py
@@ -1,18 +1,16 @@
 """
 ChEMBL dataset loader.
 """
-from __future__ import print_function
 from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
 import time
-import numpy as np
-import deepchem as dc
-import sys
 
-sys.path.append(".")
-from chembl_tasks import chembl_tasks
+import deepchem as dc
+from chembl.chembl_tasks import chembl_tasks
+
 
 # Set shard size low to avoid memory problems.
 def load_chembl(shard_size=2000, featurizer="ECFP", set="5thresh", split="random"):

--- a/examples/kaggle/kaggle_datasets.py
+++ b/examples/kaggle/kaggle_datasets.py
@@ -6,12 +6,15 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
+import sys
 import time
 
 import numpy as np
 
 import deepchem as dc
-from kaggle.kaggle_features import merck_descriptors
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+from kaggle_features import merck_descriptors
 
 
 def remove_missing_entries(dataset):

--- a/examples/kaggle/kaggle_datasets.py
+++ b/examples/kaggle/kaggle_datasets.py
@@ -1,18 +1,18 @@
 """
 KAGGLE dataset loader.
 """
-from __future__ import print_function
 from __future__ import division
+from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-import shutil
 import time
+
 import numpy as np
+
 import deepchem as dc
-import sys
-sys.path.append(".")
-from kaggle_features import merck_descriptors 
+from kaggle.kaggle_features import merck_descriptors
+
 
 def remove_missing_entries(dataset):
   """Remove missing entries.


### PR DESCRIPTION
These changes allow benchmark.py to execute.
This will break directly calling code from inside one of the submodules though (i.e. examples/chembl).

Another option which will allow executing code with the cwd of examples/chembl would be replacing calls of
```
sys.path.append(".") -> sys.path.append(os.path.dirname(os.path.abspath(__file__)))
```
