### PR TITLE
Add ButinaSplitter class

### DIFF
--- a/deepchem/data/tests/__init__.py
+++ b/deepchem/data/tests/__init__.py
@@ -28,6 +28,18 @@ def load_solubility_data():
   
   return loader.featurize(input_file)
 
+def load_butina_data():
+  """Loads solubility dataset"""
+  current_dir = os.path.dirname(os.path.abspath(__file__))
+  featurizer = dc.feat.CircularFingerprint(size=1024)
+  tasks = ["task"]
+  # task_type = "regression"
+  input_file = os.path.join(current_dir, "../../models/tests/butina_example.csv")
+  loader = dc.data.CSVLoader(
+      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
+  
+  return loader.featurize(input_file)
+
 def load_multitask_data():
   """Load example multitask data."""
   current_dir = os.path.dirname(os.path.abspath(__file__))

--- a/deepchem/models/tests/butina_example.csv
+++ b/deepchem/models/tests/butina_example.csv
@@ -1,0 +1,11 @@
+task,smiles
+0,OCC3OC(OCC2OC(OC(C#N)c1ccccc1)C(O)C(O)C2O)C(O)C(O)C3O 
+0,Cc1occc1C(=O)Nc2ccccc2
+0,CCCCCCCCCCC
+0,c1ccc2c(c1)ccc3c2ccc4c5ccccc5ccc43
+0,CCCCCCCCCCCC
+1,CCCCCCCCCCCCC
+0,Clc1cc(Cl)c(c(Cl)c1)c2c(Cl)cccc2Cl
+0,C1CCNCC1
+0,ClC4=C(Cl)C5(Cl)C3C1CC(C2OC12)C3C4(Cl)C5(Cl)Cl
+1,COc5cc4OCC3Oc2c1CC(Oc1ccc2C(=O)C3c4cc5OC)C(C)=C 

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -90,6 +90,20 @@ class TestSplitters(unittest.TestCase):
     assert sorted(merged_dataset.ids) == (
            sorted(solubility_dataset.ids))
 
+  def test_singletask_butina_split(self):
+    """
+    Test singletask ScaffoldSplitter class.
+    """
+    solubility_dataset = dc.data.tests.load_butina_data()
+    scaffold_splitter = dc.splits.ButinaSplitter()
+    train_data, valid_data, test_data = \
+        scaffold_splitter.train_valid_test_split(
+            solubility_dataset)
+    print(len(train_data), len(valid_data))
+    assert len(train_data) == 7
+    assert len(valid_data) == 3
+    assert len(test_data) == 0
+
   def test_singletask_random_k_fold_split(self):
     """
     Test singletask RandomSplitter class.
@@ -422,3 +436,8 @@ class TestSplitters(unittest.TestCase):
       # verify that there are no rows (samples) in weights matrix w
       # that have no hits.
       assert len(np.where(~w.any(axis=1))[0]) == 0
+
+
+if __name__ == "__main__":
+  import nose
+  nose.run(defaultTest=__name__)

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -125,7 +125,7 @@ def benchmark_loading_datasets(hyper_parameters,
   elif split in ['indice']:
     if not dataset in ['gdb7']:
       return
-  elif not split in [None, 'index','random','scaffold']:
+  elif not split in [None, 'index','random','scaffold', 'butina']:
     raise ValueError('Splitter function not supported')
   
   loading_functions = {'tox21': load_tox21, 'muv': load_muv,

--- a/examples/tox21/tox21_datasets.py
+++ b/examples/tox21/tox21_datasets.py
@@ -38,7 +38,8 @@ def load_tox21(featurizer='ECFP', split='index'):
 
   splitters = {'index': dc.splits.IndexSplitter(),
                'random': dc.splits.RandomSplitter(),
-               'scaffold': dc.splits.ScaffoldSplitter()}
+               'scaffold': dc.splits.ScaffoldSplitter(),
+               'butina': dc.splits.ButinaSplitter()}
   splitter = splitters[split]
   train, valid, test = splitter.train_valid_test_split(dataset)
   return tox21_tasks, (train, valid, test), transformers


### PR DESCRIPTION
This PR adds support for a ButinaSplitter that is similar to ScaffoldSplitting, except as opposed to using a hand-wavy Murcko Scaffold Decomposition it uses fingerprints. The goal here is similar to that of the ScaffoldSplitter: i.e. predict on new cores/chemotypes that are very dissimilar from that of the training set.

I'm going to run the benchmarks on this splitter and post results later.