### PR TITLE
Python36Tests: Small Changes For Python 3.6 compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,10 @@ install:
 - conda install h5py
 - pip install six
 #- pip install keras
+- conda install -c conda-forge protobuf=3.1.0
 - export KERAS_BACKEND=tensorflow
 - conda install -c omnia mdtraj
 - pip install tensorflow
-- conda install -c conda-forge protobuf=3.1.0
 - python setup.py install
 script:
 - nosetests -v deepchem --nologcapture

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ install:
 - export KERAS_BACKEND=tensorflow
 - conda install -c omnia mdtraj
 - pip install tensorflow
+- conda install -c conda-forge protobuf=3.1.0
 - python setup.py install
 script:
 - nosetests -v deepchem --nologcapture

--- a/deepchem/data/tests/test_support_generator.py
+++ b/deepchem/data/tests/test_support_generator.py
@@ -80,7 +80,7 @@ class TestSupports(unittest.TestCase):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
     # Set last n_samples/2 weights to 0
-    w[n_samples/2:] = 0
+    w[n_samples//2:] = 0
     dataset = dc.data.NumpyDataset(X, y, w, ids)
 
     n_episodes = 20
@@ -307,12 +307,12 @@ class TestSupports(unittest.TestCase):
     y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
     # Set last n_samples/2 weights to 0
-    w[n_samples/2:] = 0
+    w[n_samples//2:] = 0
     dataset = dc.data.NumpyDataset(X, y, w, ids)
 
     # Sample from first n_samples/2 elements for support
     support_inds = sorted(np.random.choice(
-        np.arange(n_samples/2), (n_support,), replace=False))
+        np.arange(n_samples//2), (n_support,), replace=False))
     support_dataset = dc.data.NumpyDataset(X[support_inds], y[support_inds],
                                            w[support_inds], ids[support_inds])
 


### PR DESCRIPTION
Use integer division instead of division when wishing to get
integer results. In python 3 division always returns a float
where as in 2.7 it returns an int if both the numerator and
denominator were ints