### PR TITLE
387: Install Rdkit From the Rdkit Channel Instead of From Omnia

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 - conda update -q conda
 - conda config --add channels http://conda.binstar.org/omnia
 - conda install pandas
-- conda install -c omnia rdkit
+- conda install -c rdkit rdkit
 - conda install -c omnia boost=1.59.0
 - conda install -c omnia openbabel
 - conda install joblib

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Installation from source is the only currently supported format. ```deepchem``` 
 
 3. `rdkit`
    ```bash
-   conda install -c omnia rdkit
+   conda install -c rdkit rdkit
    ```
 
 4. `joblib`


### PR DESCRIPTION
We now get 2016.09.x version of rdkit instead of 2015.09.x