### PR TITLE
401: Clean Up Git Ignores

### DIFF
--- a/deepchem/.gitignore
+++ b/deepchem/.gitignore
@@ -1,0 +1,3 @@
+core_grid.tar.gz
+dock/autodock_vina_1_1_2_linux_x86/
+random_full_DNN.tar.gz


### PR DESCRIPTION
The nosetests/application pulls down static assets to run computation over.  

Deepchem is already pretty good about only downloading it when it doesn't exist.

This is mostly so people don't accidentally attempt to add static assets to the git repo.

fixes deepchem/deepchem#401