### PR TITLE
394: Auto Format Using .yapf

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,4 @@
+[style]
+# YAPF uses the chromium style
+based_on_style = google
+indent_width = 2

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,4 +1,3 @@
 [style]
-# YAPF uses the chromium style
 based_on_style = google
 indent_width = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,11 @@ install:
 - conda install -c conda-forge protobuf=3.1.0
 - conda install -c omnia mdtraj
 - pip install tensorflow==0.12.1
+- pip install yapf
 - python setup.py install
 script:
 - nosetests -v deepchem --nologcapture
+- bash devtools/travis-ci/test_format_code.sh
 after_success:
 - echo $TRAVIS_SECURE_ENV_VARS
 - source devtools/travis-ci/after_sucess.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
 - conda install -c conda-forge protobuf=3.1.0
 - conda install -c omnia mdtraj
 - pip install tensorflow==0.12.1
-- pip install yapf
+- pip install yapf==0.16.0
 - python setup.py install
 script:
 - nosetests -v deepchem --nologcapture

--- a/README.md
+++ b/README.md
@@ -387,7 +387,7 @@ DeepChem uses [yapf](https://github.com/google/yapf) to autoformat code.  We cre
 
 ``` bash
 cp devtools/travis-ci/pre-commit .git/hooks
-pip install yapf
+pip install yapf==0.16.0
 ```
 
 ### Documentation Style Guidelines

--- a/README.md
+++ b/README.md
@@ -383,11 +383,12 @@ We actively encourage community contributions to DeepChem. The first place to st
 Once you've got a sense of how the package works, we encourage the use of Github issues to discuss more complex changes,  raise requests for new features or propose changes to the global architecture of DeepChem. Once consensus is reached on the issue, please submit a PR with proposed modifications. All contributed code to DeepChem will be reviewed by a member of the DeepChem team, so please make sure your code style and documentation style match our guidelines!
 
 ### Code Style Guidelines
-DeepChem broadly follows the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html). In terms of practical changes, the biggest effect is that all code uses 2-space indents instead of 4-space indents. We encourage new contributors to make use of [pylint](https://www.pylint.org/) with the following command
+DeepChem uses [yapf](https://github.com/google/yapf) to autoformat code.  We created a git pre-commit hook to make this process easier.
+
+``` bash
+cp devtools/travis-ci/pre-commit .git/hooks
+pip install yapf
 ```
-pylint --disable=invalid-name --indent-string "  " --extension-pkg-whitelist=numpy [file.py]
-```
-Aim for a score of at least 8/10 on contributed files.
 
 ### Documentation Style Guidelines
 DeepChem uses [NumPy style documentation](https://github.com/numpy/numpy/blob/master/doc/HOWTO_DOCUMENT.rst.txt). Please follow these conventions when documenting code, since we use [Sphinx+Napoleon](http://www.sphinx-doc.org/en/stable/ext/napoleon.html) to automatically generate docs on [deepchem.io](deepchem.io).

--- a/devtools/travis-ci/pre-commit
+++ b/devtools/travis-ci/pre-commit
@@ -1,9 +1,10 @@
 #!/bin/sh
-CHANGED_FILES=`git diff --cached --name-only | grep .py$`
+CHANGED_FILES=`git diff --cached --name-only | grep .py`
 if [ -z $CHANGED_FILES ]
 then
     echo "No Python Files Changed"
 else
     echo $CHANGED_FILES
     yapf -i $CHANGED_FILES
+    git diff --name-only --cached | xargs -l git add
 fi

--- a/devtools/travis-ci/pre-commit
+++ b/devtools/travis-ci/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/sh
+CHANGED_FILES=`git diff --cached --name-only | grep .py$`
+if [ -z $CHANGED_FILES ]
+then
+    echo "No Python Files Changed"
+else
+    echo $CHANGED_FILES
+    yapf -i $CHANGED_FILES
+fi

--- a/devtools/travis-ci/test_format_code.sh
+++ b/devtools/travis-ci/test_format_code.sh
@@ -14,7 +14,6 @@ then
 fi
 
 yapf -d $CHANGED_FILES > diff.txt
-cat diff.txt
 
 if [ -s diff.txt ]
 then

--- a/devtools/travis-ci/test_format_code.sh
+++ b/devtools/travis-ci/test_format_code.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
+CHANGED_FILES=`git diff --name-only $TRAVIS_COMMIT_RANGE | grep .py$`
 
 exit_success () {
     echo "Passed Formatting Test"

--- a/devtools/travis-ci/test_format_code.sh
+++ b/devtools/travis-ci/test_format_code.sh
@@ -1,0 +1,31 @@
+#!/bin/bash -e
+
+CHANGED_FILES=($(git diff --name-only $TRAVIS_COMMIT_RANGE))
+
+exit_success () {
+    echo "Passed Formatting Test"
+    exit 0
+}
+
+if [ -z $CHANGED_FILES ]
+then
+    echo "No Python Files Changed"
+    exit_success
+fi
+
+yapf -d $CHANGED_FILES > diff.txt
+cat diff.txt
+
+if [ -s diff.txt ]
+then
+    cat diff.txt
+    echo ""
+    echo "Failing Formatting Test"
+    echo "Please run yapf over the files changed"
+    echo "pip install yapf"
+    echo "yapf -i $CHANGED_FILES"
+    exit 1
+else
+    exit_success
+fi
+exit 1


### PR DESCRIPTION
Create a travis CI test which fails when code is not properly formatted.

Create a git pre-commit hook which will auto-format changed python files

## Note
This will add noise to future pull requests as they will also contain formatting changes to files touched by the PR.  An alternative would be to have someone who knows the code very well to run the formatter over /deepchem and /examples to get us in a good state before accepting this PR.

Example Failures: https://travis-ci.org/lilleswing/deepchem/builds/202329732

fixes deepchem/deepchem#394