### PR TITLE
414: Add Test Coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[report]
+omit =
+    */python?.?/*
+    */site-packages/nose/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,10 @@ install:
 - pip install yapf==0.16.0
 - python setup.py install
 script:
-- nosetests -v deepchem --nologcapture
+- nosetests --with-coverage --cover-package=deepchem -v deepchem --nologcapture
 - find ./deepchem | grep .py$ |xargs python -m doctest -v
 - bash devtools/travis-ci/test_format_code.sh
 after_success:
 - echo $TRAVIS_SECURE_ENV_VARS
+- coveralls
 - source devtools/travis-ci/after_sucess.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 - bash scripts/install_deepchem_conda.sh deepchem
 - source activate deepchem
 - pip install yapf==0.16.0
+- pip install coveralls
 - python setup.py install
 script:
 - nosetests --with-coverage --cover-package=deepchem -v deepchem --nologcapture

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ﻿# DeepChem
+[![Build Status](https://travis-ci.org/deepchem/deepchem.svg?branch=master)](https://travis-ci.org/deepchem/deepchem)
+[![Coverage Status](https://coveralls.io/repos/deepchem/deepchem/badge.svg?branch=master%2Fcoveralls)](https://coveralls.io/r/deepchem/deepchem?branch=master%2Fcoveralls)
 
 DeepChem aims to provide a high quality open-source toolchain that
 democratizes the use of deep-learning in drug discovery, materials science, and quantum

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# DeepChem
 [![Build Status](https://travis-ci.org/deepchem/deepchem.svg?branch=master)](https://travis-ci.org/deepchem/deepchem)
-[![Coverage Status](https://coveralls.io/repos/github/lilleswing/deepchem/badge.svg?branch=master)](https://coveralls.io/github/lilleswing/deepchem?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/deepchem/deepchem/badge.svg?branch=master)](https://coveralls.io/github/deepchem/deepchem?branch=master)
 
 DeepChem aims to provide a high quality open-source toolchain that
 democratizes the use of deep-learning in drug discovery, materials science, and quantum

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# DeepChem
 [![Build Status](https://travis-ci.org/deepchem/deepchem.svg?branch=master)](https://travis-ci.org/deepchem/deepchem)
-[![Coverage Status](https://coveralls.io/repos/deepchem/deepchem/badge.svg?branch=master%2Fcoveralls)](https://coveralls.io/r/deepchem/deepchem?branch=master%2Fcoveralls)
+[![Coverage Status](https://coveralls.io/repos/github/lilleswing/deepchem/badge.svg?branch=master)](https://coveralls.io/github/lilleswing/deepchem?branch=master)
 
 DeepChem aims to provide a high quality open-source toolchain that
 democratizes the use of deep-learning in drug discovery, materials science, and quantum

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -20,7 +20,7 @@ yes | pip install six
 conda install -y -c omnia mdtraj
 conda install -y scikit-learn
 conda install -y setuptools
-conda install -y -c anaconda keras=1.1.1
+conda install -y keras=1.1.1
 conda install -y -c conda-forge protobuf=3.1.0
 yes | pip install $tensorflow==0.12.1
 yes | pip install nose


### PR DESCRIPTION
Instructions for installation:

1) https://coveralls.io sign in with gihub.

2) Enable for deepchem git repo as shown in this screenshot
![selection_010](https://cloud.githubusercontent.com/assets/1225605/23276421/0eba7b06-f9bf-11e6-8023-9b6e566be600.png)

3) Have coverage statistics for your build.  We are currently at 85% coverage (way better than I was expecting!)

What the page looks like when you click on the button
![selection_011](https://cloud.githubusercontent.com/assets/1225605/23276503/64ba2d12-f9bf-11e6-992f-78cf21172fb5.png)

