### PR TITLE
Fix benchmark Code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ ENV PATH /miniconda/bin:$PATH
 # TODO: Get rid of this when there is a stable release of deepchem.
 RUN git clone https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    git checkout 415aebadff54175b7ba108964723c8f69438af94 && \
+    git checkout tags/1.0.0 && \
     bash scripts/install_deepchem_conda.sh root && \
-    pip install tensorflow-gpu==0.12.1 && \
+    pip install tensorflow-gpu==1.0.1 && \
     python setup.py develop
 
 # Clean up

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -37,7 +37,6 @@ import time
 import deepchem as dc
 import tensorflow as tf
 import argparse
-from keras import backend as K
 import csv
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.ensemble import RandomForestRegressor
@@ -493,7 +492,6 @@ def benchmark_classification(train_dataset,
 
     g = tf.Graph()
     sess = tf.Session(graph=g)
-    K.set_session(sess)
     # Building graph convolution model
     tf.set_random_seed(seed)
     graph_model = dc.nn.SequentialGraph(n_features)
@@ -693,7 +691,6 @@ def benchmark_regression(train_dataset,
 
     g = tf.Graph()
     sess = tf.Session(graph=g)
-    K.set_session(sess)
     # Building graph convoluwtion model
     tf.set_random_seed(seed)
     graph_model = dc.nn.SequentialGraph(n_features)


### PR DESCRIPTION
Jenkins after Keras upgrade to 1.2.2 kept thinking it has a Theano backend instead of TF.  I couldn't get it to switch despite creating ~/.keras/keras.json and setting the environment variable.  

But we don't actually need keras in any of the benchmark code so I removed it.

Also updated the Dockerfile for 1.0.0.