### PR TITLE
Install xgboost without interaction

### DIFF
--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -24,6 +24,6 @@ conda install -y setuptools
 conda install -y -c conda-forge keras=1.2.2
 conda install -y -c conda-forge protobuf=3.1.0
 conda install -y -c anaconda networkx=1.11
-conda install -c bioconda xgboost=0.6a2
+conda install -y -c bioconda xgboost=0.6a2
 yes | pip install $tensorflow==1.0.1
 yes | pip install nose


### PR DESCRIPTION
Install xgboost without interaction

For people who install a new env and want to grab coffee during it.
Keep consistent with other conda installs.