### PR TITLE
Small updates for atomic convs

### DIFF
--- a/contrib/atomicconv/acnn/core/opt_scaffold.py
+++ b/contrib/atomicconv/acnn/core/opt_scaffold.py
@@ -40,6 +40,7 @@ transformers = [
 ]
 for transformer in transformers:
   train_dataset = transformer.transform(train_dataset)
+  test_dataset = transformer.transform(test_dataset)
 
 at = [1., 6, 7., 8., 9., 11., 12., 15., 16., 17., 20., 25., 30., 35., 53.]
 radial = [[12.0], [0.0, 4.0, 8.0], [4.0]]
@@ -85,7 +86,7 @@ train_evaluator = dc.utils.evaluate.Evaluator(model, train_dataset,
 train_scores = train_evaluator.compute_model_performance(metric)
 print("Train scores")
 print(train_scores)
-
-print("Prediction")
-predictions = model.predict(test_dataset, transformers)
-print(predictions)
+test_evaluator = dc.utils.evaluate.Evaluator(model, test_dataset, transformers)
+test_scores = test_evaluator.compute_model_performance(metric)
+print("Test scores")
+print(test_scores)

--- a/contrib/atomicconv/acnn/core/opt_scaffold.py
+++ b/contrib/atomicconv/acnn/core/opt_scaffold.py
@@ -40,7 +40,6 @@ transformers = [
 ]
 for transformer in transformers:
   train_dataset = transformer.transform(train_dataset)
-  test_dataset = transformer.transform(test_dataset)
 
 at = [1., 6, 7., 8., 9., 11., 12., 15., 16., 17., 20., 25., 30., 35., 53.]
 radial = [[12.0], [0.0, 4.0, 8.0], [4.0]]
@@ -56,7 +55,7 @@ penalty = 0.
 model = TensorflowFragmentRegressor(
     len(pdbbind_tasks),
     rp,
-    at,
+at,
     frag1_num_atoms,
     frag2_num_atoms,
     complex_num_atoms,

--- a/contrib/atomicconv/acnn/core/opt_scaffold.py
+++ b/contrib/atomicconv/acnn/core/opt_scaffold.py
@@ -55,7 +55,7 @@ penalty = 0.
 model = TensorflowFragmentRegressor(
     len(pdbbind_tasks),
     rp,
-at,
+    at,
     frag1_num_atoms,
     frag2_num_atoms,
     complex_num_atoms,
@@ -85,7 +85,7 @@ train_evaluator = dc.utils.evaluate.Evaluator(model, train_dataset,
 train_scores = train_evaluator.compute_model_performance(metric)
 print("Train scores")
 print(train_scores)
-test_evaluator = dc.utils.evaluate.Evaluator(model, test_dataset, transformers)
-test_scores = test_evaluator.compute_model_performance(metric)
-print("Test scores")
-print(test_scores)
+
+print("Prediction")
+predictions = model.predict(test_dataset, transformers)
+print(predictions)

--- a/contrib/atomicconv/models/atomicnet_ops.py
+++ b/contrib/atomicconv/models/atomicnet_ops.py
@@ -282,7 +282,7 @@ def AtomicConvolutionLayer(X, Nbrs, Nbrs_Z, atom_types, radial_params, boxsize,
   """Atomic convoluation layer
 
   N = max_num_atoms, M = max_num_neighbors, B = batch_size, d = num_features
-  l = num_radial_filters
+  l = num_radial_filters * num_atom_types
 
   Parameters
   ----------

--- a/contrib/atomicconv/models/atomicnet_ops.py
+++ b/contrib/atomicconv/models/atomicnet_ops.py
@@ -80,8 +80,8 @@ def AtomicNNLayer(tensor, size, weights, biases, name=None):
   """
 
   if len(tensor.get_shape()) != 2:
-    raise ValueError(
-        'Dense layer input must be 2D, not %dD' % len(tensor.get_shape()))
+    raise ValueError('Dense layer input must be 2D, not %dD' %
+                     len(tensor.get_shape()))
   with tf.name_scope(name, 'fully_connected', [tensor, weights, biases]):
     return tf.nn.xw_plus_b(tensor, weights, biases)
 

--- a/contrib/atomicconv/models/legacy.py
+++ b/contrib/atomicconv/models/legacy.py
@@ -604,8 +604,8 @@ class TensorflowClassifier(TensorflowGraphModel):
       A tensor with shape batch_size containing the weighted cost for each
       example.
     """
-    return tf.mul(
-        tf.nn.softmax_cross_entropy_with_logits(logits, labels), weights)
+    return tf.multiply(
+        tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=labels), weights)
 
   def add_label_placeholders(self, graph, name_scopes):
     """Add Placeholders for labels for each task.
@@ -758,7 +758,7 @@ class TensorflowRegressor(TensorflowGraphModel):
       A tensor with shape batch_size containing the weighted cost for each
       example.
     """
-    return tf.mul(0.5 * tf.square(output - labels), weights)
+    return tf.multiply(0.5 * tf.square(output - labels), weights)
 
   def add_label_placeholders(self, graph, name_scopes):
     """Add Placeholders for labels for each task.

--- a/contrib/atomicconv/models/legacy.py
+++ b/contrib/atomicconv/models/legacy.py
@@ -416,8 +416,8 @@ class TensorflowGraphModel(Model):
     feeding and fetching the same tensor.
     """
     weights = []
-    placeholder_scope = TensorflowGraph.get_placeholder_scope(
-        graph, name_scopes)
+    placeholder_scope = TensorflowGraph.get_placeholder_scope(graph,
+                                                              name_scopes)
     with placeholder_scope:
       for task in range(self.n_tasks):
         weights.append(
@@ -605,7 +605,8 @@ class TensorflowClassifier(TensorflowGraphModel):
       example.
     """
     return tf.multiply(
-        tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=labels), weights)
+        tf.nn.softmax_cross_entropy_with_logits(logits=logits, labels=labels),
+        weights)
 
   def add_label_placeholders(self, graph, name_scopes):
     """Add Placeholders for labels for each task.
@@ -616,8 +617,8 @@ class TensorflowClassifier(TensorflowGraphModel):
     Placeholders are wrapped in identity ops to avoid the error caused by
     feeding and fetching the same tensor.
     """
-    placeholder_scope = TensorflowGraph.get_placeholder_scope(
-        graph, name_scopes)
+    placeholder_scope = TensorflowGraph.get_placeholder_scope(graph,
+                                                              name_scopes)
     with graph.as_default():
       batch_size = self.batch_size
       n_classes = self.n_classes
@@ -769,8 +770,8 @@ class TensorflowRegressor(TensorflowGraphModel):
     Placeholders are wrapped in identity ops to avoid the error caused by
     feeding and fetching the same tensor.
     """
-    placeholder_scope = TensorflowGraph.get_placeholder_scope(
-        graph, name_scopes)
+    placeholder_scope = TensorflowGraph.get_placeholder_scope(graph,
+                                                              name_scopes)
     with graph.as_default():
       batch_size = self.batch_size
       labels = []
@@ -858,8 +859,8 @@ class TensorflowMultiTaskRegressor(TensorflowRegressor):
         batch_size x n_features.
     """
     n_features = self.n_features
-    placeholder_scope = TensorflowGraph.get_placeholder_scope(
-        graph, name_scopes)
+    placeholder_scope = TensorflowGraph.get_placeholder_scope(graph,
+                                                              name_scopes)
     with graph.as_default():
       with placeholder_scope:
         self.mol_features = tf.placeholder(


### PR DESCRIPTION
Test Dataset can't be transformed as it doesn't have y values -- I changed it to a prediction.

Main change is the documentation of the atomic convolution layer getting the number of channels correct.

This is surprising to me -- my intuition in line with convolutions would be to SUM over all the atom type masks instead of making each one a feature.