### PR TITLE
Make jenkins continue to do tox21 instead of hyper parameter smashing

### DIFF
--- a/devtools/jenkins/jenkins.sh
+++ b/devtools/jenkins/jenkins.sh
@@ -4,8 +4,14 @@ bash scripts/install_deepchem_conda.sh $envname
 source activate $envname
 python setup.py install
 
-cd contrib/atomicconv/acnn/refined
-python tensor_graph_hyper_param_eval.py
+rm examples/results.csv || true
+cd examples
+python benchmark.py -d tox21
+export retval1=$?
+
+cd ..
+nosetests -v devtools/jenkins/compare_results.py --with-xunit || true
+export retval2=$?
 
 source deactivate
 conda remove --name $envname --all


### PR DESCRIPTION
Make jenkins continue to do tox21 instead of hyper parameter smashing

This one is my bad for not cleaning it up earlier.