### PR TITLE
Make TensorGraph Models inherit from sklearn.base.BaseEstimator

### DIFF
--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -16,6 +16,7 @@ import joblib
 import os
 import tempfile
 import sklearn
+from sklearn.base import BaseEstimator
 
 from deepchem.data import Dataset, pad_features
 from deepchem.trans import undo_transforms
@@ -25,7 +26,7 @@ from deepchem.utils.save import log
 from deepchem.utils.evaluate import Evaluator
 
 
-class Model(object):
+class Model(BaseEstimator):
   """
   Abstract base class for different ML models.
   """
@@ -162,7 +163,7 @@ class Model(object):
   def evaluate(self, dataset, metrics, transformers=[], per_task_metrics=False):
     """
     Evaluates the performance of this model on specified dataset.
-  
+
     Parameters
     ----------
     dataset: dc.data.Dataset

--- a/deepchem/models/tests/test_api.py
+++ b/deepchem/models/tests/test_api.py
@@ -217,6 +217,12 @@ class TestAPI(unittest.TestCase):
 
     model = dc.models.TensorGraphMultiTaskClassifier(len(tasks), n_features)
 
+    # Test Parameter getting and setting
+    param, value = 'weight_decay_penalty_type', 'l2'
+    assert model.get_params()[param] is None
+    model.set_params(**{param: value})
+    assert model.get_params()[param] == value
+
     # Fit trained model
     model.fit(train_dataset)
     model.save()

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -1,16 +1,14 @@
 package:
   name: deepchem
-  version: "0.0.4"
+  version: {{ GIT_DESCRIBE_TAG }} 
 
 source:
-    git_url: https://github.com/pandegroup/deepchem/
-    git_tag: 0.0.4
+  path: ../../
 
 build:
   number: 0
   skip:
     - [osx or win]
-    - [py3k]
 
 
 requirements:
@@ -21,10 +19,10 @@ requirements:
     - scipy
     - pandas
     - scikit-learn
+    - networkx
+    - tensorflow
     - keras
-    - theano ==0.7.2
     - rdkit
-    - openbabel 
     - joblib
     - pbr
     - h5py
@@ -36,10 +34,13 @@ requirements:
     - scipy
     - pandas
     - scikit-learn
+    - networkx
+    - tensorflow
+    - py-xgboost
     - keras
-    - theano ==0.7.2
     - rdkit
-    - openbabel 
+    - mdtraj
+    - pdbfixer
     - joblib
     - pbr
     - h5py


### PR DESCRIPTION
Fairly simple change. I also updated `meta.yaml` so that conda-build can execute via:

```bash
$ conda build -c conda-forge -c omnia devtools/conda-recipe/
```

And actually runs.