### PR TITLE
Layers own variables

### DIFF
--- a/deepchem/models/tensorgraph/graph_layers.py
+++ b/deepchem/models/tensorgraph/graph_layers.py
@@ -392,7 +392,7 @@ class DTNNStep(Layer):
         self.W_cf, self.W_df, self.W_fc, self.b_cf, self.b_df
     ]
 
-  def create_tensor(self, in_layers=None, **kwargs):
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     """description and explanation refer to deepchem.nn.DTNNStep
     parent layers: atom_features, distance, distance_membership_i, distance_membership_j
     """

--- a/deepchem/nn/model_ops.py
+++ b/deepchem/nn/model_ops.py
@@ -823,11 +823,6 @@ def fully_connected_layer(tensor,
   ValueError
     If input tensor is not 2D.
   """
-  ###################################################### DEBUG
-  #print("fully_connected_layer")
-  #print("tensor")
-  #print(tensor)
-  ###################################################### DEBUG
   if weight_init is None:
     num_features = tensor.get_shape()[-1].value
     weight_init = tf.truncated_normal([num_features, size], stddev=0.01)


### PR DESCRIPTION
Begins changes for GAN support in TensorGraph (#535) by making layers own their variables. Changes all layers so that `layer.variables` provides a list of the variables that the given layer object owns. 

Also fixes #536 by adding a new kwarg `set_tensors` to `create_tensor`. If `set_tensors=False`, then the call to `create_tensor` will have no side-effects. (There are a couple layers in `graph_layers.py` where this isn't yet entirely true, but I'm going to leave that for a follow-up PR).