### PR TITLE
Support Reinforcement Learning

### DIFF
--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -16,3 +16,5 @@ import deepchem.trans
 import deepchem.utils
 import deepchem.dock
 import deepchem.molnet
+import deepchem.rl
+

--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -17,4 +17,3 @@ import deepchem.utils
 import deepchem.dock
 import deepchem.molnet
 import deepchem.rl
-

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -47,19 +47,6 @@ class Layer(object):
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     raise NotImplementedError("Subclasses must implement for themselves")
 
-  def __key(self):
-    return self.name
-
-  def __eq__(x, y):
-    if x is None or y is None:
-      return False
-    if type(x) != type(y):
-      return False
-    return x.__key() == y.__key()
-
-  def __hash__(self):
-    return hash(self.__key())
-
   def shared(self, in_layers):
     """
     Share weights with different in tensors and a new out tensor
@@ -143,8 +130,6 @@ class Dense(Layer):
       biases_initializer=tf.zeros_initializer,
       weights_initializer=tf.contrib.layers.variance_scaling_initializer,
       time_series=False,
-      scope_name=None,
-      reuse=False,
       **kwargs):
     """Create a dense layer.
 
@@ -166,10 +151,6 @@ class Dense(Layer):
       the initializer for weight values
     time_series: bool
       if True, the dense layer is applied to each element of a batch in sequence
-    scope_name: str
-      an optional scope name for the layer's variables
-    reuse: bool
-      whether or not the layer and its variables should be reused
     """
     super(Dense, self).__init__(**kwargs)
     self.out_channels = out_channels
@@ -178,8 +159,8 @@ class Dense(Layer):
     self.biases_initializer = biases_initializer
     self.weights_initializer = weights_initializer
     self.time_series = time_series
-    self.reuse = reuse
-    self.scope_name = scope_name
+    self._reuse = False
+    self._shared_with = None
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     if in_layers is None:
@@ -192,10 +173,6 @@ class Dense(Layer):
       biases_initializer = None
     else:
       biases_initializer = self.biases_initializer()
-    if self.scope_name is None:
-      scope_name = self.name
-    else:
-      scope_name = self.scope_name
     if not self.time_series:
       self.out_tensor = tf.contrib.layers.fully_connected(
           parent.out_tensor,
@@ -203,8 +180,8 @@ class Dense(Layer):
           activation_fn=self.activation_fn,
           biases_initializer=biases_initializer,
           weights_initializer=self.weights_initializer(),
-          scope=scope_name,
-          reuse=self.reuse,
+          scope=self._get_scope_name(),
+          reuse=self._reuse,
           trainable=True)
       return self.out_tensor
     dense_fn = lambda x: tf.contrib.layers.fully_connected(x,
@@ -212,8 +189,8 @@ class Dense(Layer):
                                                            activation_fn=self.activation_fn,
                                                            biases_initializer=biases_initializer,
                                                            weights_initializer=self.weights_initializer(),
-                                                           scope=self.scope_name,
-                                                           reuse=self.reuse,
+                                                           scope=self._get_scope_name(),
+                                                           reuse=self._reuse,
                                                            trainable=True)
     out_tensor = tf.map_fn(dense_fn, parent.out_tensor)
     if set_tensors:
@@ -223,16 +200,23 @@ class Dense(Layer):
     return out_tensor
 
   def shared(self, in_layers):
-    self.reuse = True
-    return Dense(
+    copy = Dense(
         self.out_channels,
         self.activation_fn,
         self.biases_initializer,
         self.weights_initializer,
         time_series=self.time_series,
-        reuse=self.reuse,
-        scope_name=self.scope_name,
         in_layers=in_layers)
+    self._reuse = True
+    copy._reuse = True
+    copy._shared_with = self
+    return copy
+
+  def _get_scope_name(self):
+    if self._shared_with is None:
+      return self.name
+    else:
+      return self._shared_with._get_scope_name()
 
 
 class Flatten(Layer):

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -11,10 +11,10 @@ class Layer(object):
   layer_number_dict = {}
 
   def __init__(self, in_layers=None, **kwargs):
-    if "name" not in kwargs:
-      self.name = "%s_%s" % (self.__class__.__name__, self._get_layer_number())
-    else:
+    if "name" in kwargs:
       self.name = kwargs['name']
+    else:
+      self.name = None
     if "tensorboard" not in kwargs:
       self.tensorboard = False
     else:
@@ -179,8 +179,6 @@ class Dense(Layer):
     self.weights_initializer = weights_initializer
     self.time_series = time_series
     self.reuse = reuse
-    if scope_name is None:
-      scope_name = self.name
     self.scope_name = scope_name
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
@@ -194,6 +192,10 @@ class Dense(Layer):
       biases_initializer = None
     else:
       biases_initializer = self.biases_initializer()
+    if self.scope_name is None:
+      scope_name = self.name
+    else:
+      scope_name = self.scope_name
     if not self.time_series:
       self.out_tensor = tf.contrib.layers.fully_connected(
           parent.out_tensor,
@@ -201,7 +203,7 @@ class Dense(Layer):
           activation_fn=self.activation_fn,
           biases_initializer=biases_initializer,
           weights_initializer=self.weights_initializer(),
-          scope=self.scope_name,
+          scope=scope_name,
           reuse=self.reuse,
           trainable=True)
       return self.out_tensor

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -92,7 +92,7 @@ class TensorGraph(Model):
 
   def _add_layer(self, layer):
     if layer.name is None:
-      layer.name = "%s_%s" % (layer.__class__.__name__, len(self.layers)+1)
+      layer.name = "%s_%s" % (layer.__class__.__name__, len(self.layers) + 1)
     if layer.name in self.layers:
       return
     if isinstance(layer, Feature):
@@ -349,7 +349,7 @@ class TensorGraph(Model):
     shapes = []
     pre_q_inputs = []
     q = InputFifoQueue(shapes, names, in_layers=pre_q_inputs)
-    q.name = "%s_%s" % (q.__class__.__name__, len(self.layers)+1)
+    q.name = "%s_%s" % (q.__class__.__name__, len(self.layers) + 1)
 
     for layer in self.features + self.labels + self.task_weights:
       pre_q_input = layer.create_pre_q(self.batch_size)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -349,6 +349,7 @@ class TensorGraph(Model):
     shapes = []
     pre_q_inputs = []
     q = InputFifoQueue(shapes, names, in_layers=pre_q_inputs)
+    q.name = "%s_%s" % (q.__class__.__name__, len(self.layers)+1)
 
     for layer in self.features + self.labels + self.task_weights:
       pre_q_input = layer.create_pre_q(self.batch_size)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -26,6 +26,7 @@ class TensorGraph(Model):
                random_seed=None,
                use_queue=True,
                mode="regression",
+               graph=None,
                **kwargs):
     """
     TODO(LESWING) allow a model to change its learning rate
@@ -47,6 +48,9 @@ class TensorGraph(Model):
       "regression" or "classification".  "classification" models on
       predict will do an argmax(axis=2) to determine the class of the
       prediction.
+    graph: tensorflow.Graph
+      the Graph in which to create Tensorflow objects.  If None, a new Graph
+      is created.
     kwargs
     """
 
@@ -68,7 +72,7 @@ class TensorGraph(Model):
     # See TensorGraph._get_tf() for more details on lazy construction
     self.tensor_objects = {
         "FileWriter": None,
-        "Graph": tf.Graph(),
+        "Graph": graph,
         "train_op": None,
         "summary_op": None,
     }
@@ -87,6 +91,8 @@ class TensorGraph(Model):
     self.model_class = None
 
   def _add_layer(self, layer):
+    if layer.name is None:
+      layer.name = "%s_%s" % (layer.__class__.__name__, len(self.layers)+1)
     if layer.name in self.layers:
       return
     if isinstance(layer, Feature):
@@ -98,8 +104,8 @@ class TensorGraph(Model):
     self.nxgraph.add_node(layer.name)
     self.layers[layer.name] = layer
     for in_layer in layer.in_layers:
-      self.nxgraph.add_edge(in_layer.name, layer.name)
       self._add_layer(in_layer)
+      self.nxgraph.add_edge(in_layer.name, layer.name)
 
   def fit(self,
           dataset,
@@ -314,7 +320,6 @@ class TensorGraph(Model):
         tf.set_random_seed(self.random_seed)
       self._install_queue()
       order = self.topsort()
-      print(order)
       for node in order:
         with tf.name_scope(node):
           node_layer = self.layers[node]
@@ -448,8 +453,10 @@ class TensorGraph(Model):
       self.tensor_objects['Graph'] = tf.Graph()
     elif obj == "FileWriter":
       self.tensor_objects['FileWriter'] = tf.summary.FileWriter(self.model_dir)
+    elif obj == 'Optimizer':
+      self.tensor_objects['Optimizer'] = self.optimizer()
     elif obj == 'train_op':
-      self.tensor_objects['train_op'] = self.optimizer().minimize(
+      self.tensor_objects['train_op'] = self._get_tf('Optimizer').minimize(
           self.loss.out_tensor)
     elif obj == 'summary_op':
       self.tensor_objects['summary_op'] = tf.summary.merge_all(

--- a/deepchem/rl/__init__.py
+++ b/deepchem/rl/__init__.py
@@ -2,6 +2,7 @@
 
 from deepchem.rl.a3c import A3C
 
+
 class Environment(object):
   """An environment in which an actor performs actions to accomplish a task.
 
@@ -81,12 +82,14 @@ class Environment(object):
 
 class GymEnvironment(Environment):
   """This is a convenience class for working with environments from OpenAI Gym."""
+
   def __init__(self, name):
     """Create an Environment wrapping the OpenAI Gym environment with a specified name."""
     import gym
     self.env = gym.make(name)
     self.name = name
-    super().__init__([self.env.observation_space.shape], self.env.action_space.n)
+    super().__init__([self.env.observation_space.shape],
+                     self.env.action_space.n)
 
   def reset(self):
     state = self.env.reset()
@@ -132,4 +135,3 @@ class Policy(object):
     of Layers every time.
     """
     raise NotImplemented("Subclasses must implement this")
-

--- a/deepchem/rl/__init__.py
+++ b/deepchem/rl/__init__.py
@@ -9,6 +9,10 @@ class Environment(object):
   is concerned, they are simply arbitrary objects.  The environment also computes
   a reward for each action, and reports when the task has been terminated
   (meaning that no more actions may be taken.
+
+  Environment objects should be written to support pickle and deepcopy operations.
+  Many algorithms involve creating multiple copies of the Environment, possibly
+  running in different processes or even on different computers.
   """
 
   def __init__(self, state_shape, n_actions):
@@ -71,11 +75,12 @@ class Environment(object):
 
 
 class GymEnvironment(Environment):
-  """This is a convenient class for working with environments from OpenAI Gym."""
+  """This is a convenience class for working with environments from OpenAI Gym."""
   def __init__(self, name):
     """Create an Environment wrapping the OpenAI Gym environment with a specified name."""
     import gym
     self.env = gym.make(name)
+    self.name = name
     super().__init__(self.env.observation_space.shape, self.env.action_space.n)
 
   def reset(self):
@@ -85,6 +90,9 @@ class GymEnvironment(Environment):
   def step(self, action):
     self._state, reward, self._terminated, info = self.env.step(action)
     return reward
+
+  def __deepcopy__(self, memo):
+    return GymEnvironment(self.name)
 
 
 class Policy(object):

--- a/deepchem/rl/__init__.py
+++ b/deepchem/rl/__init__.py
@@ -1,0 +1,119 @@
+"""Interface for reinforcement learning."""
+
+class Environment(object):
+  """An environment in which an actor performs actions to accomplish a task.
+
+  An environment has a current state that can be queried.  When an action
+  is taken, that causes the state to be updated.  Exactly what is meant by
+  a "state" or "action" is defined by each subclass.  As far as this interface
+  is concerned, they are simply arbitrary objects.  The environment also computes
+  a reward for each action, and reports when the task has been terminated
+  (meaning that no more actions may be taken.
+  """
+
+  def __init__(self, state_shape, n_actions):
+    """Subclasses should call the superclass constructor in addition to doing their own initialization."""
+    self._state_shape = state_shape
+    self._n_actions = n_actions
+    self._state = None
+    self._terminated = None
+
+  @property
+  def state(self):
+    """The current state of the environment, represented as a class-specific object.
+    
+    If reset() has not yet been called at least once, this is undefined.
+    """
+    return self._state
+
+  @property
+  def terminated(self):
+    """Whether the task has reached its end.
+    
+    If reset() has not yet been called at least once, this is undefined.
+    """
+    return self._terminated
+
+  @property
+  def state_shape(self):
+    """The shape of the values that describe a state."""
+    return self._state_shape
+
+  @property
+  def n_actions(self):
+    """The number of possible actions that can be performed in this Environment."""
+    return self._n_actions
+
+  def reset(self):
+    """Initialize the environment in preparation for doing calculations with it.
+
+    This must be called before calling step() or querying the state.  You can call it
+    again later to reset the environment back to its original state.
+    """
+    raise NotImplemented("Subclasses must implement this")
+
+  def step(self, action):
+    """Take a time step by performing an action.
+
+    This causes the "state" and "terminated" properties to be updated.
+
+    Parameters
+    ----------
+    action: object
+      an object describing the action to take
+
+    Returns
+    -------
+    the reward earned by taking the action, represented as a float point number
+    (higher values are better)
+    """
+    raise NotImplemented("Subclasses must implement this")
+
+
+class GymEnvironment(Environment):
+  """This is a convenient class for working with environments from OpenAI Gym."""
+  def __init__(self, name):
+    """Create an Environment wrapping the OpenAI Gym environment with a specified name."""
+    import gym
+    self.env = gym.make(name)
+    super().__init__(self.env.observation_space.shape, self.env.action_space.n)
+
+  def reset(self):
+    self._state = self.env.reset()
+    self._terminated = False
+
+  def step(self, action):
+    self._state, reward, self._terminated, info = self.env.step(action)
+    return reward
+
+
+class Policy(object):
+  """A policy for taking actions within an environment.
+
+  A policy is defined by a set of TensorGraph Layer objects that perform the
+  necessary calculations.  There are many algorithms for reinforcement learning,
+  and they differ in what values they require a policy to compute.  That makes
+  it impossible to define a single interface allowing any policy to be optimized
+  with any algorithm.  Instead, this interface just tries to be as flexible and
+  generic as possible.  Each algorithm must document what values it expects
+  create_layers() to return.
+
+  Policy objects should be written to support pickling.  Many algorithms involve
+  creating multiple copies of the Policy, possibly running in different processes
+  or even on different computers.
+  """
+
+  def create_layers(self, features, **kwargs):
+    """Create the TensorGraph Layers that define the policy.
+
+    The arguments always include a Feature layer representing the current state of
+    the environment.  Depending on the algorithm being used, other arguments might
+    get passed as well.  It is up to each algorithm to document that.
+
+    This method should construct and return a dict that maps strings to Layer
+    objects.  Each algorithm must document what Layers it expects the policy to
+    create.  If this method is called multiple times, it should create a new set
+    of Layers every time.
+    """
+    raise NotImplemented("Subclasses must implement this")
+

--- a/deepchem/rl/__init__.py
+++ b/deepchem/rl/__init__.py
@@ -8,7 +8,7 @@ class Environment(object):
   a "state" or "action" is defined by each subclass.  As far as this interface
   is concerned, they are simply arbitrary objects.  The environment also computes
   a reward for each action, and reports when the task has been terminated
-  (meaning that no more actions may be taken.
+  (meaning that no more actions may be taken).
 
   Environment objects should be written to support pickle and deepcopy operations.
   Many algorithms involve creating multiple copies of the Environment, possibly

--- a/deepchem/rl/__init__.py
+++ b/deepchem/rl/__init__.py
@@ -1,5 +1,7 @@
 """Interface for reinforcement learning."""
 
+from deepchem.rl.a3c import A3C
+
 class Environment(object):
   """An environment in which an actor performs actions to accomplish a task.
 

--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -5,8 +5,12 @@ from deepchem.models.tensorgraph import TFWrapper
 from deepchem.models.tensorgraph.layers import Feature, Weights, Label, Layer
 import numpy as np
 import tensorflow as tf
+import copy
+import multiprocessing
+import threading
 
 class A3CLoss(Layer):
+  """This layer computes the loss function for A3C."""
   def __init__(self, value_weight, entropy_weight, **kwargs):
     super(A3CLoss, self).__init__(**kwargs)
     self.value_weight = value_weight
@@ -17,7 +21,7 @@ class A3CLoss(Layer):
     log_prob = tf.log(prob)
     policy_loss = -tf.reduce_sum((reward-value)*tf.reduce_sum(action*log_prob))
     value_loss = tf.reduce_sum(tf.square(reward-value))
-    entropy = tf.reduce_sum(prob*log_prob)
+    entropy = -tf.reduce_sum(prob*log_prob)
     self.out_tensor = policy_loss + self.value_weight*value_loss - self.entropy_weight*entropy
     return self.out_tensor
 
@@ -35,7 +39,7 @@ class A3C(object):
   3. An entropy term to encourage exploration.
   """
 
-  def __init__(self, env, policy, max_rollout_length, discount_factor=0.99, value_weight=0.25, entropy_weight=0.01):
+  def __init__(self, env, policy, max_rollout_length=20, discount_factor=0.99, value_weight=0.25, entropy_weight=0.01):
     """Create an object for optimizing a policy.
 
     Parameters
@@ -62,7 +66,7 @@ class A3C(object):
     self.entropy_weight = entropy_weight
     self.optimizer = TFWrapper(tf.train.AdamOptimizer, learning_rate=0.001, beta1=0.9, beta2=0.999)
 
-  def _build_graph(self):
+  def _build_graph(self, tf_graph, scope):
     """Construct a TensorGraph containing the policy and loss calculations."""
     features = Feature(shape=[None]+list(self._env.state_shape))
     policy_layers = self._policy.create_layers(features)
@@ -71,46 +75,84 @@ class A3C(object):
     rewards = Weights(shape=(None, 1))
     actions = Label(shape=(None, self._env.n_actions))
     loss = A3CLoss(self.value_weight, self.entropy_weight, in_layers=[rewards, actions, action_prob, value])
-    graph = TensorGraph(batch_size=self.max_rollout_length, use_queue=False)
+    graph = TensorGraph(batch_size=self.max_rollout_length, use_queue=False, graph=tf_graph)
     graph.add_output(action_prob)
     graph.add_output(value)
     graph.set_loss(loss)
     graph.set_optimizer(self.optimizer)
-    graph.build()
+    with graph._get_tf("Graph").as_default():
+      with tf.variable_scope(scope):
+        graph.build()
     return graph, features, rewards, actions, action_prob, value
 
-  def _create_rollout(self, sess, features, action_prob):
-    """Generate a rollout."""
-    n_actions = self._env.n_actions
-    self._env.reset()
-    states = []
-    actions = []
-    scores = []
-    for i in range(self.max_rollout_length):
-      if self._env.terminated:
-        break
-      states.append(self._env.state)
-      feed_dict = {features.out_tensor: np.expand_dims(self._env.state, axis=0)}
-      probabilities = sess.run(action_prob.out_tensor, feed_dict=feed_dict)
-      action = np.random.choice([0,1], p=probabilities[0])
-      actions.append(np.zeros(n_actions))
-      actions[i][action] = 1.0
-      scores.append(self._env.step(action))
-    for j in range(len(scores)-1, 0, -1):
-      scores[j-1] += self.discount_factor*scores[j]
-    return np.array(states), np.array(actions), np.array(scores).reshape((len(scores), 1))
-
-  def fit(self, n_episodes):
-    (graph, features, rewards, actions, action_prob, value) = self._build_graph()
+  def fit(self, total_steps):
+    (graph, features, rewards, actions, action_prob, value) = self._build_graph(None, 'global')
     with graph._get_tf("Graph").as_default():
       train_op = graph._get_tf('train_op')
       with tf.Session() as sess:
         sess.run(tf.global_variables_initializer())
-        for i in range(n_episodes):
-          episode_states, episode_actions, episode_rewards = self._create_rollout(sess, features, action_prob)
-          feed_dict = {}
-          feed_dict[features.out_tensor] = episode_states
-          feed_dict[rewards.out_tensor] = episode_rewards
-          feed_dict[actions.out_tensor] = episode_actions
-          sess.run(train_op, feed_dict=feed_dict)
+        step_count = [0]
+        workers = []
+        threads = []
+        for i in range(multiprocessing.cpu_count()):
+          workers.append(Worker(self, graph, i))
+        for worker in workers:
+          thread = threading.Thread(name=worker.scope, target=lambda: worker.run(sess, step_count, total_steps))
+          threads.append(thread)
+          thread.start()
+        for thread in threads:
+          thread.join()
 
+
+class Worker(object):
+  def __init__(self, a3c, global_graph, index):
+    self.a3c = a3c
+    self.index = index
+    self.scope = 'worker%d' % index
+    self.env = copy.deepcopy(a3c._env)
+    self.env.reset()
+    self.graph, self.features, self.rewards, self.actions, self.action_prob, self.value = a3c._build_graph(global_graph._get_tf('Graph'), self.scope)
+    local_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, self.scope)
+    global_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, 'global')
+    gradients = tf.gradients(self.graph.loss.out_tensor, local_vars)
+    grads_and_vars = list(zip(gradients, global_vars))
+    self.train_op = global_graph._get_tf('Optimizer').apply_gradients(grads_and_vars)
+    self.update_local_variables = tf.group(*[tf.assign(v1, v2) for v1, v2 in zip(local_vars, global_vars)])
+
+  def run(self, sess, step_count, total_steps):
+    with self.graph._get_tf("Graph").as_default():
+      while step_count[0] < total_steps:
+        sess.run(self.update_local_variables)
+        episode_states, episode_actions, episode_rewards = self.create_rollout(sess)
+        feed_dict = {}
+        feed_dict[self.features.out_tensor] = episode_states
+        feed_dict[self.rewards.out_tensor] = episode_rewards
+        feed_dict[self.actions.out_tensor] = episode_actions
+        sess.run(self.train_op, feed_dict=feed_dict)
+        step_count[0] += len(episode_states)
+
+  def create_rollout(self, sess):
+    """Generate a rollout."""
+    n_actions = self.env.n_actions
+    states = []
+    actions = []
+    scores = []
+    for i in range(self.a3c.max_rollout_length):
+      if self.env.terminated:
+        break
+      states.append(self.env.state)
+      feed_dict = {self.features.out_tensor: np.expand_dims(self.env.state, axis=0)}
+      probabilities = sess.run(self.action_prob.out_tensor, feed_dict=feed_dict)
+      action = np.random.choice([0,1], p=probabilities[0])
+      actions.append(np.zeros(n_actions))
+      actions[i][action] = 1.0
+      scores.append(self.env.step(action))
+    if not self.env.terminated:
+      # Add an estimate of the reward for the rest of the episode.
+      feed_dict = {self.features.out_tensor: np.expand_dims(self.env.state, axis=0)}
+      scores[-1] += sess.run(self.value.out_tensor, feed_dict)
+    for j in range(len(scores)-1, 0, -1):
+      scores[j-1] += self.a3c.discount_factor*scores[j]
+    if self.env.terminated:
+      self.env.reset()
+    return np.array(states), np.array(actions), np.array(scores).reshape((len(scores), 1))

--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -235,7 +235,7 @@ class _Worker(object):
       self.train_op = a3c._graph._get_tf('Optimizer').apply_gradients(
           grads_and_vars)
       self.update_local_variables = tf.group(
-          *[tf.assign(v1, v2) for v1, v2 in zip(local_vars, global_vars)])
+          * [tf.assign(v1, v2) for v1, v2 in zip(local_vars, global_vars)])
 
   def run(self, step_count, total_steps):
     with self.graph._get_tf("Graph").as_default():

--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -11,8 +11,10 @@ import os
 import re
 import threading
 
+
 class A3CLoss(Layer):
   """This layer computes the loss function for A3C."""
+
   def __init__(self, value_weight, entropy_weight, **kwargs):
     super(A3CLoss, self).__init__(**kwargs)
     self.value_weight = value_weight
@@ -21,15 +23,17 @@ class A3CLoss(Layer):
   def create_tensor(self, **kwargs):
     reward, action, prob, value = [layer.out_tensor for layer in self.in_layers]
     log_prob = tf.log(prob)
-    policy_loss = -tf.reduce_sum((reward-value)*tf.reduce_sum(action*log_prob))
-    value_loss = tf.reduce_sum(tf.square(reward-value))
-    entropy = -tf.reduce_sum(prob*log_prob)
-    self.out_tensor = policy_loss + self.value_weight*value_loss - self.entropy_weight*entropy
+    policy_loss = -tf.reduce_sum(
+        (reward - value) * tf.reduce_sum(action * log_prob))
+    value_loss = tf.reduce_sum(tf.square(reward - value))
+    entropy = -tf.reduce_sum(prob * log_prob)
+    self.out_tensor = policy_loss + self.value_weight * value_loss - self.entropy_weight * entropy
     return self.out_tensor
 
 
 def _create_feed_dict(features, state):
-  return dict((f.out_tensor, np.expand_dims(s, axis=0)) for f,s in zip(features, state))
+  return dict((f.out_tensor, np.expand_dims(s, axis=0))
+              for f, s in zip(features, state))
 
 
 class A3C(object):
@@ -49,7 +53,14 @@ class A3C(object):
   "action" argument passed to the environment is an integer, giving the index of the action to perform.
   """
 
-  def __init__(self, env, policy, max_rollout_length=20, discount_factor=0.99, value_weight=1.0, entropy_weight=0.01, model_dir=None):
+  def __init__(self,
+               env,
+               policy,
+               max_rollout_length=20,
+               discount_factor=0.99,
+               value_weight=1.0,
+               entropy_weight=0.01,
+               model_dir=None):
     """Create an object for optimizing a policy.
 
     Parameters
@@ -76,21 +87,30 @@ class A3C(object):
     self.discount_factor = discount_factor
     self.value_weight = value_weight
     self.entropy_weight = entropy_weight
-    self.optimizer = TFWrapper(tf.train.AdamOptimizer, learning_rate=0.001, beta1=0.9, beta2=0.999)
-    (self._graph, self._features, rewards, actions, self._action_prob, self._value) = self._build_graph(None, 'global', model_dir)
+    self.optimizer = TFWrapper(
+        tf.train.AdamOptimizer, learning_rate=0.001, beta1=0.9, beta2=0.999)
+    (self._graph, self._features, rewards, actions, self._action_prob,
+     self._value) = self._build_graph(None, 'global', model_dir)
     with self._graph._get_tf("Graph").as_default():
       self._session = tf.Session()
 
   def _build_graph(self, tf_graph, scope, model_dir):
     """Construct a TensorGraph containing the policy and loss calculations."""
-    features = [Feature(shape=[None]+list(s)) for s in self._env.state_shape]
+    features = [Feature(shape=[None] + list(s)) for s in self._env.state_shape]
     policy_layers = self._policy.create_layers(features)
     action_prob = policy_layers['action_prob']
     value = policy_layers['value']
     rewards = Weights(shape=(None, 1))
     actions = Label(shape=(None, self._env.n_actions))
-    loss = A3CLoss(self.value_weight, self.entropy_weight, in_layers=[rewards, actions, action_prob, value])
-    graph = TensorGraph(batch_size=self.max_rollout_length, use_queue=False, graph=tf_graph, model_dir=model_dir)
+    loss = A3CLoss(
+        self.value_weight,
+        self.entropy_weight,
+        in_layers=[rewards, actions, action_prob, value])
+    graph = TensorGraph(
+        batch_size=self.max_rollout_length,
+        use_queue=False,
+        graph=tf_graph,
+        model_dir=model_dir)
     graph.add_output(action_prob)
     graph.add_output(value)
     graph.set_loss(loss)
@@ -100,7 +120,8 @@ class A3C(object):
         graph.build()
     return graph, features, rewards, actions, action_prob, value
 
-  def fit(self, total_steps, max_checkpoints_to_keep=5, checkpoint_interval=600):
+  def fit(self, total_steps, max_checkpoints_to_keep=5,
+          checkpoint_interval=600):
     """Train the policy.
 
     Parameters
@@ -123,7 +144,9 @@ class A3C(object):
       for i in range(multiprocessing.cpu_count()):
         workers.append(_Worker(self, i))
       for worker in workers:
-        thread = threading.Thread(name=worker.scope, target=lambda: worker.run(step_count, total_steps))
+        thread = threading.Thread(
+            name=worker.scope,
+            target=lambda: worker.run(step_count, total_steps))
         threads.append(thread)
         thread.start()
       saver = tf.train.Saver(max_to_keep=max_checkpoints_to_keep)
@@ -133,7 +156,8 @@ class A3C(object):
         if len(threads) > 0:
           threads[0].join(checkpoint_interval)
         checkpoint_index += 1
-        saver.save(self._session, self._graph.save_file, global_step=checkpoint_index)
+        saver.save(
+            self._session, self._graph.save_file, global_step=checkpoint_index)
         if len(threads) == 0:
           break
 
@@ -151,7 +175,9 @@ class A3C(object):
     """
     with self._graph._get_tf("Graph").as_default():
       feed_dict = _create_feed_dict(self._features, state)
-      return self._session.run([self._action_prob.out_tensor, self._value.out_tensor], feed_dict=feed_dict)
+      return self._session.run(
+          [self._action_prob.out_tensor, self._value.out_tensor],
+          feed_dict=feed_dict)
 
   def select_action(self, state, deterministic=False):
     """Select an action to perform based on the environment's state.
@@ -170,11 +196,13 @@ class A3C(object):
     """
     with self._graph._get_tf("Graph").as_default():
       feed_dict = _create_feed_dict(self._features, state)
-      probabilities = self._session.run(self._action_prob.out_tensor, feed_dict=feed_dict)
+      probabilities = self._session.run(
+          self._action_prob.out_tensor, feed_dict=feed_dict)
       if deterministic:
         return probabilities.argmax()
       else:
-        return np.random.choice(np.arange(self._env.n_actions), p=probabilities[0])
+        return np.random.choice(
+            np.arange(self._env.n_actions), p=probabilities[0])
 
   def restore(self):
     """Reload the model parameters from the most recent checkpoint file."""
@@ -195,14 +223,19 @@ class _Worker(object):
     self.scope = 'worker%d' % index
     self.env = copy.deepcopy(a3c._env)
     self.env.reset()
-    self.graph, self.features, self.rewards, self.actions, self.action_prob, self.value = a3c._build_graph(a3c._graph._get_tf('Graph'), self.scope, None)
+    self.graph, self.features, self.rewards, self.actions, self.action_prob, self.value = a3c._build_graph(
+        a3c._graph._get_tf('Graph'), self.scope, None)
     with a3c._graph._get_tf("Graph").as_default():
-      local_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, self.scope)
-      global_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES, 'global')
+      local_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                     self.scope)
+      global_vars = tf.get_collection(tf.GraphKeys.TRAINABLE_VARIABLES,
+                                      'global')
       gradients = tf.gradients(self.graph.loss.out_tensor, local_vars)
       grads_and_vars = list(zip(gradients, global_vars))
-      self.train_op = a3c._graph._get_tf('Optimizer').apply_gradients(grads_and_vars)
-      self.update_local_variables = tf.group(*[tf.assign(v1, v2) for v1, v2 in zip(local_vars, global_vars)])
+      self.train_op = a3c._graph._get_tf('Optimizer').apply_gradients(
+          grads_and_vars)
+      self.update_local_variables = tf.group(
+          *[tf.assign(v1, v2) for v1, v2 in zip(local_vars, global_vars)])
 
   def run(self, step_count, total_steps):
     with self.graph._get_tf("Graph").as_default():
@@ -211,7 +244,7 @@ class _Worker(object):
         session.run(self.update_local_variables)
         episode_states, episode_actions, episode_rewards = self.create_rollout()
         feed_dict = {}
-        for f,s in zip(self.features, episode_states):
+        for f, s in zip(self.features, episode_states):
           feed_dict[f.out_tensor] = s
         feed_dict[self.rewards.out_tensor] = episode_rewards
         feed_dict[self.actions.out_tensor] = episode_actions
@@ -232,7 +265,8 @@ class _Worker(object):
       for j in range(len(state)):
         states[j].append(state[j])
       feed_dict = _create_feed_dict(self.features, state)
-      probabilities = session.run(self.action_prob.out_tensor, feed_dict=feed_dict)
+      probabilities = session.run(
+          self.action_prob.out_tensor, feed_dict=feed_dict)
       action = np.random.choice(np.arange(n_actions), p=probabilities[0])
       actions.append(np.zeros(n_actions))
       actions[i][action] = 1.0
@@ -240,9 +274,11 @@ class _Worker(object):
     if not self.env.terminated:
       # Add an estimate of the reward for the rest of the episode.
       feed_dict = _create_feed_dict(self.features, self.env.state)
-      rewards[-1] += self.a3c.discount_factor*session.run(self.value.out_tensor, feed_dict)
-    for j in range(len(rewards)-1, 0, -1):
-      rewards[j-1] += self.a3c.discount_factor*rewards[j]
+      rewards[-1] += self.a3c.discount_factor * session.run(
+          self.value.out_tensor, feed_dict)
+    for j in range(len(rewards) - 1, 0, -1):
+      rewards[j - 1] += self.a3c.discount_factor * rewards[j]
     if self.env.terminated:
       self.env.reset()
-    return np.array(states), np.array(actions), np.array(rewards).reshape((len(rewards), 1))
+    return np.array(states), np.array(actions), np.array(rewards).reshape(
+        (len(rewards), 1))

--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -1,0 +1,116 @@
+"""Asynchronous Advantage Actor-Critic (A3C) algorithm for reinforcement learning."""
+
+from deepchem.models import TensorGraph
+from deepchem.models.tensorgraph import TFWrapper
+from deepchem.models.tensorgraph.layers import Feature, Weights, Label, Layer
+import numpy as np
+import tensorflow as tf
+
+class A3CLoss(Layer):
+  def __init__(self, value_weight, entropy_weight, **kwargs):
+    super(A3CLoss, self).__init__(**kwargs)
+    self.value_weight = value_weight
+    self.entropy_weight = entropy_weight
+
+  def create_tensor(self, **kwargs):
+    reward, action, prob, value = [layer.out_tensor for layer in self.in_layers]
+    log_prob = tf.log(prob)
+    policy_loss = -tf.reduce_sum((reward-value)*tf.reduce_sum(action*log_prob))
+    value_loss = tf.reduce_sum(tf.square(reward-value))
+    entropy = tf.reduce_sum(prob*log_prob)
+    self.out_tensor = policy_loss + self.value_weight*value_loss - self.entropy_weight*entropy
+    return self.out_tensor
+
+class A3C(object):
+  """
+  Implements the Asynchronous Advantage Actor-Critic (A3C) algorithm for reinforcement learning.
+
+  This algorithm requires the policy to output two quantities: a vector giving the probably of
+  taking each action, and an estimate of the value function for the current state.  It optimizes
+  both outputs at once using a loss that is the sum of three terms:
+
+  1. The policy loss, which seeks to maximize the discounted reward for each action.
+  2. The value loss, which tries to make the value estimate match the actual discounted reward
+     that was attained at each step.
+  3. An entropy term to encourage exploration.
+  """
+
+  def __init__(self, env, policy, max_rollout_length, discount_factor=0.99, value_weight=0.25, entropy_weight=0.01):
+    """Create an object for optimizing a policy.
+
+    Parameters
+    ----------
+    env: Environment
+      the Environment to interact with
+    policy: Policy
+      the Policy to optimize.  Its create_layers() method must return a map containing the
+      keys 'action_prob' and 'value', corresponding to the action probabilities and value estimate
+    max_rollout_length: int
+      the maximum length of rollouts to generate
+    discount_factor: float
+      the discount factor to use when computing rewards
+    value_weight: float
+      a scale factor for the value loss term in the loss function
+    entropy:weight: float
+      a scale factor for the entropy term in the loss function
+    """
+    self._env = env
+    self._policy = policy
+    self.max_rollout_length = max_rollout_length
+    self.discount_factor = discount_factor
+    self.value_weight = value_weight
+    self.entropy_weight = entropy_weight
+    self.optimizer = TFWrapper(tf.train.AdamOptimizer, learning_rate=0.001, beta1=0.9, beta2=0.999)
+
+  def _build_graph(self):
+    """Construct a TensorGraph containing the policy and loss calculations."""
+    features = Feature(shape=[None]+list(self._env.state_shape))
+    policy_layers = self._policy.create_layers(features)
+    action_prob = policy_layers['action_prob']
+    value = policy_layers['value']
+    rewards = Weights(shape=(None, 1))
+    actions = Label(shape=(None, self._env.n_actions))
+    loss = A3CLoss(self.value_weight, self.entropy_weight, in_layers=[rewards, actions, action_prob, value])
+    graph = TensorGraph(batch_size=self.max_rollout_length, use_queue=False)
+    graph.add_output(action_prob)
+    graph.add_output(value)
+    graph.set_loss(loss)
+    graph.set_optimizer(self.optimizer)
+    graph.build()
+    return graph, features, rewards, actions, action_prob, value
+
+  def _create_rollout(self, sess, features, action_prob):
+    """Generate a rollout."""
+    n_actions = self._env.n_actions
+    self._env.reset()
+    states = []
+    actions = []
+    scores = []
+    for i in range(self.max_rollout_length):
+      if self._env.terminated:
+        break
+      states.append(self._env.state)
+      feed_dict = {features.out_tensor: np.expand_dims(self._env.state, axis=0)}
+      probabilities = sess.run(action_prob.out_tensor, feed_dict=feed_dict)
+      action = np.random.choice([0,1], p=probabilities[0])
+      actions.append(np.zeros(n_actions))
+      actions[i][action] = 1.0
+      scores.append(self._env.step(action))
+    for j in range(len(scores)-1, 0, -1):
+      scores[j-1] += self.discount_factor*scores[j]
+    return np.array(states), np.array(actions), np.array(scores).reshape((len(scores), 1))
+
+  def fit(self, n_episodes):
+    (graph, features, rewards, actions, action_prob, value) = self._build_graph()
+    with graph._get_tf("Graph").as_default():
+      train_op = graph._get_tf('train_op')
+      with tf.Session() as sess:
+        sess.run(tf.global_variables_initializer())
+        for i in range(n_episodes):
+          episode_states, episode_actions, episode_rewards = self._create_rollout(sess, features, action_prob)
+          feed_dict = {}
+          feed_dict[features.out_tensor] = episode_states
+          feed_dict[rewards.out_tensor] = episode_rewards
+          feed_dict[actions.out_tensor] = episode_actions
+          sess.run(train_op, feed_dict=feed_dict)
+

--- a/deepchem/rl/tests/test_a3c.py
+++ b/deepchem/rl/tests/test_a3c.py
@@ -16,20 +16,21 @@ class TestA3C(unittest.TestCase):
     # strategy is to walk away.
 
     class RouletteEnvironment(dc.rl.Environment):
+
       def __init__(self):
         super().__init__([(1,)], 38)
         self._state = [np.array([0])]
 
       def step(self, action):
         if action == 37:
-          self._terminated = True # Walk away.
+          self._terminated = True  # Walk away.
           return 0.0
         wheel = np.random.randint(37)
         if wheel == 0:
           if action == 0:
             return 35.0
           return -1.0
-        if action != 0 and wheel%2 == action%2:
+        if action != 0 and wheel % 2 == action % 2:
           return 1.0
         return -1.0
 
@@ -41,16 +42,20 @@ class TestA3C(unittest.TestCase):
     # This policy just learns a constant probability for each action, and a constant for the value.
 
     class TestPolicy(dc.rl.Policy):
+
       def create_layers(self, state, **kwargs):
         action = Dense(in_layers=state, out_channels=env.n_actions)
-        output = SoftMax(in_layers=[Reshape(in_layers=[action], shape=(-1, env.n_actions))])
+        output = SoftMax(
+            in_layers=[Reshape(in_layers=[action], shape=(-1, env.n_actions))])
         value = Dense(in_layers=state, out_channels=1)
-        return {'action_prob':output, 'value':value}
+        return {'action_prob': output, 'value': value}
 
     # Optimize it.
 
-    a3c = dc.rl.A3C(env, TestPolicy(), value_weight=100.0, max_rollout_length=50)
-    a3c.optimizer = dc.models.tensorgraph.TFWrapper(tf.train.AdamOptimizer, learning_rate=0.2)
+    a3c = dc.rl.A3C(
+        env, TestPolicy(), value_weight=100.0, max_rollout_length=50)
+    a3c.optimizer = dc.models.tensorgraph.TFWrapper(
+        tf.train.AdamOptimizer, learning_rate=0.2)
     a3c.fit(100000)
 
     # It should have learned that the expected value is very close to zero, and that the best

--- a/deepchem/rl/tests/test_a3c.py
+++ b/deepchem/rl/tests/test_a3c.py
@@ -60,3 +60,11 @@ class TestA3C(unittest.TestCase):
     assert -0.5 < value[0] < 0.5
     assert action_prob.argmax() == 37
     assert a3c.select_action([0], deterministic=True) == 37
+
+    # Verify that we can create a new A3C object, reload the parameters from the first one, and
+    # get the same result.
+
+    new_a3c = dc.rl.A3C(env, TestPolicy(), model_dir=a3c._graph.model_dir)
+    new_a3c.restore()
+    action_prob2, value2 = new_a3c.predict([0])
+    assert value2 == value


### PR DESCRIPTION
The goal of this PR is to create a generic interface for reinforcement learning, as well as an implementation of the A3C algorithm.  I still have a lot of work to do, but I'd like to start getting feedback on it.

Here's an example of what code using it looks like:

```Python
import deepchem as dc
from deepchem.rl.a3c import A3C
from deepchem.models.tensorgraph.layers import Reshape, Dense, SoftMax
import tensorflow as tf

# Create the environment.

env = dc.rl.GymEnvironment('CartPole-v0')

# Create the policy.

class TestPolicy(dc.rl.Policy):
  def create_layers(self, features, **kwargs):
    action = Dense(in_layers=[features], out_channels=2, biases_initializer=None)
    output = SoftMax(in_layers=[Reshape(in_layers=[action], shape=(-1, 2))])
    value1 = Dense(in_layers=[features], out_channels=10, activation_fn=tf.nn.relu)
    value2 = Dense(in_layers=[value1], out_channels=1)
    return {'action_prob':output, 'value':value2}

# Optimize it.

a3c = A3C(env, TestPolicy())
a3c.fit(20000)
```

I've had to make a few changes to TensorGraph to support this.  I need to be able to create several copies of a TensorGraph all sharing the same tf.Graph.  The variables they create all need to have identical names, but each in a different scope.

One issue I'd especially like feedback on.  The implementation of A3C assumes there's a fixed set of discrete actions that can be chosen, and the policy outputs a vector containing the probability of each action.  Is that going to work for everyone?  In principle A3C can also support continuous action spaces, but that would require a different interface.