### PR TITLE
Improved A3C checkpointing

### DIFF
--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -124,7 +124,7 @@ class A3C(object):
     return graph, features, rewards, actions, action_prob, value
 
   def fit(self, total_steps, max_checkpoints_to_keep=5,
-          checkpoint_interval=600):
+          checkpoint_interval=600, restore=False):
     """Train the policy.
 
     Parameters
@@ -137,6 +137,9 @@ class A3C(object):
       files are deleted.
     checkpoint_interval: float
       the time interval at which to save checkpoints, measured in seconds
+    restore: bool
+      if True, restore the model from the most recent checkpoint and continue training
+      from there.  If False, retrain the model from scratch.
     """
     with self._graph._get_tf("Graph").as_default():
       step_count = [0]
@@ -145,13 +148,16 @@ class A3C(object):
       for i in range(multiprocessing.cpu_count()):
         workers.append(_Worker(self, i))
       self._session.run(tf.global_variables_initializer())
+      if restore:
+        self.restore()
       for worker in workers:
         thread = threading.Thread(
             name=worker.scope,
             target=lambda: worker.run(step_count, total_steps))
         threads.append(thread)
         thread.start()
-      saver = tf.train.Saver(max_to_keep=max_checkpoints_to_keep)
+      variables = tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope='global')
+      saver = tf.train.Saver(variables, max_to_keep=max_checkpoints_to_keep)
       checkpoint_index = 0
       while True:
         threads = [t for t in threads if t.isAlive()]
@@ -212,7 +218,8 @@ class A3C(object):
     if last_checkpoint is None:
       raise ValueError('No checkpoint found')
     with self._graph._get_tf("Graph").as_default():
-      saver = tf.train.Saver()
+      variables = tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope='global')
+      saver = tf.train.Saver(variables)
       saver.restore(self._session, last_checkpoint)
 
 

--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -123,8 +123,11 @@ class A3C(object):
         graph.build()
     return graph, features, rewards, actions, action_prob, value
 
-  def fit(self, total_steps, max_checkpoints_to_keep=5,
-          checkpoint_interval=600, restore=False):
+  def fit(self,
+          total_steps,
+          max_checkpoints_to_keep=5,
+          checkpoint_interval=600,
+          restore=False):
     """Train the policy.
 
     Parameters
@@ -156,7 +159,8 @@ class A3C(object):
             target=lambda: worker.run(step_count, total_steps))
         threads.append(thread)
         thread.start()
-      variables = tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope='global')
+      variables = tf.get_collection(
+          tf.GraphKeys.GLOBAL_VARIABLES, scope='global')
       saver = tf.train.Saver(variables, max_to_keep=max_checkpoints_to_keep)
       checkpoint_index = 0
       while True:
@@ -218,7 +222,8 @@ class A3C(object):
     if last_checkpoint is None:
       raise ValueError('No checkpoint found')
     with self._graph._get_tf("Graph").as_default():
-      variables = tf.get_collection(tf.GraphKeys.GLOBAL_VARIABLES, scope='global')
+      variables = tf.get_collection(
+          tf.GraphKeys.GLOBAL_VARIABLES, scope='global')
       saver = tf.train.Saver(variables)
       saver.restore(self._session, last_checkpoint)
 

--- a/deepchem/rl/tests/test_a3c.py
+++ b/deepchem/rl/tests/test_a3c.py
@@ -73,3 +73,10 @@ class TestA3C(unittest.TestCase):
     new_a3c.restore()
     action_prob2, value2 = new_a3c.predict([[0]])
     assert value2 == value
+
+    # Do the same thing, only using the "restore" argument to fit().
+
+    new_a3c = dc.rl.A3C(env, TestPolicy(), model_dir=a3c._graph.model_dir)
+    new_a3c.fit(0, restore=True)
+    action_prob2, value2 = new_a3c.predict([[0]])
+    assert value2 == value


### PR DESCRIPTION
This includes two changes.  First, I added a `restore` option to `fit()` that tells it to continue training from the most recent checkpoint, rather than starting from scratch.  Second, it now only saves the variables from the global graph, not the worker graphs.  This should make saved models more portable, since they won't depend on the specific number of threads that was used for training.