### PR TITLE
Install XGBoost from conda-forge

### DIFF
--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -19,7 +19,7 @@ import deepchem as dc
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.linear_model import LinearRegression
 from sklearn.linear_model import LogisticRegression
-import xgboost
+from deepchem.utils.dependencies import xgboost
 
 
 class TestGeneralize(unittest.TestCase):

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -39,7 +39,7 @@ conda install -y -c conda-forge keras=1.2.2
 yes | pip install --upgrade $protobuf_url
 yes | pip install --upgrade $protobuf_url
 conda install -y -c anaconda networkx=1.11
-conda install -y -c bioconda xgboost=0.6a2
+conda install -y -c conda-forge xgboost=0.6a2
 conda install -y -c pillow
 conda install -y -c anaconda pandas=0.19.2
 yes | pip install $tensorflow==1.0.1


### PR DESCRIPTION
Bioconda onlyl had XGBoost for python 3.4
This meant that we no longer were able to install xgboost on 2.7 or 3.5.  We were now hard pinning the python version with my CR instead of letting it float for whatever packages were supported.

Not sure why travis green lit my PR though.