### PR TITLE
PDBBind Dataset Load Error #592

### DIFF
--- a/deepchem/utils/rdkit_util.py
+++ b/deepchem/utils/rdkit_util.py
@@ -51,6 +51,9 @@ def add_hydrogens_to_mol(mol):
     pdb_stringio.write(pdbblock)
     pdb_stringio.seek(0)
     fixer = pdbfixer.PDBFixer(pdbfile=pdb_stringio)
+    fixer.findMissingResidues()
+    fixer.findMissingAtoms()
+    fixer.addMissingAtoms()
     fixer.addMissingHydrogens(7.4)
 
     hydrogenated_io = StringIO()


### PR DESCRIPTION
Added fix to handle missing atoms in residues before assigning protonation.

 This specifically will resolve issues where atoms are missing in residues i.e. 2aac.  If the residue is not complete then assigning protonation fails.  Tested this on several problematic PDBs. 