### PR TITLE
Fixes for ACNN

### DIFF
--- a/contrib/atomicconv/acnn/core/tensor_graph_hyper_param_search.py
+++ b/contrib/atomicconv/acnn/core/tensor_graph_hyper_param_search.py
@@ -83,6 +83,9 @@ def params():
   for values in itertools.product(radial1, radial2, radial3, layer_sizes,
                                   learning_rates, epochs):
     d = {
+        "frag1_num_atoms": 140,
+        "frag2_num_atoms": 821,
+        "complex_num_atoms": 908,
         "radial": [values[0], values[1], values[2]],
         "layer_sizes": values[3],
         "learning_rate": values[4],

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -483,7 +483,7 @@ class L2Loss(Layer):
     inputs = self._get_input_tensors(in_layers, True)
     guess, label = inputs[0], inputs[1]
     out_tensor = tf.reduce_mean(
-        tf.square(guess - label), axis=list(range(1, len(label.shape))))
+        tf.square(guess - label))
     if set_tensors:
       self.out_tensor = out_tensor
     return out_tensor

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -483,7 +483,7 @@ class L2Loss(Layer):
     inputs = self._get_input_tensors(in_layers, True)
     guess, label = inputs[0], inputs[1]
     out_tensor = tf.reduce_mean(
-        tf.square(guess - label))
+        tf.square(guess - label), axis=list(range(1, len(label.shape))))
     if set_tensors:
       self.out_tensor = out_tensor
     return out_tensor

--- a/deepchem/models/tensorgraph/models/atomic_conv.py
+++ b/deepchem/models/tensorgraph/models/atomic_conv.py
@@ -9,7 +9,7 @@ __license__ = "MIT"
 import sys
 
 sys.path.append("../../models")
-from deepchem.models.tensorgraph.layers import Layer, Feature, Label, AtomicConvolution, L2Loss
+from deepchem.models.tensorgraph.layers import Layer, Feature, Label, AtomicConvolution, L2Loss, ReduceMean
 from deepchem.models import TensorGraph
 
 import numpy as np
@@ -212,7 +212,7 @@ def atomic_conv_model(
       ])
 
   label = Label(shape=(None, 1))
-  loss = L2Loss(in_layers=[score, label])
+  loss = ReduceMean(in_layers=L2Loss(in_layers=[score, label]))
 
   def feed_dict_generator(dataset, batch_size, epochs=1, pad_batches=True):
 

--- a/deepchem/models/tensorgraph/models/atomic_conv.py
+++ b/deepchem/models/tensorgraph/models/atomic_conv.py
@@ -64,7 +64,7 @@ class AtomicConvScore(Layer):
     self.layer_sizes = layer_sizes
     super(AtomicConvScore, self).__init__(**kwargs)
 
-  def _create_tensor(self):
+  def create_tensor(self, **kwargs):
     frag1_layer = self.in_layers[0].out_tensor
     frag2_layer = self.in_layers[1].out_tensor
     complex_layer = self.in_layers[2].out_tensor

--- a/deepchem/models/tensorgraph/models/atomic_conv.py
+++ b/deepchem/models/tensorgraph/models/atomic_conv.py
@@ -64,7 +64,7 @@ class AtomicConvScore(Layer):
     self.layer_sizes = layer_sizes
     super(AtomicConvScore, self).__init__(**kwargs)
 
-  def create_tensor(self, **kwargs):
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     frag1_layer = self.in_layers[0].out_tensor
     frag2_layer = self.in_layers[1].out_tensor
     complex_layer = self.in_layers[2].out_tensor


### PR DESCRIPTION
Updates to ACNN
* Dataset sizes changed -- I believe hydrogens were added @joegomes 
* layer#create_tensor now takes **kwargs
* L2Loss should reduce to single scaler 

@hxfroi the specific error you were seeing was because of the Dataset size changes.
Atomic convs takes as a parameter how big the largest fragment for each subfragment in number of atoms.  The new datasets are larger (I assume because hydrogens are no longer stripped).