### PR TITLE
Changed scaling of A3C loss function

### DIFF
--- a/deepchem/rl/a3c.py
+++ b/deepchem/rl/a3c.py
@@ -26,9 +26,9 @@ class A3CLoss(Layer):
     ]
     prob = prob + np.finfo(np.float32).eps
     log_prob = tf.log(prob)
-    policy_loss = -tf.reduce_sum(advantage * tf.reduce_sum(action * log_prob))
-    value_loss = tf.reduce_sum(tf.square(reward - value))
-    entropy = -tf.reduce_sum(prob * log_prob)
+    policy_loss = -tf.reduce_mean(advantage * tf.reduce_sum(action * log_prob))
+    value_loss = tf.reduce_mean(tf.square(reward - value))
+    entropy = -tf.reduce_mean(tf.reduce_sum(prob * log_prob, axis=1))
     self.out_tensor = policy_loss + self.value_weight * value_loss - self.entropy_weight * entropy
     return self.out_tensor
 

--- a/deepchem/rl/tests/test_a3c.py
+++ b/deepchem/rl/tests/test_a3c.py
@@ -58,9 +58,9 @@ class TestA3C(unittest.TestCase):
     a3c = dc.rl.A3C(
         env,
         TestPolicy(),
-        max_rollout_length=50,
+        max_rollout_length=20,
         optimizer=dc.models.tensorgraph.TFWrapper(
-            tf.train.AdamOptimizer, learning_rate=0.0001))
+            tf.train.AdamOptimizer, learning_rate=0.001))
     a3c.fit(100000)
 
     # It should have learned that the expected value is very close to zero, and that the best


### PR DESCRIPTION
I changed `reduce_sum()` to `reduce_mean()`.  Previously, the loss was proportional to the rollout length, which meant you had to adjust the learning rate based on the rollout length.  This change makes it a bit more convenient to work with.