### PR TITLE
Preventing TF from allocating all of the GPU mem

### DIFF
--- a/deepchem/models/tensorflow_models/__init__.py
+++ b/deepchem/models/tensorflow_models/__init__.py
@@ -482,11 +482,15 @@ class TensorflowGraphModel(Model):
     if train:
       if not self.train_graph.session:
         config = tf.ConfigProto(allow_soft_placement=True)
+        #gpu memory growth option
+        config.gpu_options.allow_growth=True
         self.train_graph.session = tf.Session(config=config)
       return self.train_graph.session
     else:
       if not self.eval_graph.session:
         config = tf.ConfigProto(allow_soft_placement=True)
+        #gpu memory growth option
+        config.gpu_options.allow_growth=True
         self.eval_graph.session = tf.Session(config=config)
       return self.eval_graph.session
 


### PR DESCRIPTION
This is a minor modification. I have tested this, and I am using it this way.

By default, TensorFlow maps nearly all of the GPU memory of all GPUs. It is one of the drawbacks of TF. 
This option helps to build a more flexible environment.
(Nevertheless, I am not happy with TF's memory management.)