### PR TITLE
Ipython Notebooks Testing Framework

### DIFF
--- a/deepchem/hyper/__init__.py
+++ b/deepchem/hyper/__init__.py
@@ -40,8 +40,6 @@ class HyperparamOpt(object):
 
     number_combinations = reduce(mul, [len(vals) for vals in hyperparam_vals])
 
-    valid_csv_out = tempfile.NamedTemporaryFile()
-    valid_stats_out = tempfile.NamedTemporaryFile()
     if use_max:
       best_validation_score = -np.inf
     else:
@@ -75,8 +73,7 @@ class HyperparamOpt(object):
       model.save()
     
       evaluator = Evaluator(model, valid_dataset, output_transformers)
-      multitask_scores = evaluator.compute_model_performance(
-          [metric], valid_csv_out.name, valid_stats_out.name)
+      multitask_scores = evaluator.compute_model_performance([metric])
       valid_score = multitask_scores[metric.name]
       all_scores[str(hyperparameter_tuple)] = valid_score
     
@@ -101,11 +98,8 @@ class HyperparamOpt(object):
       # arbitrarily return last model
       best_model, best_hyperparams = model, hyperparameter_tuple
       return best_model, best_hyperparams, all_scores
-    train_csv_out = tempfile.NamedTemporaryFile()
-    train_stats_out = tempfile.NamedTemporaryFile()
     train_evaluator = Evaluator(best_model, train_dataset, output_transformers)
-    multitask_scores = train_evaluator.compute_model_performance(
-        [metric], train_csv_out.name, train_stats_out.name)
+    multitask_scores = train_evaluator.compute_model_performance( [metric])
     train_score = multitask_scores[metric.name]
     log("Best hyperparameters: %s" % str(best_hyperparams),
         self.verbose)

--- a/deepchem/hyper/__init__.py
+++ b/deepchem/hyper/__init__.py
@@ -12,6 +12,7 @@ from operator import mul
 from deepchem.utils.evaluate import Evaluator
 from deepchem.utils.save import log
 
+
 class HyperparamOpt(object):
   """
   Provides simple hyperparameter search capabilities.
@@ -23,8 +24,13 @@ class HyperparamOpt(object):
 
   # TODO(rbharath): This function is complicated and monolithic. Is there a nice
   # way to refactor this?
-  def hyperparam_search(self, params_dict, train_dataset, valid_dataset,
-                        output_transformers, metric, use_max=True,
+  def hyperparam_search(self,
+                        params_dict,
+                        train_dataset,
+                        valid_dataset,
+                        output_transformers,
+                        metric,
+                        use_max=True,
                         logdir=None):
     """Perform hyperparams search according to params_dict.
     
@@ -32,9 +38,9 @@ class HyperparamOpt(object):
     of potential values for that hyperparam. 
 
     TODO(rbharath): This shouldn't be stored in a temporary directory.
-    """ 
+    """
     hyperparams = params_dict.keys()
-    hyperparam_vals = params_dict.values() 
+    hyperparam_vals = params_dict.values()
     for hyperparam_list in params_dict.values():
       assert isinstance(hyperparam_list, collections.Iterable)
 
@@ -47,10 +53,10 @@ class HyperparamOpt(object):
     best_hyperparams = None
     best_model, best_model_dir = None, None
     all_scores = {}
-    for ind, hyperparameter_tuple in enumerate(itertools.product(*hyperparam_vals)):
+    for ind, hyperparameter_tuple in enumerate(
+        itertools.product(*hyperparam_vals)):
       model_params = {}
-      log("Fitting model %d/%d" % (ind+1, number_combinations),
-          self.verbose)
+      log("Fitting model %d/%d" % (ind + 1, number_combinations), self.verbose)
       for hyperparam, hyperparam_val in zip(hyperparams, hyperparameter_tuple):
         model_params[hyperparam] = hyperparam_val
       log("hyperparameters: %s" % str(model_params), self.verbose)
@@ -58,7 +64,7 @@ class HyperparamOpt(object):
       if logdir is not None:
         model_dir = os.path.join(logdir, str(ind))
         log("model_dir is %s" % model_dir, self.verbose)
-        try: 
+        try:
           os.makedirs(model_dir)
         except OSError:
           if not os.path.isdir(model_dir):
@@ -71,12 +77,12 @@ class HyperparamOpt(object):
       model = self.model_class(model_params, model_dir)
       model.fit(train_dataset, **model_params)
       model.save()
-    
+
       evaluator = Evaluator(model, valid_dataset, output_transformers)
       multitask_scores = evaluator.compute_model_performance([metric])
       valid_score = multitask_scores[metric.name]
       all_scores[str(hyperparameter_tuple)] = valid_score
-    
+
       if (use_max and valid_score >= best_validation_score) or (
           not use_max and valid_score <= best_validation_score):
         best_validation_score = valid_score
@@ -87,10 +93,10 @@ class HyperparamOpt(object):
         best_model = model
       else:
         shutil.rmtree(model_dir)
-  
+
       log("Model %d/%d, Metric %s, Validation set %s: %f" %
-          (ind+1, number_combinations, metric.name, ind, valid_score),
-          self.verbose)
+          (ind + 1, number_combinations, metric.name, ind,
+           valid_score), self.verbose)
       log("\tbest_validation_score so far: %f" % best_validation_score,
           self.verbose)
     if best_model is None:
@@ -99,10 +105,9 @@ class HyperparamOpt(object):
       best_model, best_hyperparams = model, hyperparameter_tuple
       return best_model, best_hyperparams, all_scores
     train_evaluator = Evaluator(best_model, train_dataset, output_transformers)
-    multitask_scores = train_evaluator.compute_model_performance( [metric])
+    multitask_scores = train_evaluator.compute_model_performance([metric])
     train_score = multitask_scores[metric.name]
-    log("Best hyperparameters: %s" % str(best_hyperparams),
-        self.verbose)
+    log("Best hyperparameters: %s" % str(best_hyperparams), self.verbose)
     log("train_score: %f" % train_score, self.verbose)
     log("validation_score: %f" % best_validation_score, self.verbose)
     return best_model, best_hyperparams, all_scores

--- a/devtools/jenkins/jenkins.sh
+++ b/devtools/jenkins/jenkins.sh
@@ -18,5 +18,3 @@ export retval3=$?
 
 source deactivate
 conda remove --name $envname --all
-export retval=$(($retval1 + $retval2 + $retval3))
-return ${retval}

--- a/devtools/jenkins/jenkins.sh
+++ b/devtools/jenkins/jenkins.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 envname=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1`
+sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh
 bash scripts/install_deepchem_conda.sh $envname
 source activate $envname
 python setup.py install
@@ -18,4 +19,4 @@ export retval3=$?
 source deactivate
 conda remove --name $envname --all
 export retval=$(($retval1 + $retval2 + $retval3))
-exit ${retval}
+return ${retval}

--- a/devtools/jenkins/jenkins.sh
+++ b/devtools/jenkins/jenkins.sh
@@ -13,7 +13,7 @@ export retval1=$?
 cd ..
 nosetests -v devtools/jenkins/compare_results.py --with-xunit || true
 export retval2=$?
-nosetests -a 'slow' --with-timer deepchem --with-xunit -unit-file=slow_tests.xml|| true
+nosetests -a 'slow' --with-timer deepchem --with-xunit --xunit-file=slow_tests.xml|| true
 export retval3=$?
 
 source deactivate

--- a/devtools/jenkins/test_notebooks.sh
+++ b/devtools/jenkins/test_notebooks.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+envname=`cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1`
+sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh
+export python_version=2.7
+bash scripts/install_deepchem_conda.sh $envname
+source activate $envname
+python setup.py install
+conda install jupyter
+conda install nbconvert
+conda install jupyter_client
+conda install ipykernel
+conda install matplotlib
+pip install nglview
+conda install ipywidgets
+
+cd examples/notesbooks
+jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output tmp.ipynb protein_ligand_complex_notebook.ipynb
+
+nosetests --with-timer tests.py --with-xunit -unit-file=notebook_tests.xml|| true
+
+source deactivate
+conda remove --name $envname --all
+export retval=$(($retval1 + $retval2 + $retval3))
+return ${retval}

--- a/devtools/jenkins/test_notebooks.sh
+++ b/devtools/jenkins/test_notebooks.sh
@@ -17,5 +17,4 @@ cd examples/notebooks
 nosetests --with-timer tests.py --with-xunit --xunit-file=notebook_tests.xml|| true
 
 source deactivate
-#conda remove --name $envname --all
-return 0
+conda remove --name $envname --all

--- a/devtools/jenkins/test_notebooks.sh
+++ b/devtools/jenkins/test_notebooks.sh
@@ -13,12 +13,9 @@ conda install matplotlib
 pip install nglview
 conda install ipywidgets
 
-cd examples/notesbooks
-jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output tmp.ipynb protein_ligand_complex_notebook.ipynb
-
+cd examples/notebooks
 nosetests --with-timer tests.py --with-xunit --xunit-file=notebook_tests.xml|| true
 
 source deactivate
-conda remove --name $envname --all
-export retval=$(($retval1 + $retval2 + $retval3))
-return ${retval}
+#conda remove --name $envname --all
+return 0

--- a/devtools/jenkins/test_notebooks.sh
+++ b/devtools/jenkins/test_notebooks.sh
@@ -16,7 +16,7 @@ conda install ipywidgets
 cd examples/notesbooks
 jupyter-nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output tmp.ipynb protein_ligand_complex_notebook.ipynb
 
-nosetests --with-timer tests.py --with-xunit -unit-file=notebook_tests.xml|| true
+nosetests --with-timer tests.py --with-xunit --xunit-file=notebook_tests.xml|| true
 
 source deactivate
 conda remove --name $envname --all

--- a/examples/notebooks/Multitask Networks on MUV.ipynb
+++ b/examples/notebooks/Multitask Networks on MUV.ipynb
@@ -9,19 +9,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Automatic pdb calling has been turned OFF\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%reload_ext autoreload\n",
     "%autoreload 2\n",
@@ -31,22 +23,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Columns of dataset: ['MUV-466' 'MUV-548' 'MUV-600' 'MUV-644' 'MUV-652' 'MUV-689' 'MUV-692'\n",
-      " 'MUV-712' 'MUV-713' 'MUV-733' 'MUV-737' 'MUV-810' 'MUV-832' 'MUV-846'\n",
-      " 'MUV-852' 'MUV-858' 'MUV-859' 'mol_id' 'smiles']\n",
-      "Number of examples in dataset: 93127\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import deepchem as dc\n",
     "\n",
@@ -65,24 +46,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test0.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test1.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test10.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test11.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test2.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test3.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test4.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test5.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test6.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test7.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test8.png' /><img style='width: 140px; margin: 0px; float: left; border: 1px solid black;' src='test9.png' />"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from rdkit import Chem\n",
     "from rdkit.Chem import Draw\n",
@@ -114,150 +82,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading raw samples now.\n",
-      "shard_size: 8192\n",
-      "About to start loading CSV from ../../datasets/muv.csv.gz\n",
-      "Loading shard 1 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 0 took 22.680 s\n",
-      "Loading shard 2 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 1 took 31.196 s\n",
-      "Loading shard 3 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 2 took 29.828 s\n",
-      "Loading shard 4 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 3 took 16.055 s\n",
-      "Loading shard 5 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 4 took 21.150 s\n",
-      "Loading shard 6 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 5 took 16.878 s\n",
-      "Loading shard 7 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 6 took 16.032 s\n",
-      "Loading shard 8 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 7 took 16.518 s\n",
-      "Loading shard 9 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 8 took 17.401 s\n",
-      "Loading shard 10 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 9 took 21.326 s\n",
-      "Loading shard 11 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "Featurizing sample 4000\n",
-      "Featurizing sample 5000\n",
-      "Featurizing sample 6000\n",
-      "Featurizing sample 7000\n",
-      "Featurizing sample 8000\n",
-      "TIMING: featurizing shard 10 took 23.441 s\n",
-      "Loading shard 12 of size 8192.\n",
-      "Featurizing sample 0\n",
-      "Featurizing sample 1000\n",
-      "Featurizing sample 2000\n",
-      "Featurizing sample 3000\n",
-      "TIMING: featurizing shard 11 took 8.318 s\n",
-      "TIMING: dataset construction took 246.032 s\n",
-      "Loading dataset from disk.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "MUV_tasks = ['MUV-692', 'MUV-689', 'MUV-846', 'MUV-859', 'MUV-644',\n",
     "             'MUV-548', 'MUV-852', 'MUV-600', 'MUV-810', 'MUV-712',\n",
@@ -273,25 +102,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Computing train/valid/test indices\n",
-      "TIMING: dataset construction took 6.272 s\n",
-      "Loading dataset from disk.\n",
-      "TIMING: dataset construction took 3.243 s\n",
-      "Loading dataset from disk.\n",
-      "TIMING: dataset construction took 3.498 s\n",
-      "Loading dataset from disk.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "splitter = dc.splits.RandomSplitter(dataset_file)\n",
     "train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(\n",
@@ -302,61 +117,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Fitting model 1/1\n",
-      "hyperparameters: {'learning_rate': 0.001, 'layer_sizes': (1000,), 'data_shape': (1024,), 'dropouts': (0.5,), 'activation': 'relu', 'decay': 1e-06, 'batch_size': 50, 'penalty': 0.0, 'nesterov': False, 'init': 'glorot_uniform', 'bias_init_consts': (1.0,), 'weight_init_stddevs': (0.1,), 'batchnorm': False, 'nb_layers': 1, 'nb_epoch': 1, 'momentum': 0.9}\n",
-      "Training for 1 epochs\n",
-      "On batch 0\n",
-      "On batch 50\n",
-      "On batch 100\n",
-      "On batch 150\n",
-      "On batch 200\n",
-      "On batch 250\n",
-      "On batch 300\n",
-      "On batch 350\n",
-      "On batch 400\n",
-      "On batch 450\n",
-      "On batch 500\n",
-      "On batch 550\n",
-      "On batch 600\n",
-      "On batch 650\n",
-      "On batch 700\n",
-      "On batch 750\n",
-      "On batch 800\n",
-      "On batch 850\n",
-      "On batch 900\n",
-      "On batch 950\n",
-      "On batch 1000\n",
-      "On batch 1050\n",
-      "On batch 1100\n",
-      "On batch 1150\n",
-      "On batch 1200\n",
-      "On batch 1250\n",
-      "On batch 1300\n",
-      "On batch 1350\n",
-      "On batch 1400\n",
-      "On batch 1450\n",
-      "Ending epoch 0: Average loss 0.0517954\n",
-      "On batch 0\n",
-      "TIMING: model fitting took 42.847 s True\n",
-      "computed_metrics: [0.65548567435359884, 0.3938885157824043, 0.91541865214431595, 0.39478957915831664, 0.68465248721524885, 0.74978870858688307, 0.80529733424470273, 0.77885952712100137, 0.79980310400741261, 0.88896680691912111, 0.5185931899641576, 0.5150129017124091, 0.75240054869684503, 0.36638813096862211, 0.58238095238095244, 0.61817558299039777, 0.68414343983684567]\n",
-      "Model 1/1, Metric mean-roc_auc_score, Validation set 0: 0.653179\n",
-      "\tbest_validation_score so far: 0.653179\n",
-      "computed_metrics: [0.9154553963735379, 0.93463278293773655, 0.98457975954502508, 0.93589327852250226, 0.97265932420872547, 0.9838091436190004, 0.97946596833011079, 0.92610806949042246, 0.88254565136882901, 0.94433074824070085, 0.93797633429015803, 0.94311234732601956, 0.93923263973993476, 0.94550404459919302, 0.90309495615889945, 0.87384089962146405, 0.99468966106036016]\n",
-      "Best hyperparameters: (1e-06, (1024,), 1, 'relu', (1000,), 50, 0.0, False, 'glorot_uniform', (1.0,), (0.1,), 1, False, (0.5,), 0.001, 0.9)\n",
-      "train_score: 0.940996\n",
-      "validation_score: 0.653179\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import numpy.random\n",

--- a/examples/notebooks/protein_ligand_complex_notebook.ipynb
+++ b/examples/notebooks/protein_ligand_complex_notebook.ipynb
@@ -617,15 +617,10 @@
  ],
  "metadata": {
   "celltoolbar": "Slideshow",
-  "kernelspec": {
-   "display_name": "Python 2",
-   "language": "python",
-   "name": "python2"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 2.0
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
@@ -639,7 +634,7 @@
     "77e7e93946884ed7a2a1a48808f99a90": {
      "views": [
       {
-       "cell_index": 10
+       "cell_index": 10.0
       }
      ]
     }

--- a/examples/notebooks/protein_ligand_complex_notebook.ipynb
+++ b/examples/notebooks/protein_ligand_complex_notebook.ipynb
@@ -4,8 +4,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# ```deepchem```: Machine Learning models for Drug Discovery\n",
-    "#Tutorial 1: Basic Protein-Ligand Complex Featurized Models"
+    "# ```DeepChem```: Basic Protein-Ligand Affinity Models\n",
+    "#Tutorial: Use machine learning to model protein-ligand affinity."
    ]
   },
   {
@@ -16,7 +16,7 @@
     "\n",
     "Copyright 2016, Stanford University\n",
     "\n",
-    "#Welcome to the ```deepchem``` tutorial. In this iPython Notebook, one can follow along with the code below to learn how to fit machine learning models with rich predictive power on chemical datasets.  "
+    "This DeepChem tutorial demonstrates how to use mach.ine learning for modeling protein-ligand binding affinity"
    ]
   },
   {
@@ -78,13 +78,23 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Warning: No xgboost installed on your system\n",
+      "Attempting to run %s will throw runtime errors\n"
+     ]
+    }
+   ],
    "source": [
-    "dataset_file= \"../datasets/pdbbind_core_df.pkl.gz\"\n",
-    "from deepchem.utils.save import load_from_disk\n",
-    "dataset = load_from_disk(dataset_file)"
+    "import deepchem as dc\n",
+    "\n",
+    "dataset_file= \"../../datasets/pdbbind_core_df.pkl.gz\"\n",
+    "raw_dataset = dc.utils.save.load_from_disk(dataset_file)"
    ]
   },
   {
@@ -145,9 +155,9 @@
     }
    ],
    "source": [
-    "print(\"Type of dataset is: %s\" % str(type(dataset)))\n",
-    "print(dataset[:5])\n",
-    "print(\"Shape of dataset is: %s\" % str(dataset.shape))"
+    "print(\"Type of dataset is: %s\" % str(type(raw_dataset)))\n",
+    "print(raw_dataset[:5])\n",
+    "print(\"Shape of dataset is: %s\" % str(raw_dataset.shape))"
    ]
   },
   {
@@ -159,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false,
     "scrolled": true
@@ -172,9 +182,55 @@
     "import mdtraj as md\n",
     "import numpy as np\n",
     "import deepchem.utils.visualization\n",
-    "from deepchem.utils.visualization import combine_mdtraj, visualize_complex, convert_lines_to_mdtraj\n",
+    "#from deepchem.utils.visualization import combine_mdtraj, visualize_complex, convert_lines_to_mdtraj\n",
     "\n",
-    "first_protein, first_ligand = dataset.iloc[0][\"protein_pdb\"], dataset.iloc[0][\"ligand_pdb\"]\n",
+    "def combine_mdtraj(protein, ligand):\n",
+    "  chain = protein.topology.add_chain()\n",
+    "  residue = protein.topology.add_residue(\"LIG\", chain, resSeq=1)\n",
+    "  for atom in ligand.topology.atoms:\n",
+    "      protein.topology.add_atom(atom.name, atom.element, residue)\n",
+    "  protein.xyz = np.hstack([protein.xyz, ligand.xyz])\n",
+    "  protein.topology.create_standard_bonds()\n",
+    "  return protein\n",
+    "\n",
+    "def visualize_complex(complex_mdtraj):\n",
+    "  ligand_atoms = [a.index for a in complex_mdtraj.topology.atoms if \"LIG\" in str(a.residue)]\n",
+    "  binding_pocket_atoms = md.compute_neighbors(complex_mdtraj, 0.5, ligand_atoms)[0]\n",
+    "  binding_pocket_residues = list(set([complex_mdtraj.topology.atom(a).residue.resSeq for a in binding_pocket_atoms]))\n",
+    "  binding_pocket_residues = [str(r) for r in binding_pocket_residues]\n",
+    "  binding_pocket_residues = \" or \".join(binding_pocket_residues)\n",
+    "\n",
+    "  traj = nglview.MDTrajTrajectory( complex_mdtraj ) # load file from RCSB PDB\n",
+    "  ngltraj = nglview.NGLWidget( traj )\n",
+    "  ngltraj.representations = [\n",
+    "  { \"type\": \"cartoon\", \"params\": {\n",
+    "  \"sele\": \"protein\", \"color\": \"residueindex\"\n",
+    "  } },\n",
+    "  { \"type\": \"licorice\", \"params\": {\n",
+    "  \"sele\": \"(not hydrogen) and (%s)\" %  binding_pocket_residues\n",
+    "  } },\n",
+    "  { \"type\": \"ball+stick\", \"params\": {\n",
+    "  \"sele\": \"LIG\"\n",
+    "  } }\n",
+    "  ]\n",
+    "  return ngltraj\n",
+    "\n",
+    "def visualize_ligand(ligand_mdtraj):\n",
+    "  traj = nglview.MDTrajTrajectory( ligand_mdtraj ) # load file from RCSB PDB\n",
+    "  ngltraj = nglview.NGLWidget( traj )\n",
+    "  ngltraj.representations = [\n",
+    "    { \"type\": \"ball+stick\", \"params\": {\"sele\": \"all\" } } ]\n",
+    "  return ngltraj\n",
+    "\n",
+    "def convert_lines_to_mdtraj(molecule_lines):\n",
+    "  tempdir = tempfile.mkdtemp()\n",
+    "  molecule_file = os.path.join(tempdir, \"molecule.pdb\")\n",
+    "  with open(molecule_file, \"wb\") as f:\n",
+    "    f.writelines(molecule_lines)\n",
+    "  molecule_mdtraj = md.load(molecule_file)\n",
+    "  return molecule_mdtraj\n",
+    "\n",
+    "first_protein, first_ligand = raw_dataset.iloc[0][\"protein_pdb\"], raw_dataset.iloc[0][\"ligand_pdb\"]\n",
     "\n",
     "protein_mdtraj = convert_lines_to_mdtraj(first_protein)\n",
     "ligand_mdtraj = convert_lines_to_mdtraj(first_ligand)\n",
@@ -183,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false,
     "slideshow": {
@@ -192,9 +248,8 @@
    },
    "outputs": [],
    "source": [
-    "if DISPLAY:\n",
-    "    ngltraj = visualize_complex(complex_mdtraj)\n",
-    "    ngltraj"
+    "ngltraj = visualize_complex(complex_mdtraj)\n",
+    "ngltraj"
    ]
   },
   {
@@ -210,23 +265,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "from deepchem.featurizers.fingerprints import CircularFingerprint\n",
-    "from deepchem.featurizers.basic import RDKitDescriptors\n",
-    "from deepchem.featurizers.nnscore import NNScoreComplexFeaturizer\n",
-    "from deepchem.featurizers.grid_featurizer import GridFeaturizer\n",
-    "grid_featurizer = GridFeaturizer(voxel_width=16.0, feature_types=\"voxel_combined\", voxel_feature_types=[\"ecfp\",\n",
-    "                                 \"splif\", \"hbond\", \"pi_stack\", \"cation_pi\", \"salt_bridge\"], ecfp_power=5, splif_power=5,\n",
-    "                                 parallel=True, flatten=True)\n",
-    "compound_featurizers = [CircularFingerprint(size=128)]\n",
-    "# TODO(rbharath, enf): The grid featurizer breaks. Need to debug before code release\n",
-    "complex_featurizers = []\n",
-    "#complex_featurizers = [grid_featurizer]"
+    "grid_featurizer = dc.feat.RdkitGridFeaturizer(\n",
+    "    voxel_width=16.0, feature_types=\"voxel_combined\", \n",
+    "    voxel_feature_types=[\"ecfp\", \"splif\", \"hbond\", \"pi_stack\", \"cation_pi\", \"salt_bridge\"], \n",
+    "    ecfp_power=5, splif_power=5, parallel=True, flatten=True)\n",
+    "compound_featurizer = dc.feat.CircularFingerprint(size=128)"
    ]
   },
   {
@@ -235,63 +284,7 @@
    "source": [
     "Note how we separate our featurizers into those that featurize individual chemical compounds, compound_featurizers, and those that featurize molecular complexes, complex_featurizers.\n",
     "\n",
-    "Now, let's perform the actual featurization. Calling ```featurizer.featurize()``` will return an instance of class ```FeaturizedSamples```. Internally, ```featurizer.featurize()``` (a) computes the user-specified features on the data, (b) transforms the inputs into X and y NumPy arrays suitable for ML algorithms, and (c) constructs a ```FeaturizedSamples()``` instance that has useful methods, such as an iterator, over the featurized data."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "#Make a directory in which to store the featurized complexes.\n",
-    "import tempfile, shutil\n",
-    "base_dir = \"./tutorial_output\"\n",
-    "if not os.path.exists(base_dir):\n",
-    "    os.makedirs(base_dir)\n",
-    "data_dir = os.path.join(base_dir, \"data\")\n",
-    "if not os.path.exists(data_dir):\n",
-    "    os.makedirs(data_dir)\n",
-    "    \n",
-    "featurized_samples_file = os.path.join(data_dir, \"featurized_samples.joblib\")\n",
-    "\n",
-    "feature_dir = os.path.join(base_dir, \"features\")\n",
-    "if not os.path.exists(feature_dir):\n",
-    "    os.makedirs(feature_dir)\n",
-    "\n",
-    "samples_dir = os.path.join(base_dir, \"samples\")\n",
-    "if not os.path.exists(samples_dir):\n",
-    "    os.makedirs(samples_dir)\n",
-    "\n",
-    "train_dir = os.path.join(base_dir, \"train\")\n",
-    "if not os.path.exists(train_dir):\n",
-    "    os.makedirs(train_dir)\n",
-    "\n",
-    "valid_dir = os.path.join(base_dir, \"valid\")\n",
-    "if not os.path.exists(valid_dir):\n",
-    "    os.makedirs(valid_dir)\n",
-    "\n",
-    "test_dir = os.path.join(base_dir, \"test\")\n",
-    "if not os.path.exists(test_dir):\n",
-    "    os.makedirs(test_dir)\n",
-    "\n",
-    "model_dir = os.path.join(base_dir, \"model\")\n",
-    "if not os.path.exists(model_dir):\n",
-    "    os.makedirs(model_dir)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "import deepchem.featurizers.featurize\n",
-    "from deepchem.featurizers.featurize import DataFeaturizer"
+    "Now, let's perform the actual featurization. Calling ```loader.featurize()``` will return an instance of class ```Dataset```. Internally, ```loader.featurize()``` (a) computes the specified features on the data, (b) transforms the inputs into ```X``` and ```y``` NumPy arrays suitable for ML algorithms, and (c) constructs a ```Dataset()``` instance that has useful methods, such as an iterator, over the featurized data. This is a little complicated, so we will use MoleculeNet to featurize the PDBBind core set for us."
    ]
   },
   {
@@ -300,40 +293,23 @@
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading dataset from disk.\n",
+      "TIMING: dataset construction took 0.024 s\n",
+      "Loading dataset from disk.\n",
+      "TIMING: dataset construction took 0.010 s\n",
+      "Loading dataset from disk.\n",
+      "TIMING: dataset construction took 0.010 s\n",
+      "Loading dataset from disk.\n"
+     ]
+    }
+   ],
    "source": [
-    "featurizers = compound_featurizers + complex_featurizers\n",
-    "featurizer = DataFeaturizer(tasks=[\"label\"],\n",
-    "                            smiles_field=\"smiles\",\n",
-    "                            protein_pdb_field=\"protein_pdb\",\n",
-    "                            ligand_pdb_field=\"ligand_pdb\",\n",
-    "                            compound_featurizers=compound_featurizers,\n",
-    "                            complex_featurizers=complex_featurizers,\n",
-    "                            id_field=\"complex_id\",\n",
-    "                            verbose=False)\n",
-    "if PARALLELIZE:\n",
-    "    from ipyparallel import Client\n",
-    "    c = Client()\n",
-    "    dview = c[:]\n",
-    "else:\n",
-    "    dview = None\n",
-    "featurized_samples = featurizer.featurize(dataset_file, feature_dir, samples_dir,\n",
-    "                                          worker_pool=dview, shard_size=32)\n",
-    "\n",
-    "from deepchem.utils.save import save_to_disk, load_from_disk\n",
-    "\n",
-    "save_to_disk(featurized_samples, featurized_samples_file)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "featurized_samples = load_from_disk(featurized_samples_file)"
+    "PDBBIND_tasks, (train_dataset, valid_dataset, test_dataset), transformers = dc.molnet.load_pdbbind_grid()"
    ]
   },
   {
@@ -344,49 +320,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "splittype = \"random\"\n",
-    "\n",
-    "train_samples, test_samples = featurized_samples.train_test_split(\n",
-    "    splittype, train_dir, test_dir, seed=2016)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "We generate separate instances of the Dataset() object to hermetically seal the train dataset from the test dataset. This style lends itself easily to validation-set type hyperparameter searches, which we will illustate in a separate section of this tutorial. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from deepchem.utils.dataset import Dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "train_dataset = Dataset(data_dir=train_dir, samples=train_samples, \n",
-    "                        featurizers=compound_featurizers, tasks=[\"label\"])\n",
-    "test_dataset = Dataset(data_dir=test_dir, samples=test_samples, \n",
-    "                       featurizers=compound_featurizers, tasks=[\"label\"])"
    ]
   },
   {
@@ -397,79 +334,32 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "from deepchem.transformers import NormalizationTransformer\n",
-    "from deepchem.transformers import ClippingTransformer\n",
-    "\n",
-    "input_transformers = [NormalizationTransformer(transform_X=True, dataset=train_dataset),\n",
-    "                      ClippingTransformer(transform_X=True, dataset=train_dataset)]\n",
-    "output_transformers = [NormalizationTransformer(transform_y=True, dataset=train_dataset)]\n",
-    "transformers = input_transformers + output_transformers\n",
-    "for transformer in transformers:\n",
-    "    transformer.transform(train_dataset)\n",
-    "for transformer in transformers:\n",
-    "    transformer.transform(test_dataset)"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, we're ready to do some learning! To set up a model, we will need: (a) a dictionary ```task_types``` that maps a task, in this case ```label```, i.e. the Ki, to the type of the task, in this case ```regression```. For the multitask use case, one will have a series of keys, each of which is a different task (Ki, solubility, renal half-life, etc.) that maps to a different task type (regression or classification).\n",
+    "Now, we're ready to do some learning! \n",
     "\n",
     "To fit a deepchem model, first we instantiate one of the provided (or user-written) model classes. In this case, we have a created a convenience class to wrap around any ML model available in Sci-Kit Learn that can in turn be used to interoperate with deepchem. To instantiate an ```SklearnModel```, you will need (a) task_types, (b) model_params, another ```dict``` as illustrated below, and (c) a ```model_instance``` defining the type of model you would like to fit, in this case a ```RandomForestRegressor```."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
     "from sklearn.ensemble import RandomForestRegressor\n",
-    "from deepchem.models.standard import SklearnModel"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "task_types = {\"label\": \"regression\"}\n",
-    "model_params = {\"data_shape\": train_dataset.get_data_shape()}\n",
     "\n",
-    "model = SklearnModel(task_types, model_params, model_instance=RandomForestRegressor())\n",
-    "model.fit(train_dataset)\n",
-    "model_dir = tempfile.mkdtemp()\n",
-    "model.save(model_dir)"
+    "sklearn_model = RandomForestRegressor(n_estimators=100)\n",
+    "model = dc.models.SklearnModel(sklearn_model)\n",
+    "model.fit(train_dataset)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "from deepchem.utils.evaluate import Evaluator\n",
-    "import pandas as pd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -478,74 +368,26 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Saving predictions to <open file '<fdopen>', mode 'w+b' at 0x7f389f4c3c00>\n",
-      "Saving model performance scores to <open file '<fdopen>', mode 'w+b' at 0x7f389f4c3db0>\n",
-      "Saving predictions to <open file '<fdopen>', mode 'w+b' at 0x7f389f4c3d20>\n",
-      "Saving model performance scores to <open file '<fdopen>', mode 'w+b' at 0x7f389f4c3e40>\n",
-      "/tmp/tmpK2BRxB\n"
+      "computed_metrics: [0.87165637813866481]\n",
+      "RF Train set R^2 0.871656\n",
+      "computed_metrics: [0.1561422855082335]\n",
+      "RF Valid set R^2 0.156142\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>task_name</th>\n",
-       "      <th>r2_score</th>\n",
-       "      <th>rms_error</th>\n",
-       "      <th>split</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>label</td>\n",
-       "      <td>0.801475</td>\n",
-       "      <td>0.959558</td>\n",
-       "      <td>train</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>label</td>\n",
-       "      <td>0.218699</td>\n",
-       "      <td>2.273835</td>\n",
-       "      <td>test</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  task_name  r2_score  rms_error  split\n",
-       "0     label  0.801475   0.959558  train\n",
-       "0     label  0.218699   2.273835   test"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
-    "evaluator = Evaluator(model, train_dataset, output_transformers, verbose=True)\n",
-    "with tempfile.NamedTemporaryFile() as train_csv_out:\n",
-    "  with tempfile.NamedTemporaryFile() as train_stats_out:\n",
-    "    _, train_r2score = evaluator.compute_model_performance(\n",
-    "        train_csv_out, train_stats_out)\n",
+    "from deepchem.utils.evaluate import Evaluator\n",
+    "import pandas as pd\n",
     "\n",
-    "evaluator = Evaluator(model, test_dataset, output_transformers, verbose=True)\n",
-    "test_csv_out = tempfile.NamedTemporaryFile()\n",
-    "with tempfile.NamedTemporaryFile() as test_stats_out:\n",
-    "    _, test_r2score = evaluator.compute_model_performance(\n",
-    "        test_csv_out, test_stats_out)\n",
+    "metric = dc.metrics.Metric(dc.metrics.r2_score)\n",
     "\n",
-    "print test_csv_out.name\n",
-    "train_test_performance = pd.concat([train_r2score, test_r2score])\n",
-    "train_test_performance[\"split\"] = [\"train\", \"test\"]\n",
-    "train_test_performance"
+    "evaluator = Evaluator(model, train_dataset, transformers)\n",
+    "train_r2score = evaluator.compute_model_performance([metric])\n",
+    "print(\"RF Train set R^2 %f\" % (train_r2score[\"r2_score\"]))\n",
+    "\n",
+    "evaluator = Evaluator(model, valid_dataset, transformers)\n",
+    "valid_r2score = evaluator.compute_model_performance([metric])\n",
+    "print(\"RF Valid set R^2 %f\" % (valid_r2score[\"r2_score\"]))"
    ]
   },
   {
@@ -559,36 +401,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 5.0557  5.716   6.1845  7.9055  5.9617  6.3135  5.3563  7.0066  5.6421\n",
+      "  6.334   6.5798  6.5744  4.9209  6.9901  7.2046  6.5845  6.9427  6.9793\n",
+      "  6.9515  5.9193]\n"
+     ]
+    }
+   ],
    "source": [
-    "predictions = pd.read_csv(test_csv_out.name)\n",
-    "predictions = predictions.sort(['label'], ascending=[0])"
+    "predictions = model.predict(test_dataset)\n",
+    "print(predictions)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
-    "from deepchem.utils.visualization import visualize_ligand\n",
+    "# TODO(rbharath): This cell visualizes the ligand with highest predicted activity. Commenting it out for now. Fix this later\n",
+    "#from deepchem.utils.visualization import visualize_ligand\n",
     "\n",
-    "top_ligand = predictions.iloc[0]['ids']\n",
-    "ligand1 = convert_lines_to_mdtraj(dataset.loc[dataset['complex_id']==top_ligand]['ligand_pdb'].values[0])\n",
-    "if DISPLAY:\n",
-    "    ngltraj = visualize_ligand(ligand1)\n",
-    "    ngltraj"
+    "#top_ligand = predictions.iloc[0]['ids']\n",
+    "#ligand1 = convert_lines_to_mdtraj(dataset.loc[dataset['complex_id']==top_ligand]['ligand_pdb'].values[0])\n",
+    "#if DISPLAY:\n",
+    "#    ngltraj = visualize_ligand(ligand1)\n",
+    "#    ngltraj"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "collapsed": false,
     "slideshow": {
@@ -597,11 +450,12 @@
    },
    "outputs": [],
    "source": [
-    "worst_ligand = predictions.iloc[predictions.shape[0]-2]['ids']\n",
-    "ligand1 = convert_lines_to_mdtraj(dataset.loc[dataset['complex_id']==worst_ligand]['ligand_pdb'].values[0])\n",
-    "if DISPLAY:\n",
-    "    ngltraj = visualize_ligand(ligand1)\n",
-    "    ngltraj"
+    "# TODO(rbharath): This cell visualizes the ligand with lowest predicted activity. Commenting it out for now. Fix this later\n",
+    "#worst_ligand = predictions.iloc[predictions.shape[0]-2]['ids']\n",
+    "#ligand1 = convert_lines_to_mdtraj(dataset.loc[dataset['complex_id']==worst_ligand]['ligand_pdb'].values[0])\n",
+    "#if DISPLAY:\n",
+    "#    ngltraj = visualize_ligand(ligand1)\n",
+    "#    ngltraj"
    ]
   },
   {
@@ -624,12 +478,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the previous section, we featurized only the ligand. The signal we observed in R^2 reflects the ability of circular fingerprints and random forests to learn general features that make ligands \"drug-like.\" However, the affinity of a drug for a target is determined not only by the drug itself, of course, but the way in which it interacts with a protein. "
+    "In the previous section, we featurized only the ligand. The signal we observed in R^2 reflects the ability of grid fingerprints and random forests to learn general features that make ligands \"drug-like.\" In this section, we demonstrate how to use hyperparameter searching to find a higher scoring ligands."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -638,72 +492,109 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Model 0/5, Metric r2_score, Validation set 0: 0.686145\n",
-      "\tbest_validation_score so  far: -inf\n",
-      "Model 1/5, Metric r2_score, Validation set 1: 0.688894\n",
-      "\tbest_validation_score so  far: 0.686145\n",
-      "Model 2/5, Metric r2_score, Validation set 2: 0.733131\n",
-      "\tbest_validation_score so  far: 0.688894\n",
-      "Model 3/5, Metric r2_score, Validation set 3: 0.753555\n",
-      "\tbest_validation_score so  far: 0.733131\n",
-      "Model 4/5, Metric r2_score, Validation set 4: 0.747959\n",
-      "\tbest_validation_score so  far: 0.753555\n",
-      "Best hyperparameters: [('n_estimators', 80), ('data_shape', (128,))]\n",
-      "train_score: 0.870723\n",
-      "validation_score: 0.753555\n"
+      "Fitting model 1/12\n",
+      "hyperparameters: {'n_estimators': 10, 'max_features': 'auto'}\n",
+      "computed_metrics: [0.11307395856711755]\n",
+      "Model 1/12, Metric r2_score, Validation set 0: 0.113074\n",
+      "\tbest_validation_score so far: 0.113074\n",
+      "Fitting model 2/12\n",
+      "hyperparameters: {'n_estimators': 10, 'max_features': 'sqrt'}\n",
+      "computed_metrics: [0.099148571900583904]\n",
+      "Model 2/12, Metric r2_score, Validation set 1: 0.099149\n",
+      "\tbest_validation_score so far: 0.113074\n",
+      "Fitting model 3/12\n",
+      "hyperparameters: {'n_estimators': 10, 'max_features': 'log2'}\n",
+      "computed_metrics: [0.011951380345950557]\n",
+      "Model 3/12, Metric r2_score, Validation set 2: 0.011951\n",
+      "\tbest_validation_score so far: 0.113074\n",
+      "Fitting model 4/12\n",
+      "hyperparameters: {'n_estimators': 10, 'max_features': None}\n",
+      "computed_metrics: [0.088399300891687682]\n",
+      "Model 4/12, Metric r2_score, Validation set 3: 0.088399\n",
+      "\tbest_validation_score so far: 0.113074\n",
+      "Fitting model 5/12\n",
+      "hyperparameters: {'n_estimators': 50, 'max_features': 'auto'}\n",
+      "computed_metrics: [0.15902254520297032]\n",
+      "Model 5/12, Metric r2_score, Validation set 4: 0.159023\n",
+      "\tbest_validation_score so far: 0.159023\n",
+      "Fitting model 6/12\n",
+      "hyperparameters: {'n_estimators': 50, 'max_features': 'sqrt'}\n",
+      "computed_metrics: [0.11169781065527806]\n",
+      "Model 6/12, Metric r2_score, Validation set 5: 0.111698\n",
+      "\tbest_validation_score so far: 0.159023\n",
+      "Fitting model 7/12\n",
+      "hyperparameters: {'n_estimators': 50, 'max_features': 'log2'}\n",
+      "computed_metrics: [0.059318984812613107]\n",
+      "Model 7/12, Metric r2_score, Validation set 6: 0.059319\n",
+      "\tbest_validation_score so far: 0.159023\n",
+      "Fitting model 8/12\n",
+      "hyperparameters: {'n_estimators': 50, 'max_features': None}\n",
+      "computed_metrics: [0.19599469907033895]\n",
+      "Model 8/12, Metric r2_score, Validation set 7: 0.195995\n",
+      "\tbest_validation_score so far: 0.195995\n",
+      "Fitting model 9/12\n",
+      "hyperparameters: {'n_estimators': 100, 'max_features': 'auto'}\n",
+      "computed_metrics: [0.13128321736117132]\n",
+      "Model 9/12, Metric r2_score, Validation set 8: 0.131283\n",
+      "\tbest_validation_score so far: 0.195995\n",
+      "Fitting model 10/12\n",
+      "hyperparameters: {'n_estimators': 100, 'max_features': 'sqrt'}\n",
+      "computed_metrics: [0.18386751402403434]\n",
+      "Model 10/12, Metric r2_score, Validation set 9: 0.183868\n",
+      "\tbest_validation_score so far: 0.195995\n",
+      "Fitting model 11/12\n",
+      "hyperparameters: {'n_estimators': 100, 'max_features': 'log2'}\n",
+      "computed_metrics: [0.079031671201846287]\n",
+      "Model 11/12, Metric r2_score, Validation set 10: 0.079032\n",
+      "\tbest_validation_score so far: 0.195995\n",
+      "Fitting model 12/12\n",
+      "hyperparameters: {'n_estimators': 100, 'max_features': None}\n",
+      "computed_metrics: [0.16382517016852427]\n",
+      "Model 12/12, Metric r2_score, Validation set 11: 0.163825\n",
+      "\tbest_validation_score so far: 0.195995\n",
+      "computed_metrics: [0.86969508698615849]\n",
+      "Best hyperparameters: (50, None)\n",
+      "train_score: 0.869695\n",
+      "validation_score: 0.195995\n"
      ]
     }
    ],
    "source": [
-    "import deepchem.models.standard\n",
-    "from deepchem.models.standard import SklearnModel\n",
-    "from deepchem.utils.dataset import Dataset\n",
-    "from deepchem.utils.evaluate import Evaluator\n",
-    "from deepchem.hyperparameters import HyperparamOpt\n",
-    "\n",
-    "train_dir, validation_dir, test_dir = tempfile.mkdtemp(), tempfile.mkdtemp(), tempfile.mkdtemp()\n",
-    "splittype=\"random\"\n",
-    "train_samples, validation_samples, test_samples = featurized_samples.train_valid_test_split(\n",
-    "    splittype, train_dir, validation_dir, test_dir, seed=2016)\n",
-    "\n",
-    "task_types = {\"label\": \"regression\"}\n",
-    "performance = pd.DataFrame()\n",
-    "\n",
-    "def model_builder(task_types, params_dict, verbosity):\n",
-    "    n_estimators = params_dict[\"n_estimators\"]\n",
-    "    return SklearnModel(\n",
-    "        task_types, params_dict,\n",
-    "        model_instance=RandomForestRegressor(n_estimators=n_estimators))\n",
+    "def rf_model_builder(model_params, model_dir):\n",
+    "  sklearn_model = RandomForestRegressor(**model_params)\n",
+    "  return dc.models.SklearnModel(sklearn_model, model_dir)\n",
     "\n",
     "params_dict = {\n",
-    "    \"n_estimators\": [10, 20, 40, 80, 160],\n",
-    "    \"data_shape\": [train_dataset.get_data_shape()],\n",
-    "    }\n",
+    "    \"n_estimators\": [10, 50, 100],\n",
+    "    \"max_features\": [\"auto\", \"sqrt\", \"log2\", None],\n",
+    "}\n",
     "\n",
-    "optimizer = HyperparamOpt(model_builder, {\"pIC50\": \"regression\"})\n",
-    "for feature_type in (complex_featurizers + compound_featurizers):\n",
-    "    train_dataset = Dataset(data_dir=train_dir, samples=train_samples, \n",
-    "                            featurizers=[feature_type], tasks=[\"label\"])\n",
-    "    validation_dataset = Dataset(data_dir=validation_dir, samples=validation_samples, \n",
-    "                                 featurizers=[feature_type], tasks=[\"label\"])\n",
-    "\n",
-    "    for transformer in transformers:\n",
-    "        transformer.transform(train_dataset)\n",
-    "    for transformer in transformers:\n",
-    "        transformer.transform(test_dataset)\n",
-    "        \n",
-    "    best_rf, best_rf_hyperparams, all_rf_results = optimizer.hyperparam_search(\n",
-    "    params_dict, train_dataset, test_dataset, output_transformers, metric=\"r2_score\")"
+    "metric = dc.metrics.Metric(dc.metrics.r2_score)\n",
+    "optimizer = dc.hyper.HyperparamOpt(rf_model_builder)\n",
+    "best_rf, best_rf_hyperparams, all_rf_results = optimizer.hyperparam_search(\n",
+    "    params_dict, train_dataset, valid_dataset, transformers,\n",
+    "    metric=metric)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false,
     "scrolled": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYUAAAEWCAYAAACJ0YulAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAIABJREFUeJzt3XmcjXX7wPHPlagRoUiifZExtpqopEIPKUp+7epJxpBU\npKZSSqkeyi7CGKEsKdlCTZYmS8gyNIZI0sNQZF8GY+b6/XHu8RyT2cycc59z5nq/XvNyzr1e555x\nrvu73N+vqCrGGGMMwFluB2CMMSZwWFIwxhhzkiUFY4wxJ1lSMMYYc5IlBWOMMSdZUjDGGHOSJQXj\ncyKSICLtnNetReQ7P5zzChFRETnb1+cyJpRYUghSIrJFRFJF5JCI/CkiY0SklNf6MSJy3Fmf+fOI\nmzEDqOp4VW2S23Yi8raIjPNVHM71u8vrfSURGSUiO0TkoIj8IiLviMh5Xtunel3L77Ic73ER+UNE\nDovINBG5wFexn+azJHvFlS4iR73ev+6vOHKIb5uI3On1vrKIjHb+bg+IyHoR6SEiYV7be1/rb7Ic\n7wnnWh8SkSkiUtbPHymkWVIIbi1UtRRQG6gDdMuy/kNVLeX1M6mgJwzFO2/nC3wJEAbcoqqlgX8B\nZYCrvTZt4XUtm3jtXx0YATwJVASOAB/7K35VrZ4ZF7AQeM4rzv9k3d7N36GIlMdzrc8G6qnq+cDd\nQHngKq9Nm3l9hmZe+9fEc21bAxcDacAQf8VfFFhSCAGq+icQjyc55JtTzfKCiGwWkb9FpI+InOWs\nayMii0VkgIjsBt52lrd17vD2iki8iFzudbx/OXfa+0VkCCBe69qIyCKv99VFZI6I7BGRv0TkdRG5\nG3gdeMS5G1zjbFvG624+RUTeE5FizrpiItLXiX8zcG8+LkFX4CDwhKpuAVDVraraRVV/zsP+rYGv\nVXWBqh4C3gRaiUjp01zrV0VkcpZlg0RksNf12eyUVn4Xkdb5+BynJSLtRGSBiAwWkT1Ad+fajfHa\n5hoRUa/3ZZ27+R3OnXvPzL+J0xz/PRGZJCJfOnGvEJEa2YTzMrAb+Leq/gGgqn+o6vOqmpyHj/ME\nME1VF3ld64dEpGSeLobJlSWFECAiVYBmwKYCHOYBIBK4AbgfaOu1rh6wGc9d8Psicj+eL+1WQAU8\nd6cTnVjKA1OA7nju/n4D6mcTd2lgLvAtcAlwDTBPVb8F/gNMcu4Uazm7jAFOONvVAZoA7Zx10UBz\nZ3kk8GA+PvtdwBRVzchlu/EisktEvhORWl7LqwNrMt+o6m/AMeC60xzjc+CezIThJLWHgQlOVdVg\nPHfJpYFbgdX5+Bw5uRVYj+f39UEetv8MSMVTUroRT5J9OoftWwETgAuAycDUbEokmdc6t/F1PheR\nnc4Nh3eCyXqtNwIZwLW5HM/kkSWF4DZNRA4CW4GdQI8s618WkX3Oz9+5HOsDVd2jqv8FBgKPea3b\nrqofqeoJVU0FngF6qep6VT2B5wu8tlNauAdIVtXJqprmHOvPbM7ZHPhTVfup6lFVPaiqy063oYhU\ndI7dRVUPq+pOYADwqLPJw8BA5w5/D9Arl8/r7UJgRy7btAauAC4HvgfiveqySwH7s2x/APhHScG5\nO16FJwkDNAKOqOpS530GECEiYaq6I493z3nxX1Udpqrpzu8wWyJSGc+X94uqekRV/8Lze3w0h92W\nqepU53feBzgfuOk02+XlWj+K51pfCSzCc63LOOvyfK3NmbGkENxaOneUdwLX47kz99ZXVcs6P1nX\nZbXV6/UfeO7cT7cOPF+MgzITDrAHTxVRZWe/k9s7d4RZ9890KZ6SRF5cDhQHdniddwRwkbP+lPM6\nnyGvdgOVctpAVReraqrzJdkL2Ac0cFYfwvMl6K0Mniqp05nA/5Lu4857VPUw8AiepLtDRGaJyPX5\n+Bw5ye53cDqXA+cAf3ld66F4Soq5Hl9V04EUTv0bypSXa73IuUk4rKrv4mmjudVZfbprfT7ZX2uT\nT5YUQoCq/oCnaqVvAQ5zqdfry4Dt3qfIsu1WoINXwimrqmGq+iOeu8CTxxIRyXLsrMe5Kpt1pzvn\nMaC81znPV9XqzvpTzut8hryaCzyQXZ15DvFltpUkAyerk0TkaqAEsDGbfb8E7nSq/R7ASQoAqhqv\nqv/C88X5CzAyHzHlFq+3w4B3PfzFXq+34vkiviDLta6Zw/G9f+dn4blB2H6a7TKvtZxmXU6xZ3et\nq+L5Hvs1H8czObCkEDoGAv/KUtedHzEiUk5ELgU6Azn1VBoOdHN63WQ2AD/krJsFVBeRVk6d8guc\n+oXjbSZQSUS6iMg5IlJaROo56/4Crsj8olbVHcB3QD8ROV9EzhKRq0XkDmf7L4AXRKSKiJQDXsvH\nZ++P525zbGaDuXi6TfYXkZoicpmI1BeREiJyrojE4CmVLXb2Hw+0EJEGTrvAu3jqzU9796qqu4AE\nYDTwu6qud85ZUUTud45xDM9dcW7tHGdqNXCHiFzqVIOdvF6quhX4Aejrda2vEZHbczheXSf24nga\nkw8Cy0+zXV881260iFwGnjYxp7G9unieL7lVRIo717obnt/NEmf/cUBLZ5tSQE/gS1U9UqCrYU6y\npBAinC+aT4G3zvAQ04GVeL4sZgGjcjjXVDyNlZ+LyAFgLZ6GblT1b+AhoDeeqoJr+d+XZ9bjHMTT\n9bMFnnaHX4GGzuovnX93i8gq5/W/8dyBrwP24mnQzKyKGImnB9YaPHX2U/L6wZ02iFvxdG9c5rTT\nzMNTd70JT331MOecKXi6UDZT1d3O/sl4qnzG42nbOQ94NpfTTsBTbz/Ba9lZeHpCbcdTJXcH0BHA\nSTiH8vqZ8uBbYCqQBPwEzMiy/gk8nyPzWn9J9skd51hPOHE/ArRy2ptO4fx93OK8Xe5c6znA33g6\nM5TGUy2Yea0b4bnWe539fwaew9Ng/xeev4fn8/G5TS7EJtkxTlfEa1W1IL2XTBElIu8BVVS1jdux\nmIKzkoIxxpiTfJYUROQTp5/xWq9lD4nnkfwMEYn01bmNMcacGZ9VHzmNUoeAT1U1wllWDU/D2Qjg\nZVVd4ZOTG2OMOSM+GwNFVReIyBVZlmX2svDVaY0xxhRAwA5uJiLtgfYA55133o3XX19Yz/AYY0zo\nOn78OFu2bOHgwYMAf6tqhfzsH7BJQVVjgViAyMhIXbHCapqMMSY76enpDB06lNdffx0RYciQITz3\n3HP5ebIfsN5HxhgT9NavX8/tt99O586dadCgAWvXrqVTp05ndCxLCsYYE6TS0tJ4//33qV27Nr/8\n8guffvops2fP5vLLL89952z4rPpIRCbiGaitvIhswzOC5x7gIzzD984SkdWq2tRXMRhjTKhatWoV\nbdu2Zc2aNTz00EN89NFHVKyY05iFeePL3kePZbNqqq/OaYwxoS41NZV33nmHvn37UqFCBaZMmcID\nDzyQ+455FLANzcYYY061YMEC2rVrx6+//kpUVBR9+vShXLlyhXoOa1MwxpgAd+DAATp16sQdd9xB\nWloac+bMIS4urtATAlhSMMaYgPbNN98QERHBsGHD6NKlC2vXruWuu+7y2fksKRhjTADavXs3//73\nv7nnnnsoVaoUixcvZsCAAZx33nk+Pa8lBWOMCSCqyhdffEG1atWYOHEib775JomJidxyyy2571wI\nrKHZGGMCxPbt23n22WeZPn06N954I3PmzKFWrTOdTPHMWEnBGGNcpqqMGjWK8PBw4uPj+fDDD1m6\ndKnfEwJYScEYY1y1efNmoqOjmT9/PrfffjtxcXFce+21rsVjJQVjjHFBeno6AwcOpEaNGixfvpxh\nw4bx/fffu5oQwEoKxhjjd8nJyURFRbFs2TLuuecehg8fzqWXXup2WICVFIwxxm+OHz/Ou+++S506\nddi0aRPjxo1j5syZAZMQwEoKxhjjF8uXLycqKoqkpCQeffRRBg0axEUXXeR2WP9gJQVjjPGhI0eO\nEBMTw80338zu3buZPn06EydODMiEAFZSMMYYn0lISCA6OppNmzYRHR1Nnz59KFOmjNth5chKCsYY\nU8j279/PM888Q8OGDcnIyGDevHnExsYGfEIAHyYFEflERHaKyFqvZReIyBwR+dX5t/CH+DPGGBfN\nmjWL6tWrM3LkSLp27UpSUhKNGjVyO6w882VJYQxwd5ZlrwHzVPVaYJ7z3hhjgt6uXbto3bo1zZs3\np2zZsvz444/069ePkiVLuh1avvgsKajqAjzTb3q7HxjrvB4LtPTV+Y0xxh9UlYkTJxIeHs6XX37J\n22+/zapVq6hXr57boZ0Rfzc0V1TVHc7rP4GCTyhqjDEu2bZtGx07dmTmzJnUrVuXUaNGERER4XZY\nBeJaQ7OqKqDZrReR9iKyQkRW7Nq1y4+RGWNMzjIyMoiNjaV69erMmzePfv368eOPPwZ9QgD/J4W/\nRKQSgPPvzuw2VNVYVY1U1cgKFSr4LUBjjMnJpk2baNy4MR06dODGG28kKSmJrl27UqxYMbdDKxT+\nTgozgKec108B0/18fmOMOSPp6en069ePmjVrsmrVKmJjY5k3bx5XX32126EVKp+1KYjIROBOoLyI\nbAN6AL2BL0QkCvgDeNhX5zfGmMKydu1a2rZty/Lly2nRogXDhg2jcuXKboflEz5LCqr6WDarGvvq\nnMYYU5iOHTtGr169+M9//kOZMmWYOHEijzzyCCLidmg+Y8NcGGPMaSxbtoyoqCiSk5Np3bo1AwcO\npHz58m6H5XM2zIUxxng5fPgwXbt25ZZbbmH//v3MnDmTcePGFYmEAFZSMMaYk+bPn090dDSbN2/m\nmWee4YMPPuD88893Oyy/sqRgioRpiSn0id/A9n2pXFI2jJimVWlZJzQbCk3+7du3j5iYGOLi4rjm\nmmtISEjgjjvucDssV1j1kQl50xJT6DYliZR9qSiQsi+VblOSmJaY4nZoJgDMmDGD6tWr88knnxAT\nE8OaNWuKbEIASwqmCOgTv4HUtPRTlqWmpdMnfoNLEfnWtMQU6veez5WvzaJ+7/mW/LKxc+dOHn30\nUe6//34uvPBCli1bxocffhh0A9gVNksKJuRt35ear+XBzEpFuVNVxo0bR7Vq1Zg6dSrvvvsuK1as\nIDIy0u3QAoIlBRPyLikblq/lwayolYrya+vWrTRv3pwnn3yS6667jsTERLp3706JEiXcDi1gWFIw\nIS+maVXCip86Lk1Y8WLENK3qUkS+U5RKRfmRkZHBsGHDqF69OgkJCQwcOJBFixYRHh7udmgBx3of\nmZCX2cuoKPQ+uqRsGCmnSQChWCrKq19//ZV27dqxYMECGjduTGxsLFdddZXbYQUsSwqmSGhZp3JI\nJoGsYppWpduUpFOqkEK1VJSbEydO0L9/f3r06ME555zDqFGjePrpp0N6iIrCYEnBmBBSlEpFOVmz\nZg1RUVGsXLmSli1bMnToUC655BK3wwoKlhSMCTFFpVR0OseOHeO9996jd+/eXHDBBXzxxRc8+OCD\nVjrIB0sKxpiQsGTJEqKioli/fj3//ve/6d+/PxdeeKHbYQUd631kjAlqhw4dokuXLtSvX59Dhw4x\ne/Zsxo4dawnhDFlJwRgTtObMmUP79u3ZsmULnTp1olevXpQuXdrtsIKaKyUFEeksImtFJFlEurgR\ngzEmeO3du5eoqCiaNGlCiRIlWLBgAUOGDLGEUAj8nhREJAKIBuoCtYDmInKNv+MwxgSnqVOnEh4e\nztixY3nttddYs2YNDRo0cDuskOFGSaEasExVj6jqCeAHoJULcRhjgsiff/7JQw89RKtWrbj44ov5\n6aef6NWrF+eee67boYUUN9oU1gLvi8iFQCpwD7Ai60Yi0h5oD3DZZZf5NUBjwOZgCBSqymeffUaX\nLl04fPgw77//PjExMRQvXtzt0EKS35OCqq4XkQ+A74DDwGog/TTbxQKxAJGRkerXIE2RlznaaOaT\nwZmjjQKWGPzojz/+oEOHDsTHx3PrrbcyatQorr/+erfDCmmuNDSr6ihVvVFVbwf2AhvdiMOY7Nho\no+7KyMhg6NChREREsGjRIgYPHszChQstIfiBK11SReQiVd0pIpfhaU+42Y04jMmOjTbqng0bNtCu\nXTsWLVpEkyZNGDFiBFdccYXbYRUZbj289pWIrAO+Bjqp6j6X4jDmtIrSHAyBIi0tjd69e1OrVi2S\nk5MZM2YM3377rSUEP3Or+qiBqoarai1VnedGDMbkpCjNwRAIEhMTqVevHt26daN58+asW7eOp556\nysYscoENc2HMabSsU5lerWpQuWwYAlQuG0avVjWskbmQHT16lNdff52bbrqJ7du3M3nyZCZPnszF\nF1/sdmhFlg1zYUw23BpttKh0hV28eDFRUVFs2LCBNm3a0K9fPy644AK3wyryrKRgTADJ7Aqbsi8V\n5X9dYaclprgdWqE5ePAgzz//PA0aNODo0aPEx8czevRoSwgBwpKCMQEk1LvCxsfHExERwdChQ3n+\n+edZu3YtTZo0cTss48WSgjEBJFS7wu7Zs4c2bdpw9913U7JkSRYuXMigQYMoVaqU26GZLCwpGBNA\nQrEr7OTJk6lWrRrjxo3jjTfeIDExkfr167sdlsmGJQVjAkgodYXdsWMH//d//8dDDz1E5cqVWbFi\nBe+9954NYBfgLCkYE0BCoSusqjJ69GjCw8OZNWsWvXv35qeffqJ27dpuh2bywLqkGhNg3OoKWxi2\nbNlC+/btmTNnDg0aNGDkyJFUrRp8pZyizEoKxpgCS09PZ/DgwURERLBkyRKGDh1KQkKCJYQgZCUF\nY3ws1B9GW79+PVFRUSxZsoS7776bESNG2BwoQcxKCsb4UCg/jJaWlsb7779P7dq12bBhA59++imz\nZ8+2hBDkLCkY40Oh+jDaypUriYyMpHv37rRs2ZJ169bx5JNP2gB2IcCSgjE+FGoPo6WmpvLaa69R\nr149du7cydSpU5k0aRIVK1Z0OzRTSCwpGONDofQw2oIFC6hVqxYffPABbdq0Yd26dbRs2dLtsEwh\ncyUpiMiLIpIsImtFZKKI2NMsJiQFw8No0xJTqN97Ple+Nov6vef/o73jwIEDdOrUiTvuuIMTJ04w\nd+5c4uLiKFeunEsRG1/ye1IQkcrAC0CkqkYAxYBH/R2HMf4Q6A+j5dYQPnv2bCIiIhg2bBhdunQh\nKSmJxo0buxu08Sm3uqSeDYSJSBpQEtjuUhzG+FwgP4yWXUP4f6b8xFf9pzBu3DjCw8P58ccfuflm\nm0q9KPB7UlDVFBHpC/wXSAW+U9Xvsm4nIu2B9oB1cTPGR7I2eKsqR35ZxMq5w0k8fpg333yTN954\ng3POOcelCI2/+T0piEg54H7gSmAf8KWIPKGq47y3U9VYIBYgMjJS/R2nMUXBJWXDSHESw4mDu9kz\nZxipvy7lvMrX8ePsL6lZs6bLERp/c6Oh+S7gd1XdpappwBTgVhfiMKbIi2lalXPPPouDa75j+6hn\nOfr7Kio0jmLs1O8sIRRRbrQp/Be4WURK4qk+agyscCEOY4q8mmWOUeK799mzfDHnXBpB+MOv8Fbr\nRgHbBmJ8z402hWUiMhlYBZwAEnGqiYwx/pE5gF337t0pVqwYw4cPJzo6mrPOskeXijpXeh+pag+g\nhxvnNqaoS05OJioqimXLlnHvvfcyfPhwqlSp4nZYJkDYbYExRcTx48fp2bMnderUYdOmTYwfP56v\nv/7aEoI5hQ2dbUwuQmHo6+XLlxMVFUVSUhKPPfYYgwYNokKFCm6HZQKQJQVTaELhyzOrzCd+Mx/w\nynziFwiKz3bkyBF69OhB//79qVSpEjNmzKBFixZuh2UCmFUfmUIRqvMGBPPQ1wkJCdSqVYu+ffvS\nrl07kpOTLSGYXFlSMIUimL88cxKMQ1/v37+fZ555hoYNG6KqzJ8/nxEjRlCmTBm3QzNBwKqPTKEI\n1C/PglZpeT/xm3V5IJo5cybPPPMMO3bs4KWXXqJnz56ULFnS7bBMELGSgikUgThvQGFUaQXD0NcA\nu3bt4vHHH6dFixaUK1eOJUuW0LdvX0sIJt8sKZhCEYhfnoVRpRXoQ1+rKhMnTiQ8PJzJkyfz9ttv\ns3LlSurWret2aCZI5Vh9JCKlgSZA5v+AFDyjmh70dWAmuGR+SQZS76PCqtIK1KGvt23bRseOHZk5\ncyZ169Zl1KhRREREuB2WCXLZJgURaQ28C8zDkwwAagJ9RORNVR3vh/hMEAm0L89gaw/Iq4yMDOLi\n4oiJiSEtLY3+/fvzwgsvUKxYsdx3NiYXOZUU3sIzO9oe74UiciGwBLCkYAJaTNOqpzxjAO5XaRXU\npk2biI6OJiEhgYYNGzJy5Eiuvvpqt8MyISSnNgUB0k6zPM1ZZ0xAC/T2gPw4ceIEffv2pUaNGqxa\ntYqRI0cyb948Swim0OVUUvgAWC0is4GtzrLLgLuBXr4OzJjCEGhVWmciKSmJqKgoli9fTosWLRg2\nbBiVKwf3ZzKBK9uSgqqOAuoCy/CUDARYCtzsrDPG+NCxY8fo0aMHN9xwA1u2bOHzzz9n+vTplhCM\nT+XY+0hVdwPjctrGGFP4li1bRlRUFMnJyTzxxBMMGDCA8uXLux2WKQKyLSmIyFNeryuJSLyI7BaR\nBSJy7ZmeUESqishqr58DItLlTI9nTCg5fPgwXbt25ZZbbmH//v3MnDmTzz77zBKC8ZucGpo7e70e\nAEwHKgIfAR+f6QlVdYOq1lbV2sCNwBFg6pkez5hQMX/+fGrWrMmAAQN45plnSE5O5t5773U7LFPE\n5PWJ5utV9WNVPaGqXwKFddvSGPhNVf8opOMZE3T27dtHdHQ0jRs35qyzziIhIYGPP/6Y888/3+3Q\nTBGUU5tCFRHpj6eBuYKIFFfVtDzslx+PAhNPt0JE2gPtAS677LJCOp0xgWX69Ol07NiRv/76i1de\neYW3336bsLDgfrjOBLecvty7eb1eC5QG9ojIxcA3BT2xiJQA7stynpNUNRaIBYiMjNSCns+YQLJz\n505eeOEFJk2aRM2aNZkxYwaRkZFuh2VM9kkhu26nqvon8EohnLsZsEpV/yqEYxkTFFSV8ePH07lz\nZw4dOsS7777Lq6++SvHixd0OzRgg595HvUSkw2mWdxCR9wvh3I+RTdWRMaFo69atNG/enCeffJLr\nrruOxMREunfvbgnBBJScGpqb4lTfZBEH3F+Qk4rIecC/gCkFOY4xwSAjI4Nhw4ZRvXp1EhISGDhw\nIIsWLSI8PNzt0Iz5h5zaFIqr6j/q8lU1XaRgQx+p6mHgwgIdxJggsHHjRtq1a8fChQu56667iI2N\n5corr3Q7LGOylVNSOCYiV6vqb94LReRq4JhvwzIm+HhP/VmpdAmu3ZnAF7H9Offcc/nkk09o06YN\nBb2hMsbXckoKPYDZIvIusNJZFgl0B17ydWDGBJPMqT9T09I5vnMzK8cMYslfv1Gv4d1MHf8JlSpV\ncjtEY/Ikp95Hs0RkG56eRjHO4rXAI6q62h/BGRMs+sRv4EjqUfb/+Dn7l03mrHNLU/7+1zir3l2W\nEExQyW1AvDVAaz/FYkzQ2py8it3fDCZt91bOi2hEuUbtKBZ2Pjv2H3U7NGPyJafpOKcC2T40pqqt\nfBKRMUHk0KFDdO/enT/HD6ZY6fJc9NA7hF1148n1wT71pyl6ciopDPFbFMYEoTlz5tC+fXu2bNlC\ns4efYtPl93H8rHNOrg/2qT9N0ZRTm8I8fwZiTLDYu3cvL730EqNHj+a6665jwYIFNGjQ4JTeR5eU\nDSOmadWgn/XNFD2FNbCdMSEt8wv/15/msW/ucNKP7Kdbt2689dZbnHvuuUBoTP1pjCUFY3IxLTGF\nmE9/YPs3H3Nkw2KKX3QVlz38DnUfeuBkQjAmVOQ5KYjIOapqD62ZgOGP6hpVJabXR2z+eigZacco\ne/u/Ob9uK7TY2fSJ32AlAxNycp1kR0TqikgS8KvzvpaIfOTzyIzJQebDYin7UlEgZV8q3aYkMS0x\npdDO8ccff9CsWTM2ffkBxS+8lEueHkyZWx5GinnupbbvSy20cxkTKPIy89pgoDmwG04+u9DQl0EZ\nk5s+8RtITUs/ZVlqWjp94jcU+NgZGRkMGTKE6tWrs2jRIq5s8TwVW3sSgzfrbmpCUV6SwlmnmS4z\n/bRbGuMn2d2lF/TufcOGDdx+++08//zz3HbbbSQnJ9P/nVcpWeLU4a2tu6kJVXlJCltFpC6gIlJM\nRLoAG30clzE5yu4u/Uzv3tPS0ujVqxe1atVi3bp1jBkzhm+++YbLL7+clnUq06tVDSqXDUOAymXD\n6NWqhrUnmJCUl4bmjniqkC4D/gLmOsuMcU1M06onB6DLdKZ374mJiURFRZGYmMiDDz7IRx99xMUX\nX3zKNtbd1BQVuSYFVd0JPFqYJxWRsngm64nAM5RGW1VdUpjnMMElvz2JMtcVpPfR0aNH6dmzJx9+\n+CHly5fnq6++olWrMx+9xR5eM6Eg16QgIiM5zRhIqtq+AOcdBHyrqg+KSAmgZAGOZYKc97DT8L+e\nRECuieFMv3QXLVpEu3bt2LBhA08//TT9+vWjXLlyZ3QsOPPPYEygyUubwlxgnvOzGLiIAkyyIyJl\ngNuBUQCqelxV953p8Uzw82VPoqwOHjzIc889R4MGDTh27Bjx8fF88sknBUoI4N/PYIwv5aX6aJL3\nexH5DFhUgHNeCewCRotILTwT+HR2puj0Pk97oD3AZZddVoDTmUDnq55EWcXHx9O+fXu2bt3KCy+8\nwPvvv0+pUqUK5dj++gzG+FpeSgpZXQlULMA5zwZuAIapah3gMPBa1o1UNVZVI1U1skKFCgU4nQl0\nhd2TKKs9e/bw1FNPcffdd1OyZEkWLVrEoEGDCi0hgO8/gzH+kpcnmveKyB7nZx8wB+hWgHNuA7ap\n6jLn/WQ8ScIUUTFNqxJWvNgpywrrOYDJkydTrVo1JkyYwBtvvEFiYiK33nprtttPS0yhfu/5XPna\nLOr3np/nJ6R9+RmM8accq4/EM8t4LSDzf0aGqmY78U5eqOqfIrJVRKqq6gagMbCuIMc0wa0wehJl\ntWPHDp6JfMuGAAAYFElEQVR77jmmTJnCDTfcQHx8PLVr185xn4I0FvviMxjjBsntO15E1qpqRKGe\nVKQ2ni6pJYDNwNOquje77SMjI3XFihWFGYIJUarKmDFj6Nq1K6mpqbzzzju89NJLnH127o/k1O89\nn5TTtAFULhvG4tca+SJcY3xKRFaqamR+9snLw2urRaSOqiaeYVz/oKqrgXwFakxufv/9d9q3b8/c\nuXNp0KABcXFxXHfddXne3xqLjcmhTUFEMhNGHWC5iGwQkVUikigiq/wTnjG5S09PZ/DgwURERLB0\n6VI+/vhjEhIS8pUQwBqLjYGcSwo/4WkAvs9PsRiTb+vXrycqKoolS5bQrFkzhg8ffsZdmAtz6Axj\nglVOSUEAVPU3P8ViTJ6lpaXx4Ycf0rNnT0qVKsVnn31G69at8fSNODPWWGxMzkmhgoh0zW6lqvb3\nQTzG5GrlypW0bduWn3/+mYcffpiPPvqIiy66qFCObQPfmaIup+cUigGlgNLZ/BjjV6mpqbz66qvU\nq1ePXbt2MXXqVCZNmlRoCcEYk3NJYYeq9vRbJMbkYMGCBbRr145ff/2Vdu3a0adPH8qWLet2WMaE\nnJxKCmdeOWtMITlw4ADPPvssd9xxBydOnGDu3LmMHDnSEoIxPpJTUmjstyiMOY3Zs2cTERHB8OHD\nefHFF0lKSqJxY/uzNMaXsq0+UtU9/gzEmEx///03L774IuPGjSM8PJwff/yRm2++2e2wjCkSzmSU\nVGN8QlX54osvCA8P5/PPP+ett95i1apVlhCM8aO8DHNhjM9t376dZ599lunTpxMZGcncuXOpWbOm\n3+MItSk1Q+3zGN+zpGBcpaqMGjWKl19+mWPHjtG3b186d+6cpwHsCluoTakZap/H+IdVHxnXbN68\nmbvuuovo6Ghq165NUlJSnkc09YVQm1Iz1D6P8Q9LCsbv0tPTGTBgABERESxfvpwRI0Ywf/58rrnm\nGlfjCrVRUkPt8xj/sKRg/Co5OZn69evTtWtXGjVqxLp162jfvj1nneX+n2KojZIaap/H+Icr/xNF\nZIuIJInIahGx2XOKgOPHj9OzZ0/q1KnDb7/9xoQJE/j666+pUqWK26GdFGpTaoba5zH+4WZDc0NV\n/dvF8xs/Wb58OW3btmXt2rU8/vjjDBw4kAoVKrgd1j+E2iipofZ5jH/kOh2nT04qsgWIzGtSsOk4\ng9ORI0d46623GDBgAJUqVWLYsGG0aNHC7bCMKTLOZDpOtypyFZgrIitFpP3pNhCR9iKyQkRW7Nq1\ny8/hmYJKSEigZs2a9OvXj+joaJKTky0hGBME3EoKt6lqbaAZ0ElEbs+6garGqmqkqkYGYlWDOb39\n+/fToUMHGjZsCMD8+fMZPnw4ZcqUcTkyY0xeuJIUVDXF+XcnMBWo60YcpnDNnDmT6tWrExcXx8sv\nv8zPP/98MjkYY4KD35OCiJwnIqUzXwNNgLX+jsMUnl27dvH444/TokULypUrx5IlS+jTpw8lS5Z0\nOzRjTD650fuoIjDVmUv3bGCCqn7rQhymgFSVzz//nBdeeIH9+/fzzjvv8Nprr1GiRAm3QzPGnCG/\nJwVV3QzU8vd5TeHatm0bHTt2ZObMmdSrV49Ro0ZRvXp1t8MyxhSQ+4+RmqCSkZHBiBEjCA8PZ968\nefTv35/FixdbQjAmRNgoqSbPNm3aRHR0NAkJCTRq1IiRI0dy1VVXuR2WMaYQWUnB5OrEiRP07duX\nGjVqsGrVKkaOHMncuXMtIRgTgqykYHKUlJREVFQUy5cv57777uPjjz+mcmUbJsGYUGUlBXNax44d\no0ePHtxwww1s2bKFSZMmMW3aNEsIxoQ4KymYf1i6dClRUVGsW7eOJ554goEDB3LhhRe6HZYxxg+s\npGBOOnz4MF27duXWW2/lwIEDzJo1i88++8wSgjFFiJUUDADz5s0jOjqa33//nY4dO9K7d2/OP/98\nt8MyxviZJYUibt++fcTExBAXF8e1117LDz/8wO23/2N8QlPIpiWm2DwHJiBZ9VERNn36dMLDwxk9\nejSvvvoqa9assYTgB9MSU+g2JYmUfakokLIvlW5TkpiWmOJ2aMZYUiiKdu7cyaOPPkrLli256KKL\nWLZsGb179yYszObu9Yc+8RtITUs/ZVlqWjp94je4FJEx/2NJoQhRVcaNG0e1atWYOnUq7733HsuX\nL+fGG290O7QiZfu+1HwtN8afLCkUEf/973+59957efLJJ6latSqrV6/mjTfeoHjx4m6HVuRcUvb0\nJbLslhvjT5YUQlxGRgbDhg2jevXq/PDDDwwaNIiFCxdSrVo1t0MrsmKaViWseLFTloUVL0ZM06ou\nRWTM/1jvoxC2ceNG2rVrx8KFC7nrrruIjY3lyiuvdDusIi+zl5H1PjKByLWkICLFgBVAiqo2dyuO\nUHTixAn69+9Pjx49OPfcc/nkk09o06YNzsRGJgC0rFPZkoAJSG6WFDoD6wF7QqoQrVmzhrZt27Jq\n1SoeeOABhg4dSqVKldwOyxgTJFxpUxCRKsC9QJwb5w9FR48epXv37kRGRpKSksLkyZOZMmWKJQRj\nTL64VVIYCLwClM5uAxFpD7QHuOyyy/wUVnD68ccfiYqK4pdffuGpp56if//+XHDBBW6HZYwJQn4v\nKYhIc2Cnqq7MaTtVjVXVSFWNrFChgp+iCy6HDh2ic+fO3HbbbRw5coRvv/2WMWPGWEIwxpwxN6qP\n6gP3icgW4HOgkYiMcyGOoDZnzhxq1KjB4MGD6dSpE2vXrqVp06Zuh2WMCXJ+Twqq2k1Vq6jqFcCj\nwHxVfcLfcQSrvXv30rZtW5o0acI555zDwoUL+eijjyhdOtuaOGOMyTN7eC2ITJkyhfDwcD799FO6\ndevG6tWrue2229wOyxgTQlx9eE1VE4AEN2MIBn/++SfPPfccX331FbVr12b27NnUqVPH7bCMMSHI\nSgoBTFUZO3Ys4eHhzJw5k//85z/89NNPlhCMMT5jw1wEqD/++IMOHToQHx9P/fr1iYuL4/rrr3c7\nLGNMiLOSQoDJyMhgyJAhVK9encWLFzNkyBAWLFhgCcEY4xdWUgggGzZsICoqisWLF9O0aVNGjBjB\n5Zdf7nZYxpgixEoKASAtLY1evXpRq1Yt1q1bx9ixY/nmm28sIRhj/M5KCi5LTEykbdu2rF69mgcf\nfJAhQ4ZQsWJFt8MyxhRRVlJwydGjR+nWrRs33XQTf/75J1999RVffvmlJQRjjKuspOCCRYsWERUV\nxcaNG3n66afp168f5cqVczssY4yxkoI/HTx4kOeee44GDRpw/PhxvvvuOz755BNLCMaYgGElBT+J\nj4+nffv2bN26lc6dO/Pee+9RqlQpt8Pyu2mJKTYNpTEBzJKCj+3evZuuXbvy6aefUq1aNRYvXswt\nt9zidliumJaYQrcpSaSmpQOQsi+VblOSACwxGBMgrPrIR1SVyZMnEx4ezoQJE+jevTuJiYlFNiGA\nZ6L6zISQKTUtnT7xG1yKyBiTlZUUfGDHjh106tSJqVOncuONN/Ldd99Rq1Ytt8Ny3fZ9qflabozx\nPyspFCJVZfTo0YSHh/PNN9/wwQcfsHTpUksIjkvKhuVruTHG/ywpFJLff/+dJk2a0LZtW2rWrMma\nNWt45ZVXOPtsK4xlimlalbDixU5ZFla8GDFNq7oUkTEmKzfmaD5XRH4SkTUikiwi7/g7hsKUnp7O\n4MGDiYiIYNmyZQwbNozvv/+e6667zu3QAk7LOpXp1aoGlcuGIUDlsmH0alXDGpmNCSBu3MYeAxqp\n6iERKQ4sEpFvVHWpC7EUyLp162jXrh1LliyhWbNmjBgxgksvvdTtsAJayzqVLQkYE8DcmKNZVfWQ\n87a486P+jqMg0tLSeO+996hTpw4bN25k3LhxzJo1yxKCMSbouVLhLSLFgJXANcBQVV3mRhxnYuXK\nlbRt25aff/6ZRx55hMGDB3PRRRe5HZYxxhQKVxqaVTVdVWsDVYC6IhKRdRsRaS8iK0Rkxa5du/wf\nZBapqam8+uqr1K1bl127djFt2jQ+//xzSwjGmJDiau8jVd0HfA/cfZp1saoaqaqRFSpU8H9wXhYs\nWECtWrX48MMPiYqKYt26ddx///2uxmSMMb7gRu+jCiJS1nkdBvwL+MXfceTFgQMHePbZZ7njjjtI\nT09n3rx5xMbGUrZsWbdDM8YYn3CjTaESMNZpVzgL+EJVZ7oQR45mz55Nhw4d2L59O127dqVnz56c\nd955bodljDE+5fekoKo/A3X8fd68+vvvv+nSpQvjx48nPDycyZMnU69ePbfDMsYYv7Anmh2qyqRJ\nkwgPD2fSpEn06NGDVatWWUIwxhQpNgYDsH37djp27MiMGTO46aabmDdvHjVq1HA7LGOM8bsiXVJQ\nVeLi4ggPD2fOnDn07duXJUuWWEIwxhRZRbaksHnzZqKjo5k/fz533nknI0eO5JprrnE7LGOMcVWR\nKymkp6czYMAAIiIiWLFiBSNGjGDevHmWEIwxhiJWUli7di1RUVH89NNPNG/enGHDhlGlShW3wzLG\nmIBRJEoKx48f55133uGGG25g8+bNTJgwgRkzZlhCMMaYLEK+pLB8+XLatm3L2rVrefzxxxk4cCBu\nD5thjDGBKmRLCkeOHOHll1/m5ptvZu/evXz99deMHz/eEoIxxuQgJEsKCQkJtGvXjt9++40OHTrw\nwQcfUKZMGbfDCmrTElPoE7+B7ftSuaRsGDFNq9pkOcaEoJAqKezfv58OHTrQsGFDAL7//nuGDx9u\nCaGApiWm0G1KEin7UlEgZV8q3aYkMS0xxe3QjDGFLGSSwtdff014eDhxcXG8/PLL/Pzzz9x5551u\nhxUS+sRvIDUt/ZRlqWnp9Inf4FJExhhfCfqksGvXLh5//HHuu+8+LrzwQpYuXUqfPn0oWbKk26GF\njO37UvO13BgTvII2KagqEyZMoFq1akyePJmePXuyYsUKbrrpJrdDCzmXlA3L13JjTPAKyqSwbds2\n7rvvPlq3bs0111xDYmIib775JiVKlHA7tJAU07QqYcWLnbIsrHgxYppWdSkiY4yvBFVSyMjIYMSI\nEYSHhzN//nwGDBjA4sWLqV69utuhhbSWdSrTq1UNKpcNQ4DKZcPo1aqG9T4yJgT5vUuqiFwKfApU\nBBSIVdVBue23adMmoqOjSUhIoHHjxsTGxnLVVVf5OlzjaFmnsiUBY4oAN55TOAG8pKqrRKQ0sFJE\n5qjquux2+Ouvv6hRowbnnHMOcXFxtG3bFhHxX8TGGFNE+L36SFV3qOoq5/VBYD2Q4y3otm3baNq0\nKevWrSMqKsoSgjHG+IioqnsnF7kCWABEqOqBLOvaA+2dtxHAWr8Gl7vywN9uB5FFIMYEgRmXxZQ3\nFlPeBWJcVVW1dH52cC0piEgp4AfgfVWdksu2K1Q10j+R5Y3FlHeBGJfFlDcWU94FYlxnEpMrvY9E\npDjwFTA+t4RgjDHGf/yeFMTTIDAKWK+q/f19fmOMMdlzo6RQH3gSaCQiq52fe3LZJ9YPceWXxZR3\ngRiXxZQ3FlPeBWJc+Y7J1YZmY4wxgSWonmg2xhjjW5YUjDHGnBTQSUFELhWR70VknYgki0jnAIjp\nXBH5SUTWODG943ZMmUSkmIgkishMt2MBEJEtIpLktButcDseABEpKyKTReQXEVkvIrcEQExVvdrX\nVovIARHpEgBxvej8ja8VkYkicm4AxNTZiSfZrWskIp+IyE4RWeu17AIRmSMivzr/lguAmB5yrlOG\niOS5W2pAJwX+NyRGOHAz0ElEwl2O6RjQSFVrAbWBu0XkZpdjytQZzxPigaShqtYOoP7bg4BvVfV6\noBYBcL1UdYNzjWoDNwJHgKluxiQilYEXgEhVjQCKAY+6HFMEEA3UxfO7ay4i17gQyhjg7izLXgPm\nqeq1wDznvdsxrQVa4XlAOM8COimcyZAYfohJVfWQ87a48+N6a72IVAHuBeLcjiVQiUgZ4HY8XaJR\n1eOqus/dqP6hMfCbqv7hdiB4xkYLE5GzgZLAdpfjqQYsU9UjqnoCz8OvrfwdhKouAPZkWXw/MNZ5\nPRZo6XZMqrpeVfM9PWJAJwVvzpAYdYBl7kZysppmNbATmKOqrscEDAReATLcDsSLAnNFZKUzbInb\nrgR2AaOdarY4ETnP7aCyeBSY6HYQqpoC9AX+C+wA9qvqd+5GxVqggYhcKCIlgXuAS12OKVNFVd3h\nvP4TzyjQQSkokoIzJMZXQJesYyS5QVXTnaJ+FaCuU6x1jYg0B3aq6ko34ziN25zr1AxP1d/tLsdz\nNnADMExV6wCH8X8xP1siUgK4D/gyAGIph+fu90rgEuA8EXnCzZhUdT3wAfAd8C2wGkjPcScXqKef\nv+u1B2cq4JNCIA+J4VQ9fM8/6/L8rT5wn4hsAT7H82DgOHdDOnm3iaruxFNHXtfdiNgGbPMq2U3G\nkyQCRTNglar+5XYgwF3A76q6S1XTgCnArS7HhKqOUtUbVfV2YC+w0e2YHH+JSCUA59+dLsdzxgI6\nKQTikBgiUkFEyjqvw4B/Ab+4GZOqdlPVKqp6BZ7qh/mq6updnYic58yXgVNF0wSXR7pV1T+BrSKS\nOY9oYyDbeTxc8BgBUHXk+C9ws4iUdP4fNiYAGuVF5CLn38vwtCdMcDeik2YATzmvnwKmuxhLgbgx\nyU5+ZA6JkeTU4QO8rqqzXYypEjBWRIrhSapfqGpAdAENMBWBqc7cF2cDE1T1W3dDAuB5YLxTVbMZ\neNrleICTifNfQAe3YwFQ1WUiMhlYhacXYCKBMYzDVyJyIZAGdHKjo4CITATuBMqLyDagB9Ab+EJE\nooA/gIcDIKY9wEdABWCWiKxW1aa5HsuGuTDGGJMpoKuPjDHG+JclBWOMMSdZUjDGGHOSJQVjjDEn\nWVIwxhhzkiUFE7BEJN0ZNXStiHzpDG1wpse6M3P0WBG5T0SyfZLZGUn12TM4x9si8vKZxOS8byYi\nK5xRgRNFpJ+zvI2I7PIaRbWd1z5POSNz/ioiT53uPMbkhyUFE8hSndFDI4DjwDPeK8Uj33/DqjpD\nVXvnsElZIN9JoSCcoVKGAE84owJHApu8NpmUOZKqqsY5+1yApz96PTxPi/fw95DNJvRYUjDBYiFw\njYhcISIbRORTPE9IXyoiTURkiYisckoUpQBE5G7xzJuwCq/RNJ077yHO64oiMlU882OsEZFb8TyI\ndLVzV97H2S5GRJaLyM/iNYeGiLwhIhtFZBFQldMQkTEiMtwpBWx0xqrK6hXgfVX9BU6OrzUsl2vS\nFM+AjHtUdS8wB2fIFRHp7ZQ4fhaRvrleXWMcgf5EszE4Qzc3wzMIGsC1wFOqulREygPdgbtU9bCI\nvAp0FZEPgZFAIzx33JOyOfxg4AdVfcB5Sr0UnkHyIpzB/BCRJs456wICzHAG9zuMZ1iR2nj+L60C\nshuU8Apn/6uB7+Wf8wBEAP1yuAz/JyJ3ABuAF1V1K55h5Ld6bbMNqOw88fsAcL2qauawLMbkhZUU\nTCALc4Y3WYFnLJ5RzvI/VHWp8/pmIBxY7Gz7FHA5cD2eAd1+dUatzG6AwEbAMDh5d77/NNs0cX4S\n8XzxX48nSTQApjrj+x/AM/5Ndr5Q1QxV/RXP8BrX5/7xT/oauEJVa+ApDYzNZfv9wFFglIi0wjNp\njzF5YiUFE8hSM+/WMzljKR32XoSnCuWxLNudsl8BCdBLVUdkOUd+poPMOp5M1vfJeGZdW/OPHVV3\ne72NAz50XqfgGe8mUxUgQVVPiEhdPIPYPQg8hyf5GZMrKymYYLcUqJ9ZHeOMznodnpFrrxCRq53t\nHstm/3lAR2ffYuKZne0gUNprm3igrVdbRWVntM4FQEsRCXNGhG2RQ5wPichZTjxX4akG8tYHeN2J\nHWfbZ5zXlby2u4//jVYaDzQRkXJOA3MTIN6Js4wzcOSLeKauNCZPrKRggpqq7hKRNsBEETnHWdxd\nVTeKZ7a3WSJyBE9DdenTHKIzEOuMbpkOdFTVJSKyWDyToH+jqjEiUg1Y4pRUDuHpJbRKRCbhubvf\nCSzPIdT/Aj8B5wPPqOpR51iZn+Nnp+Qx0el6q0Bmd9UXROQ+PKOV7gHaOPvsEZF3vc7b01lWCZgu\nIufiKeV0zf1KGuNho6Qa42MiMgaYqaqT3Y7FmNxY9ZExxpiTrKRgjDHmJCspGGOMOcmSgjHGmJMs\nKRhjjDnJkoIxxpiTLCkYY4w56f8BsEFCM4s5B84AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f40bd14d810>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "%matplotlib inline\n",
     "\n",
@@ -711,298 +602,16 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "# TODO(rbharath, enf): Need to fix this to work with new hyperparam-opt framework.\n",
-    "\n",
-    "#df = pd.DataFrame(performance[['r2_score','split','featurizer']].values, index=performance['n_trees'].values, columns=['r2_score', 'split', 'featurizer'])\n",
-    "#df = df.loc[df['split']==\"validation\"]\n",
-    "#df = df.drop('split', 1)\n",
-    "#fingerprint_df = df[df['featurizer'].str.contains('fingerprint')].drop('featurizer', 1)\n",
-    "#print fingerprint_df\n",
-    "#fingerprint_df.columns = ['ligand fingerprints']\n",
-    "#grid_df = df[df['featurizer'].str.contains('grid')].drop('featurizer', 1)\n",
-    "#grid_df.columns = ['complex features']\n",
-    "#df = pd.concat([fingerprint_df, grid_df], axis=1)\n",
-    "#print(df)\n",
-    "\n",
-    "#plt.clf()\n",
-    "#df.plot()\n",
-    "#plt.ylabel(\"$R^2$\")\n",
-    "#plt.xlabel(\"Number of trees\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 36,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n",
-      "feature_types\n",
-      "[]\n"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "need at least one array to stack",
-     "traceback": [
-      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[1;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[1;32m<ipython-input-36-e47c7d5b4d3d>\u001b[0m in \u001b[0;36m<module>\u001b[1;34m()\u001b[0m\n\u001b[0;32m      6\u001b[0m \u001b[0mfeature_type\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcomplex_featurizers\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m      7\u001b[0m train_dataset = Dataset(data_dir=train_dir, samples=train_samples, \n\u001b[1;32m----> 8\u001b[1;33m                     featurizers=feature_type, tasks=[\"label\"])\n\u001b[0m\u001b[0;32m      9\u001b[0m validation_dataset = Dataset(data_dir=validation_dir, samples=validation_samples, \n\u001b[0;32m     10\u001b[0m                    featurizers=feature_type, tasks=[\"label\"])\n",
-      "\u001b[1;32m/home/rbharath/deepchem/deepchem/utils/dataset.py\u001b[0m in \u001b[0;36m__init__\u001b[1;34m(self, data_dir, tasks, samples, featurizers, use_user_specified_features)\u001b[0m\n\u001b[0;32m     50\u001b[0m       \u001b[1;31m# TODO(rbharath): Still a bit of information leakage.\u001b[0m\u001b[1;33m\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     51\u001b[0m       \u001b[1;32mfor\u001b[0m \u001b[0mdf_file\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mdf\u001b[0m \u001b[1;32min\u001b[0m \u001b[0mzip\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0msamples\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mdataset_files\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0msamples\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0miterdataframes\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m---> 52\u001b[1;33m         \u001b[0mretval\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mwrite_dataset_single_partial\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdf_file\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mdf\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m     53\u001b[0m         \u001b[1;32mif\u001b[0m \u001b[0mretval\u001b[0m \u001b[1;32mis\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0mNone\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m     54\u001b[0m           \u001b[0mmetadata_rows\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mretval\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/home/rbharath/deepchem/deepchem/utils/dataset.py\u001b[0m in \u001b[0;36mwrite_dataset_single\u001b[1;34m(val, data_dir, feature_types, tasks)\u001b[0m\n\u001b[0;32m    180\u001b[0m     \u001b[1;32mreturn\u001b[0m \u001b[0mNone\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    181\u001b[0m   \u001b[0mtask_names\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0msorted\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtasks\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 182\u001b[1;33m   \u001b[0mids\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mX\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0my\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mw\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0m_df_to_numpy\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mdf\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mfeature_types\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mtasks\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    183\u001b[0m   \u001b[0mX_sums\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mX_sum_squares\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mX_n\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcompute_sums_and_nb_sample\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mX\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    184\u001b[0m   \u001b[0my_sums\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0my_sum_squares\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0my_n\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mcompute_sums_and_nb_sample\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0my\u001b[0m\u001b[1;33m,\u001b[0m \u001b[0mw\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/home/rbharath/deepchem/deepchem/utils/dataset.py\u001b[0m in \u001b[0;36m_df_to_numpy\u001b[1;34m(df, feature_types, tasks)\u001b[0m\n\u001b[0;32m    240\u001b[0m       \u001b[1;32mcontinue\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    241\u001b[0m     \u001b[0mtensors\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mfeatures\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 242\u001b[1;33m   \u001b[0mx\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mnp\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mstack\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0mtensors\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    243\u001b[0m   \u001b[0msorted_ids\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mdf\u001b[0m\u001b[1;33m[\u001b[0m\u001b[1;34m\"mol_id\"\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    244\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;32m/home/rbharath/anaconda/lib/python2.7/site-packages/numpy/core/shape_base.pyc\u001b[0m in \u001b[0;36mstack\u001b[1;34m(arrays, axis)\u001b[0m\n\u001b[0;32m    333\u001b[0m     \u001b[0marrays\u001b[0m \u001b[1;33m=\u001b[0m \u001b[1;33m[\u001b[0m\u001b[0masanyarray\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0marr\u001b[0m\u001b[1;33m)\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0marr\u001b[0m \u001b[1;32min\u001b[0m \u001b[0marrays\u001b[0m\u001b[1;33m]\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    334\u001b[0m     \u001b[1;32mif\u001b[0m \u001b[1;32mnot\u001b[0m \u001b[0marrays\u001b[0m\u001b[1;33m:\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[1;32m--> 335\u001b[1;33m         \u001b[1;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[1;33m(\u001b[0m\u001b[1;34m'need at least one array to stack'\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0m\u001b[0;32m    336\u001b[0m \u001b[1;33m\u001b[0m\u001b[0m\n\u001b[0;32m    337\u001b[0m     \u001b[0mshapes\u001b[0m \u001b[1;33m=\u001b[0m \u001b[0mset\u001b[0m\u001b[1;33m(\u001b[0m\u001b[0marr\u001b[0m\u001b[1;33m.\u001b[0m\u001b[0mshape\u001b[0m \u001b[1;32mfor\u001b[0m \u001b[0marr\u001b[0m \u001b[1;32min\u001b[0m \u001b[0marrays\u001b[0m\u001b[1;33m)\u001b[0m\u001b[1;33m\u001b[0m\u001b[0m\n",
-      "\u001b[1;31mValueError\u001b[0m: need at least one array to stack"
-     ],
-     "output_type": "error"
-    }
-   ],
-   "source": [
-    "train_dir, validation_dir, test_dir = tempfile.mkdtemp(), tempfile.mkdtemp(), tempfile.mkdtemp()\n",
-    "splittype=\"random\"\n",
-    "train_samples, validation_samples, test_samples = featurized_samples.train_valid_test_split(\n",
-    "    splittype, train_dir, validation_dir, test_dir, seed=2016)\n",
-    "\n",
-    "feature_type = complex_featurizers\n",
-    "train_dataset = Dataset(data_dir=train_dir, samples=train_samples, \n",
-    "                    featurizers=feature_type, tasks=[\"label\"])\n",
-    "validation_dataset = Dataset(data_dir=validation_dir, samples=validation_samples, \n",
-    "                   featurizers=feature_type, tasks=[\"label\"])\n",
-    "test_dataset = Dataset(data_dir=test_dir, samples=test_samples, \n",
-    "                   featurizers=feature_type, tasks=[\"label\"])\n",
-    "\n",
-    "for transformer in transformers:\n",
-    "    transformer.transform(train_dataset)\n",
-    "for transformer in transformers:\n",
-    "    transformer.transform(valid_dataset)\n",
-    "for transformer in transformers:\n",
-    "    transformer.transform(test_dataset)\n",
-    "\n",
-    "model_params = {\"data_shape\": train_dataset.get_data_shape()}\n",
-    "rf_model = SklearnModel(task_types, model_params, model_instance=RandomForestRegressor(n_estimators=20))\n",
-    "rf_model.fit(train_dataset)\n",
-    "model_dir = tempfile.mkdtemp()\n",
-    "rf_model.save(model_dir)\n",
-    "\n",
-    "\n",
-    "evaluator = Evaluator(rf_model, train_dataset, output_transformers, verbose=True)\n",
-    "with tempfile.NamedTemporaryFile() as train_csv_out:\n",
-    "  with tempfile.NamedTemporaryFile() as train_stats_out:\n",
-    "    _, train_r2score = evaluator.compute_model_performance(\n",
-    "        train_csv_out, train_stats_out)\n",
-    "\n",
-    "evaluator = Evaluator(rf_model, test_dataset, output_transformers, verbose=True)\n",
-    "test_csv_out = tempfile.NamedTemporaryFile()\n",
-    "with tempfile.NamedTemporaryFile() as test_stats_out:\n",
-    "    predictions, test_r2score = evaluator.compute_model_performance(\n",
-    "        test_csv_out, test_stats_out)\n",
-    "\n",
-    "train_test_performance = pd.concat([train_r2score, test_r2score])\n",
-    "train_test_performance[\"split\"] = [\"train\", \"test\"]\n",
-    "train_test_performance[\"featurizer\"] = [str(feature_type.__class__), str(feature_type.__class__)]\n",
-    "train_test_performance[\"n_trees\"] = [n_trees, n_trees]\n",
-    "print(train_test_performance)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false,
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "import deepchem.models.deep\n",
-    "from deepchem.models.deep import SingleTaskDNN\n",
-    "import numpy.random\n",
-    "from operator import mul\n",
-    "import itertools\n",
-    "\n",
-    "params_dict = {\"activation\": [\"relu\"],\n",
-    "                \"momentum\": [.9],\n",
-    "                \"batch_size\": [50],\n",
-    "                \"init\": [\"glorot_uniform\"],\n",
-    "                \"data_shape\": [train_dataset.get_data_shape()],\n",
-    "                \"learning_rate\": np.power(10., np.random.uniform(-5, -2, size=5)),\n",
-    "                \"decay\": np.power(10., np.random.uniform(-6, -4, size=5)),\n",
-    "                \"nb_hidden\": [1000],\n",
-    "                \"nb_epoch\": [40],\n",
-    "                \"nesterov\": [False],\n",
-    "                \"dropout\": [.5],\n",
-    "                \"nb_layers\": [1],\n",
-    "                \"batchnorm\": [False],\n",
-    "              }\n",
-    "\n",
-    "\n",
-    "optimizer = HyperparamOpt(SingleTaskDNN, task_types)\n",
-    "best_dnn, best_hyperparams, all_results = optimizer.hyperparam_search(\n",
-    "    params_dict, train_dataset, valid_dataset, output_transformers, metric=\"r2_score\", verbosity=None)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "dnn_test_csv_out = tempfile.NamedTemporaryFile()\n",
-    "dnn_test_stats_out = tempfile.NamedTemporaryFile()\n",
-    "dnn_test_evaluator = Evaluator(best_dnn, test_dataset)\n",
-    "dnn_test_df, dnn_test_r2score = dnn_test_evaluator.compute_model_performance(\n",
-    "    dnn_test_csv_out, dnn_test_stats_out)\n",
-    "dnn_test_r2_score = dnn_test_r2score.iloc[0][\"r2_score\"]\n",
-    "print(\"DNN Test set R^2 %f\" % (dnn_test_r2_score))\n",
-    "\n",
-    "task = \"label\"\n",
-    "dnn_predicted_test = np.array(dnn_test_df[task + \"_pred\"])\n",
-    "dnn_true_test = np.array(dnn_test_df[task])\n",
-    "\n",
-    "plt.clf()\n",
-    "plt.scatter(dnn_true_test, dnn_predicted_test)\n",
-    "plt.xlabel('Predicted Ki')\n",
-    "plt.ylabel('True Ki')\n",
-    "plt.title(r'DNN predicted vs. true Ki')\n",
-    "plt.xlim([-2, 2])\n",
-    "plt.ylim([-2, 2])\n",
-    "plt.plot([-3, 3], [-3, 3], marker=\".\", color='k')\n",
-    "\n",
-    "rf_test_csv_out = tempfile.NamedTemporaryFile()\n",
-    "rf_test_stats_out = tempfile.NamedTemporaryFile()\n",
-    "rf_test_evaluator = Evaluator(rf_model, test_dataset)\n",
-    "rf_test_df, rf_test_r2score = rf_test_evaluator.compute_model_performance(\n",
-    "    rf_test_csv_out, rf_test_stats_out)\n",
-    "rf_test_r2_score = rf_test_r2score.iloc[0][\"r2_score\"]\n",
-    "print(\"RF Test set R^2 %f\" % (rf_test_r2_score))\n",
-    "plt.show()\n",
-    "\n",
-    "task = \"label\"\n",
-    "rf_predicted_test = np.array(rf_test_df[task + \"_pred\"])\n",
-    "rf_true_test = np.array(rf_test_df[task])\n",
-    "plt.scatter(rf_true_test, rf_predicted_test)\n",
-    "plt.xlabel('Predicted Ki')\n",
-    "plt.ylabel('True Ki')\n",
-    "plt.title(r'RF predicted vs. true Ki')\n",
-    "plt.xlim([-2, 2])\n",
-    "plt.ylim([-2, 2])\n",
-    "plt.plot([-3, 3], [-3, 3], marker=\".\", color='k')\n",
+    "rf_predicted_test = best_rf.predict(test_dataset)\n",
+    "rf_true_test = test_dataset.y\n",
+    "plt.scatter(rf_predicted_test, rf_true_test)\n",
+    "plt.xlabel('Predicted pIC50s')\n",
+    "plt.ylabel('True IC50')\n",
+    "plt.title(r'RF predicted IC50 vs. True pIC50')\n",
+    "plt.xlim([2, 11])\n",
+    "plt.ylim([2, 11])\n",
+    "plt.plot([2, 11], [2, 11], color='k')\n",
     "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "predictions = dnn_test_df.sort(['label'], ascending=[0])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "top_complex = predictions.iloc[0]['ids']\n",
-    "best_complex = dataset.loc[dataset['complex_id']==top_complex]\n",
-    "\n",
-    "protein_mdtraj = convert_lines_to_mdtraj(best_complex[\"protein_pdb\"].values[0])\n",
-    "ligand_mdtraj = convert_lines_to_mdtraj(best_complex[\"ligand_pdb\"].values[0])\n",
-    "complex_mdtraj = combine_mdtraj(protein_mdtraj, ligand_mdtraj)\n",
-    "if DISPLAY:\n",
-    "    ngltraj = visualize_complex(complex_mdtraj)\n",
-    "    ngltraj"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "top_complex = predictions.iloc[1]['ids']\n",
-    "best_complex = dataset.loc[dataset['complex_id']==top_complex]\n",
-    "\n",
-    "protein_mdtraj = convert_lines_to_mdtraj(best_complex[\"protein_pdb\"].values[0])\n",
-    "ligand_mdtraj = convert_lines_to_mdtraj(best_complex[\"ligand_pdb\"].values[0])\n",
-    "complex_mdtraj = combine_mdtraj(protein_mdtraj, ligand_mdtraj)\n",
-    "if DISPLAY:\n",
-    "    ngltraj = visualize_complex(complex_mdtraj)\n",
-    "    ngltraj"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "top_complex = predictions.iloc[predictions.shape[0]-1]['ids']\n",
-    "best_complex = dataset.loc[dataset['complex_id']==top_complex]\n",
-    "\n",
-    "protein_mdtraj = convert_lines_to_mdtraj(best_complex[\"protein_pdb\"].values[0])\n",
-    "ligand_mdtraj = convert_lines_to_mdtraj(best_complex[\"ligand_pdb\"].values[0])\n",
-    "complex_mdtraj = combine_mdtraj(protein_mdtraj, ligand_mdtraj)\n",
-    "if DISPLAY:\n",
-    "    ngltraj = visualize_complex(complex_mdtraj)\n",
-    "    ngltraj"
    ]
   }
  ],
@@ -1016,14 +625,26 @@
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2.0
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.13"
+  },
+  "widgets": {
+   "state": {
+    "77e7e93946884ed7a2a1a48808f99a90": {
+     "views": [
+      {
+       "cell_index": 10
+      }
+     ]
+    }
+   },
+   "version": "1.2.0"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/tests.py
+++ b/examples/notebooks/tests.py
@@ -26,7 +26,6 @@ def _notebook_read(path):
 
     fout.seek(0)
     nb = nbformat.read(fout, nbformat.current_nbformat)
-  # nb = nbformat.read(fout, nbformat.current_nbformat)
 
   errors = [output for cell in nb.cells if "outputs" in cell
             for output in cell["outputs"] \

--- a/examples/notebooks/tests.py
+++ b/examples/notebooks/tests.py
@@ -19,9 +19,10 @@ def _notebook_read(path):
   """
 
   with tempfile.NamedTemporaryFile(suffix=".ipynb") as fout:
-    args = ["jupyter-nbconvert", "--to", "notebook", "--execute",
-            "--ExecutePreprocessor.timeout=60",
-            "--output", fout.name, path]
+    args = [
+        "jupyter-nbconvert", "--to", "notebook", "--execute",
+        "--ExecutePreprocessor.timeout=60", "--output", fout.name, path
+    ]
     subprocess.check_call(args)
 
     fout.seek(0)

--- a/examples/notebooks/tests.py
+++ b/examples/notebooks/tests.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+import tempfile
+
+import nbformat
+
+
+def _notebook_read(path):
+  """
+  Parameters
+  ----------
+  path: str
+  path to ipython notebook
+
+  Returns
+  -------
+  nb: notebook object
+  errors: list of Exceptions
+  """
+
+  with tempfile.NamedTemporaryFile(suffix=".ipynb") as fout:
+    args = ["jupyter-nbconvert", "--to", "notebook", "--execute",
+            "--ExecutePreprocessor.timeout=60",
+            "--output", fout.name, path]
+    subprocess.check_call(args)
+
+    fout.seek(0)
+    nb = nbformat.read(fout, nbformat.current_nbformat)
+  # nb = nbformat.read(fout, nbformat.current_nbformat)
+
+  errors = [output for cell in nb.cells if "outputs" in cell
+            for output in cell["outputs"] \
+            if output.output_type == "error"]
+
+  return nb, errors
+
+
+def test_protein_ligand_complex_notebook():
+  nb, errors = _notebook_read("protein_ligand_complex_notebook.ipynb")
+  assert errors == []


### PR DESCRIPTION
There have been multiple Github issues around bugs/errors in the ipython notebooks.  That means people are using them!  So it is time to put them under test.

This is built on top of https://github.com/deepchem/deepchem/pull/709 and ensures that protein_ligand_complex_notebook.ipynb does not throw any errors.

In order to add additional notebooks under test all you have to do is add another test in examples/notebooks/tests.py. i.e. to test Multitask Networks on MUV.ipynb

```python
def test_protein_ligand_complex_notebook():
  nb, errors = _notebook_read("Multitask Networks on MUV.ipynb")
  assert errors == []
```
and then we will run a test to ensure the notebook does not throw any exceptions when run.  The tests are currently run with python 2.7 as protein_ligand_complex_notebook.ipynb relies on python 2.7 pickle files.

These tests will run on the Stanford continuous integration box on every PR into master.  On failure it will e-mail the deepchem-dev@googlegroups.com mailing group.

From inside the Stanford VPN
http://171.65.103.54:8080/job/notebook_tests