### PR TITLE
Implemented Layer.shape

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -738,6 +738,8 @@ class Constant(Layer):
     dtype: tf.DType
       the data type of the output value.
     """
+    if not isinstance(value, np.ndarray):
+      value = np.array(value)
     self.value = value
     self.dtype = dtype
     self._shape = tuple(value.shape)
@@ -763,6 +765,8 @@ class Variable(Layer):
     dtype: tf.DType
       the data type of the output value.
     """
+    if not isinstance(initial_value, np.ndarray):
+      initial_value = np.array(initial_value)
     self.initial_value = initial_value
     self.dtype = dtype
     self._shape = tuple(initial_value.shape)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -391,6 +391,16 @@ class TensorGraph(Model):
       writer.add_graph(self._get_tf("Graph"))
       writer.close()
 
+    # As a sanity check, make sure all tensors have the correct shape.
+
+    for layer in self.layers.values():
+      try:
+        assert list(layer.shape) == layer.out_tensor.get_shape().as_list(
+        ), '%s: Expected shape %s does not match actual shape %s' % (
+            layer.name, layer.shape, layer.out_tensor.get_shape().as_list())
+      except NotImplementedError:
+        pass
+
   def _install_queue(self):
     """
     """

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -516,10 +516,12 @@ class TestLayers(test_util.TensorFlowTestCase):
     value1 = np.random.uniform(size=(2, 3)).astype(np.float32)
     value2 = np.random.uniform(size=(1, 6, 1)).astype(np.float32)
     with self.test_session() as sess:
-      out_tensor = Add()(tf.constant(value1), tf.constant(value2))
+      out_tensor = ReduceSquareDifference()(tf.constant(value1),
+                                            tf.constant(value2))
       result = out_tensor.eval()
-      assert result.shape == (1, 6, 1)
-      assert np.array_equal(value1.reshape((1, 6, 1)) + value2, result)
+      diff = value1.reshape((1, 6, 1)) - value2
+      loss = np.mean(diff**2)
+      assert (loss - result) / loss < 1e-6
 
   def test_squeeze_inputs(self):
     """Test that layers can automatically reshape inconsistent inputs."""

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -43,7 +43,7 @@ def test_Flatten_pickle():
 def test_Reshape_pickle():
   tg = TensorGraph()
   feature = Feature(shape=(tg.batch_size, 1))
-  layer = Reshape(shape=(-1, 2), in_layers=feature)
+  layer = Reshape(shape=(None, 2), in_layers=feature)
   tg.add_output(layer)
   tg.set_loss(layer)
   tg.build()
@@ -53,7 +53,7 @@ def test_Reshape_pickle():
 def test_Squeeze_pickle():
   tg = TensorGraph()
   feature = Feature(shape=(tg.batch_size, 1))
-  layer = Squeeze(squeeze_dims=-1, in_layers=feature)
+  layer = Squeeze(in_layers=feature)
   tg.add_output(layer)
   tg.set_loss(layer)
   tg.build()
@@ -133,7 +133,7 @@ def test_Concat_pickle():
 def test_Constant_pickle():
   tg = TensorGraph()
   feature = Feature(shape=(tg.batch_size, 1))
-  layer = Constant(np.expand_dims([17] * tg.batch_size, -1))
+  layer = Constant(np.array([15.0]))
   output = Add(in_layers=[feature, layer])
   tg.add_output(output)
   tg.set_loss(output)
@@ -144,7 +144,7 @@ def test_Constant_pickle():
 def test_Variable_pickle():
   tg = TensorGraph()
   feature = Feature(shape=(tg.batch_size, 1))
-  layer = Variable(np.expand_dims([17] * tg.batch_size, -1))
+  layer = Variable(np.array([15.0]))
   output = Multiply(in_layers=[feature, layer])
   tg.add_output(output)
   tg.set_loss(output)
@@ -226,7 +226,7 @@ def test_ReduceSquareDifference_pickle():
 
 def test_Conv2D_pickle():
   tg = TensorGraph()
-  feature = Feature(shape=(tg.batch_size, 10, 10))
+  feature = Feature(shape=(tg.batch_size, 10, 10, 1))
   layer = Conv2D(num_outputs=3, in_layers=feature)
   tg.add_output(layer)
   tg.set_loss(layer)


### PR DESCRIPTION
Fixes #714.  I've implemented it for all the standard layer classes, but not the specialized ones like graph convolutions or atomic convolutions.  I'll leave it to the authors of those classes to do it.  You just need to set `_shape` in the constructor.  In the mean time, you'll get a `NotImplementedError` if you try to get the shape of one of those layers, or another layer that depends on them.

TensorGraph checks the predicted shape against the actual shape of the output tensor, so if I've made any mistakes in calculating them they'll get caught there.  Hopefully there aren't too many bugs, but I expect there are a lot of special cases that aren't covered by the test suite.  If you find bugs, let me know.