### PR TITLE
Adds load_qm7 to top level and fixes doc bug in tictactoe.py

### DIFF
--- a/contrib/rl/tictactoe.py
+++ b/contrib/rl/tictactoe.py
@@ -47,7 +47,7 @@ def eval_tic_tac_toe(value_weight,
                      games=10**4,
                      rollouts=10**5):
   """
-    Returns the average reward over 1k games after 10k rollouts
+    Returns the average reward over 1k games after 100k rollouts
     :param value_weight:
     :return:
     """

--- a/deepchem/molnet/__init__.py
+++ b/deepchem/molnet/__init__.py
@@ -17,6 +17,7 @@ from deepchem.molnet.load_function.nci_datasets import load_nci
 from deepchem.molnet.load_function.pcba_datasets import load_pcba
 from deepchem.molnet.load_function.pdbbind_datasets import load_pdbbind_grid
 from deepchem.molnet.load_function.ppb_datasets import load_ppb
+from deepchem.molnet.load_function.qm7_datasets import load_qm7
 from deepchem.molnet.load_function.qm7_datasets import load_qm7_from_mat, load_qm7b_from_mat
 from deepchem.molnet.load_function.qm8_datasets import load_qm8
 from deepchem.molnet.load_function.qm9_datasets import load_qm9


### PR DESCRIPTION
A pair of small bugfixes:
- Exposes `dc.molnet.load_qm7`
- Changes 10K rollouts to 100K rollouts in comments for `tictactoe.py`