### PR TITLE
Quieter Log for Installing DeepChem Deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ install:
 - pip install coveralls
 - python setup.py install
 script:
-- nosetests --with-flaky -a '!slow' --with-timer --with-coverage --cover-package=deepchem -v deepchem --nologcapture
+- nosetests --with-flaky -a '!slow' --with-timer --with-coverage --cover-package=deepchem --processes=-1 -v deepchem --nologcapture
+--processes=NUM¶
 - find ./deepchem | grep .py$ |xargs python -m doctest -v
 - bash devtools/travis-ci/test_format_code.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ install:
 - pip install coveralls
 - python setup.py install
 script:
-- nosetests --with-flaky -a '!slow' --with-timer --with-coverage --cover-package=deepchem --processes=-1 -v deepchem --nologcapture
+- nosetests --with-flaky -a '!slow' --with-timer --with-coverage --cover-package=deepchem -v deepchem --nologcapture
 - find ./deepchem | grep .py$ |xargs python -m doctest -v
 - bash devtools/travis-ci/test_format_code.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
 - python setup.py install
 script:
 - nosetests --with-flaky -a '!slow' --with-timer --with-coverage --cover-package=deepchem --processes=-1 -v deepchem --nologcapture
---processes=NUM¶
 - find ./deepchem | grep .py$ |xargs python -m doctest -v
 - bash devtools/travis-ci/test_format_code.sh
 after_success:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ git clone https://github.com/deepchem/deepchem.git      # Clone deepchem source 
 cd deepchem
 bash scripts/install_deepchem_conda.sh deepchem
 source activate deepchem
-pip install tensorflow-gpu==1.0.1                       # If you want GPU support
+pip install tensorflow-gpu==1.2.1                       # If you want GPU support
 python setup.py install                                 # Manual install
 nosetests -v deepchem --nologcapture                    # Run tests
 ```
@@ -110,7 +110,7 @@ conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=1.2.0
     contact your local sysadmin to work out a custom installation. If your
     version of Linux is recent, then the following command will work:
     ```
-    pip install tensorflow-gpu
+    pip install tensorflow-gpu==1.2.1
     ```
 
 9. `deepchem`: Clone the `deepchem` github repo:

--- a/deepchem/dock/binding_pocket.py
+++ b/deepchem/dock/binding_pocket.py
@@ -224,7 +224,7 @@ class RFConvexHullPocketFinder(BindingPocketFinder):
     print("About to download trained model.")
     # TODO(rbharath): Shift refined to full once trained.
     call((
-        "wget -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/pocket_random_refined_RF.tar.gz"
+        "wget -nv -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/pocket_random_refined_RF.tar.gz"
     ).split())
     call(("tar -zxvf pocket_random_refined_RF.tar.gz").split())
     call(("mv pocket_random_refined_RF %s" % (self.base_dir)).split())

--- a/deepchem/dock/docking.py
+++ b/deepchem/dock/docking.py
@@ -41,7 +41,7 @@ class VinaGridRFDocker(Docker):
     self.base_dir = tempfile.mkdtemp()
     print("About to download trained model.")
     call((
-        "wget -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/random_full_RF.tar.gz"
+        "wget -nv -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/random_full_RF.tar.gz"
     ).split())
     call(("tar -zxvf random_full_RF.tar.gz").split())
     call(("mv random_full_RF %s" % (self.base_dir)).split())
@@ -79,7 +79,7 @@ class VinaGridDNNDocker(object):
     self.base_dir = tempfile.mkdtemp()
     print("About to download trained model.")
     call((
-        "wget -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/random_full_DNN.tar.gz"
+        "wget -nv -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/random_full_DNN.tar.gz"
     ).split())
     call(("tar -zxvf random_full_DNN.tar.gz").split())
     call(("mv random_full_DNN %s" % (self.base_dir)).split())

--- a/deepchem/dock/pose_generation.py
+++ b/deepchem/dock/pose_generation.py
@@ -66,7 +66,7 @@ class VinaPoseGenerator(PoseGenerator):
       print("Vina not available. Downloading")
       # TODO(rbharath): May want to move this file to S3 so we can ensure it's
       # always available.
-      wget_cmd = "wget -c http://vina.scripps.edu/download/autodock_vina_1_1_2_linux_x86.tgz"
+      wget_cmd = "wget -nv -c http://vina.scripps.edu/download/autodock_vina_1_1_2_linux_x86.tgz"
       call(wget_cmd.split())
       print("Downloaded Vina. Extracting")
       download_cmd = "tar xzvf autodock_vina_1_1_2_linux_x86.tgz"

--- a/deepchem/dock/pose_generation.py
+++ b/deepchem/dock/pose_generation.py
@@ -90,7 +90,7 @@ class VinaPoseGenerator(PoseGenerator):
     if out_dir is None:
       out_dir = tempfile.mkdtemp()
 
-    # Prepare receptor 
+    # Prepare receptor
     receptor_name = os.path.basename(protein_file).split(".")[0]
     protein_hyd = os.path.join(out_dir, "%s.pdb" % receptor_name)
     protein_pdbqt = os.path.join(out_dir, "%s.pdbqt" % receptor_name)
@@ -117,7 +117,7 @@ class VinaPoseGenerator(PoseGenerator):
         pockets, pocket_atoms_maps, pocket_coords = self.pocket_finder.find_pockets(
             protein_file, ligand_file)
         # TODO(rbharath): Handle multiple pockets instead of arbitrarily selecting
-        # first pocket. 
+        # first pocket.
         print("Computing centroid and size of proposed pocket.")
         pocket_coord = pocket_coords[0]
         protein_centroid = np.mean(pocket_coord, axis=1)
@@ -157,10 +157,10 @@ class VinaPoseGenerator(PoseGenerator):
     if not dry_run:
       print("About to call Vina")
       call(
-          "%s --config %s --log %s --out %s" %
-          (self.vina_cmd, conf_file, log_file, out_pdbqt),
+          "%s --config %s --log %s --out %s" % (self.vina_cmd, conf_file,
+                                                log_file, out_pdbqt),
           shell=True)
     # TODO(rbharath): Convert the output pdbqt to a pdb file.
 
-    # Return docked files 
+    # Return docked files
     return protein_hyd, out_pdbqt

--- a/deepchem/dock/tests/test_pose_scoring.py
+++ b/deepchem/dock/tests/test_pose_scoring.py
@@ -28,7 +28,7 @@ class TestPoseScoring(unittest.TestCase):
   def setUp(self):
     """Downloads dataset."""
     call(
-        "wget -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/core_grid.tar.gz".
+        "wget -nv -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/core_grid.tar.gz".
         split())
     call("tar -zxvf core_grid.tar.gz".split())
     self.core_dataset = dc.data.DiskDataset("core_grid/")

--- a/deepchem/models/autoencoder_models/autoencoder.py
+++ b/deepchem/models/autoencoder_models/autoencoder.py
@@ -62,7 +62,7 @@ class TensorflowMoleculeEncoder(Model):
     weights_file = os.path.join(current_dir, weights_filename)
 
     if not os.path.exists(weights_file):
-      wget_command = "wget -c http://karlleswing.com/misc/keras-molecule/model.h5"
+      wget_command = "wget -nv -c http://karlleswing.com/misc/keras-molecule/model.h5"
       call(wget_command.split())
       mv_cmd = "mv model.h5 %s" % weights_file
       call(mv_cmd.split())
@@ -132,7 +132,7 @@ class TensorflowMoleculeDecoder(Model):
     weights_file = os.path.join(current_dir, weights_filename)
 
     if not os.path.exists(weights_file):
-      wget_command = "wget -c http://karlleswing.com/misc/keras-molecule/model.h5"
+      wget_command = "wget -nv -c http://karlleswing.com/misc/keras-molecule/model.h5"
       call(wget_command.split())
       mv_cmd = "mv model.h5 %s" % weights_file
       call(mv_cmd.split())

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -5,6 +5,8 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
+from nose.plugins.attrib import attr
+
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"
@@ -1357,6 +1359,7 @@ class TestOverfit(test_util.TensorFlowTestCase):
 
     assert scores[regression_metric.name] > .8
 
+  @attr("slow")
   def test_MPNN_singletask_regression_overfit(self):
     """Test MPNN overfits tiny data."""
     np.random.seed(123)

--- a/deepchem/molnet/load_function/kaggle_datasets.py
+++ b/deepchem/molnet/load_function/kaggle_datasets.py
@@ -60,15 +60,15 @@ def gen_kaggle(KAGGLE_tasks,
                             "KAGGLE_test2_disguised_combined_full.csv.gz")
   if not os.path.exists(train_files):
     os.system(
-        'wget -c -P ' + data_dir +
+        'wget -nv -c -P ' + data_dir +
         ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz'
     )
     os.system(
-        'wget -c -P ' + data_dir +
+        'wget -nv -c -P ' + data_dir +
         ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz'
     )
     os.system(
-        'wget -c -P ' + data_dir +
+        'wget -nv -c -P ' + data_dir +
         ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz'
     )
 

--- a/devtools/jenkins/test_notebooks.sh
+++ b/devtools/jenkins/test_notebooks.sh
@@ -17,4 +17,4 @@ cd examples/notebooks
 nosetests --with-timer tests.py --with-xunit --xunit-file=notebook_tests.xml|| true
 
 source deactivate
-#conda remove --name $envname --all
+conda remove --name $envname --all

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -20,19 +20,19 @@ fi
 export envname=$1
 conda create -y --name $envname python=$python_version
 source activate $envname
-conda install -y -c omnia pdbfixer=1.4
-conda install -y -c rdkit rdkit
-conda install -y -c conda-forge joblib=0.11
-conda install -y -c conda-forge six
-conda install -y -c conda-forge mdtraj
-conda install -y -c conda-forge scikit-learn=0.18.1
-conda install -y -c conda-forge setuptools
-conda install -y -c conda-forge keras=1.2.2
-conda install -y -c conda-forge networkx=1.11
-conda install -y -c conda-forge xgboost=0.6a2
-conda install -y -c conda-forge pillow=4.2.1
-conda install -y -c conda-forge pandas=0.19.2
-conda install -y -c conda-forge $tensorflow=1.2.1
-conda install -y -c conda-forge nose=1.3.7
-conda install -y -c conda-forge nose-timer=0.7.0
-conda install -y -c conda-forge flaky=3.3.0
+conda install -y -q -c omnia pdbfixer=1.4
+conda install -y -q-c rdkit rdkit
+conda install -y -q -c conda-forge joblib=0.11
+conda install -y -q -c conda-forge six
+conda install -y -q -c conda-forge mdtraj
+conda install -y -q -c conda-forge scikit-learn=0.18.1
+conda install -y -q -c conda-forge setuptools
+conda install -y -q -c conda-forge keras=1.2.2
+conda install -y -q -c conda-forge networkx=1.11
+conda install -y -q -c conda-forge xgboost=0.6a2
+conda install -y -q -c conda-forge pillow=4.2.1
+conda install -y -q -c conda-forge pandas=0.19.2
+conda install -y -q -c conda-forge $tensorflow=1.2.1
+conda install -y -q -c conda-forge nose=1.3.7
+conda install -y -q -c conda-forge nose-timer=0.7.0
+conda install -y -q -c conda-forge flaky=3.3.0

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -21,7 +21,7 @@ export envname=$1
 conda create -y --name $envname python=$python_version
 source activate $envname
 conda install -y -q -c omnia pdbfixer=1.4
-conda install -y -q-c rdkit rdkit
+conda install -y -q -c rdkit rdkit
 conda install -y -q -c conda-forge joblib=0.11
 conda install -y -q -c conda-forge six
 conda install -y -q -c conda-forge mdtraj


### PR DESCRIPTION
Build is failing because our log is too long.
One of the major sources for log length is progress bars for anaconda downloads.
Script no longer prints download bars to stdout.