### PR TITLE
Automatic conversion of Layers to Tensors

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -161,6 +161,16 @@ class Layer(object):
     elif self.summary_op == 'histogram':
       tf.summary.histogram(self.name, self.tb_input, self.collections)
 
+  def _as_graph_element(self):
+    return self.out_tensor._as_graph_element()
+
+
+def _convert_layer_to_tensor(value, dtype=None, name=None, as_ref=False):
+  return tf.convert_to_tensor(value.out_tensor, dtype=dtype, name=name)
+
+
+tf.register_tensor_conversion_function(Layer, _convert_layer_to_tensor)
+
 
 class TensorWrapper(Layer):
   """Used to wrap a tensorflow tensor."""

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -530,3 +530,14 @@ class TestLayers(test_util.TensorFlowTestCase):
       out_tensor = Squeeze(squeeze_dims=1)(tf.constant(value1))
       result = out_tensor.eval()
       assert result.shape == (2,)
+
+  def test_convert_to_tensor(self):
+    """Test implicit conversion of Layers to Tensors."""
+    v = Variable(np.array([1.5]))
+    v.create_tensor()
+    with self.test_session() as sess:
+      sess.run(tf.global_variables_initializer())
+      result = sess.run(v)
+      assert result == 1.5
+      result = sess.run(tf.gradients(v, v))
+      assert result[0] == 1.0


### PR DESCRIPTION
This allows you to treat Layers as Tensors in various contexts without needing to explicitly reference the `out_tensor` field.  This is especially convenient when you want to let users pass either a Layer or a Tensor for a value.