### PR TITLE
Convert One-Shot Layers to TensorGraph Layers

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -1405,21 +1405,37 @@ class LSTMStep(Layer):
   def __init__(self,
                output_dim,
                input_dim,
-               init=initializations.glorot_uniform,
-               inner_init=initializations.orthogonal,
-               activation=activations.tanh,
-               inner_activation=activations.hard_sigmoid,
+               init_fn=initializations.glorot_uniform,
+               inner_init_fn=initializations.orthogonal,
+               activation_fn=activations.tanh,
+               inner_activation_fn=activations.hard_sigmoid,
                **kwargs):
+    """
+    Parameters
+    ----------
+    output_dim: int
+      Dimensionality of output vectors.
+    input_dim: int
+      Dimensionality of input vectors.
+    init_fn: object 
+      TensorFlow initialization to use for W. 
+    inner_init_fn: object 
+      TensorFlow initialization to use for U. 
+    activation_fn: object 
+      TensorFlow activation to use for output. 
+    inner_activation_fn: object 
+      TensorFlow activation to use for inner steps. 
+    """
 
     super(LSTMStep, self).__init__(**kwargs)
 
-    self.init = init
-    self.inner_init = inner_init
+    self.init = init_fn
+    self.inner_init = inner_init_fn
     self.output_dim = output_dim
 
     # No other forget biases supported right now.
-    self.activation = activation
-    self.inner_activation = inner_activation
+    self.activation = activation_fn
+    self.inner_activation = inner_activation_fn
     self.input_dim = input_dim
 
   def get_initial_states(self, input_shape):
@@ -1637,14 +1653,7 @@ class IterRefLSTMEmbedding(Layer):
   than that from AttnLSTMEmbeding.
   """
 
-  def __init__(self,
-               n_test,
-               n_support,
-               n_feat,
-               max_depth,
-               init='glorot_uniform',
-               activation='linear',
-               **kwargs):
+  def __init__(self, n_test, n_support, n_feat, max_depth, **kwargs):
     """
     Unlike the AttnLSTM model which only modifies the test vectors
     additively, this model allows for an additive update to be
@@ -1661,10 +1670,6 @@ class IterRefLSTMEmbedding(Layer):
       Number of input atom features
     max_depth: int
       Number of LSTM Embedding layers.
-    init: string
-      Type of weight initialization (from Keras)
-    activation: string
-      Activation type (ReLu/Linear/etc.)
     """
     super(IterRefLSTMEmbedding, self).__init__(**kwargs)
 

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -89,14 +89,7 @@ class Layer(object):
       in_layers = [in_layers]
     tensors = []
     for input in in_layers:
-      if isinstance(input, tf.Tensor):
-        tensors.append(input)
-      elif isinstance(input, tf.Variable):
-        tensors.append(input)
-      elif isinstance(input, Layer):
-        tensors.append(input.out_tensor)
-      else:
-        raise ValueError('Unexpected input: ' + str(input))
+      tensors.append(tf.convert_to_tensor(input))
     if reshape and len(tensors) > 1:
       shapes = [t.get_shape() for t in tensors]
       if any(s != shapes[0] for s in shapes[1:]):

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -389,6 +389,10 @@ class TensorGraph(Model):
       for node in order:
         with tf.name_scope(node):
           node_layer = self.layers[node]
+          ########################################################### DEBUG
+          print("node_layer")
+          print(node_layer)
+          ########################################################### DEBUG
           node_layer.create_tensor(training=self._training_placeholder)
           self.rnn_initial_states += node_layer.rnn_initial_states
           self.rnn_final_states += node_layer.rnn_final_states
@@ -506,6 +510,10 @@ class TensorGraph(Model):
 
     # Pickle itself
     pickle_name = os.path.join(self.model_dir, "model.pickle")
+    ######################################################### DEBUG
+    print("self")
+    print(self)
+    ######################################################### DEBUG
     with open(pickle_name, 'wb') as fout:
       try:
         pickle.dump(self, fout)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -389,10 +389,6 @@ class TensorGraph(Model):
       for node in order:
         with tf.name_scope(node):
           node_layer = self.layers[node]
-          ############################################################ DEBUG
-          #print("node_layer")
-          #print(node_layer)
-          ############################################################ DEBUG
           node_layer.create_tensor(training=self._training_placeholder)
           self.rnn_initial_states += node_layer.rnn_initial_states
           self.rnn_final_states += node_layer.rnn_final_states
@@ -510,28 +506,7 @@ class TensorGraph(Model):
 
     # Pickle itself
     pickle_name = os.path.join(self.model_dir, "model.pickle")
-    ########################################################## DEBUG
-    #print("self")
-    #print(self)
 
-    #def debug_pickle(instance):
-    #  attribute = None
-
-    #  for k, v in instance.__dict__.iteritems():
-    #    print("checking: %s" % k)
-    #    print("type(v)")
-    #    print(type(v))
-    #    try:
-    #      pickle.dumps(v)
-    #    except:
-    #      attribute = k
-    #      break
-
-    #  return attribute  
-    #debug_pickle(self)
-    ##pickle.dumps(self)
-
-    ########################################################## DEBUG
     with open(pickle_name, 'wb') as fout:
       try:
         pickle.dump(self, fout)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -389,10 +389,10 @@ class TensorGraph(Model):
       for node in order:
         with tf.name_scope(node):
           node_layer = self.layers[node]
-          ########################################################### DEBUG
-          print("node_layer")
-          print(node_layer)
-          ########################################################### DEBUG
+          ############################################################ DEBUG
+          #print("node_layer")
+          #print(node_layer)
+          ############################################################ DEBUG
           node_layer.create_tensor(training=self._training_placeholder)
           self.rnn_initial_states += node_layer.rnn_initial_states
           self.rnn_final_states += node_layer.rnn_final_states
@@ -510,10 +510,28 @@ class TensorGraph(Model):
 
     # Pickle itself
     pickle_name = os.path.join(self.model_dir, "model.pickle")
-    ######################################################### DEBUG
-    print("self")
-    print(self)
-    ######################################################### DEBUG
+    ########################################################## DEBUG
+    #print("self")
+    #print(self)
+
+    #def debug_pickle(instance):
+    #  attribute = None
+
+    #  for k, v in instance.__dict__.iteritems():
+    #    print("checking: %s" % k)
+    #    print("type(v)")
+    #    print(type(v))
+    #    try:
+    #      pickle.dumps(v)
+    #    except:
+    #      attribute = k
+    #      break
+
+    #  return attribute  
+    #debug_pickle(self)
+    ##pickle.dumps(self)
+
+    ########################################################## DEBUG
     with open(pickle_name, 'wb') as fout:
       try:
         pickle.dump(self, fout)

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -43,7 +43,7 @@ from deepchem.models.tensorgraph.layers import WeightedError
 from deepchem.models.tensorgraph.layers import VinaFreeEnergy
 from deepchem.models.tensorgraph.layers import WeightedLinearCombo
 from deepchem.models.tensorgraph.layers import TensorWrapper
-from deepchem.models.tensorgraph.layers import LSTMStep 
+from deepchem.models.tensorgraph.layers import LSTMStep
 from deepchem.models.tensorgraph.layers import AttnLSTMEmbedding
 from deepchem.models.tensorgraph.layers import IterRefLSTMEmbedding
 
@@ -405,7 +405,7 @@ class TestLayers(test_util.TensorFlowTestCase):
     n_test = 5
     n_feat = 10
 
-    y = np.random.rand(n_test, 2*n_feat)
+    y = np.random.rand(n_test, 2 * n_feat)
     state_zero = np.random.rand(n_test, n_feat)
     state_one = np.random.rand(n_test, n_feat)
     with self.test_session() as sess:
@@ -413,15 +413,14 @@ class TestLayers(test_util.TensorFlowTestCase):
       state_zero = tf.convert_to_tensor(state_zero, dtype=tf.float32)
       state_one = tf.convert_to_tensor(state_one, dtype=tf.float32)
 
-      lstm = LSTMStep(n_feat, 2*n_feat)
+      lstm = LSTMStep(n_feat, 2 * n_feat)
       out_tensor = lstm(y, state_zero, state_one)
       sess.run(tf.global_variables_initializer())
-      h_out, h_copy_out, c_out = (
-        out_tensor[0].eval(), out_tensor[1][0].eval(), out_tensor[1][1].eval())
+      h_out, h_copy_out, c_out = (out_tensor[0].eval(), out_tensor[1][0].eval(),
+                                  out_tensor[1][1].eval())
       assert h_out.shape == (n_test, n_feat)
       assert h_copy_out.shape == (n_test, n_feat)
       assert c_out.shape == (n_test, n_feat)
-
 
   def test_attn_lstm_embedding(self):
     """Test that attention LSTM computation works properly."""
@@ -457,8 +456,8 @@ class TestLayers(test_util.TensorFlowTestCase):
       test = tf.convert_to_tensor(test, dtype=tf.float32)
       support = tf.convert_to_tensor(support, dtype=tf.float32)
 
-      iter_ref_embedding_layer = IterRefLSTMEmbedding(
-          n_test, n_support, n_feat, max_depth)
+      iter_ref_embedding_layer = IterRefLSTMEmbedding(n_test, n_support, n_feat,
+                                                      max_depth)
       out_tensor = iter_ref_embedding_layer(test, support)
       sess.run(tf.global_variables_initializer())
       test_out, support_out = out_tensor[0].eval(), out_tensor[1].eval()

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -445,7 +445,7 @@ def test_MP_pickle():
 def test_LSTMStep_pickle():
   """Tests that LSTMStep can be pickled."""
   n_feat = 10
-  tg = TensorGraph(use_queue=False)
+  tg = TensorGraph()
   y = Feature(shape=(None, 2*n_feat))
   state_zero = Feature(shape=(None, n_feat))
   state_one = Feature(shape=(None, n_feat))

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -444,14 +444,14 @@ def test_MP_pickle():
 
 def test_LSTMStep_pickle():
   """Tests that LSTMStep can be pickled."""
-  n_test = 100
-  n_feat = 20
-  tg = TensorGraph()
-  y = Feature(shape=(n_test, n_feat))
-  state_zero = Feature(shape=(n_test, n_feat))
-  state_one = Feature(shape=(n_test, n_feat))
+  n_feat = 10
+  tg = TensorGraph(use_queue=False)
+  y = Feature(shape=(None, 2*n_feat))
+  state_zero = Feature(shape=(None, n_feat))
+  state_one = Feature(shape=(None, n_feat))
   lstm = LSTMStep(n_feat, 2*n_feat, in_layers=[y, state_zero, state_one])
   tg.add_output(lstm)
+  tg.set_loss(lstm)
   tg.build()
   tg.save()
 

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -5,7 +5,7 @@ from deepchem.models.tensorgraph.layers import Feature, Conv1D, Dense, Flatten, 
     CombineMeanStd, Repeat, GRU, L2Loss, Concat, SoftMax, Constant, Variable, Add, Multiply, InteratomicL2Distances, \
     SoftMaxCrossEntropy, ReduceMean, ToFloat, ReduceSquareDifference, Conv2D, MaxPool, ReduceSum, GraphConv, GraphPool, \
     GraphGather, BatchNorm, WeightedError, \
-    LSTMStep
+    LSTMStep, AttnLSTMEmbedding
 from deepchem.models.tensorgraph.graph_layers import Combine_AP, Separate_AP, \
     WeaveLayer, WeaveGather, DTNNEmbedding, DTNNGather, DTNNStep, \
     DTNNExtract, DAGLayer, DAGGather, MessagePassing, SetGather
@@ -438,6 +438,24 @@ def test_MP_pickle():
   MP = MessagePassing(5, in_layers=[atom_feature, pair_feature, atom_to_pair])
   tg.add_output(MP)
   tg.set_loss(MP)
+  tg.build()
+  tg.save()
+
+
+def test_AttnLSTM_pickle():
+  """Tests that AttnLSTM can be pickled."""
+  max_depth = 5
+  n_test = 5
+  n_support = 5
+  n_feat = 10
+
+  tg = TensorGraph(batch_size=n_test)
+  test = Feature(shape=(None, n_feat))
+  support = Feature(shape=(None, n_feat))
+  out = AttnLSTMEmbedding(n_test, n_support, n_feat, max_depth,
+                          in_layers=[test, support])
+  tg.add_output(out)
+  tg.set_loss(out)
   tg.build()
   tg.save()
 

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -4,7 +4,8 @@ from deepchem.models import TensorGraph
 from deepchem.models.tensorgraph.layers import Feature, Conv1D, Dense, Flatten, Reshape, Squeeze, Transpose, \
     CombineMeanStd, Repeat, GRU, L2Loss, Concat, SoftMax, Constant, Variable, Add, Multiply, InteratomicL2Distances, \
     SoftMaxCrossEntropy, ReduceMean, ToFloat, ReduceSquareDifference, Conv2D, MaxPool, ReduceSum, GraphConv, GraphPool, \
-    GraphGather, BatchNorm, WeightedError
+    GraphGather, BatchNorm, WeightedError, \
+    LSTMStep
 from deepchem.models.tensorgraph.graph_layers import Combine_AP, Separate_AP, \
     WeaveLayer, WeaveGather, DTNNEmbedding, DTNNGather, DTNNStep, \
     DTNNExtract, DAGLayer, DAGGather, MessagePassing, SetGather
@@ -437,6 +438,20 @@ def test_MP_pickle():
   MP = MessagePassing(5, in_layers=[atom_feature, pair_feature, atom_to_pair])
   tg.add_output(MP)
   tg.set_loss(MP)
+  tg.build()
+  tg.save()
+
+
+def test_LSTMStep_pickle():
+  """Tests that LSTMStep can be pickled."""
+  n_test = 100
+  n_feat = 20
+  tg = TensorGraph()
+  y = Feature(shape=(n_test, n_feat))
+  state_zero = Feature(shape=(n_test, n_feat))
+  state_one = Feature(shape=(n_test, n_feat))
+  lstm = LSTMStep(n_feat, 2*n_feat, in_layers=[y, state_zero, state_one])
+  tg.add_output(lstm)
   tg.build()
   tg.save()
 

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -5,7 +5,7 @@ from deepchem.models.tensorgraph.layers import Feature, Conv1D, Dense, Flatten, 
     CombineMeanStd, Repeat, GRU, L2Loss, Concat, SoftMax, Constant, Variable, Add, Multiply, InteratomicL2Distances, \
     SoftMaxCrossEntropy, ReduceMean, ToFloat, ReduceSquareDifference, Conv2D, MaxPool, ReduceSum, GraphConv, GraphPool, \
     GraphGather, BatchNorm, WeightedError, \
-    LSTMStep, AttnLSTMEmbedding
+    LSTMStep, AttnLSTMEmbedding, IterRefLSTMEmbedding
 from deepchem.models.tensorgraph.graph_layers import Combine_AP, Separate_AP, \
     WeaveLayer, WeaveGather, DTNNEmbedding, DTNNGather, DTNNStep, \
     DTNNExtract, DAGLayer, DAGGather, MessagePassing, SetGather
@@ -452,8 +452,8 @@ def test_AttnLSTM_pickle():
   tg = TensorGraph(batch_size=n_test)
   test = Feature(shape=(None, n_feat))
   support = Feature(shape=(None, n_feat))
-  out = AttnLSTMEmbedding(n_test, n_support, n_feat, max_depth,
-                          in_layers=[test, support])
+  out = AttnLSTMEmbedding(
+      n_test, n_support, n_feat, max_depth, in_layers=[test, support])
   tg.add_output(out)
   tg.set_loss(out)
   tg.build()
@@ -464,10 +464,27 @@ def test_LSTMStep_pickle():
   """Tests that LSTMStep can be pickled."""
   n_feat = 10
   tg = TensorGraph()
-  y = Feature(shape=(None, 2*n_feat))
+  y = Feature(shape=(None, 2 * n_feat))
   state_zero = Feature(shape=(None, n_feat))
   state_one = Feature(shape=(None, n_feat))
-  lstm = LSTMStep(n_feat, 2*n_feat, in_layers=[y, state_zero, state_one])
+  lstm = LSTMStep(n_feat, 2 * n_feat, in_layers=[y, state_zero, state_one])
+  tg.add_output(lstm)
+  tg.set_loss(lstm)
+  tg.build()
+  tg.save()
+
+
+def test_IterRefLSTM_pickle():
+  """Tests that IterRefLSTM can be pickled."""
+  n_feat = 10
+  max_depth = 5
+  n_test = 5
+  n_support = 5
+  tg = TensorGraph()
+  test = Feature(shape=(None, n_feat))
+  support = Feature(shape=(None, n_feat))
+  lstm = IterRefLSTMEmbedding(
+      n_test, n_support, n_feat, max_depth, in_layers=[test, support])
   tg.add_output(lstm)
   tg.set_loss(lstm)
   tg.build()

--- a/deepchem/nn/layers.py
+++ b/deepchem/nn/layers.py
@@ -355,10 +355,11 @@ class GraphGather(Layer):
     batch_size: int
       Number of elements in batch of data.
     """
-    warnings.warn("The dc.nn.GraphGather is "
-                  "deprecated. Will be removed in DeepChem 1.4. "
-                  "Will be replaced by dc.models.tensorgraph.layers.GraphGather",
-                  DeprecationWarning)
+    warnings.warn(
+        "The dc.nn.GraphGather is "
+        "deprecated. Will be removed in DeepChem 1.4. "
+        "Will be replaced by dc.models.tensorgraph.layers.GraphGather",
+        DeprecationWarning)
     super(GraphGather, self).__init__(**kwargs)
 
     self.activation = activations.get(activation)  # Get activations

--- a/deepchem/nn/layers.py
+++ b/deepchem/nn/layers.py
@@ -8,6 +8,7 @@ __author__ = "Han Altae-Tran and Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"
 
+import warnings
 import numpy as np
 import tensorflow as tf
 from deepchem.nn import activations
@@ -236,6 +237,10 @@ class GraphConv(Layer):
     min_deg: int, optional
       Minimum degree of atoms in molecules.
     """
+    warnings.warn("The dc.nn.GraphConv is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by dc.models.tensorgraph.layers.GraphConv",
+                  DeprecationWarning)
     super(GraphConv, self).__init__(**kwargs)
 
     self.init = initializations.get(init)  # Set weight initialization
@@ -350,6 +355,10 @@ class GraphGather(Layer):
     batch_size: int
       Number of elements in batch of data.
     """
+    warnings.warn("The dc.nn.GraphGather is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by dc.models.tensorgraph.layers.GraphGather",
+                  DeprecationWarning)
     super(GraphGather, self).__init__(**kwargs)
 
     self.activation = activations.get(activation)  # Get activations
@@ -423,6 +432,10 @@ class GraphPool(Layer):
     min_deg: int, optional
       Minimum degree of atoms in molecules.
     """
+    warnings.warn("The dc.nn.GraphPool is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by dc.models.tensorgraph.layers.GraphPool",
+                  DeprecationWarning)
     self.max_deg = max_deg
     self.min_deg = min_deg
     super(GraphPool, self).__init__(**kwargs)
@@ -628,6 +641,11 @@ class ResiLSTMEmbedding(Layer):
     activation: string
       Activation type (ReLu/Linear/etc.)
     """
+    warnings.warn("The dc.nn.ResiLSTMEmbedding is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by "
+                  "dc.models.tensorgraph.layers.IterRefLSTM",
+                  DeprecationWarning)
     super(ResiLSTMEmbedding, self).__init__(**kwargs)
 
     self.init = initializations.get(init)  # Set weight initialization
@@ -764,6 +782,11 @@ class LSTMStep(Layer):
                inner_activation='hard_sigmoid',
                **kwargs):
 
+    warnings.warn("The dc.nn.LSTMStep is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by dc.models.tensorgraph.layers.LSTMStep",
+                  DeprecationWarning)
+
     super(LSTMStep, self).__init__(**kwargs)
 
     self.output_dim = output_dim
@@ -840,6 +863,12 @@ class DTNNEmbedding(Layer):
     init: str, optional
       Weight initialization for filters.
     """
+
+    warnings.warn("The dc.nn.DTNNEmbedding is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by "
+                  "dc.models.tensorgraph.graph_layers.DTNNEmbedding",
+                  DeprecationWarning)
     self.n_embedding = n_embedding
     self.periodic_table_length = periodic_table_length
     self.init = initializations.get(init)  # Set weight initialization
@@ -898,6 +927,11 @@ class DTNNStep(Layer):
     activation: str, optional
       Activation function applied
     """
+    warnings.warn("The dc.nn.DTNNStep is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by "
+                  "dc.models.tensorgraph.graph_layers.DTNNStep",
+                  DeprecationWarning)
     self.n_embedding = n_embedding
     self.n_distance = n_distance
     self.n_hidden = n_hidden
@@ -995,6 +1029,11 @@ class DTNNGather(Layer):
     activation: str, optional
       Activation function applied
     """
+    warnings.warn("The dc.nn.DTNNGather is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by "
+                  "dc.models.tensorgraph.graph_layers.DTNNGather",
+                  DeprecationWarning)
     self.n_embedding = n_embedding
     self.layer_sizes = layer_sizes
     self.n_outputs = n_outputs
@@ -1085,6 +1124,11 @@ class DAGLayer(Layer):
     batch_size: int, optional
       number of molecules in a batch
     """
+    warnings.warn("The dc.nn.DAGLayer is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by "
+                  "dc.models.tensorgraph.graph_layers.DAGLayer",
+                  DeprecationWarning)
     super(DAGLayer, self).__init__(**kwargs)
 
     self.init = initializations.get(init)  # Set weight initialization
@@ -1242,6 +1286,11 @@ class DAGGather(Layer):
     dropout: float, optional
       Dropout probability, not supported
     """
+    warnings.warn("The dc.nn.DAGGather is "
+                  "deprecated. Will be removed in DeepChem 1.4. "
+                  "Will be replaced by "
+                  "dc.models.tensorgraph.graph_layers.DAGGather",
+                  DeprecationWarning)
     super(DAGGather, self).__init__(**kwargs)
 
     self.init = initializations.get(init)  # Set weight initialization

--- a/deepchem/nn/tests/test_layers.py
+++ b/deepchem/nn/tests/test_layers.py
@@ -42,9 +42,6 @@ class TestLayers(test_util.TensorFlowTestCase):
     with self.test_session() as sess:
       input_layer = dc.nn.Input(shape=(32,))
 
-  #def test_batch_normalization(self):
-  #  """Tests that batch normalization layers can be created."""
-
   def test_graph_convolution(self):
     """Tests that Graph Convolution transforms shapes correctly."""
     n_atoms = 5


### PR DESCRIPTION
This PR works on converting the one-shot layers to TensorGraph layers. Also deprecates all the old layers in `dc.nn.layers`.

Still running into some strange bugs when trying to pickle the one-shot layers. Will remove [WIP] once these errors are handled.