### PR TITLE
Bugfixes for transformers and add a L1Loss function

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -653,6 +653,20 @@ class Weights(Input):
     super(Weights, self).__init__(**kwargs)
 
 
+class L1Loss(Layer):
+
+  def __init__(self, **kwargs):
+    super(L1Loss, self).__init__(**kwargs)
+
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
+    inputs = self._get_input_tensors(in_layers, True)
+    guess, label = inputs[0], inputs[1]
+    out_tensor = tf.reduce_mean(
+        tf.abs(guess - label), axis=list(range(1, len(label.shape))))
+    if set_tensors:
+      self.out_tensor = out_tensor
+    return out_tensor
+
 class L2Loss(Layer):
 
   def __init__(self, **kwargs):

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -68,8 +68,8 @@ class Layer(object):
   def shape(self):
     """Get the shape of this Layer's output."""
     if '_shape' not in dir(self):
-      raise NotImplementedError("%s: shape is not known" %
-                                self.__class__.__name__)
+      raise NotImplementedError(
+          "%s: shape is not known" % self.__class__.__name__)
     return self._shape
 
   def _get_input_tensors(self, in_layers, reshape=False):
@@ -1731,8 +1731,8 @@ class NeighborList(Layer):
     # List of length N_atoms each of shape (M_nbrs)
     padded_dists = [
         tf.reduce_sum((atom_coord - padded_nbr_coord)**2, axis=1)
-        for (atom_coord, padded_nbr_coord
-            ) in zip(atom_coords, padded_nbr_coords)
+        for (atom_coord,
+             padded_nbr_coord) in zip(atom_coords, padded_nbr_coords)
     ]
 
     padded_closest_nbrs = [
@@ -1743,8 +1743,8 @@ class NeighborList(Layer):
     # N_atoms elts of size (M_nbrs,) each
     padded_neighbor_list = [
         tf.gather(padded_atom_nbrs, padded_closest_nbr)
-        for (padded_atom_nbrs, padded_closest_nbr
-            ) in zip(padded_nbrs, padded_closest_nbrs)
+        for (padded_atom_nbrs,
+             padded_closest_nbr) in zip(padded_nbrs, padded_closest_nbrs)
     ]
 
     neighbor_list = tf.stack(padded_neighbor_list)

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -68,8 +68,8 @@ class Layer(object):
   def shape(self):
     """Get the shape of this Layer's output."""
     if '_shape' not in dir(self):
-      raise NotImplementedError(
-          "%s: shape is not known" % self.__class__.__name__)
+      raise NotImplementedError("%s: shape is not known" %
+                                self.__class__.__name__)
     return self._shape
 
   def _get_input_tensors(self, in_layers, reshape=False):
@@ -666,6 +666,7 @@ class L1Loss(Layer):
     if set_tensors:
       self.out_tensor = out_tensor
     return out_tensor
+
 
 class L2Loss(Layer):
 
@@ -1730,8 +1731,8 @@ class NeighborList(Layer):
     # List of length N_atoms each of shape (M_nbrs)
     padded_dists = [
         tf.reduce_sum((atom_coord - padded_nbr_coord)**2, axis=1)
-        for (atom_coord,
-             padded_nbr_coord) in zip(atom_coords, padded_nbr_coords)
+        for (atom_coord, padded_nbr_coord
+            ) in zip(atom_coords, padded_nbr_coords)
     ]
 
     padded_closest_nbrs = [
@@ -1742,8 +1743,8 @@ class NeighborList(Layer):
     # N_atoms elts of size (M_nbrs,) each
     padded_neighbor_list = [
         tf.gather(padded_atom_nbrs, padded_closest_nbr)
-        for (padded_atom_nbrs,
-             padded_closest_nbr) in zip(padded_nbrs, padded_closest_nbrs)
+        for (padded_atom_nbrs, padded_closest_nbr
+            ) in zip(padded_nbrs, padded_closest_nbrs)
     ]
 
     neighbor_list = tf.stack(padded_neighbor_list)

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -971,6 +971,8 @@ class ANITransformer(Transformer):
     self.transform_y = transform_y
     self.transform_w = transform_w
     self.compute_graph = self.build()
+    self.sess = tf.Session(graph=self.compute_graph)
+    self.transform_batch_size = 128
     assert self.transform_X
     assert not self.transform_y
     assert not self.transform_w
@@ -978,19 +980,23 @@ class ANITransformer(Transformer):
   def transform_array(self, X, y, w):
     if self.transform_X:
       n_samples = X.shape[0]
-      batches = np.linspace(0, n_samples, int(n_samples / 100) + 1).astype(int)
+
       X_out = []
-      sess = tf.Session(graph=self.compute_graph)
       num_transformed = 0
-      for i, start in enumerate(batches):
-        if start == batches[-1]:
-          X_batch = X[start:]
-        else:
-          X_batch = X[start:batches[i + 1]]
-        output = sess.run([self.outputs], feed_dict={self.inputs: X_batch})[0]
+      start = 0
+
+      batch_size = self.transform_batch_size
+
+      while True:
+        end = min((start+1)*batch_size, X.shape[0])
+        X_batch = X[(start*batch_size):end]
+        output = self.sess.run([self.outputs], feed_dict={self.inputs: X_batch})[0]
         X_out.append(output)
         num_transformed = num_transformed + X_batch.shape[0]
         print('%i samples transformed' % num_transformed)
+        start += 1
+        if end >= len(X):
+          break
 
       X_new = np.concatenate(X_out, axis=0)
       assert X_new.shape[0] == X.shape[0]

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -988,9 +988,10 @@ class ANITransformer(Transformer):
       batch_size = self.transform_batch_size
 
       while True:
-        end = min((start+1)*batch_size, X.shape[0])
-        X_batch = X[(start*batch_size):end]
-        output = self.sess.run([self.outputs], feed_dict={self.inputs: X_batch})[0]
+        end = min((start + 1) * batch_size, X.shape[0])
+        X_batch = X[(start * batch_size):end]
+        output = self.sess.run(
+            [self.outputs], feed_dict={self.inputs: X_batch})[0]
         X_out.append(output)
         num_transformed = num_transformed + X_batch.shape[0]
         print('%i samples transformed' % num_transformed)


### PR DESCRIPTION
This PR

1. Adds an L1Loss layer.
2. Reuses an existing session. We often call transform_array in a hot loop which was creating numerous additional sessions.
3. Modifies linspace so its a little more sensical. Before, suppose n_samples was 323:

For large values of n_samples, it's fine:

```
np.linspace(0, 323400, int(323400/100)+1).astype(int)
>> array([     0,    100,    200, ..., 323200, 323300, 323400])
```


For small values of n_samples, this actually doesn't iterate in mod 100:

```
np.linspace(0, 323, int(323/100)+1).astype(int)
>> array([  0, 107, 215, 323])
```

This is now fixed so it always iterates in self.transform_batch_size.