### PR TITLE
RandomGroupSplitter

### DIFF
--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -11,5 +11,6 @@ from deepchem.splits.splitters import ScaffoldSplitter
 from deepchem.splits.splitters import SpecifiedSplitter
 from deepchem.splits.splitters import IndexSplitter
 from deepchem.splits.splitters import IndiceSplitter
+from deepchem.splits.splitters import RandomGroupSplitter
 from deepchem.splits.task_splitter import merge_fold_datasets
 from deepchem.splits.task_splitter import TaskSplitter

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -259,8 +259,6 @@ class RandomGroupSplitter(Splitter):
     valid_groups = shuffled_group_idxs[train_cutoff:valid_cutoff]
     test_groups = shuffled_group_idxs[valid_cutoff:]
 
-    print(train_groups, valid_groups, test_groups)
-
     train_idxs = list(itertools.chain(*group_idxs[train_groups]))
     valid_idxs = list(itertools.chain(*group_idxs[valid_groups]))
     test_idxs = list(itertools.chain(*group_idxs[test_groups]))

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -25,6 +25,37 @@ class TestSplitters(unittest.TestCase):
   Test some basic splitters.
   """
 
+  def test_random_group_split(self):
+    solubility_dataset = dc.data.tests.load_solubility_data()
+
+    groups = [0, 4, 1, 2, 3, 7, 0, 3, 1, 0]
+    # 0 1 2 3 4 5 6 7 8 9
+
+    group_splitter = dc.splits.RandomGroupSplitter(groups)
+
+    train_idxs, valid_idxs, test_idxs = group_splitter.split(
+        solubility_dataset, frac_train=0.5, frac_valid=0.25, frac_test=0.25)
+
+    print(train_idxs, valid_idxs, test_idxs)
+    print(len(train_idxs), len(valid_idxs), len(test_idxs))
+
+    class_ind = [-1] * 10
+
+    all_idxs = []
+    for s in train_idxs + valid_idxs + test_idxs:
+      all_idxs.append(s)
+
+    print(sorted(all_idxs))
+
+    assert sorted(all_idxs) == list(range(10))
+
+    for split_idx, split in enumerate([train_idxs, valid_idxs, test_idxs]):
+      for s in split:
+        if class_ind[s] == -1:
+          class_ind[s] = split_idx
+        else:
+          assert class_ind[s] == split_idx
+
   def test_singletask_random_split(self):
     """
     Test singletask RandomSplitter class.

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -36,16 +36,11 @@ class TestSplitters(unittest.TestCase):
     train_idxs, valid_idxs, test_idxs = group_splitter.split(
         solubility_dataset, frac_train=0.5, frac_valid=0.25, frac_test=0.25)
 
-    print(train_idxs, valid_idxs, test_idxs)
-    print(len(train_idxs), len(valid_idxs), len(test_idxs))
-
     class_ind = [-1] * 10
 
     all_idxs = []
     for s in train_idxs + valid_idxs + test_idxs:
       all_idxs.append(s)
-
-    print(sorted(all_idxs))
 
     assert sorted(all_idxs) == list(range(10))
 


### PR DESCRIPTION
This PR adds support for splitting by constraining the split with groups. This is particularly useful if you want to split a dataset with multiple conformations for a set of distinct molecules. For the purposes of cross validation, it is quite important that splits occur across groups to ensure sufficient diversity between test and training set data.

I would've liked to add more functionality so it could work with any arbitrary splitter, but there are discussion points on the statistics of each group that would be deemed sensible. 
