### PR TITLE
No Queue at the Same Time As Tensorboard

### DIFF
--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -94,7 +94,9 @@ class TensorGraph(Model):
     self.rnn_final_states = []
     self.rnn_zero_states = []
     if self.use_queue and self.tensorboard:
-      raise ValueError("Currently TensorGraph cannot both use_queue and tensorboard at the same time")
+      raise ValueError(
+          "Currently TensorGraph cannot both use_queue and tensorboard at the same time"
+      )
 
   def _add_layer(self, layer):
     if layer.name is None:

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -93,6 +93,8 @@ class TensorGraph(Model):
     self.rnn_initial_states = []
     self.rnn_final_states = []
     self.rnn_zero_states = []
+    if self.use_queue and self.tensorboard:
+      raise ValueError("Currently TensorGraph cannot both use a queue and tensorboard")
 
   def _add_layer(self, layer):
     if layer.name is None:

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -94,7 +94,7 @@ class TensorGraph(Model):
     self.rnn_final_states = []
     self.rnn_zero_states = []
     if self.use_queue and self.tensorboard:
-      raise ValueError("Currently TensorGraph cannot both use a queue and tensorboard")
+      raise ValueError("Currently TensorGraph cannot both use_queue and tensorboard at the same time")
 
   def _add_layer(self, layer):
     if layer.name is None:


### PR DESCRIPTION
https://github.com/deepchem/deepchem/issues/795

Due to how we implement Tensorboard logging we cannot have both Tensorboard and queues on at the same time.

TensorBoard needs the Inputs values in place to go through the summary ops to collect tensorboard statistics.

I added a check and a note in the constructor so we don't accidentally hit this state.