### PR TITLE
Don't use wget

### DIFF
--- a/deepchem/models/autoencoder_models/autoencoder.py
+++ b/deepchem/models/autoencoder_models/autoencoder.py
@@ -6,6 +6,7 @@ import warnings
 from deepchem.models import Model
 from deepchem.models.autoencoder_models.model import MoleculeVAE
 from deepchem.feat.one_hot import zinc_charset
+from deepchem.utils import download_url
 import os
 from subprocess import call
 
@@ -64,8 +65,8 @@ class TensorflowMoleculeEncoder(Model):
     weights_file = os.path.join(current_dir, weights_filename)
 
     if not os.path.exists(weights_file):
-      wget_command = "wget -nv -c http://karlleswing.com/misc/keras-molecule/model.h5"
-      call(wget_command.split())
+      download_url("http://karlleswing.com/misc/keras-molecule/model.h5",
+                   current_dir)
       mv_cmd = "mv model.h5 %s" % weights_file
       call(mv_cmd.split())
     return TensorflowMoleculeEncoder(
@@ -136,8 +137,8 @@ class TensorflowMoleculeDecoder(Model):
     weights_file = os.path.join(current_dir, weights_filename)
 
     if not os.path.exists(weights_file):
-      wget_command = "wget -nv -c http://karlleswing.com/misc/keras-molecule/model.h5"
-      call(wget_command.split())
+      download_url("http://karlleswing.com/misc/keras-molecule/model.h5",
+                   current_dir)
       mv_cmd = "mv model.h5 %s" % weights_file
       call(mv_cmd.split())
     return TensorflowMoleculeDecoder(

--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -14,19 +14,15 @@ def load_bace_regression(featurizer='ECFP', split='random', reload=True):
   """Load bace datasets."""
   # Featurize bace dataset
   print("About to featurize bace dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "bace_r/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "bace.csv")
 
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/bace.csv '
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/bace.csv'
     )
 
   bace_tasks = ["pIC50"]
@@ -52,7 +48,7 @@ def load_bace_regression(featurizer='ECFP', split='random', reload=True):
       tasks=bace_tasks, smiles_field="mol", featurizer=featurizer)
 
   dataset = loader.featurize(dataset_file, shard_size=8192)
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)
@@ -80,19 +76,15 @@ def load_bace_classification(featurizer='ECFP', split='random', reload=True):
   """Load bace datasets."""
   # Featurize bace dataset
   print("About to featurize bace dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "bace_c/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "bace.csv")
 
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/bace.csv '
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/bace.csv'
     )
 
   bace_tasks = ["Class"]
@@ -118,7 +110,7 @@ def load_bace_classification(featurizer='ECFP', split='random', reload=True):
       tasks=bace_tasks, smiles_field="mol", featurizer=featurizer)
 
   dataset = loader.featurize(dataset_file, shard_size=8192)
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
   ]

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -13,18 +13,14 @@ def load_bbbp(featurizer='ECFP', split='random', reload=True):
   """Load blood-brain barrier penetration datasets """
   # Featurize bbb dataset
   print("About to featurize bbbp dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "bbbp/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "BBBP.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/BBBP.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/BBBP.csv'
     )
 
   bbbp_tasks = ["p_np"]

--- a/deepchem/molnet/load_function/chembl_datasets.py
+++ b/deepchem/molnet/load_function/chembl_datasets.py
@@ -16,46 +16,35 @@ def load_chembl(shard_size=2000,
                 split="random",
                 reload=True):
 
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "chembl/" + featurizer + "/" + split)
 
   dataset_path = os.path.join(data_dir, "chembl_%s.csv.gz" % set)
   if not os.path.exists(dataset_path):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_5thresh.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_5thresh.csv.gz'
     )
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_sparse.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_sparse.csv.gz'
     )
-    os.system(
-        'wget -P ' + os.path.join(data_dir, 'chembl_year_sets') +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_test.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_test.csv.gz'
     )
-    os.system(
-        'wget -P ' + os.path.join(data_dir, 'chembl_year_sets') +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_train.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_train.csv.gz'
     )
-    os.system(
-        'wget -P ' + os.path.join(data_dir, 'chembl_year_sets') +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_valid.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_valid.csv.gz'
     )
-    os.system(
-        'wget -P ' + os.path.join(data_dir, 'chembl_year_sets') +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_test.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_test.csv.gz'
     )
-    os.system(
-        'wget -P ' + os.path.join(data_dir, 'chembl_year_sets') +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_train.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_train.csv.gz'
     )
-    os.system(
-        'wget -P ' + os.path.join(data_dir, 'chembl_year_sets') +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_valid.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_valid.csv.gz'
     )
 
   print("About to load ChEMBL dataset.")

--- a/deepchem/molnet/load_function/clearance_datasets.py
+++ b/deepchem/molnet/load_function/clearance_datasets.py
@@ -14,18 +14,14 @@ def load_clearance(featurizer='ECFP', split='random', reload=True):
   # Featurize clearance dataset
   print("About to featurize clearance dataset.")
   print("About to load clearance dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "clearance/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "clearance.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/clearance.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/clearance.csv'
     )
 
   clearance_tasks = ['exp']
@@ -49,7 +45,7 @@ def load_clearance(featurizer='ECFP', split='random', reload=True):
       tasks=clearance_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -14,18 +14,14 @@ import deepchem
 def load_clintox(featurizer='ECFP', split='index', reload=True):
   """Load clintox datasets."""
 
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "clintox/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "clintox.csv.gz")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/clintox.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/clintox.csv.gz'
     )
 
   print("About to load clintox dataset.")

--- a/deepchem/molnet/load_function/delaney_datasets.py
+++ b/deepchem/molnet/load_function/delaney_datasets.py
@@ -13,19 +13,15 @@ def load_delaney(featurizer='ECFP', split='index', reload=True):
   """Load delaney datasets."""
   # Featurize Delaney dataset
   print("About to featurize Delaney dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "delaney/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "delaney-processed.csv")
 
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/delaney-processed.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/delaney-processed.csv'
     )
 
   delaney_tasks = ['measured log solubility in mols per litre']
@@ -48,7 +44,7 @@ def load_delaney(featurizer='ECFP', split='index', reload=True):
       tasks=delaney_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -13,18 +13,14 @@ def load_hiv(featurizer='ECFP', split='index', reload=True):
   """Load hiv datasets. Does not do train/test split"""
   # Featurize hiv dataset
   print("About to featurize hiv dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "hiv/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "HIV.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/HIV.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/HIV.csv'
     )
 
   hiv_tasks = ["HIV_active"]
@@ -47,7 +43,7 @@ def load_hiv(featurizer='ECFP', split='index', reload=True):
   loader = deepchem.data.CSVLoader(
       tasks=hiv_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
   ]

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -13,18 +13,14 @@ def load_hopv(featurizer='ECFP', split='index', reload=True):
   """Load HOPV datasets. Does not do train/test split"""
   # Featurize HOPV dataset
   print("About to featurize HOPV dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "hopv/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "hopv.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/hopv.tar.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/hopv.tar.gz'
     )
     os.system('tar -zxvf ' + os.path.join(data_dir, 'hopv.tar.gz') + ' -C ' +
               data_dir)
@@ -53,7 +49,7 @@ def load_hopv(featurizer='ECFP', split='index', reload=True):
       tasks=hopv_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)

--- a/deepchem/molnet/load_function/kaggle_datasets.py
+++ b/deepchem/molnet/load_function/kaggle_datasets.py
@@ -59,17 +59,14 @@ def gen_kaggle(KAGGLE_tasks,
   test_files = os.path.join(data_dir,
                             "KAGGLE_test2_disguised_combined_full.csv.gz")
   if not os.path.exists(train_files):
-    os.system(
-        'wget -nv -c -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz'
     )
-    os.system(
-        'wget -nv -c -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz'
     )
-    os.system(
-        'wget -nv -c -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz'
     )
 
   # Featurize KAGGLE dataset
@@ -125,10 +122,7 @@ def load_kaggle(shard_size=2000, featurizer=None, split=None, reload=True):
       '3A4', 'CB1', 'DPP4', 'HIVINT', 'HIV_PROT', 'LOGD', 'METAB', 'NK1', 'OX1',
       'OX2', 'PGP', 'PPB', 'RAT_F', 'TDI', 'THROMBIN'
   ]
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
 
   data_dir = os.path.join(data_dir, "kaggle")
   train_dir = os.path.join(data_dir, "train_dir")

--- a/deepchem/molnet/load_function/lipo_datasets.py
+++ b/deepchem/molnet/load_function/lipo_datasets.py
@@ -14,18 +14,14 @@ def load_lipo(featurizer='ECFP', split='index', reload=True):
   # Featurize Lipophilicity dataset
   print("About to featurize Lipophilicity dataset.")
   print("About to load Lipophilicity dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "lipo/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "Lipophilicity.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/Lipophilicity.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/Lipophilicity.csv'
     )
 
   Lipo_tasks = ['exp']
@@ -49,7 +45,7 @@ def load_lipo(featurizer='ECFP', split='index', reload=True):
       tasks=Lipo_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -13,18 +13,14 @@ def load_muv(featurizer='ECFP', split='index', reload=True, K=4):
   """Load MUV datasets. Does not do train/test split"""
   # Load MUV dataset
   print("About to load MUV dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "muv/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "muv.csv.gz")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/muv.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/muv.csv.gz'
     )
 
   MUV_tasks = sorted([
@@ -55,7 +51,7 @@ def load_muv(featurizer='ECFP', split='index', reload=True, K=4):
       tasks=MUV_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
   ]

--- a/deepchem/molnet/load_function/nci_datasets.py
+++ b/deepchem/molnet/load_function/nci_datasets.py
@@ -15,18 +15,14 @@ def load_nci(featurizer='ECFP', shard_size=1000, split='random', reload=True):
 
   # Load nci dataset
   print("About to load NCI dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "nci/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "nci_unique.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/nci_unique.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/nci_unique.csv'
     )
 
   all_nci_tasks = ([

--- a/deepchem/molnet/load_function/pcba_datasets.py
+++ b/deepchem/molnet/load_function/pcba_datasets.py
@@ -12,18 +12,14 @@ import deepchem
 def load_pcba(featurizer='ECFP', split='random', reload=True):
   """Load PCBA datasets. Does not do train/test split"""
 
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "pcba/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "pcba.csv.gz")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/pcba.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/pcba.csv.gz'
     )
 
   # Featurize PCBA dataset
@@ -75,7 +71,7 @@ def load_pcba(featurizer='ECFP', split='random', reload=True):
       tasks=PCBA_tasks, smiles_field="smiles", featurizer=featurizer)
 
   dataset = loader.featurize(dataset_file)
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
   ]

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -20,25 +20,19 @@ import pandas as pd
 def featurize_pdbbind(data_dir=None, feat="grid", subset="core"):
   """Featurizes pdbbind according to provided featurization"""
   tasks = ["-logKd/Ki"]
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   data_dir = os.path.join(data_dir, "pdbbind")
   dataset_dir = os.path.join(data_dir, "%s_%s" % (subset, feat))
 
   if not os.path.exists(dataset_dir):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/core_grid.tar.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/core_grid.tar.gz'
     )
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/full_grid.tar.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/full_grid.tar.gz'
     )
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/refined_grid.tar.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/refined_grid.tar.gz'
     )
     os.system('tar -zxvf ' + os.path.join(data_dir, 'core_grid.tar.gz') + ' -C '
               + data_dir)
@@ -73,10 +67,7 @@ def load_pdbbind_grid(split="random",
     for transformer in transformers:
       test = transformer.transform(test)
   else:
-    if "DEEPCHEM_DATA_DIR" in os.environ:
-      data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-    else:
-      data_dir = "/tmp"
+    data_dir = deepchem.utils.get_data_dir()
     if reload:
       save_dir = os.path.join(
           data_dir, "pdbbind_" + subset + "/" + featurizer + "/" + split)
@@ -84,9 +75,8 @@ def load_pdbbind_grid(split="random",
     dataset_file = os.path.join(data_dir, subset + "_smiles_labels.csv")
 
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/' +
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/' +
           subset + "_smiles_labels.csv")
 
     tasks = ["-logKd/Ki"]

--- a/deepchem/molnet/load_function/ppb_datasets.py
+++ b/deepchem/molnet/load_function/ppb_datasets.py
@@ -14,18 +14,14 @@ def load_ppb(featurizer='ECFP', split='index', reload=True):
   # Featurize PPB dataset
   print("About to featurize PPB dataset.")
   print("About to load PPB dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "ppb/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "PPB.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/PPB.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/PPB.csv'
     )
 
   PPB_tasks = ['exp']
@@ -49,7 +45,7 @@ def load_ppb(featurizer='ECFP', split='index', reload=True):
       tasks=PPB_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -14,10 +14,7 @@ import scipy.io
 def load_qm7_from_mat(featurizer='CoulombMatrix',
                       split='stratified',
                       reload=True):
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "qm7/" + featurizer + "/" + split)
 
@@ -33,9 +30,8 @@ def load_qm7_from_mat(featurizer='CoulombMatrix',
     dataset_file = os.path.join(data_dir, "qm7.mat")
 
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.mat'
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.mat'
       )
     dataset = scipy.io.loadmat(dataset_file)
     X = dataset['X']
@@ -46,9 +42,8 @@ def load_qm7_from_mat(featurizer='CoulombMatrix',
     dataset_file = os.path.join(data_dir, "qm7.mat")
 
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.mat'
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.mat'
       )
     dataset = scipy.io.loadmat(dataset_file)
     X = np.concatenate([np.expand_dims(dataset['Z'], 2), dataset['R']], axis=2)
@@ -58,9 +53,8 @@ def load_qm7_from_mat(featurizer='CoulombMatrix',
   else:
     dataset_file = os.path.join(data_dir, "qm7.csv")
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.csv '
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.csv'
       )
     if featurizer == 'ECFP':
       featurizer = deepchem.feat.CircularFingerprint(size=1024)
@@ -103,17 +97,12 @@ def load_qm7_from_mat(featurizer='CoulombMatrix',
 def load_qm7b_from_mat(featurizer='CoulombMatrix',
                        split='stratified',
                        reload=True):
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
-
+  data_dir = deepchem.utils.get_data_dir()
   dataset_file = os.path.join(data_dir, "qm7b.mat")
 
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7b.mat'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7b.mat'
     )
   dataset = scipy.io.loadmat(dataset_file)
 
@@ -149,17 +138,12 @@ def load_qm7(featurizer='CoulombMatrix', split='random', reload=True):
   """Load qm7 datasets."""
   # Featurize qm7 dataset
   print("About to featurize qm7 dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
-
+  data_dir = deepchem.utils.get_data_dir()
   dataset_file = os.path.join(data_dir, "gdb7.sdf")
 
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb7.tar.gz '
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb7.tar.gz'
     )
     os.system('tar -zxvf ' + os.path.join(data_dir, 'gdb7.tar.gz') + ' -C ' +
               data_dir)

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -10,28 +10,23 @@ import deepchem
 
 
 def load_qm8(featurizer='CoulombMatrix', split='random', reload=True):
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "qm8/" + featurizer + "/" + split)
 
   if featurizer in ['CoulombMatrix', 'BPSymmetryFunction', 'MP', 'Raw']:
     dataset_file = os.path.join(data_dir, "qm8.sdf")
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb8.tar.gz '
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb8.tar.gz'
       )
       os.system('tar -zxvf ' + os.path.join(data_dir, 'gdb8.tar.gz') + ' -C ' +
                 data_dir)
   else:
     dataset_file = os.path.join(data_dir, "qm8.csv")
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm8.csv '
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm8.csv'
       )
 
   qm8_tasks = [

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -13,10 +13,7 @@ def load_qm9(featurizer='CoulombMatrix', split='random', reload=True):
   """Load qm9 datasets."""
   # Featurize qm9 dataset
   print("About to featurize qm9 dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "qm9/" + featurizer + "/" + split)
 
@@ -24,18 +21,16 @@ def load_qm9(featurizer='CoulombMatrix', split='random', reload=True):
     dataset_file = os.path.join(data_dir, "gdb9.sdf")
 
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb9.tar.gz '
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb9.tar.gz'
       )
       os.system('tar -zxvf ' + os.path.join(data_dir, 'gdb9.tar.gz') + ' -C ' +
                 data_dir)
   else:
     dataset_file = os.path.join(data_dir, "qm9.csv")
     if not os.path.exists(dataset_file):
-      os.system(
-          'wget -P ' + data_dir +
-          ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm9.csv '
+      deepchem.utils.download_url(
+          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm9.csv'
       )
 
   qm9_tasks = [

--- a/deepchem/molnet/load_function/sampl_datasets.py
+++ b/deepchem/molnet/load_function/sampl_datasets.py
@@ -14,18 +14,14 @@ def load_sampl(featurizer='ECFP', split='index', reload=True):
   # Featurize SAMPL dataset
   print("About to featurize SAMPL dataset.")
   print("About to load SAMPL dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "sampl/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "SAMPL.csv")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/SAMPL.csv'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/SAMPL.csv'
     )
 
   SAMPL_tasks = ['expt']
@@ -49,7 +45,7 @@ def load_sampl(featurizer='ECFP', split='index', reload=True):
       tasks=SAMPL_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=dataset)

--- a/deepchem/molnet/load_function/sider_datasets.py
+++ b/deepchem/molnet/load_function/sider_datasets.py
@@ -11,18 +11,14 @@ import deepchem
 
 def load_sider(featurizer='ECFP', split='index', reload=True, K=4):
   print("About to load SIDER dataset.")
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "sider/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "sider.csv.gz")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/sider.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/sider.csv.gz'
     )
 
   dataset = deepchem.utils.save.load_from_disk(dataset_file)

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -12,10 +12,7 @@ import deepchem
 def load_tox21(featurizer='ECFP', split='index', reload=True, K=4):
   """Load Tox21 datasets. Does not do train/test split"""
   # Featurize Tox21 dataset
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "tox21/" + featurizer + "/" + split)
 
@@ -32,9 +29,8 @@ def load_tox21(featurizer='ECFP', split='index', reload=True, K=4):
 
   dataset_file = os.path.join(data_dir, "tox21.csv.gz")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/tox21.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/tox21.csv.gz'
     )
 
   if featurizer == 'ECFP':

--- a/deepchem/molnet/load_function/toxcast_datasets.py
+++ b/deepchem/molnet/load_function/toxcast_datasets.py
@@ -11,18 +11,14 @@ import deepchem
 
 def load_toxcast(featurizer='ECFP', split='index', reload=True):
 
-  if "DEEPCHEM_DATA_DIR" in os.environ:
-    data_dir = os.environ["DEEPCHEM_DATA_DIR"]
-  else:
-    data_dir = "/tmp"
+  data_dir = deepchem.utils.get_data_dir()
   if reload:
     save_dir = os.path.join(data_dir, "toxcast/" + featurizer + "/" + split)
 
   dataset_file = os.path.join(data_dir, "toxcast_data.csv.gz")
   if not os.path.exists(dataset_file):
-    os.system(
-        'wget -P ' + data_dir +
-        ' http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/toxcast_data.csv.gz'
+    deepchem.utils.download_url(
+        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/toxcast_data.csv.gz'
     )
 
   dataset = deepchem.utils.save.load_from_disk(dataset_file)
@@ -52,7 +48,7 @@ def load_toxcast(featurizer='ECFP', split='index', reload=True):
       tasks=TOXCAST_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
   ]

--- a/deepchem/utils/__init__.py
+++ b/deepchem/utils/__init__.py
@@ -10,9 +10,16 @@ import gzip
 import numpy as np
 import os
 import pandas as pd
+import tempfile
 
 from rdkit import Chem
 from rdkit.Chem.Scaffolds import MurckoScaffold
+
+try:
+  from urllib.request import urlretrieve  # Python 3
+except:
+  from urllib import urlretrieve  # Python 2
+
 
 def pad_array(x, shape, fill=0, both=False):
   """
@@ -47,6 +54,35 @@ def pad_array(x, shape, fill=0, both=False):
   x = np.pad(x, pad, mode='constant', constant_values=fill)
   return x
 
+
+def get_data_dir():
+  """Get the DeepChem data directory."""
+  if 'DEEPCHEM_DATA_DIR' in os.environ:
+    return os.environ['DEEPCHEM_DATA_DIR']
+  return tempfile.gettempdir()
+
+
+def download_url(url, dest_dir=get_data_dir(), name=None):
+  """Download a file to disk.
+
+  Parameters
+  ----------
+  url: str
+    the URL to download from
+  dest_dir: str
+    the directory to save the file in
+  name: str
+    the file name to save it as.  If omitted, it will try to extract a file name from the URL
+  """
+  if name is None:
+    name = url
+    if '?' in name:
+      name = name[:name.find('?')]
+    if '/' in name:
+      name = name[name.rfind('/') + 1:]
+  urlretrieve(url, os.path.join(dest_dir, name))
+
+
 class ScaffoldGenerator(object):
   """
   Generate molecular scaffolds.
@@ -56,6 +92,7 @@ class ScaffoldGenerator(object):
   include_chirality : : bool, optional (default False)
       Include chirality in scaffolds.
   """
+
   def __init__(self, include_chirality=False):
     self.include_chirality = include_chirality
 


### PR DESCRIPTION
See #687.  I replaced all uses of `wget` in molnet, plus a few others.  There are a few more places that still use `wget`, but they're doing slightly stranger things, and I figured it would be best to let the authors of those files fix them.  You can now use `dc.utils.download_url()` as a standard way for downloading files.  (It's just a thin wrapper around `urlretrieve`.)