### PR TITLE
Miniconda for tests vs anaconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ python:
 sudo: required
 dist: trusty
 install:
-- if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then wget https://repo.continuum.io/archive/Anaconda2-4.3.0-Linux-x86_64.sh
-  -O anaconda.sh; else wget https://repo.continuum.io/archive/Anaconda3-4.3.0-Linux-x86_64.sh
-  -O anaconda.sh; fi
+- wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O anaconda.sh;
 - export python_version=$TRAVIS_PYTHON_VERSION
 - bash anaconda.sh -b -p $HOME/anaconda
 - export PATH="$HOME/anaconda/bin:$PATH"


### PR DESCRIPTION
Miniconda is smaller than Full anaconda, want to see if we can shave off build time.

Also we don't need different versions because we explicitly pass through python version when creating the environment.