### PR TITLE
3D convolution and max pooling

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -1222,6 +1222,86 @@ class Conv2D(Layer):
     return out_tensor
 
 
+class Conv3D(Layer):
+  """A 3D convolution on the input.
+
+  This layer expects its input to be a five dimensional tensor of shape
+  (batch size, height, width, depth, # channels).
+  If there is only one channel, the fifth dimension may optionally be omitted.
+  """
+
+  def __init__(self,
+               num_outputs,
+               kernel_size=5,
+               stride=1,
+               padding='SAME',
+               activation_fn=tf.nn.relu,
+               normalizer_fn=None,
+               scope_name=None,
+               **kwargs):
+    """Create a Conv3D layer.
+
+    Parameters
+    ----------
+    num_outputs: int
+      the number of outputs produced by the convolutional kernel
+    kernel_size: int or tuple
+      the width of the convolutional kernel.  This can be either a three element tuple, giving
+      the kernel size along each dimension, or an integer to use the same size along both
+      dimensions.
+    stride: int or tuple
+      the stride between applications of the convolutional kernel.  This can be either a three
+      element tuple, giving the stride along each dimension, or an integer to use the same
+      stride along both dimensions.
+    padding: str
+      the padding method to use, either 'SAME' or 'VALID'
+    activation_fn: object
+      the Tensorflow activation function to apply to the output
+    normalizer_fn: object
+      the Tensorflow normalizer function to apply to the output
+    """
+    self.num_outputs = num_outputs
+    self.kernel_size = kernel_size
+    self.stride = stride
+    self.padding = padding
+    self.activation_fn = activation_fn
+    self.normalizer_fn = normalizer_fn
+    super(Conv3D, self).__init__(**kwargs)
+    if scope_name is None:
+      scope_name = self.name
+    self.scope_name = scope_name
+    try:
+      parent_shape = self.in_layers[0].shape
+      strides = stride
+      if isinstance(stride, int):
+        strides = (stride, stride, stride)
+      self._shape = (parent_shape[0], parent_shape[1] // strides[0],
+                     parent_shape[2] // strides[1],
+                     parent_shape[3] // strides[2], num_outputs)
+    except:
+      pass
+
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
+    inputs = self._get_input_tensors(in_layers)
+    parent_tensor = inputs[0]
+    if len(parent_tensor.get_shape()) == 4:
+      parent_tensor = tf.expand_dims(parent_tensor, 4)
+    out_tensor = tf.layers.conv3d(
+        parent_tensor,
+        filters=self.num_outputs,
+        kernel_size=self.kernel_size,
+        strides=self.stride,
+        padding=self.padding,
+        activation=self.activation_fn,
+        activity_regularizer=self.normalizer_fn,
+        name=self.scope_name)
+    out_tensor = out_tensor
+    if set_tensors:
+      self._record_variable_scope(self.scope_name)
+      self.out_tensor = out_tensor
+    return out_tensor
+
+
 class MaxPool(Layer):
 
   def __init__(self,
@@ -1244,6 +1324,53 @@ class MaxPool(Layer):
     inputs = self._get_input_tensors(in_layers)
     in_tensor = inputs[0]
     out_tensor = tf.nn.max_pool(
+        in_tensor, ksize=self.ksize, strides=self.strides, padding=self.padding)
+    if set_tensors:
+      self.out_tensor = out_tensor
+    return out_tensor
+
+
+class MaxPool3D(Layer):
+  """A 3D max pooling on the input.
+
+  This layer expects its input to be a five dimensional tensor of shape
+  (batch size, height, width, depth, # channels).
+  """
+
+  def __init__(self,
+               ksize=[1, 2, 2, 2, 1],
+               strides=[1, 2, 2, 2, 1],
+               padding='SAME',
+               **kwargs):
+    """Create a MaxPool3D layer.
+
+    Parameters
+    ----------
+    ksize: list
+      size of the window for each dimension of the input tensor. Must have
+      length of 5 and ksize[0] = ksize[4] = 1.
+    strides: list
+      stride of the sliding window for each dimension of input. Must have
+      length of 5 and strides[0] = strides[4] = 1.
+    padding: str
+      the padding method to use, either 'SAME' or 'VALID'
+    """
+
+    self.ksize = ksize
+    self.strides = strides
+    self.padding = padding
+    super(MaxPool3D, self).__init__(**kwargs)
+    try:
+      parent_shape = self.in_layers[0].shape
+      self._shape = tuple(None if p is None else p // s
+                          for p, s in zip(parent_shape, strides))
+    except:
+      pass
+
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
+    inputs = self._get_input_tensors(in_layers)
+    in_tensor = inputs[0]
+    out_tensor = tf.nn.max_pool3d(
         in_tensor, ksize=self.ksize, strides=self.strides, padding=self.padding)
     if set_tensors:
       self.out_tensor = out_tensor

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -34,7 +34,9 @@ from deepchem.models.tensorgraph.layers import ToFloat
 from deepchem.models.tensorgraph.layers import ReduceSum
 from deepchem.models.tensorgraph.layers import ReduceSquareDifference
 from deepchem.models.tensorgraph.layers import Conv2D
+from deepchem.models.tensorgraph.layers import Conv3D
 from deepchem.models.tensorgraph.layers import MaxPool
+from deepchem.models.tensorgraph.layers import MaxPool3D
 from deepchem.models.tensorgraph.layers import InputFifoQueue
 from deepchem.models.tensorgraph.layers import GraphConv
 from deepchem.models.tensorgraph.layers import GraphPool
@@ -368,6 +370,23 @@ class TestLayers(test_util.TensorFlowTestCase):
       out_tensor = out_tensor.eval()
       assert out_tensor.shape == (batch_size, length, width, out_channels)
 
+  def test_conv_3D(self):
+    """Test that Conv3D can be invoked."""
+    length = 4
+    width = 5
+    depth = 6
+    in_channels = 2
+    out_channels = 3
+    batch_size = 20
+    in_tensor = np.random.rand(batch_size, length, width, depth, in_channels)
+    with self.test_session() as sess:
+      in_tensor = tf.convert_to_tensor(in_tensor, dtype=tf.float32)
+      out_tensor = Conv3D(out_channels, kernel_size=1)(in_tensor)
+      sess.run(tf.global_variables_initializer())
+      out_tensor = out_tensor.eval()
+      assert out_tensor.shape == (batch_size, length, width, depth,
+                                  out_channels)
+
   def test_max_pool(self):
     """Test that MaxPool can be invoked."""
     length = 2
@@ -381,6 +400,21 @@ class TestLayers(test_util.TensorFlowTestCase):
       sess.run(tf.global_variables_initializer())
       out_tensor = out_tensor.eval()
       assert out_tensor.shape == (batch_size, 1, 1, in_channels)
+
+  def test_max_pool_3D(self):
+    """Test that MaxPool3D can be invoked."""
+    length = 2
+    width = 2
+    depth = 2
+    in_channels = 2
+    batch_size = 20
+    in_tensor = np.random.rand(batch_size, length, width, depth, in_channels)
+    with self.test_session() as sess:
+      in_tensor = tf.convert_to_tensor(in_tensor, dtype=tf.float32)
+      out_tensor = MaxPool3D()(in_tensor)
+      sess.run(tf.global_variables_initializer())
+      out_tensor = out_tensor.eval()
+      assert out_tensor.shape == (batch_size, 1, 1, 1, in_channels)
 
   def test_input_fifo_queue(self):
     """Test InputFifoQueue can be invoked."""

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -5,6 +5,7 @@ from deepchem.models.tensorgraph.layers import Feature, Conv1D, Dense, Flatten, 
     CombineMeanStd, Repeat, Gather, GRU, L2Loss, Concat, SoftMax, Constant, Variable, Add, Multiply, Log, InteratomicL2Distances, \
     SoftMaxCrossEntropy, ReduceMean, ToFloat, ReduceSquareDifference, Conv2D, MaxPool, ReduceSum, GraphConv, GraphPool, \
     GraphGather, BatchNorm, WeightedError, \
+    Conv3D, MaxPool3D, \
     LSTMStep, AttnLSTMEmbedding, IterRefLSTMEmbedding
 from deepchem.models.tensorgraph.graph_layers import Combine_AP, Separate_AP, \
     WeaveLayer, WeaveGather, DTNNEmbedding, DTNNGather, DTNNStep, \
@@ -255,10 +256,30 @@ def test_Conv2D_pickle():
   tg.save()
 
 
+def test_Conv3D_pickle():
+  tg = TensorGraph()
+  feature = Feature(shape=(tg.batch_size, 10, 10, 10, 1))
+  layer = Conv3D(num_outputs=3, in_layers=feature)
+  tg.add_output(layer)
+  tg.set_loss(layer)
+  tg.build()
+  tg.save()
+
+
 def test_MaxPool_pickle():
   tg = TensorGraph()
   feature = Feature(shape=(tg.batch_size, 10, 10, 10))
   layer = MaxPool(in_layers=feature)
+  tg.add_output(layer)
+  tg.set_loss(layer)
+  tg.build()
+  tg.save()
+
+
+def test_MaxPool3D_pickle():
+  tg = TensorGraph()
+  feature = Feature(shape=(tg.batch_size, 10, 10, 10, 10))
+  layer = MaxPool3D(in_layers=feature)
   tg.add_output(layer)
   tg.set_loss(layer)
   tg.build()


### PR DESCRIPTION
Implementation of the two new layers discussed in #821 : `Conv3D` which uses `tf.layers.conv3d` and `MaxPool3D` which uses `tf.nn.max_pool3d`