### PR TITLE
Layers support math operators

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -162,6 +162,39 @@ class Layer(object):
     else:
       return self.out_tensor
 
+  def __add__(self, other):
+    if not isinstance(other, Layer):
+      other = Constant(other)
+    return Add([self, other])
+
+  def __radd__(self, other):
+    if not isinstance(other, Layer):
+      other = Constant(other)
+    return Add([other, self])
+
+  def __sub__(self, other):
+    if not isinstance(other, Layer):
+      other = Constant(other)
+    return Add([self, other], weights=[1.0, -1.0])
+
+  def __rsub__(self, other):
+    if not isinstance(other, Layer):
+      other = Constant(other)
+    return Add([other, self], weights=[1.0, -1.0])
+
+  def __mul__(self, other):
+    if not isinstance(other, Layer):
+      other = Constant(other)
+    return Multiply([self, other])
+
+  def __rmul__(self, other):
+    if not isinstance(other, Layer):
+      other = Constant(other)
+    return Multiply([other, self])
+
+  def __neg__(self):
+    return Multiply([self, Constant(-1.0)])
+
 
 def _convert_layer_to_tensor(value, dtype=None, name=None, as_ref=False):
   return tf.convert_to_tensor(value.out_tensor, dtype=dtype, name=name)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -291,16 +291,15 @@ class TensorGraph(Model):
     elif not isinstance(outputs, collections.Sequence):
       outputs = [outputs]
     with self._get_tf("Graph").as_default():
-      out_tensors = [x.out_tensor for x in self.outputs]
       # Gather results for each output
-      results = [[] for out in out_tensors]
+      results = [[] for out in outputs]
       for feed_dict in generator:
         feed_dict = {
             self.layers[k.name].out_tensor: v
             for k, v in six.iteritems(feed_dict)
         }
         feed_dict[self._training_placeholder] = 0.0
-        feed_results = self.session.run(out_tensors, feed_dict=feed_dict)
+        feed_results = self.session.run(outputs, feed_dict=feed_dict)
         if len(feed_results) > 1:
           if len(transformers):
             raise ValueError("Does not support transformations "
@@ -328,7 +327,7 @@ class TensorGraph(Model):
     """
     return self.predict_on_generator(generator, transformers, outputs)
 
-  def predict_on_batch(self, X, transformers=[]):
+  def predict_on_batch(self, X, transformers=[], outputs=None):
     """Generates predictions for input samples, processing samples in a batch.
 
     Parameters
@@ -344,9 +343,9 @@ class TensorGraph(Model):
     """
     dataset = NumpyDataset(X=X, y=None)
     generator = self.default_generator(dataset, predict=True, pad_batches=False)
-    return self.predict_on_generator(generator, transformers)
+    return self.predict_on_generator(generator, transformers, outputs)
 
-  def predict_proba_on_batch(self, X, transformers=[]):
+  def predict_proba_on_batch(self, X, transformers=[], outputs=None):
     """Generates predictions for input samples, processing samples in a batch.
 
     Parameters
@@ -360,7 +359,7 @@ class TensorGraph(Model):
     -------
     A Numpy array of predictions.
     """
-    return self.predict_on_batch(X, transformers)
+    return self.predict_on_batch(X, transformers, outputs)
 
   def predict(self, dataset, transformers=[], outputs=None):
     """


### PR DESCRIPTION
Fixes #818.  I've implemented the `+`, `-`, and `*` operators.  I haven't implemented `/` because we don't currently have a Divide layer, but that could easily be added.  I also supported combining a Layer with a constant (either a number or a numpy array), in which case the constant automatically gets wrapped in Constant layer.  But note that if the constant is an array, the Layer *must* be on the left.  So `layer+array` works, but `array+layer` doesn't.  That's because numpy also overrides the same operators, and in that case the object on the left gets precedence.

I also fixed some bugs in TensorGraph related to the `outputs` argument that I ran into while implementing this.