### PR TITLE
Graphconv error bar fix for #838

### DIFF
--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -55,3 +55,18 @@ def test_graph_conv_regression_model():
   model.save()
   model = TensorGraph.load_from_dir(model.model_dir)
   scores = model.evaluate(dataset, [metric], transformers)
+
+
+def test_graph_conv_error_bars():
+  tasks, dataset, transformers, metric = get_dataset('regression', 'GraphConv')
+
+  batch_size = 50
+  model = GraphConvTensorGraph(
+      len(tasks), batch_size=batch_size, mode='regression')
+
+  model.fit(dataset, nb_epoch=1)
+
+  mu, sigma = model.bayesian_predict(
+      dataset, transformers, untransform=True, n_passes=24)
+  assert mu.shape == (len(dataset), len(tasks))
+  assert sigma.shape == (len(dataset), len(tasks))

--- a/examples/delaney/delaney_graphconv_error_bars.py
+++ b/examples/delaney/delaney_graphconv_error_bars.py
@@ -43,7 +43,7 @@ model.save()
 model.load_from_dir('model_saves')
 
 mu, sigma = model.bayesian_predict(
-    valid_dataset.X, transformers, untransform=True, n_passes=24)
+    valid_dataset, transformers, untransform=True, n_passes=24)
 print(mu[:4])
 print(sigma[:4])
 


### PR DESCRIPTION
Fixes #838 by adding back function `bayesian_predict_on_batch` (deleted in #763) to`GraphConvTensorGraph` (previously, the function resided in `TensorGraph` but wasn't adequately general hence was deleted). In a future PR, I'd like to work out a general `bayesian_predict` method for `TensorGraph`, but this PR only solves the limited case for `GraphConvTensorGraph`.

@peastman Would you mind reviewing this PR?