### PR TITLE
Prefetch shards for DiskDataset

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -14,6 +14,7 @@ from deepchem.utils.save import log
 import tempfile
 import time
 import shutil
+from multiprocessing.dummy import Pool
 
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
@@ -643,8 +644,12 @@ class DiskDataset(Dataset):
         shard_perm = np.random.permutation(num_shards)
       else:
         shard_perm = np.arange(num_shards)
+      pool = Pool(1)
+      next_shard = pool.apply_async(dataset.get_shard, (shard_perm[0],))
       for i in range(num_shards):
-        X, y, w, ids = dataset.get_shard(shard_perm[i])
+        X, y, w, ids = next_shard.get()
+        if i < num_shards - 1:
+          next_shard = pool.apply_async(dataset.get_shard, (shard_perm[i + 1],))
         n_samples = X.shape[0]
         # TODO(rbharath): This happens in tests sometimes, but don't understand why?
         # Handle edge case.

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -644,50 +644,51 @@ class DiskDataset(Dataset):
         shard_perm = np.random.permutation(num_shards)
       else:
         shard_perm = np.arange(num_shards)
-      pool = Pool(1)
-      next_shard = pool.apply_async(dataset.get_shard, (shard_perm[0],))
-      for i in range(num_shards):
-        X, y, w, ids = next_shard.get()
-        if i < num_shards - 1:
-          next_shard = pool.apply_async(dataset.get_shard, (shard_perm[i + 1],))
-        n_samples = X.shape[0]
-        # TODO(rbharath): This happens in tests sometimes, but don't understand why?
-        # Handle edge case.
-        if n_samples == 0:
-          continue
-        if not deterministic:
-          sample_perm = np.random.permutation(n_samples)
-        else:
-          sample_perm = np.arange(n_samples)
-        if batch_size is None:
-          shard_batch_size = n_samples
-        else:
-          shard_batch_size = batch_size
-        interval_points = np.linspace(
-            0,
-            n_samples,
-            np.ceil(float(n_samples) / shard_batch_size) + 1,
-            dtype=int)
-        for j in range(len(interval_points) - 1):
-          indices = range(interval_points[j], interval_points[j + 1])
-          perm_indices = sample_perm[indices]
-          X_batch = X[perm_indices]
-
-          if y is not None:
-            y_batch = y[perm_indices]
+      with Pool(1) as pool:
+        next_shard = pool.apply_async(dataset.get_shard, (shard_perm[0],))
+        for i in range(num_shards):
+          X, y, w, ids = next_shard.get()
+          if i < num_shards - 1:
+            next_shard = pool.apply_async(dataset.get_shard,
+                                          (shard_perm[i + 1],))
+          n_samples = X.shape[0]
+          # TODO(rbharath): This happens in tests sometimes, but don't understand why?
+          # Handle edge case.
+          if n_samples == 0:
+            continue
+          if not deterministic:
+            sample_perm = np.random.permutation(n_samples)
           else:
-            y_batch = None
-
-          if w is not None:
-            w_batch = w[perm_indices]
+            sample_perm = np.arange(n_samples)
+          if batch_size is None:
+            shard_batch_size = n_samples
           else:
-            w_batch = None
+            shard_batch_size = batch_size
+          interval_points = np.linspace(
+              0,
+              n_samples,
+              np.ceil(float(n_samples) / shard_batch_size) + 1,
+              dtype=int)
+          for j in range(len(interval_points) - 1):
+            indices = range(interval_points[j], interval_points[j + 1])
+            perm_indices = sample_perm[indices]
+            X_batch = X[perm_indices]
 
-          ids_batch = ids[perm_indices]
-          if pad_batches:
-            (X_batch, y_batch, w_batch, ids_batch) = pad_batch(
-                shard_batch_size, X_batch, y_batch, w_batch, ids_batch)
-          yield (X_batch, y_batch, w_batch, ids_batch)
+            if y is not None:
+              y_batch = y[perm_indices]
+            else:
+              y_batch = None
+
+            if w is not None:
+              w_batch = w[perm_indices]
+            else:
+              w_batch = None
+
+            ids_batch = ids[perm_indices]
+            if pad_batches:
+              (X_batch, y_batch, w_batch, ids_batch) = pad_batch(
+                  shard_batch_size, X_batch, y_batch, w_batch, ids_batch)
+            yield (X_batch, y_batch, w_batch, ids_batch)
 
     return iterate(self)
 


### PR DESCRIPTION
`DiskDataset.iterbatches()` would load one shard, then iterate over the batches in it to be processed, and then not start loading the next shard until it was completely done.  This meant the GPU spent a lot of time sitting idle, waiting for the next shard to be loaded.  In the test I looked at, this accounted for about 20% of the total time during fitting.

I've changed it so as soon as it starts processing one shard, it immediately begins loading the next shard in a separate thread.  By the time it finishes processing a shard, the next one is ready to go.

(The changes are much more minor than it looks like.  Most of what it's highlighting as changes is just indentation.)