### PR TITLE
Changes to support copying pieces of models

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -977,6 +977,30 @@ class Variable(Layer):
     return out_tensor
 
 
+class StopGradient(Layer):
+  """Block the flow of gradients.
+
+  This layer copies its input directly to its output, but reports that all
+  gradients of its output are zero.  This means, for example, that optimizers
+  will not try to optimize anything "upstream" of this layer."""
+
+  def __init__(self, in_layers=None, **kwargs):
+    super(StopGradient, self).__init__(in_layers, **kwargs)
+    try:
+      self._shape = tuple(self.in_layers[0].shape)
+    except:
+      pass
+
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
+    inputs = self._get_input_tensors(in_layers)
+    if len(inputs) > 1:
+      raise ValueError("Only one layer supported.")
+    out_tensor = tf.stop_gradient(inputs[0])
+    if set_tensors:
+      self.out_tensor = out_tensor
+    return out_tensor
+
+
 def _max_dimension(x, y):
   if x is None:
     return y

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -180,6 +180,20 @@ class Layer(object):
     specific existing ones.  For example, you can clone a stack of layers, while
     connecting the topmost ones to different inputs.
 
+    For example, consider a stack of dense layers that depend on an input:
+
+    >>> input = Feature(shape=(None, 100))
+    >>> dense1 = Dense(100, in_layers=input)
+    >>> dense2 = Dense(100, in_layers=dense1)
+    >>> dense3 = Dense(100, in_layers=dense2)
+
+    The following will clone all three dense layers, but not the input layer.
+    Instead, the input to the first dense layer will be a different layer
+    specified in the replacements map.
+
+    >>> replacements = {input: new_input}
+    >>> dense3_copy = dense3.copy(replacements)
+
     Parameters
     ----------
     replacements: map
@@ -982,7 +996,13 @@ class StopGradient(Layer):
 
   This layer copies its input directly to its output, but reports that all
   gradients of its output are zero.  This means, for example, that optimizers
-  will not try to optimize anything "upstream" of this layer."""
+  will not try to optimize anything "upstream" of this layer.
+
+  For example, suppose you have pre-trained a stack of layers to perform a
+  calculation.  You want to use the result of that calculation as the input to
+  another layer, but because they are already pre-trained, you do not want the
+  optimizer to modify them.  You can wrap the output in a StopGradient layer,
+  then use that as the input to the next layer."""
 
   def __init__(self, in_layers=None, **kwargs):
     super(StopGradient, self).__init__(in_layers, **kwargs)

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -180,6 +180,13 @@ class TensorGraph(Model):
       self.session.run(tf.global_variables_initializer())
       if restore:
         self.restore()
+      else:
+        # Initialize variables that have pre-trained values.
+        for layer in self.layers.values():
+          if layer.variable_values is not None:
+            variables = self.get_layer_variables(layer)
+            for var, val in zip(variables, layer.variable_values):
+              self.session.run(var.assign(val))
       avg_loss, n_batches = 0.0, 0.0
       coord = tf.train.Coordinator()
       n_samples = 0
@@ -330,11 +337,11 @@ class TensorGraph(Model):
     """Generates predictions for input samples, processing samples in a batch.
 
     Parameters
-    ---------- 
+    ----------
     X: ndarray
       the input data, as a Numpy array.
     transformers: List
-      List of dc.trans.Transformers 
+      List of dc.trans.Transformers
 
     Returns
     -------
@@ -348,11 +355,11 @@ class TensorGraph(Model):
     """Generates predictions for input samples, processing samples in a batch.
 
     Parameters
-    ---------- 
+    ----------
     X: ndarray
       the input data, as a Numpy array.
     transformers: List
-      List of dc.trans.Transformers 
+      List of dc.trans.Transformers
 
     Returns
     -------
@@ -370,7 +377,7 @@ class TensorGraph(Model):
       Dataset to make prediction on
     transformers: list
       List of dc.trans.Transformers.
-    outputs: object 
+    outputs: object
       If outputs is None, then will assume outputs = self.outputs[0] (single
       output). If outputs is a Layer/Tensor, then will evaluate and return as a
       single ndarray. If outputs is a list of Layers/Tensors, will return a list
@@ -391,7 +398,7 @@ class TensorGraph(Model):
       Dataset to make prediction on
     transformers: list
       List of dc.trans.Transformers.
-    outputs: object 
+    outputs: object
       If outputs is None, then will assume outputs = self.outputs[0] (single
       output). If outputs is a Layer/Tensor, then will evaluate and return as a
       single ndarray. If outputs is a list of Layers/Tensors, will return a list

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -39,6 +39,7 @@ from deepchem.models.tensorgraph.layers import Reshape
 from deepchem.models.tensorgraph.layers import SluiceLoss
 from deepchem.models.tensorgraph.layers import SoftMax
 from deepchem.models.tensorgraph.layers import SoftMaxCrossEntropy
+from deepchem.models.tensorgraph.layers import StopGradient
 from deepchem.models.tensorgraph.layers import TensorWrapper
 from deepchem.models.tensorgraph.layers import TimeSeriesDense
 from deepchem.models.tensorgraph.layers import ToFloat
@@ -240,6 +241,16 @@ class TestLayers(test_util.TensorFlowTestCase):
       out_tensor = Variable(value)()
       sess.run(tf.global_variables_initializer())
       assert np.array_equal(value, out_tensor.eval())
+
+  def test_stop_gradient(self):
+    """Test that StopGradient can be invoked."""
+    batch_size = 10
+    n_features = 5
+    in_tensor = np.random.rand(batch_size, n_features)
+    with self.test_session() as sess:
+      in_tensor = tf.convert_to_tensor(in_tensor, dtype=tf.float32)
+      out_tensor = StopGradient()(in_tensor)
+      assert np.array_equal(in_tensor.eval(), out_tensor.eval())
 
   def test_add(self):
     """Test that Add can be invoked."""

--- a/deepchem/models/tensorgraph/tests/test_layers_pickle.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_pickle.py
@@ -7,7 +7,7 @@ from deepchem.models.tensorgraph.graph_layers import Combine_AP, Separate_AP, \
   DTNNExtract, DAGLayer, DAGGather, MessagePassing, SetGather
 from deepchem.models.tensorgraph.layers import Feature, Conv1D, Dense, Flatten, Reshape, Squeeze, Transpose, \
   CombineMeanStd, Repeat, Gather, GRU, L2Loss, Concat, SoftMax, \
-  Constant, Variable, Add, Multiply, Log, Exp, InteratomicL2Distances, \
+  Constant, Variable, StopGradient, Add, Multiply, Log, Exp, InteratomicL2Distances, \
   SoftMaxCrossEntropy, ReduceMean, ToFloat, ReduceSquareDifference, Conv2D, MaxPool2D, ReduceSum, GraphConv, GraphPool, \
   GraphGather, BatchNorm, WeightedError, \
   Conv3D, MaxPool3D, \
@@ -161,6 +161,16 @@ def test_Variable_pickle():
   feature = Feature(shape=(tg.batch_size, 1))
   layer = Variable(np.array([15.0]))
   output = Multiply(in_layers=[feature, layer])
+  tg.add_output(output)
+  tg.set_loss(output)
+  tg.build()
+  tg.save()
+
+
+def test_StopGradient_pickle():
+  tg = TensorGraph()
+  feature = Feature(shape=(tg.batch_size, 1))
+  output = StopGradient(feature)
   tg.add_output(output)
   tg.set_loss(output)
   tg.build()


### PR DESCRIPTION
This includes all the changes described in #844, except for the option to have `TensorGraph.save()` record variable values.  I wasn't sure whether we actually want that feature or not.