### PR TITLE
Replace tar calls by python function from deepchem.utils

### DIFF
--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -22,8 +22,8 @@ def load_hopv(featurizer='ECFP', split='index', reload=True):
     deepchem.utils.download_url(
         'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/hopv.tar.gz'
     )
-    os.system('tar -zxvf ' + os.path.join(data_dir, 'hopv.tar.gz') + ' -C ' +
-              data_dir)
+    deepchem.utils.untargz_file(
+        os.path.join(data_dir, 'hopv.tar.gz'), data_dir)
 
   hopv_tasks = [
       'HOMO', 'LUMO', 'electrochemical_gap', 'optical_gap', 'PCE', 'V_OC',

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -22,8 +22,7 @@ def load_hopv(featurizer='ECFP', split='index', reload=True):
     deepchem.utils.download_url(
         'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/hopv.tar.gz'
     )
-    deepchem.utils.untargz_file(
-        os.path.join(data_dir, 'hopv.tar.gz'), data_dir)
+    deepchem.utils.untargz_file(os.path.join(data_dir, 'hopv.tar.gz'), data_dir)
 
   hopv_tasks = [
       'HOMO', 'LUMO', 'electrochemical_gap', 'optical_gap', 'PCE', 'V_OC',

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -34,12 +34,12 @@ def featurize_pdbbind(data_dir=None, feat="grid", subset="core"):
     deepchem.utils.download_url(
         'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/refined_grid.tar.gz'
     )
-    os.system('tar -zxvf ' + os.path.join(data_dir, 'core_grid.tar.gz') + ' -C '
-              + data_dir)
-    os.system('tar -zxvf ' + os.path.join(data_dir, 'full_grid.tar.gz') + ' -C '
-              + data_dir)
-    os.system('tar -zxvf ' + os.path.join(data_dir, 'refined_grid.tar.gz') +
-              ' -C ' + data_dir)
+    deepchem.utils.untargz_file(
+        os.path.join(data_dir, 'core_grid.tar.gz'), data_dir)
+    deepchem.utils.untargz_file(
+        os.path.join(data_dir, 'full_grid.tar.gz'), data_dir)
+    deepchem.utils.untargz_file(
+        os.path.join(data_dir, 'refined_grid.tar.gz'), data_dir)
 
   return deepchem.data.DiskDataset(dataset_dir), tasks
 

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -145,8 +145,8 @@ def load_qm7(featurizer='CoulombMatrix', split='random', reload=True):
     deepchem.utils.download_url(
         'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb7.tar.gz'
     )
-    os.system('tar -zxvf ' + os.path.join(data_dir, 'gdb7.tar.gz') + ' -C ' +
-              data_dir)
+    deepchem.utils.untargz_file(
+        os.path.join(data_dir, 'gdb7.tar.gz'), data_dir)
 
   qm7_tasks = ["u0_atom"]
   if featurizer == 'CoulombMatrix':

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -145,8 +145,7 @@ def load_qm7(featurizer='CoulombMatrix', split='random', reload=True):
     deepchem.utils.download_url(
         'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb7.tar.gz'
     )
-    deepchem.utils.untargz_file(
-        os.path.join(data_dir, 'gdb7.tar.gz'), data_dir)
+    deepchem.utils.untargz_file(os.path.join(data_dir, 'gdb7.tar.gz'), data_dir)
 
   qm7_tasks = ["u0_atom"]
   if featurizer == 'CoulombMatrix':

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -20,8 +20,8 @@ def load_qm8(featurizer='CoulombMatrix', split='random', reload=True):
       deepchem.utils.download_url(
           'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb8.tar.gz'
       )
-      os.system('tar -zxvf ' + os.path.join(data_dir, 'gdb8.tar.gz') + ' -C ' +
-                data_dir)
+      deepchem.utils.untargz_file(
+          os.path.join(data_dir, 'gdb8.tar.gz'), data_dir)
   else:
     dataset_file = os.path.join(data_dir, "qm8.csv")
     if not os.path.exists(dataset_file):


### PR DESCRIPTION
Replaced for hopv, pdbbind, qm7 and qm8 loaders
If some loaders still have tar call function and are missing from the list, please tell me and I can update them