### PR TITLE
Dataset.iterbatches not iterating in batch_size

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -324,10 +324,12 @@ class NumpyDataset(Dataset):
         sample_perm = np.arange(n_samples)
       if batch_size is None:
         batch_size = n_samples
-      interval_points = np.linspace(
-          0, n_samples, np.ceil(float(n_samples) / batch_size) + 1, dtype=int)
-      for j in range(len(interval_points) - 1):
-        indices = range(interval_points[j], interval_points[j + 1])
+      batch_idx = 0
+      num_batches = np.math.ceil(n_samples / batch_size)
+      while batch_idx < num_batches:
+        start = batch_idx * batch_size
+        end = min(n_samples, (batch_idx + 1) * batch_size)
+        indices = range(start, end)
         perm_indices = sample_perm[indices]
         X_batch = dataset._X[perm_indices]
         y_batch = dataset._y[perm_indices]
@@ -336,6 +338,7 @@ class NumpyDataset(Dataset):
         if pad_batches:
           (X_batch, y_batch, w_batch, ids_batch) = pad_batch(
               batch_size, X_batch, y_batch, w_batch, ids_batch)
+        batch_idx += 1
         yield (X_batch, y_batch, w_batch, ids_batch)
 
     return iterate(self, batch_size, deterministic, pad_batches)
@@ -663,13 +666,13 @@ class DiskDataset(Dataset):
           shard_batch_size = n_samples
         else:
           shard_batch_size = batch_size
-        interval_points = np.linspace(
-            0,
-            n_samples,
-            np.ceil(float(n_samples) / shard_batch_size) + 1,
-            dtype=int)
-        for j in range(len(interval_points) - 1):
-          indices = range(interval_points[j], interval_points[j + 1])
+
+        batch_idx = 0
+        num_batches = np.math.ceil(n_samples / shard_batch_size)
+        while batch_idx < num_batches:
+          start = batch_idx * shard_batch_size
+          end = min(n_samples, (batch_idx + 1) * shard_batch_size)
+          indices = range(start, end)
           perm_indices = sample_perm[indices]
           X_batch = X[perm_indices]
 
@@ -687,6 +690,7 @@ class DiskDataset(Dataset):
           if pad_batches:
             (X_batch, y_batch, w_batch, ids_batch) = pad_batch(
                 shard_batch_size, X_batch, y_batch, w_batch, ids_batch)
+          batch_idx += 1
           yield (X_batch, y_batch, w_batch, ids_batch)
       pool.close()
 

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -379,8 +379,30 @@ class TestDatasets(unittest.TestCase):
     X_means, y_means = np.mean(X, axis=0), np.mean(y, axis=0)
     X_stds, y_stds = np.std(X, axis=0), np.std(y, axis=0)
     comp_X_means, comp_X_stds, comp_y_means, comp_y_stds = \
-        solubility_dataset.get_statistics()
+      solubility_dataset.get_statistics()
     np.testing.assert_allclose(comp_X_means, X_means)
     np.testing.assert_allclose(comp_y_means, y_means)
     np.testing.assert_allclose(comp_X_stds, X_stds)
     np.testing.assert_allclose(comp_y_stds, y_stds)
+
+  def test_disk_iterate_batch_size(self):
+    solubility_dataset = dc.data.tests.load_solubility_data()
+    X, y, _, _ = (solubility_dataset.X, solubility_dataset.y,
+                  solubility_dataset.w, solubility_dataset.ids)
+    batch_sizes = []
+    for X, y, _, _ in solubility_dataset.iterbatches(
+        3, pad_batches=False, deterministic=True):
+      batch_sizes.append(len(X))
+    self.assertEqual([3, 3, 3, 1], batch_sizes)
+
+  def test_numpy_iterate_batch_size(self):
+    solubility_dataset = dc.data.tests.load_solubility_data()
+    X, y, _, _ = (solubility_dataset.X, solubility_dataset.y,
+                  solubility_dataset.w, solubility_dataset.ids)
+    solubility_dataset = dc.data.NumpyDataset.from_DiskDataset(
+        solubility_dataset)
+    batch_sizes = []
+    for X, y, _, _ in solubility_dataset.iterbatches(
+        3, pad_batches=False, deterministic=True):
+      batch_sizes.append(len(X))
+    self.assertEqual([3, 3, 3, 1], batch_sizes)


### PR DESCRIPTION
https://github.com/deepchem/deepchem/issues/881

Before we were dividing the samples into n_batches using float math and then casting the edge-posts to ints.  This could create systems when one would alternate between batch sizes of n, and n-1.

Now we select as many batches we can that fulfill the batch_size parameter and only fill the last batch.