### PR TITLE
fix for IRV transformer

### DIFF
--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -677,14 +677,15 @@ class IRVTransformer():
     values = []
     top_labels = []
     with g_temp.as_default():
-      labels_tf = tf.constant(y)
-      similarity_placeholder = tf.placeholder(
-          dtype=tf.float64, shape=(None, reference_len))
-      value, indice = tf.nn.top_k(
-          similarity_placeholder, k=self.K + 1, sorted=True)
-      # the tf graph here pick up the (K+1) highest similarity values
-      # and their indices
-      top_label = tf.gather(labels_tf, indice)
+      with tf.device('/cpu:0'):
+        labels_tf = tf.constant(y)
+        similarity_placeholder = tf.placeholder(
+            dtype=tf.float64, shape=(None, reference_len))
+        value, indice = tf.nn.top_k(
+            similarity_placeholder, k=self.K + 1, sorted=True)
+        # the tf graph here pick up the (K+1) highest similarity values
+        # and their indices
+        top_label = tf.gather(labels_tf, indice)
       # map the indices to labels
       feed_dict = {}
       with tf.Session() as sess:


### PR DESCRIPTION
tensorflow1.3 raises exception from topkkernel when using IRVTransformer on GPU #896 , change the top_k operation temporarily to CPU to avoid the issue.