### PR TITLE
fix DataLoader for shard_size=None

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -189,7 +189,7 @@ class DataLoader(object):
   def featurize(self, input_files, data_dir=None, shard_size=8192):
     """Featurize provided files and write to specified location."""
     log("Loading raw samples now.", self.verbose)
-    log("shard_size: %d" % shard_size, self.verbose)
+    log("shard_size: {}".format(shard_size), self.verbose)
 
     if not isinstance(input_files, list):
       input_files = [input_files]

--- a/deepchem/data/tests/test_data_loader.py
+++ b/deepchem/data/tests/test_data_loader.py
@@ -33,6 +33,15 @@ class TestDataLoader(unittest.TestCase):
         tasks=[], smiles_field="smiles", featurizer=featurizer)
     loader.featurize(input_file)
 
+  def test_none_shard_size(self):
+    """Test a shard_size of None for the CSVLoader. (Process the whole file at once)"""
+    input_file = os.path.join(self.current_dir,
+                              "../../models/tests/example.csv")
+    featurizer = dc.feat.CircularFingerprint(size=1024)
+    loader = dc.data.CSVLoader(
+         tasks=[], smiles_field="smiles", featurizer=featurizer)
+    loader.featurize(input_file, shard_size=None)
+
   def scaffold_test_train_valid_test_split(self):
     """Test of singletask RF ECFP regression API."""
     splittype = "scaffold"


### PR DESCRIPTION
The CSVLoader handles shard_size=None perfectly, however it fails due to logging.