### PR TITLE
Fix featurizer name error

### DIFF
--- a/examples/benchmark_curve.py
+++ b/examples/benchmark_curve.py
@@ -105,10 +105,13 @@ for dataset in datasets:
         featurizer = CheckFeaturizer[pair][0]
         n_features = CheckFeaturizer[pair][1]
       else:
-        supported_combinations = [key for key in CheckFeaturizer.keys() if pair[0] == key[0]]
-        supported_models = [k[1] for k in supported_combinations] 
-        raise ValueError("Model %s not supported for %s dataset. Please choose from the following:\n%s"
-          % (pair[1], pair[0], "  ".join(supported_models)))
+        supported_combinations = [
+            key for key in CheckFeaturizer.keys() if pair[0] == key[0]
+        ]
+        supported_models = [k[1] for k in supported_combinations]
+        raise ValueError(
+            "Model %s not supported for %s dataset. Please choose from the following:\n%s"
+            % (pair[1], pair[0], "  ".join(supported_models)))
 
       tasks, all_dataset, transformers = load_dataset(
           dataset, featurizer, split='index')

--- a/examples/benchmark_curve.py
+++ b/examples/benchmark_curve.py
@@ -104,6 +104,13 @@ for dataset in datasets:
       if pair in CheckFeaturizer:
         featurizer = CheckFeaturizer[pair][0]
         n_features = CheckFeaturizer[pair][1]
+      else:
+        supported_combinations = [key for key in CheckFeaturizer.keys() if pair[0] == key[0]]
+        print(supported_combinations)
+        supported_models = [k[1] for k in supported_combinations] 
+        raise ValueError(
+          "Model %s not supported for %s dataset. Please choose from the following:\n%s"
+          % (pair[1], pair[0], " ".join(supported_models)))
 
       tasks, all_dataset, transformers = load_dataset(
           dataset, featurizer, split='index')

--- a/examples/benchmark_curve.py
+++ b/examples/benchmark_curve.py
@@ -106,11 +106,9 @@ for dataset in datasets:
         n_features = CheckFeaturizer[pair][1]
       else:
         supported_combinations = [key for key in CheckFeaturizer.keys() if pair[0] == key[0]]
-        print(supported_combinations)
         supported_models = [k[1] for k in supported_combinations] 
-        raise ValueError(
-          "Model %s not supported for %s dataset. Please choose from the following:\n%s"
-          % (pair[1], pair[0], " ".join(supported_models)))
+        raise ValueError("Model %s not supported for %s dataset. Please choose from the following:\n%s"
+          % (pair[1], pair[0], "  ".join(supported_models)))
 
       tasks, all_dataset, transformers = load_dataset(
           dataset, featurizer, split='index')


### PR DESCRIPTION
Minor Issue: `(dataset, model)` combination was not being validated. I was trying to obtain learning curves for `bbbp` using different models and obtained `NameError: featurizer not defined` for combinations not available in `CheckFeaturizer` in `check_availability.py`. This should fix it. 