### PR TITLE
Update GraphConv Notebook for New TensorGraph Predict API

### DIFF
--- a/examples/notebooks/graph_convolutional_networks_for_tox21.ipynb
+++ b/examples/notebooks/graph_convolutional_networks_for_tox21.ipynb
@@ -13,7 +13,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from __future__ import division\n",
@@ -70,7 +72,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/rbharath/anaconda2/lib/python2.7/site-packages/tensorflow/python/ops/gradients_impl.py:91: UserWarning: Converting sparse IndexedSlices to a dense Tensor of unknown shape. This may consume a large amount of memory.\n",
+      "/home/leswing/miniconda3/envs/deepchem/lib/python3.5/site-packages/tensorflow/python/ops/gradients_impl.py:95: UserWarning: Converting sparse IndexedSlices to a dense Tensor of unknown shape. This may consume a large amount of memory.\n",
       "  \"Converting sparse IndexedSlices to a dense Tensor of unknown shape. \"\n"
      ]
     },
@@ -79,9 +81,19 @@
      "output_type": "stream",
      "text": [
       "Starting epoch 0\n",
-      "Ending global_step 129: Average loss 586.57\n",
-      "TIMING: model fitting took 17.082 s\n"
+      "Ending global_step 126: Average loss 590.739\n",
+      "TIMING: model fitting took 7.317 s\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "590.7391258118645"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -110,10 +122,10 @@
      "output_type": "stream",
      "text": [
       "Evaluating model\n",
-      "computed_metrics: [0.82355634419908874, 0.84317769495469375, 0.83831967490229498, 0.78265073415417696, 0.67514582634690545, 0.78648566994877722, 0.71947133017380849, 0.68636368747841314, 0.77653631284916202, 0.66689869847282113, 0.77872709187364375, 0.74727748235240998]\n",
-      "Training ROC-AUC Score: 0.760384\n",
-      "computed_metrics: [0.76064908722109537, 0.82394038192827201, 0.83087572150072142, 0.7314288959563835, 0.60984975330966895, 0.60837196235426316, 0.59852764937510705, 0.65035114358925683, 0.71262721074992585, 0.58264411027568919, 0.71303258145363402, 0.66946153846153844]\n",
-      "Validation ROC-AUC Score: 0.690980\n"
+      "computed_metrics: [0.80045699830862893, 0.83618637604367374, 0.83908539936708681, 0.77873855933094183, 0.67692252993044244, 0.75578036941489168, 0.75895796821704797, 0.70234314980793855, 0.76387081283102387, 0.65924917162534913, 0.78448201448364341, 0.76675448900822296]\n",
+      "Training ROC-AUC Score: 0.760236\n",
+      "computed_metrics: [0.71533171721169553, 0.74090608465608465, 0.81106357802757933, 0.70627859684799188, 0.63177272727272715, 0.6326016835811501, 0.61491865697473169, 0.71286314850043442, 0.67676006592889104, 0.51656328658755846, 0.75414979999520937, 0.6603359173126615]\n",
+      "Validation ROC-AUC Score: 0.681129\n"
      ]
     }
    ],
@@ -138,7 +150,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from deepchem.models.tensorgraph.tensor_graph import TensorGraph\n",
@@ -160,7 +174,9 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from deepchem.models.tensorgraph.layers import Feature\n",
@@ -187,7 +203,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "from deepchem.models.tensorgraph.layers import Dense, GraphConv, BatchNorm\n",
@@ -233,7 +251,7 @@
    "outputs": [],
    "source": [
     "from deepchem.models.tensorgraph.layers import Dense, SoftMax, \\\n",
-    "    SoftMaxCrossEntropy, WeightedError, Concat\n",
+    "    SoftMaxCrossEntropy, WeightedError, Stack\n",
     "from deepchem.models.tensorgraph.layers import Label, Weights\n",
     "\n",
     "costs = []\n",
@@ -249,7 +267,7 @@
     "    labels.append(label)\n",
     "    cost = SoftMaxCrossEntropy(in_layers=[label, classification])\n",
     "    costs.append(cost)\n",
-    "all_cost = Concat(in_layers=costs, axis=1)\n",
+    "all_cost = Stack(in_layers=costs, axis=1)\n",
     "weights = Weights(shape=(None, len(tox21_tasks)))\n",
     "loss = WeightedError(in_layers=[all_cost, weights])\n",
     "tg.set_loss(loss)"
@@ -264,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "metadata": {
     "collapsed": true
    },
@@ -279,7 +297,7 @@
     "        print('Starting epoch %i' % epoch)\n",
     "    for ind, (X_b, y_b, w_b, ids_b) in enumerate(\n",
     "        dataset.iterbatches(\n",
-    "            batch_size, pad_batches=True, deterministic=True)):\n",
+    "            batch_size, pad_batches=pad_batches, deterministic=True)):\n",
     "      d = {}\n",
     "      for index, label in enumerate(labels):\n",
     "        d[label] = to_one_hot(y_b[:, index])\n",
@@ -302,7 +320,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -310,9 +328,19 @@
      "output_type": "stream",
      "text": [
       "Starting epoch 0\n",
-      "Ending global_step 129: Average loss 586.139\n",
-      "TIMING: model fitting took 21.158 s\n"
+      "Ending global_step 251: Average loss 530.84\n",
+      "TIMING: model fitting took 6.949 s\n"
      ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "530.8396410260882"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -330,18 +358,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {},
+   "execution_count": 13,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "Evaluating model\n",
-      "computed_metrics: [0.48489674611520039, 0.49062127172873471, 0.49497985043341852, 0.50670994717906093, 0.47636546814871089, 0.50538527032779901, 0.47652531174729351, 0.49406973662015952, 0.49345587239947747, 0.51160175820338205, 0.48764342697532359, 0.505495556795303]\n",
-      "Training ROC-AUC Score: 0.493979\n",
-      "computed_metrics: [0.49546025306674396, 0.44814469802825652, 0.51528679653679654, 0.50477055883689226, 0.50335989998437258, 0.5068829891838742, 0.57539376819037835, 0.50612128689380276, 0.45944076672265588, 0.58692564745196329, 0.48453889353012158, 0.48315384615384616]\n",
-      "Valid ROC-AUC Score: 0.505790\n"
+      "computed_metrics: [0.83463194036351052, 0.86218739964675661, 0.84894031662657832, 0.80217986671584707, 0.70559942152332189, 0.79751934844253025, 0.8103057689046107, 0.71659210162938414, 0.80849247997327445, 0.72071717294380933, 0.83433314746710274, 0.78304357554399506]\n",
+      "Training ROC-AUC Score: 0.793712\n",
+      "computed_metrics: [0.78221936377578793, 0.78993055555555547, 0.81705388431256543, 0.77777071682765631, 0.66802272727272727, 0.67197702777122181, 0.64295604015230179, 0.72305596655628368, 0.74692724275959499, 0.63050611290902547, 0.80023473616134511, 0.73880275624461667]\n",
+      "Valid ROC-AUC Score: 0.732455\n"
      ]
     }
    ],
@@ -349,13 +379,27 @@
     "metric = dc.metrics.Metric(\n",
     "    dc.metrics.roc_auc_score, np.mean, mode=\"classification\")\n",
     "\n",
+    "def reshape_y_pred(y_true, y_pred):\n",
+    "    \"\"\"\n",
+    "    TensorGraph.Predict returns a list of arrays, one for each output\n",
+    "    We also have to remove the padding on the last batch\n",
+    "    Metrics taks results of shape (samples, n_task, prob_of_class)\n",
+    "    \"\"\"\n",
+    "    n_samples = len(y_true)\n",
+    "    retval = np.stack(y_pred, axis=1)\n",
+    "    return retval[:n_samples]\n",
+    "    \n",
+    "\n",
     "print(\"Evaluating model\")\n",
-    "train_scores = tg.evaluate_generator(data_generator(train_dataset, predict=True),\n",
-    "                                     [metric], labels=labels, weights=[weights])\n",
-    "print(\"Training ROC-AUC Score: %f\" % train_scores[\"mean-roc_auc_score\"])\n",
-    "valid_scores = tg.evaluate_generator(data_generator(valid_dataset, predict=True),\n",
-    "                                     [metric], labels=labels, weights=[weights])\n",
-    "print(\"Valid ROC-AUC Score: %f\" % valid_scores[\"mean-roc_auc_score\"])"
+    "train_predictions = tg.predict_on_generator(data_generator(train_dataset, predict=True))\n",
+    "train_predictions = reshape_y_pred(train_dataset.y, train_predictions)\n",
+    "train_scores = metric.compute_metric(train_dataset.y, train_predictions, train_dataset.w)\n",
+    "print(\"Training ROC-AUC Score: %f\" % train_scores)\n",
+    "\n",
+    "valid_predictions = tg.predict_on_generator(data_generator(valid_dataset, predict=True))\n",
+    "valid_predictions = reshape_y_pred(valid_dataset.y, valid_predictions)\n",
+    "valid_scores = metric.compute_metric(valid_dataset.y, valid_predictions, valid_dataset.w)\n",
+    "print(\"Valid ROC-AUC Score: %f\" % valid_scores)"
    ]
   },
   {
@@ -364,6 +408,15 @@
    "source": [
     "Success! The model we've constructed behaves nearly identically to `GraphConvTensorGraph`. If you're looking to build your own custom models, you can follow the example we've provided here to do so. We hope to see exciting constructions from your end soon!"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
TensorGraph predict API now returns a list of tensors.

This means that we cannot use the metrics API over them without reshaping.  Updating notebook to show this and calling metrics.compute_metrics manually.