### PR TITLE
[WIP] Predict Loss as Output

### DIFF
--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -279,11 +279,11 @@ class TensorGraph(Model):
           deterministic=deterministic,
           pad_batches=pad_batches):
         feed_dict = dict()
-        if len(self.labels) == 1 and y_b is not None and not predict:
+        if len(self.labels) == 1 and y_b is not None:
           feed_dict[self.labels[0]] = y_b
         if len(self.features) == 1 and X_b is not None:
           feed_dict[self.features[0]] = X_b
-        if len(self.task_weights) == 1 and w_b is not None and not predict:
+        if len(self.task_weights) == 1 and w_b is not None:
           feed_dict[self.task_weights[0]] = w_b
         for (initial_state, zero_state) in zip(self.rnn_initial_states,
                                                self.rnn_zero_states):
@@ -349,7 +349,11 @@ class TensorGraph(Model):
 
       final_results = []
       for result_list in results:
-        final_results.append(np.concatenate(result_list, axis=0))
+        try:
+          result_list = np.concatenate(result_list, axis=0)
+        except ValueError as e:
+          pass
+        final_results.append(result_list)
       # If only one output, just return array
       if len(final_results) == 1:
         return final_results[0]


### PR DESCRIPTION
Allows predicting the loss as output
```python
import numpy as np
import deepchem as dc

# Only for debug!
np.random.seed(123)

# Load Tox21 dataset
n_features = 1024
tox21_tasks, tox21_datasets, transformers = dc.molnet.load_tox21()
train_dataset, valid_dataset, test_dataset = tox21_datasets

# Fit models
metric = dc.metrics.Metric(dc.metrics.roc_auc_score, np.mean)

model = dc.models.MultiTaskClassifier(
    len(tox21_tasks),
    n_features,
    layer_sizes=[1000],
    dropouts=[.25],
    learning_rate=0.001,
    batch_size=50,
    use_queue=False)

# Fit trained model
model.fit(train_dataset, nb_epoch=1)
valid_loss = model.predict(valid_dataset, outputs=model.loss)
print(np.mean(valid_loss))
```

Bug is brought up here https://github.com/deepchem/deepchem/issues/1040