### PR TITLE
README and usability updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ git clone https://github.com/deepchem/deepchem.git      # Clone deepchem source 
 cd deepchem
 bash scripts/install_deepchem_conda.sh deepchem
 source activate deepchem
-conda install -c conda-forge tensorflow-gpu=1.3.0      # If you want GPU support
+yes | pip install tensorflow-gpu==1.4.0      # If you want GPU support
 python setup.py install                                # Manual install
 nosetests -a '!slow' -v deepchem --nologcapture        # Run tests
 ```
@@ -71,82 +71,12 @@ via this installation procedure.
 
 ### Easy Install via Conda
 ```bash
-conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=1.3.0
+conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=1.3.1
 ```
 
-### Installing Dependencies Manually
-
-1. Download the **64-bit** Python 2.7 or Python 3.5 versions of Anaconda for linux [here](https://www.continuum.io/downloads#_unix).
-   Follow the [installation instructions](http://docs.continuum.io/anaconda/install#linux-install)
-
-2. `rdkit`
-   ```bash
-   conda install -c rdkit rdkit
-   ```
-
-3. `joblib`
-   ```bash
-   conda install joblib
-   ```
-
-4. `six`
-   ```bash
-   pip install six
-   ```
-5. `networkx`
-   ```bash
-   conda install -c anaconda networkx=1.11
-   ```
-
-6. `mdtraj`
-   ```bash
-   conda install -c omnia mdtraj
-   ```
-
-7. `pdbfixer`
-   ```bash
-   conda install -c omnia pdbfixer=1.4
-   ```
-
-8. `tensorflow`: Installing `tensorflow` on older versions of Linux (which
-    have glibc < 2.17) can be very challenging. For these older Linux versions,
-    contact your local sysadmin to work out a custom installation. If your
-    version of Linux is recent, then the following command will work:
-    ```
-    pip install tensorflow-gpu==1.3.0
-    ```
-
-9. `deepchem`: Clone the `deepchem` github repo:
-   ```bash
-   git clone https://github.com/deepchem/deepchem.git
-   ```
-   `cd` into the `deepchem` directory and execute
-   ```bash
-   python setup.py install
-   ```
-
-10. To run test suite, install `nosetests`:
-   ```bash
-   pip install nose
-   ```
-   Make sure that the correct version of `nosetests` is active by running
-   ```bash
-   which nosetests
-   ```
-   You might need to uninstall a system install of `nosetests` if
-   there is a conflict.
-
-11. If installation has been successful, all tests in test suite should pass:
-    ```bash
-    nosetests -v deepchem --nologcapture
-    ```
-    Note that the full test-suite uses up a fair amount of memory.
-    Try running tests for one submodule at a time if memory proves an issue.
-
 ### Using a Docker Image
-For major releases we will create docker environments with everything pre-installed.
-In order to get GPU support you will have to use the 
-[nvidia-docker](https://github.com/NVIDIA/nvidia-docker) plugin.
+Using a docker image requires an NVIDIA GPU.  If you do not have a GPU please follow the directions for [using a conda environment](#using-a-conda-environment)
+In order to get GPU support you will have to use the [nvidia-docker](https://github.com/NVIDIA/nvidia-docker) plugin.
 ``` bash
 # This will the download the latest stable deepchem docker image into your images
 docker pull deepchemio/deepchem
@@ -176,7 +106,9 @@ import deepchem as dc
    ```
 
 ## Getting Started
-The first step to getting started is looking at the examples in the `examples/` directory. Try running some of these examples on your system and verify that the models train successfully. Afterwards, to apply `deepchem` to a new problem, try starting from one of the existing examples and modifying it step by step to work with your new use-case.
+Two good tutorials to get started are [Graph Convolutional Networks](https://deepchem.io/docs/notebooks/graph_convolutional_networks_for_tox21.html) and [Multitask_Networks_on_MUV](https://deepchem.io/docs/notebooks/Multitask_Networks_on_MUV.html). Follow along with the tutorials to see how to predict properties on molecules using neural networks.
+
+Afterwards you can go through other [tutorials](https://deepchem.io/docs/notebooks/index.html), and look through our examples in the `examples` directory. To apply `deepchem` to a new problem, try starting from one of the existing examples or tutorials and modifying it step by step to work with your new use-case. If you have questions or comments you can raise them on our [gitter](https://gitter.im/deepchem/Lobby).
 
 ### Input Formats
 Accepted input formats for deepchem include csv, pkl.gz, and sdf files. For

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -44,4 +44,5 @@ conda install -y -q -c conda-forge zlib=1.2.11
 conda install -y -q -c conda-forge requests=2.18.4
 conda install -y -q -c conda-forge xgboost=0.6a2
 conda install -y -q -c conda-forge simdna=0.4.2
+conda install -y -q -c conda-forge jupyter=1.0.0
 conda install -y -q -c rdkit rdkit=2017.09.1


### PR DESCRIPTION
Install jupyter by default when installing from source.  I'm not going to update the conda package to include it for 1.3.1, as its a small issue, but I will for 2.0.0.

Update README for getting started to point to the Graph Convs tutorial and the MUV tutorial.