### PR TITLE
fix metric dimension bug in gaussian_process.py for user defined model_class

### DIFF
--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -225,8 +225,8 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
         model.fit(train_dataset, **hyper_parameters)
         model.save()
         evaluator = Evaluator(model, valid_dataset, output_transformers)
-        multitask_scores = evaluator.compute_model_performance([metric])
-        score = multitask_scores[metric.name]
+        multitask_scores = evaluator.compute_model_performance(metric)
+        score = multitask_scores[metric[0].name]
 
       with open(log_file, 'a') as f:
         # Record performances


### PR DESCRIPTION
When using a user defined model_class,     
GaussianProcessHyperparamOpt will  have Error in metric dimension.  
This is my first pull request on github, please correct me if I made any mistakes.
```python
def model_builder(hyper_parameters, model_dir):
  return dc.models.ANIRegression(
    len(tasks),
    max_num_atoms,
    model_dir=model_dir,
    use_queue=True,
    mode="regression",
    #atomic_number_differentiated=True,
    )

optimizer = dc.hyper.GaussianProcessHyperparamOpt(model_builder)

```

>Traceback (most recent call last):
  File "ANI.py", line 108, in <module>
    max_iter=20,
  File "/pubhome/jcyang/.local/lib/python2.7/site-packages/deepchem/hyper/gaussian_process.py", line 251, in hyperparam_search
    gpgo.run(max_iter=max_iter)
  File "/pubhome/jcyang/.local/lib/python2.7/site-packages/pyGPGO/GPGO.py", line 188, in run
    self._firstRun(self.init_evals)
  File "/pubhome/jcyang/.local/lib/python2.7/site-packages/pyGPGO/GPGO.py", line 88, in _firstRun
    self.y[i] = self.f(**s_param)
  File "/pubhome/jcyang/.local/lib/python2.7/site-packages/deepchem/hyper/gaussian_process.py", line 228, in f
    multitask_scores = evaluator.compute_model_performance([metric])
  File "/pubhome/jcyang/.local/lib/python2.7/site-packages/deepchem/utils/evaluate.py", line 99, in compute_model_performance
    mode = metrics[0].mode
AttributeError: 'list' object has no attribute 'mode'