### PR TITLE
remove Direct from Source from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ democratizes the use of deep-learning in drug discovery, materials science, quan
 * [Requirements](#requirements)
 * [Installation](#installation)
     * [Conda Environment](#using-a-conda-environment)
-    * [Direct from Source](#installing-dependencies-manually)
     * [Docker](#using-a-docker-image)
 * [FAQ](#faq)
 * [Getting Started](#getting-started)


### PR DESCRIPTION
Referencing issue in #1100. Updated the README.md by removing `Direct from Source` as installing via conda installs from the source.