### PR TITLE
8x faster graph normalization

### DIFF
--- a/contrib/torch/pytorch_graphconv.py
+++ b/contrib/torch/pytorch_graphconv.py
@@ -6,7 +6,6 @@ import torch.optim as optim
 import random
 import numpy as np
 from sklearn.metrics import roc_auc_score
-import scipy
 
 
 def symmetric_normalize_adj(adj):
@@ -24,8 +23,8 @@ def symmetric_normalize_adj(adj):
     adj = adj[:n_atoms, :n_atoms]
     degree = np.sum(adj, axis=1)
     D = np.diag(degree)
-    D_sqrt = scipy.linalg.sqrtm(D)
-    D_sqrt_inv = scipy.linalg.inv(D_sqrt)
+    D_sqrt = np.sqrt(D)
+    D_sqrt_inv = np.linalg.inv(D_sqrt)
     sym_norm = D_sqrt_inv.dot(adj)
     sym_norm = sym_norm.dot(D_sqrt_inv)
     new_adj = np.zeros(orig_shape)


### PR DESCRIPTION
2 changes:
1. numpy matrix inversion is 2x faster than scipy inversion
2. For diagonal matrices, np.sqrt and scipy.linalg.sqrtm give the same result because there are no interaction terms. But np.sqrt is 250x faster.