### PR TITLE
Replaced print statements with logging statements for deepchem/data and deepchem/dock

### DIFF
--- a/deepchem/data/supports.py
+++ b/deepchem/data/supports.py
@@ -286,7 +286,7 @@ class EpisodeGenerator(object):
     self.trial_num = 0
     time_end = time.time()
     logger.info("Constructing EpisodeGenerator took %s seconds" %
-          str(time_end - time_start))
+                str(time_end - time_start))
 
   def __iter__(self):
     return self

--- a/deepchem/data/supports.py
+++ b/deepchem/data/supports.py
@@ -133,7 +133,7 @@ def get_task_test(dataset, n_episodes, n_test, task, log_every_n=50):
   tests = []
   for episode in range(n_episodes):
     if episode % log_every_n == 0:
-      print("Sampling test %d" % episode)
+      logger.info("Sampling test %d" % episode)
     inds = ids[episode]
     X_batch = X_task[inds]
     y_batch = np.squeeze(y_task[inds, task])
@@ -166,7 +166,7 @@ def get_single_task_test(dataset, batch_size, task, replace=True):
 
 def get_single_task_support(dataset, n_pos, n_neg, task, replace=True):
   """Generates one support set purely for specified task.
-  
+
   Parameters
   ----------
   datasets: dc.data.Dataset
@@ -190,7 +190,7 @@ def get_single_task_support(dataset, n_pos, n_neg, task, replace=True):
 
 def get_task_support(dataset, n_episodes, n_pos, n_neg, task, log_every_n=50):
   """Generates one support set purely for specified task.
-  
+
   Parameters
   ----------
   datasets: dc.data.Dataset
@@ -221,7 +221,7 @@ def get_task_support(dataset, n_episodes, n_pos, n_neg, task, log_every_n=50):
   supports = []
   for episode in range(n_episodes):
     if episode % log_every_n == 0:
-      print("Sampling support %d" % episode)
+      logger.info("Sampling support %d" % episode)
     # No replacement allowed for supports
     pos_ids = np.random.choice(len(pos_mols), (n_pos,), replace=False)
     neg_ids = np.random.choice(len(neg_mols), (n_neg,), replace=False)
@@ -285,7 +285,7 @@ class EpisodeGenerator(object):
     self.task_num = 0
     self.trial_num = 0
     time_end = time.time()
-    print("Constructing EpisodeGenerator took %s seconds" %
+    logger.info("Constructing EpisodeGenerator took %s seconds" %
           str(time_end - time_start))
 
   def __iter__(self):

--- a/deepchem/data/test_data_loader.py
+++ b/deepchem/data/test_data_loader.py
@@ -14,7 +14,7 @@ class TestCSVLoader(TestCase):
     fin = tempfile.NamedTemporaryFile(mode='w', delete=False)
     fin.write("smiles,endpoint\nc1ccccc1,1")
     fin.close()
-    print(fin.name)
+    logger.info(fin.name)
     featurizer = dc.feat.CircularFingerprint(size=1024)
     tasks = ["endpoint"]
     loader = dc.data.CSVLoader(

--- a/deepchem/data/tests/test_drop.py
+++ b/deepchem/data/tests/test_drop.py
@@ -21,11 +21,11 @@ class TestDrop(unittest.TestCase):
     len_full = 25
 
     current_dir = os.path.dirname(os.path.realpath(__file__))
-    print("About to load emols dataset.")
+    logger.warn("About to load emols dataset.")
     dataset_file = os.path.join(current_dir, "mini_emols.csv")
 
     # Featurize emols dataset
-    print("About to featurize datasets.")
+    logger.warn("About to featurize datasets.")
     featurizer = dc.feat.CircularFingerprint(size=1024)
     emols_tasks = ['activity']
 

--- a/deepchem/data/tests/test_load.py
+++ b/deepchem/data/tests/test_load.py
@@ -60,12 +60,12 @@ class TestLoad(unittest.TestCase):
     data_dir = tempfile.mkdtemp()
 
     # Load dataset
-    print("About to load dataset.")
+    logger.info("About to load dataset.")
     dataset_file = os.path.join(current_dir,
                                 "../../models/tests/multitask_example.csv")
 
     # Featurize tox21 dataset
-    print("About to featurize dataset.")
+    logger.info("About to featurize dataset.")
     featurizer = dc.feat.CircularFingerprint(size=1024)
     all_tasks = ["task%d" % i for i in range(17)]
 
@@ -82,7 +82,7 @@ class TestLoad(unittest.TestCase):
     y_tasks, w_tasks, = [], []
     dataset = dc.data.DiskDataset(data_dir)
     for ind, task in enumerate(all_tasks):
-      print("Processing task %s" % task)
+      logger.info("Processing task %s" % task)
 
       X_task, y_task, w_task, ids_task = (dataset.X, dataset.y, dataset.w,
                                           dataset.ids)
@@ -113,12 +113,12 @@ class TestLoad(unittest.TestCase):
     data_dir = tempfile.mkdtemp()
 
     # Load dataset
-    print("About to load dataset.")
+    logger.info("About to load dataset.")
     dataset_file = os.path.join(current_dir,
                                 "../../models/tests/multitask_example.csv")
 
     # Featurize tox21 dataset
-    print("About to featurize dataset.")
+    logger.info("About to featurize dataset.")
     featurizer = dc.feat.CircularFingerprint(size=1024)
     all_tasks = ["task%d" % i for i in range(17)]
     # For debugging purposes
@@ -137,7 +137,7 @@ class TestLoad(unittest.TestCase):
     ####### Do singletask load
     y_tasks, w_tasks, ids_tasks = [], [], []
     for task in tasks:
-      print("Processing task %s" % task)
+      logger.info("Processing task %s" % task)
       if os.path.exists(data_dir):
         shutil.rmtree(data_dir)
       loader = dc.data.CSVLoader(

--- a/deepchem/data/tests/test_reload.py
+++ b/deepchem/data/tests/test_reload.py
@@ -25,7 +25,7 @@ class TestReload(unittest.TestCase):
   def _run_muv_experiment(self, dataset_file, reload=False):
     """Loads or reloads a small version of MUV dataset."""
     # Load MUV dataset
-    print("About to featurize compounds")
+    logger.info("About to featurize compounds")
     featurizer = dc.feat.CircularFingerprint(size=1024)
     raw_dataset = dc.utils.save.load_from_disk(dataset_file)
     MUV_tasks = [
@@ -38,7 +38,7 @@ class TestReload(unittest.TestCase):
     dataset = loader.featurize(dataset_file)
     assert len(dataset) == len(raw_dataset)
 
-    print("About to split compounds into train/valid/test")
+    logger.info("About to split compounds into train/valid/test")
     splitter = dc.splits.ScaffoldSplitter()
     frac_train, frac_valid, frac_test = .8, .1, .1
     train_dataset, valid_dataset, test_dataset = \
@@ -60,7 +60,7 @@ class TestReload(unittest.TestCase):
     transformers = [
         dc.trans.BalancingTransformer(transform_w=True, dataset=train_dataset)
     ]
-    print("Transforming datasets")
+    logger.info("Transforming datasets")
     for dataset in [train_dataset, valid_dataset, test_dataset]:
       for transformer in transformers:
         dataset = transformer.transform(dataset)
@@ -73,11 +73,11 @@ class TestReload(unittest.TestCase):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     dataset_file = os.path.join(current_dir,
                                 "../../../datasets/mini_muv.csv.gz")
-    print("Running experiment for first time without reload.")
+    logger.info("Running experiment for first time without reload.")
     (len_train, len_valid, len_test) = self._run_muv_experiment(
         dataset_file, reload)
 
-    print("Running experiment for second time with reload.")
+    logger.info("Running experiment for second time with reload.")
     reload = True
     (len_reload_train, len_reload_valid,
      len_reload_test) = (self._run_muv_experiment(dataset_file, reload))
@@ -91,11 +91,11 @@ class TestReload(unittest.TestCase):
     current_dir = os.path.dirname(os.path.abspath(__file__))
     dataset_file = os.path.join(current_dir,
                                 "../../../datasets/mini_muv.csv.gz")
-    print("Running experiment for first time with reload.")
+    logger.info("Running experiment for first time with reload.")
     (len_train, len_valid, len_test) = self._run_muv_experiment(
         dataset_file, reload)
 
-    print("Running experiment for second time with reload.")
+    logger.info("Running experiment for second time with reload.")
     (len_reload_train, len_reload_valid,
      len_reload_test) = (self._run_muv_experiment(dataset_file, reload))
     assert len_train == len_reload_train

--- a/deepchem/data/tests/test_support_generator.py
+++ b/deepchem/data/tests/test_support_generator.py
@@ -1,5 +1,5 @@
 """
-Simple Tests for Support Generation 
+Simple Tests for Support Generation
 """
 from __future__ import print_function
 from __future__ import division
@@ -379,6 +379,6 @@ class TestSupports(unittest.TestCase):
       task_w = dataset.w[:, task]
       task_y = task_y[task_w != 0]
       assert len(task_y) == len(support) + len(task_dataset)
-      print("Verifying that task_dataset doesn't overlap with support.")
+      logger.info("Verifying that task_dataset doesn't overlap with support.")
       for task_id in task_dataset.ids:
         assert task_id not in set(support.ids)

--- a/deepchem/dock/binding_pocket.py
+++ b/deepchem/dock/binding_pocket.py
@@ -100,7 +100,7 @@ def boxes_to_atoms(atom_coords, boxes):
   for box_ind, box in enumerate(boxes):
     box_atoms = []
     (x_min, x_max), (y_min, y_max), (z_min, z_max) = box
-    print("Handing box %d/%d" % (box_ind, len(boxes)))
+    logger.info("Handing box %d/%d" % (box_ind, len(boxes)))
     for atom_ind in range(len(atom_coords)):
       atom = atom_coords[atom_ind]
       x_cont = x_min <= atom[0] and atom[0] <= x_max
@@ -221,7 +221,7 @@ class RFConvexHullPocketFinder(BindingPocketFinder):
 
     # Load binding pocket model
     self.base_dir = tempfile.mkdtemp()
-    print("About to download trained model.")
+    logger.info("About to download trained model.")
     # TODO(rbharath): Shift refined to full once trained.
     call((
         "wget -nv -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/pocket_random_refined_RF.tar.gz"

--- a/deepchem/dock/docking.py
+++ b/deepchem/dock/docking.py
@@ -1,5 +1,5 @@
 """
-Docks protein-ligand pairs 
+Docks protein-ligand pairs
 """
 from __future__ import print_function
 from __future__ import division
@@ -39,7 +39,7 @@ class VinaGridRFDocker(Docker):
   def __init__(self, exhaustiveness=10, detect_pockets=False):
     """Builds model."""
     self.base_dir = tempfile.mkdtemp()
-    print("About to download trained model.")
+    logger.warn("About to download trained model.")
     call((
         "wget -nv -c http://deepchem.io.s3-website-us-west-1.amazonaws.com/trained_models/random_full_RF.tar.gz"
     ).split())

--- a/deepchem/dock/pose_generation.py
+++ b/deepchem/dock/pose_generation.py
@@ -63,18 +63,18 @@ class VinaPoseGenerator(PoseGenerator):
     if self.detect_pockets:
       self.pocket_finder = RFConvexHullPocketFinder()
     if not os.path.exists(self.vina_dir):
-      print("Vina not available. Downloading")
+      logger.warn("Vina not available. Downloading")
       # TODO(rbharath): May want to move this file to S3 so we can ensure it's
       # always available.
       wget_cmd = "wget -nv -c http://vina.scripps.edu/download/autodock_vina_1_1_2_linux_x86.tgz"
       call(wget_cmd.split())
-      print("Downloaded Vina. Extracting")
+      logger.info("Downloaded Vina. Extracting")
       download_cmd = "tar xzvf autodock_vina_1_1_2_linux_x86.tgz"
       call(download_cmd.split())
-      print("Moving to final location")
+      logger.info("Moving to final location")
       mv_cmd = "mv autodock_vina_1_1_2_linux_x86 %s" % current_dir
       call(mv_cmd.split())
-      print("Cleanup: removing downloaded vina tar.gz")
+      logger.warn("Cleanup: removing downloaded vina tar.gz")
       rm_cmd = "rm autodock_vina_1_1_2_linux_x86.tgz"
       call(rm_cmd.split())
     self.vina_cmd = os.path.join(self.vina_dir, "bin/vina")
@@ -113,12 +113,12 @@ class VinaPoseGenerator(PoseGenerator):
         protein_range = mol_xyz_util.get_molecule_range(receptor_mol[0])
         box_dims = protein_range + 5.0
       else:
-        print("About to find putative binding pockets")
+        logger.info("About to find putative binding pockets")
         pockets, pocket_atoms_maps, pocket_coords = self.pocket_finder.find_pockets(
             protein_file, ligand_file)
         # TODO(rbharath): Handle multiple pockets instead of arbitrarily selecting
         # first pocket.
-        print("Computing centroid and size of proposed pocket.")
+        logger.info("Computing centroid and size of proposed pocket.")
         pocket_coord = pocket_coords[0]
         protein_centroid = np.mean(pocket_coord, axis=1)
         pocket = pockets[0]
@@ -155,7 +155,7 @@ class VinaPoseGenerator(PoseGenerator):
     out_pdbqt = os.path.join(out_dir, "%s_docked.pdbqt" % ligand_name)
     # TODO(rbharath): Let user specify the number of poses required.
     if not dry_run:
-      print("About to call Vina")
+      logger.warn("About to call Vina")
       call(
           "%s --config %s --log %s --out %s" % (self.vina_cmd, conf_file,
                                                 log_file, out_pdbqt),

--- a/deepchem/dock/tests/test_binding_pocket.py
+++ b/deepchem/dock/tests/test_binding_pocket.py
@@ -1,5 +1,5 @@
 """
-Tests for binding pocket detection. 
+Tests for binding pocket detection.
 """
 from __future__ import division
 from __future__ import print_function
@@ -20,7 +20,7 @@ from deepchem.utils import rdkit_util
 
 class TestBindingPocket(unittest.TestCase):
   """
-  Does sanity checks on binding pocket generation. 
+  Does sanity checks on binding pocket generation.
   """
 
   def test_convex_init(self):
@@ -87,7 +87,7 @@ class TestBindingPocket(unittest.TestCase):
     boxes = [box1, box2]
     merged_boxes, _ = dc.dock.binding_pocket.merge_overlapping_boxes(
         mapping, boxes)
-    print("merged_boxes")
+    logger.info("merged_boxes")
     print(merged_boxes)
     assert len(merged_boxes) == 1
     assert merged_boxes[0] == ((1, 3), (1, 3), (1, 3))
@@ -99,8 +99,8 @@ class TestBindingPocket(unittest.TestCase):
     boxes = [box1, box2]
     merged_boxes, _ = dc.dock.binding_pocket.merge_overlapping_boxes(
         mapping, boxes)
-    print("merged_boxes")
-    print(merged_boxes)
+    logger.info("merged_boxes")
+    logger.info(merged_boxes)
     assert len(merged_boxes) == 1
     assert merged_boxes[0] == ((1, 3), (1, 3), (1, 3))
 
@@ -115,8 +115,8 @@ class TestBindingPocket(unittest.TestCase):
     }
     merged_boxes, _ = dc.dock.binding_pocket.merge_overlapping_boxes(
         mapping, boxes)
-    print("merged_boxes")
-    print(merged_boxes)
+    logger.info("merged_boxes")
+    logger.info(merged_boxes)
     assert len(merged_boxes) == 1
     assert merged_boxes[0] == ((1, 3), (1, 3), (1, 3))
 
@@ -135,10 +135,10 @@ class TestBindingPocket(unittest.TestCase):
         protein_file, ligand_file)
     # Test that every atom in pocket maps exists
     n_protein_atoms = protein.xyz.shape[1]
-    print("protein.xyz.shape")
-    print(protein.xyz.shape)
-    print("n_protein_atoms")
-    print(n_protein_atoms)
+    logger.info("protein.xyz.shape")
+    logger.info(protein.xyz.shape)
+    logger.info("n_protein_atoms")
+    logger.info(n_protein_atoms)
     for pocket in pockets:
       pocket_atoms = pocket_atoms_map[pocket]
       for atom in pocket_atoms:
@@ -166,12 +166,12 @@ class TestBindingPocket(unittest.TestCase):
         protein_file, ligand_file)
     # Test that every atom in pocket maps exists
     n_protein_atoms = protein.xyz.shape[1]
-    print("protein.xyz.shape")
-    print(protein.xyz.shape)
-    print("n_protein_atoms")
-    print(n_protein_atoms)
-    print("len(pockets)")
-    print(len(pockets))
+    logger.info("protein.xyz.shape")
+    logger.info(protein.xyz.shape)
+    logger.info("n_protein_atoms")
+    logger.info(n_protein_atoms)
+    logger.info("len(pockets)")
+    logger.info(len(pockets))
     for pocket in pockets:
       pocket_atoms = pocket_atoms_map[pocket]
       for atom in pocket_atoms:
@@ -191,16 +191,16 @@ class TestBindingPocket(unittest.TestCase):
     pockets, pocket_atoms, _ = finder.find_pockets(protein_file, ligand_file)
 
     # Add active site to dict
-    print("active_site_box")
-    print(active_site_box)
+    logger.info("active_site_box")
+    logger.info(active_site_box)
     pocket_atoms[active_site_box] = active_site_atoms
     overlapping_pocket = False
     for pocket in pockets:
-      print("pocket")
-      print(pocket)
+      logger.info("pocket")
+      logger.info(pocket)
       overlap = dc.dock.binding_pocket.compute_overlap(pocket_atoms,
                                                        active_site_box, pocket)
       if overlap > .5:
         overlapping_pocket = True
-      print("Overlap for pocket is %f" % overlap)
+      logger.info("Overlap for pocket is %f" % overlap)
     assert overlapping_pocket

--- a/deepchem/dock/tests/test_pose_scoring.py
+++ b/deepchem/dock/tests/test_pose_scoring.py
@@ -1,5 +1,5 @@
 """
-Tests for Pose Scoring 
+Tests for Pose Scoring
 """
 from __future__ import print_function
 from __future__ import division
@@ -24,7 +24,7 @@ from deepchem.utils import get_data_dir
 
 class TestPoseScoring(unittest.TestCase):
   """
-  Does sanity checks on pose generation. 
+  Does sanity checks on pose generation.
   """
 
   def setUp(self):
@@ -39,7 +39,7 @@ class TestPoseScoring(unittest.TestCase):
     """Tests that pose-score works."""
     sklearn_model = RandomForestRegressor(n_estimators=10)
     model = dc.models.SklearnModel(sklearn_model)
-    print("About to fit model on core set")
+    logger.warn("About to fit model on core set")
     model.fit(self.core_dataset)
 
     pose_scorer = dc.dock.GridPoseScorer(model, feat="grid")
@@ -52,7 +52,7 @@ class TestPoseScoring(unittest.TestCase):
 
     sklearn_model = RandomForestRegressor(n_estimators=10)
     model = dc.models.SklearnModel(sklearn_model)
-    print("About to fit model on core set")
+    logger.warn("About to fit model on core set")
     model.fit(self.core_dataset)
 
     pose_scorer = dc.dock.GridPoseScorer(model, feat="grid")


### PR DESCRIPTION
I replaced deepchem/data and deepchem/dock print statements with logging statements. For most cases, I used logger.info to record information. However, in pose_generation.py, test_pose_scoring.py, test_drop.py I used logger.warn as these were key testing steps where Vina was called and the model was being fitted to the core set.

Hoping to get feedback/comments before I work on removing the rest of the print statements.