### PR TITLE
prevent generation of docs for tests

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -83,7 +83,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', '**.ipynb_checkpoints']
+exclude_patterns = ['_build', '**.ipynb_checkpoints', '*tests*']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
Updated the exclusion list in order to prevent Sphinx from generating docs for test directories