### PR TITLE
Version bumps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,8 @@ ENV PATH /miniconda/bin:$PATH
 # Install deepchem with GPU support from github using Tue 14 Mar 2017 git head
 # TODO: Get rid of this when there is a stable release of deepchem.
 RUN conda update -n base conda
-RUN git clone https://github.com/lilleswing/deepchem.git && \
+RUN export LANG=en_US.UTF-8 && \
+    git clone https://github.com/lilleswing/deepchem.git && \
     cd deepchem && \
     git checkout version-bumps && \
     sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV PATH /miniconda/bin:$PATH
 # TODO: Get rid of this when there is a stable release of deepchem.
 RUN git clone https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    git checkout tags/1.3.1 && \
+    git checkout tags/2.0.0 && \
     sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh && \
     bash scripts/install_deepchem_conda.sh root && \
     python setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ENV PATH /miniconda/bin:$PATH
 
 # Install deepchem with GPU support from github using Tue 14 Mar 2017 git head
 # TODO: Get rid of this when there is a stable release of deepchem.
-RUN git clone https://github.com/deepchem/deepchem.git && \
+RUN git clone https://github.com/lilleswing/deepchem.git && \
     cd deepchem && \
-    git checkout tags/2.0.0 && \
+    git checkout version-bumps && \
     sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh && \
     bash scripts/install_deepchem_conda.sh root && \
     python setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ ENV PATH /miniconda/bin:$PATH
 # TODO: Get rid of this when there is a stable release of deepchem.
 RUN conda update -n base conda
 RUN export LANG=en_US.UTF-8 && \
-    git clone https://github.com/lilleswing/deepchem.git && \
+    git clone https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    git checkout version-bumps && \
+    git checkout 2.0.0 && \
     sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh && \
     bash scripts/install_deepchem_conda.sh && \
     python setup.py develop

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,13 +26,11 @@ RUN export LANG=en_US.UTF-8 && \
     git checkout version-bumps && \
     sed -i -- 's/tensorflow$/tensorflow-gpu/g' scripts/install_deepchem_conda.sh && \
     bash scripts/install_deepchem_conda.sh && \
-    python setup.py develop && \
-    python -c 'import deepchem'
+    python setup.py develop
 
 # Clean up
 RUN cd deepchem && \
     git clean -fX
 
 # Check that we can import DeepChem
-RUN source activate deepchem
 #RUN pip install nose && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,6 @@ RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
     rm -f $MINICONDA
 ENV PATH /miniconda/bin:$PATH
 
-# Install deepchem conda package from omnia
-# TODO: Uncomment this when there is a stable release of deepchem.
-#RUN conda config --add channels omnia
-#RUN conda install --yes deepchem
-
-# Install deepchem with GPU support from github using Tue 14 Mar 2017 git head
-# TODO: Get rid of this when there is a stable release of deepchem.
 RUN conda update -n base conda
 RUN export LANG=en_US.UTF-8 && \
     git clone https://github.com/deepchem/deepchem.git && \
@@ -31,6 +24,3 @@ RUN export LANG=en_US.UTF-8 && \
 # Clean up
 RUN cd deepchem && \
     git clean -fX
-
-# Check that we can import DeepChem
-#RUN pip install nose && \

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ via this installation procedure.
 ### Easy Install via Conda
 
 ```bash
-conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=1.3.1
+conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.0.0
 ```
 **Note:** `Easy Install` installs the latest stable version of `deepchem` and _does not install from source_. If you need to install from source make sure you follow the steps [here](#using-a-conda-environment).
 
@@ -182,4 +182,4 @@ DeepChem is supported by a number of corporate partners who use DeepChem to solv
 
 
 ## Version
-1.3.1
+2.0.0

--- a/devtools/conda-recipe/deepchem/meta.yaml
+++ b/devtools/conda-recipe/deepchem/meta.yaml
@@ -1,10 +1,10 @@
 package:
   name: {{ environ.get('package_name', 'deepchem') }}
-  version: "1.3.1"
+  version: "2.0.0"
 
 source:
-    git_url: https://github.com/deepchem/deepchem.git
-    git_tag: 1.3.0
+    git_url: https://github.com/lilleswing/deepchem.git
+    git_tag: version-bumps
 
 build:
   number: 0
@@ -21,21 +21,22 @@ requirements:
   run:
     - python {{ environ.get('python_version', '3.5') }}
     - pdbfixer ==1.4
-    - rdkit ==2017.03.1
-    - icu ==56.1
-    - mdtraj ==1.8.0
+    - mdtraj ==1.9.1
     - joblib ==0.11
     - scikit-learn ==0.18.1
-    - keras ==1.2.2
     - networkx ==1.11
     - xgboost ==0.6a2
-    - pillow ==4.2.1
-    - pandas ==0.19.2
-    - {{ environ.get('tensorflow_enabled','tensorflow') }} ==1.3.0
+    - pillow ==4.3.0
+    - pandas ==0.22.0
+    - {{ environ.get('tensorflow_enabled','tensorflow') }} ==1.5.0
     - nose ==1.3.7
     - nose-timer ==0.7.0
     - flaky ==3.3.0
     - zlib ==1.2.11
+    - requests ==2.18.4
+    - simdna ==0.4.2
+    - jupyter=1.0.0
+    - rdkit ==2017.09.1
 
 
 test:

--- a/devtools/conda-recipe/deepchem/meta.yaml
+++ b/devtools/conda-recipe/deepchem/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pdbfixer ==1.4
     - mdtraj ==1.9.1
     - joblib ==0.11
-    - scikit-learn ==0.18.1
+    - scikit-learn ==0.19.1
     - networkx ==1.11
     - xgboost ==0.6a2
     - pillow ==4.3.0

--- a/devtools/conda-recipe/deepchem/meta.yaml
+++ b/devtools/conda-recipe/deepchem/meta.yaml
@@ -4,7 +4,7 @@ package:
 
 source:
     git_url: https://github.com/lilleswing/deepchem.git
-    git_tag: version-bumps
+    git_tag: 2.0.0
 
 build:
   number: 0

--- a/devtools/conda-recipe/deepchem/meta.yaml
+++ b/devtools/conda-recipe/deepchem/meta.yaml
@@ -8,7 +8,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [osx or win]
+  skip: True  # [win]
 
 
 requirements:

--- a/devtools/conda-recipe/deepchem/meta.yaml
+++ b/devtools/conda-recipe/deepchem/meta.yaml
@@ -3,7 +3,7 @@ package:
   version: "2.0.0"
 
 source:
-    git_url: https://github.com/lilleswing/deepchem.git
+    git_url: https://github.com/deepchem/deepchem.git
     git_tag: 2.0.0
 
 build:
@@ -37,12 +37,6 @@ requirements:
     - simdna ==0.4.2
     - jupyter=1.0.0
     - rdkit ==2017.09.1
-
-
-test:
-
-  imports:
-    - deepchem
 
 
 about:

--- a/devtools/jenkins/conda_build.sh
+++ b/devtools/jenkins/conda_build.sh
@@ -8,14 +8,14 @@ export python_version=2.7
 conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
 export python_version=3.5
 conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
-export python_version=3.6
-conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
+#export python_version=3.6
+#conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
 
-export package_name=deepchem-gpu
-export tensorflow_enabled=tensorflow-gpu
-export python_version=2.7
-conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
-export python_version=3.5
-conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
-export python_version=3.6
-conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
+#export package_name=deepchem-gpu
+#export tensorflow_enabled=tensorflow-gpu
+#export python_version=2.7
+#conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
+#export python_version=3.5
+#conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge
+#export python_version=3.6
+#conda build deepchem -c defaults -c rdkit -c omnia -c conda-forge

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -6,15 +6,19 @@
 export tensorflow=tensorflow
 
 
-if [ -z "$1" ]
-then
-    echo "Must Specify Conda Environment Name"
-fi
-
 if [ -z "$python_version" ]
 then
     echo "Using python 3.5 by default"
     export python_version=3.5
+fi
+
+if [ -z "$1" ];
+then
+    echo "Installing DeepChem in current env"
+else
+    export envname=$1
+    conda create -y --name $envname python=$python_version
+    source activate $envname
 fi
 
 unamestr=`uname`
@@ -23,9 +27,6 @@ if [[ "$unamestr" == 'Darwin' ]]; then
    conda install -y -q conda=4.3.25
 fi
 
-export envname=$1
-conda create -y --name $envname python=$python_version
-source activate $envname
 conda install -y -q -c omnia pdbfixer=1.4
 conda install -y -q -c conda-forge joblib=0.11
 conda install -y -q -c conda-forge six=1.10.0

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -32,7 +32,6 @@ conda install -y -q -c conda-forge six=1.10.0
 conda install -y -q -c deepchem mdtraj=1.9.1
 conda install -y -q -c conda-forge scikit-learn=0.19.1
 conda install -y -q -c conda-forge setuptools=36.2.2
-conda install -y -q -c conda-forge keras=1.2.2
 conda install -y -q -c conda-forge networkx=1.11
 conda install -y -q -c conda-forge pillow=4.3.0
 conda install -y -q -c conda-forge pandas=0.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,6 @@
 name = deepchem
 author = Bharath Ramsundar, Evan Feinberg, Pande Lab Stanford
 summary = Deep-learning models for drug discovery and quantum chemistry
-description-file = README.md
 home-page = https://github.com/pandegroup/deepchem
 license = MIT
 version = 2.0.1


### PR DESCRIPTION
What needed to get done to get conda builds for osx and linux.
Check it out
https://anaconda.org/deepchem/deepchem
```bash
conda install -c deepchem -c rdkit -c conda-forge -c omnia deepchem=2.0.0
```
Also docker images are out.
https://hub.docker.com/r/deepchemio/deepchem/tags/
```
nvidia-docker run -i -t deepchemio/deepchem
```