### PR TITLE
Fix README description for tutorials folder

### DIFF
--- a/examples/notebooks/README.md
+++ b/examples/notebooks/README.md
@@ -1,5 +1,4 @@
-This directory contains broken examples which no longer work. These ipython notebooks contain some useful pedagogical material despite having broken code.
-
+This directory contains tutorials for DeepChem usage. If you'd like to contribute a new tutorial to DeepChem, please raise a pull request that adds a new IPython notebook to this directory.
 
 Tips:
 To use images in your code use


### PR DESCRIPTION
Closing and re-opening this PR since the previous one (#1128) had test issues.

Fixes the description in the README for the tutorials folder.