### PR TITLE
Issue1138 mg graph conv tensor graph to graph conv model

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -25,3 +25,7 @@ from deepchem.models.tensorgraph.models.gan import GAN, WGAN
 from deepchem.models.tensorgraph.models.text_cnn import TextCNNTensorGraph
 from deepchem.models.tensorgraph.sequential import Sequential
 from deepchem.models.tensorgraph.models.sequence_dnn import SequenceDNN
+
+#################### Compatibility imports for renamed TensorGraph models. Remove below with DeepChem 3.0. ####################
+
+from deepchem.models.tensorgraph.models.graph_models import GraphConvTensorGraph

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -17,7 +17,7 @@ from deepchem.models.tensorgraph.IRV import TensorflowMultiTaskIRVClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskRegressor
 from deepchem.models.tensorgraph.progressive_multitask import ProgressiveMultitaskRegressor
-from deepchem.models.tensorgraph.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvTensorGraph, MPNNTensorGraph
+from deepchem.models.tensorgraph.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvModel, MPNNTensorGraph
 from deepchem.models.tensorgraph.models.symmetry_function_regression import BPSymmetryFunctionRegression, ANIRegression
 
 from deepchem.models.tensorgraph.models.seqtoseq import SeqToSeq

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1151,10 +1151,9 @@ import warnings
 
 class GraphConvTensorGraph(GraphConvModel):
 
-  def __init__(self, *args, **kwargs):
+  warnings.warn("GraphConvTensorGraph is deprecated and has been renamed to GraphConvModel and will be removed in DeepChem 3.0.", FutureWarning)
 
-    warnings.warn("GraphConvTensorGraph is deprecated and has been renamed to GraphConvModel. "
-                    "Will be removed in DeepChem 3.0.", DeprecationWarning)
+  def __init__(self, *args, **kwargs):
 
     super(GraphConvTensorGraph, self).__init__(*args, **kwargs)
 

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -664,7 +664,7 @@ class PetroskiSuchTensorGraph(TensorGraph):
         per_task_metrics=per_task_metrics)
 
 
-class GraphConvTensorGraph(TensorGraph):
+class GraphConvModel(TensorGraph):
 
   def __init__(self,
                n_tasks,
@@ -700,7 +700,7 @@ class GraphConvTensorGraph(TensorGraph):
     self.graph_conv_layers = graph_conv_layers
     kwargs['use_queue'] = False
     self.number_atom_features = number_atom_features
-    super(GraphConvTensorGraph, self).__init__(**kwargs)
+    super(GraphConvModel, self).__init__(**kwargs)
     self.build_graph()
 
   def build_graph(self):
@@ -824,7 +824,7 @@ class GraphConvTensorGraph(TensorGraph):
           result = undo_transforms(feed_results[0], transformers)
           feed_results = [result]
         for ind, result in enumerate(feed_results):
-          # GraphConvTensorGraph constantly outputs batch_size number of
+          # GraphConvModel constantly outputs batch_size number of
           # results, only valid samples should be appended to final results
           results[ind].append(result[:n_samples])
 

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1143,3 +1143,18 @@ class MPNNTensorGraph(TensorGraph):
 
   def predict_on_generator(self, generator, transformers=[]):
     return self.predict_proba_on_generator(generator, transformers)
+
+
+#################### Deprecation warnings for renamed TensorGraph models ####################
+
+import warnings
+
+class GraphConvTensorGraph(GraphConvModel):
+
+  def __init__(self, *args, **kwargs):
+
+    warnings.warn("GraphConvTensorGraph is deprecated and has been renamed to GraphConvModel. "
+                    "Will be removed in DeepChem 3.0.", DeprecationWarning)
+
+    super(GraphConvTensorGraph, self).__init__(*args, **kwargs)
+

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1149,11 +1149,13 @@ class MPNNTensorGraph(TensorGraph):
 
 import warnings
 
+
 class GraphConvTensorGraph(GraphConvModel):
 
-  warnings.warn("GraphConvTensorGraph is deprecated and has been renamed to GraphConvModel and will be removed in DeepChem 3.0.", FutureWarning)
+  warnings.warn(
+      "GraphConvTensorGraph is deprecated and has been renamed to GraphConvModel and will be removed in DeepChem 3.0.",
+      FutureWarning)
 
   def __init__(self, *args, **kwargs):
 
     super(GraphConvTensorGraph, self).__init__(*args, **kwargs)
-

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import deepchem
 from deepchem.data import NumpyDataset
-from deepchem.models import GraphConvTensorGraph
+from deepchem.models import GraphConvModel
 from deepchem.models import TensorGraph
 from deepchem.molnet.load_function.delaney_datasets import load_delaney
 from deepchem.models.tensorgraph.layers import ReduceSum, L2Loss
@@ -43,7 +43,7 @@ class TestGraphModels(unittest.TestCase):
         'classification', 'GraphConv')
 
     batch_size = 50
-    model = GraphConvTensorGraph(
+    model = GraphConvModel(
         len(tasks), batch_size=batch_size, mode='classification')
 
     model.fit(dataset, nb_epoch=1)
@@ -58,7 +58,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'GraphConv')
 
     batch_size = 50
-    model = GraphConvTensorGraph(
+    model = GraphConvModel(
         len(tasks), batch_size=batch_size, mode='regression')
 
     model.fit(dataset, nb_epoch=1)
@@ -73,7 +73,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'GraphConv', num_tasks=1)
 
     batch_size = 50
-    model = GraphConvTensorGraph(
+    model = GraphConvModel(
         len(tasks), batch_size=batch_size, mode='regression')
 
     model.fit(dataset, nb_epoch=1)
@@ -102,7 +102,7 @@ class TestGraphModels(unittest.TestCase):
     X = featurizer.featurize(dataset.X)
     dataset = deepchem.data.NumpyDataset(X, np.array(y))
     batch_size = 50
-    model = GraphConvTensorGraph(
+    model = GraphConvModel(
         len(tasks),
         number_atom_features=featurizer.feature_length(),
         batch_size=batch_size,
@@ -121,7 +121,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'GraphConv', num_tasks=1)
 
     batch_size = 50
-    model = GraphConvTensorGraph(
+    model = GraphConvModel(
         len(tasks), batch_size=batch_size, mode='regression')
 
     model.fit(dataset, nb_epoch=1)

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -58,8 +58,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'GraphConv')
 
     batch_size = 50
-    model = GraphConvModel(
-        len(tasks), batch_size=batch_size, mode='regression')
+    model = GraphConvModel(len(tasks), batch_size=batch_size, mode='regression')
 
     model.fit(dataset, nb_epoch=1)
     scores = model.evaluate(dataset, [metric], transformers)
@@ -73,8 +72,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'GraphConv', num_tasks=1)
 
     batch_size = 50
-    model = GraphConvModel(
-        len(tasks), batch_size=batch_size, mode='regression')
+    model = GraphConvModel(len(tasks), batch_size=batch_size, mode='regression')
 
     model.fit(dataset, nb_epoch=1)
 
@@ -121,8 +119,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'GraphConv', num_tasks=1)
 
     batch_size = 50
-    model = GraphConvModel(
-        len(tasks), batch_size=batch_size, mode='regression')
+    model = GraphConvModel(len(tasks), batch_size=batch_size, mode='regression')
 
     model.fit(dataset, nb_epoch=1)
     model.save()

--- a/deepchem/molnet/run_benchmark_models.py
+++ b/deepchem/molnet/run_benchmark_models.py
@@ -191,7 +191,7 @@ def benchmark_classification(train_dataset,
     n_filters = hyper_parameters['n_filters']
     n_fully_connected_nodes = hyper_parameters['n_fully_connected_nodes']
 
-    model = deepchem.models.GraphConvTensorGraph(
+    model = deepchem.models.GraphConvModel(
         len(tasks),
         graph_conv_layers=[n_filters] * 2,
         dense_layer_size=n_fully_connected_nodes,
@@ -507,7 +507,7 @@ def benchmark_regression(train_dataset,
     n_filters = hyper_parameters['n_filters']
     n_fully_connected_nodes = hyper_parameters['n_fully_connected_nodes']
 
-    model = deepchem.models.GraphConvTensorGraph(
+    model = deepchem.models.GraphConvModel(
         len(tasks),
         graph_conv_layers=[n_filters] * 2,
         dense_layer_size=n_fully_connected_nodes,

--- a/examples/adme/run_benchmarks.py
+++ b/examples/adme/run_benchmarks.py
@@ -74,8 +74,7 @@ def experiment(dataset_file, method='GraphConv', split='scaffold'):
 
   model = None
   if method == 'GraphConv':
-    model = GraphConvModel(
-        len(tasks), batch_size=BATCH_SIZE, mode="regression")
+    model = GraphConvModel(len(tasks), batch_size=BATCH_SIZE, mode="regression")
   elif method == 'RF':
 
     def model_builder_rf(model_dir):

--- a/examples/adme/run_benchmarks.py
+++ b/examples/adme/run_benchmarks.py
@@ -14,7 +14,7 @@ from sklearn import svm
 import tensorflow as tf
 tf.set_random_seed(123)
 import deepchem as dc
-from deepchem.models.tensorgraph.models.graph_models import GraphConvTensorGraph
+from deepchem.models.tensorgraph.models.graph_models import GraphConvModel
 
 BATCH_SIZE = 128
 # Set to higher values to get better numbers
@@ -74,7 +74,7 @@ def experiment(dataset_file, method='GraphConv', split='scaffold'):
 
   model = None
   if method == 'GraphConv':
-    model = GraphConvTensorGraph(
+    model = GraphConvModel(
         len(tasks), batch_size=BATCH_SIZE, mode="regression")
   elif method == 'RF':
 

--- a/examples/chembl/chembl_graph_conv.py
+++ b/examples/chembl/chembl_graph_conv.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 
-from models import GraphConvTensorGraph
+from models import GraphConvModel
 
 np.random.seed(123)
 import tensorflow as tf
@@ -30,7 +30,7 @@ n_feat = 75
 # Batch size of models
 batch_size = 128
 
-model = GraphConvTensorGraph(
+model = GraphConvModel(
     len(chembl_tasks), batch_size=batch_size, mode='regression')
 
 # Fit trained model

--- a/examples/clintox/clintox_graph_conv.py
+++ b/examples/clintox/clintox_graph_conv.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 
-from models import GraphConvTensorGraph
+from models import GraphConvModel
 
 np.random.seed(123)
 import tensorflow as tf
@@ -31,7 +31,7 @@ metric = dc.metrics.Metric(
 n_feat = 75
 # Batch size of models
 batch_size = 50
-model = GraphConvTensorGraph(
+model = GraphConvModel(
     len(clintox_tasks), batch_size=batch_size, mode='classification')
 
 # Fit trained model

--- a/examples/delaney/delaney_graph_conv.py
+++ b/examples/delaney/delaney_graph_conv.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 
-from models import GraphConvTensorGraph
+from models import GraphConvModel
 
 np.random.seed(123)
 import tensorflow as tf
@@ -29,7 +29,7 @@ metric = dc.metrics.Metric(dc.metrics.pearson_r2_score, np.mean)
 n_feat = 75
 # Batch size of models
 batch_size = 128
-model = GraphConvTensorGraph(
+model = GraphConvModel(
     len(delaney_tasks), batch_size=batch_size, mode='regression')
 
 # Fit trained model

--- a/examples/delaney/delaney_graphconv_error_bars.py
+++ b/examples/delaney/delaney_graphconv_error_bars.py
@@ -27,7 +27,7 @@ delaney_tasks, delaney_datasets, transformers = dc.molnet.load_delaney(
 train_dataset, valid_dataset, test_dataset = delaney_datasets
 metric = dc.metrics.Metric(dc.metrics.pearson_r2_score, np.mean)
 
-model = dc.models.GraphConvTensorGraph(
+model = dc.models.GraphConvModel(
     len(delaney_tasks),
     batch_size=BATCH_SIZE,
     learning_rate=LR,

--- a/examples/hopv/hopv_graph_conv.py
+++ b/examples/hopv/hopv_graph_conv.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 
-from models import GraphConvTensorGraph
+from models import GraphConvModel
 
 np.random.seed(123)
 import tensorflow as tf
@@ -30,7 +30,7 @@ metric = [
 n_feat = 75
 # Batch size of models
 batch_size = 50
-model = GraphConvTensorGraph(
+model = GraphConvModel(
     len(hopv_tasks), batch_size=batch_size, mode='regression')
 
 # Fit trained model

--- a/examples/notebooks/Using_Tensorboard.ipynb
+++ b/examples/notebooks/Using_Tensorboard.ipynb
@@ -50,7 +50,7 @@
     "from IPython.display import Image, display\n",
     "import deepchem as dc\n",
     "from deepchem.molnet import load_tox21\n",
-    "from deepchem.models.tensorgraph.models.graph_models import GraphConvTensorGraph\n",
+    "from deepchem.models.tensorgraph.models.graph_models import GraphConvModel\n",
     "\n",
     "# Load Tox21 dataset\n",
     "tox21_tasks, tox21_datasets, transformers = load_tox21(featurizer='GraphConv')\n",
@@ -109,7 +109,7 @@
    ],
    "source": [
     "# Construct the model with tensorbaord on\n",
-    "model = GraphConvTensorGraph(len(tox21_tasks),  mode='classification', tensorboard=True)\n",
+    "model = GraphConvModel(len(tox21_tasks),  mode='classification', tensorboard=True)\n",
     "\n",
     "# Fit the model\n",
     "model.fit(train_dataset, nb_epoch=10)"
@@ -154,7 +154,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you click \"GRAPHS\" at the top you can see a visual layout of the model.  Here is what our GraphConvTensorGraph Model looks like"
+    "If you click \"GRAPHS\" at the top you can see a visual layout of the model.  Here is what our GraphConvModel Model looks like"
    ]
   },
   {

--- a/examples/notebooks/graph_convolutional_networks_for_tox21.ipynb
+++ b/examples/notebooks/graph_convolutional_networks_for_tox21.ipynb
@@ -25,7 +25,7 @@
     "import numpy as np \n",
     "import tensorflow as tf\n",
     "import deepchem as dc\n",
-    "from deepchem.models.tensorgraph.models.graph_models import GraphConvTensorGraph"
+    "from deepchem.models.tensorgraph.models.graph_models import GraphConvModel"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's now train a graph convolutional network on this dataset. DeepChem has the class `GraphConvTensorGraph` that wraps a standard graph convolutional architecture underneath the hood for user convenience. Let's instantiate an object of this class and train it on our dataset."
+    "Let's now train a graph convolutional network on this dataset. DeepChem has the class `GraphConvModel` that wraps a standard graph convolutional architecture underneath the hood for user convenience. Let's instantiate an object of this class and train it on our dataset."
    ]
   },
   {
@@ -97,7 +97,7 @@
     }
    ],
    "source": [
-    "model = GraphConvTensorGraph(\n",
+    "model = GraphConvModel(\n",
     "    len(tox21_tasks), batch_size=50, mode='classification')\n",
     "# Set nb_epoch=10 for better results.\n",
     "model.fit(train_dataset, nb_epoch=1)"
@@ -144,7 +144,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "What's going on under the hood? Could we build `GraphConvTensorGraph` ourselves? Of course! The first step is to create a `TensorGraph` object. This object will hold the \"computational graph\" that defines the computation that a graph convolutional network will perform."
+    "What's going on under the hood? Could we build `GraphConvModel` ourselves? Of course! The first step is to create a `TensorGraph` object. This object will hold the \"computational graph\" that defines the computation that a graph convolutional network will perform."
    ]
   },
   {
@@ -406,7 +406,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Success! The model we've constructed behaves nearly identically to `GraphConvTensorGraph`. If you're looking to build your own custom models, you can follow the example we've provided here to do so. We hope to see exciting constructions from your end soon!"
+    "Success! The model we've constructed behaves nearly identically to `GraphConvModel`. If you're looking to build your own custom models, you can follow the example we've provided here to do so. We hope to see exciting constructions from your end soon!"
    ]
   },
   {

--- a/examples/qm7/qm7_tensorgraph_GraphConv.py
+++ b/examples/qm7/qm7_tensorgraph_GraphConv.py
@@ -25,7 +25,7 @@ metric = [
 # Batch size of models
 batch_size = 64
 
-model = dc.models.GraphConvTensorGraph(
+model = dc.models.GraphConvModel(
     len(tasks), batch_size=batch_size, learning_rate=0.001, mode="regression")
 
 # Fit trained model

--- a/examples/tox21/tox21_tensorgraph_graph_conv.py
+++ b/examples/tox21/tox21_tensorgraph_graph_conv.py
@@ -13,7 +13,7 @@ import tensorflow as tf
 tf.set_random_seed(123)
 import deepchem as dc
 from deepchem.molnet import load_tox21
-from deepchem.models.tensorgraph.models.graph_models import GraphConvTensorGraph
+from deepchem.models.tensorgraph.models.graph_models import GraphConvModel
 
 model_dir = "/tmp/graph_conv"
 
@@ -30,7 +30,7 @@ metric = dc.metrics.Metric(
 # Batch size of models
 batch_size = 50
 
-model = GraphConvTensorGraph(
+model = GraphConvModel(
     len(tox21_tasks), batch_size=batch_size, mode='classification')
 
 model.fit(train_dataset, nb_epoch=10)


### PR DESCRIPTION
Initial commits involving conversion of `dc.model.GraphConvTensorGraph` to `dc.models.GraphConvModel` (see [here](https://github.com/deepchem/deepchem/issues/1138)) so that progress can be tracked.

This code has been updated to use the `Model` notation discussed in the above issue. 
Note the following:
* All instances of `GraphConvTensorGraph` have been converted to `GraphConvModel` in code, unittests, examples, and notebooks. I checked several of the unittests and examples, but not all of them. (Let me know if you'd like that done.)
* A deprecation warning has been added to a wrapper class `GraphConvModel` [here](https://github.com/mlgill/deepchem/blob/48aa329a1cb6c65ab347b0847b63d8d4856f296f/deepchem/models/tensorgraph/models/graph_models.py#L1152-L1159). I used `FutureWarning` as `DeprecationWarning` does not seem to print a message to my ipython terminal (??). I have added the wrapper class to the end of the same module as the new class so that all imports will be identical.
* The higher-level model import has also been fixed [here](https://github.com/mlgill/deepchem/blob/48aa329a1cb6c65ab347b0847b63d8d4856f296f/deepchem/models/__init__.py#L29-L31).