### PR TITLE
Renaming `WeaveTensorGraph` to `WeaveTensorModel`

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -17,7 +17,7 @@ from deepchem.models.tensorgraph.IRV import TensorflowMultiTaskIRVClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskRegressor
 from deepchem.models.tensorgraph.progressive_multitask import ProgressiveMultitaskRegressor
-from deepchem.models.tensorgraph.models.graph_models import WeaveTensorModel, DTNNTensorGraph, DAGTensorGraph, GraphConvModel, MPNNTensorGraph
+from deepchem.models.tensorgraph.models.graph_models import WeaveModel, DTNNTensorGraph, DAGTensorGraph, GraphConvModel, MPNNTensorGraph
 from deepchem.models.tensorgraph.models.symmetry_function_regression import BPSymmetryFunctionRegression, ANIRegression
 
 from deepchem.models.tensorgraph.models.seqtoseq import SeqToSeq

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -16,7 +16,7 @@ from deepchem.models.tensorgraph.fcnet import MultiTaskFitTransformRegressor
 from deepchem.models.tensorgraph.IRV import TensorflowMultiTaskIRVClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskRegressor
-from deepchem.models.tensorgraph.progressive_multitask import ProgressiveMultitaskRegressor
+from deepchem.models.tensorgraph.progressive_multitask import ProgressiveMultitaskRegressor, ProgressiveMultitaskClassifier
 from deepchem.models.tensorgraph.models.graph_models import WeaveModel, DTNNTensorGraph, DAGTensorGraph, GraphConvModel, MPNNTensorGraph
 from deepchem.models.tensorgraph.models.symmetry_function_regression import BPSymmetryFunctionRegression, ANIRegression
 

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -17,7 +17,7 @@ from deepchem.models.tensorgraph.IRV import TensorflowMultiTaskIRVClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskClassifier
 from deepchem.models.tensorgraph.robust_multitask import RobustMultitaskRegressor
 from deepchem.models.tensorgraph.progressive_multitask import ProgressiveMultitaskRegressor
-from deepchem.models.tensorgraph.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvModel, MPNNTensorGraph
+from deepchem.models.tensorgraph.models.graph_models import WeaveTensorModel, DTNNTensorGraph, DAGTensorGraph, GraphConvModel, MPNNTensorGraph
 from deepchem.models.tensorgraph.models.symmetry_function_regression import BPSymmetryFunctionRegression, ANIRegression
 
 from deepchem.models.tensorgraph.models.seqtoseq import SeqToSeq
@@ -28,4 +28,4 @@ from deepchem.models.tensorgraph.models.sequence_dnn import SequenceDNN
 
 #################### Compatibility imports for renamed TensorGraph models. Remove below with DeepChem 3.0. ####################
 
-from deepchem.models.tensorgraph.models.graph_models import GraphConvTensorGraph
+from deepchem.models.tensorgraph.models.graph_models import WeaveTensorGraph, GraphConvTensorGraph

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1155,7 +1155,8 @@ TENSORGRAPH_DEPRECATION = "{} is deprecated and has been renamed to {} and will 
 class GraphConvTensorGraph(GraphConvModel):
 
   warnings.warn(
-      TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph", "GraphConvModel"), FutureWarning)
+      TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph", "GraphConvModel"),
+      FutureWarning)
 
   def __init__(self, *args, **kwargs):
 
@@ -1165,7 +1166,8 @@ class GraphConvTensorGraph(GraphConvModel):
 class WeaveTensorGraph(WeaveModel):
 
   warnings.warn(
-      TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph", "WeaveModel"), FutureWarning)
+      TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph", "WeaveModel"),
+      FutureWarning)
 
   def __init__(self, *args, **kwargs):
 

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -20,7 +20,7 @@ from deepchem.models.tensorgraph.tensor_graph import TensorGraph
 from deepchem.trans import undo_transforms
 
 
-class WeaveTensorModel(TensorGraph):
+class WeaveModel(TensorGraph):
 
   def __init__(self,
                n_tasks,
@@ -52,7 +52,7 @@ class WeaveTensorModel(TensorGraph):
     self.n_hidden = n_hidden
     self.n_graph_feat = n_graph_feat
     self.mode = mode
-    super(WeaveTensorModel, self).__init__(**kwargs)
+    super(WeaveModel, self).__init__(**kwargs)
     self.build_graph()
 
   def build_graph(self):
@@ -183,7 +183,7 @@ class WeaveTensorModel(TensorGraph):
         yield feed_dict
 
   def predict_on_generator(self, generator, transformers=[], outputs=None):
-    out = super(WeaveTensorModel, self).predict_on_generator(
+    out = super(WeaveModel, self).predict_on_generator(
         generator, transformers=[], outputs=outputs)
     if outputs is None:
       outputs = self.outputs
@@ -1162,11 +1162,11 @@ class GraphConvTensorGraph(GraphConvModel):
     super(GraphConvTensorGraph, self).__init__(*args, **kwargs)
 
 
-class WeaveTensorGraph(WeaveTensorModel):
+class WeaveTensorGraph(WeaveModel):
 
   warnings.warn(
       TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph"), FutureWarning)
 
   def __init__(self, *args, **kwargs):
 
-    super(WeaveTensorModel, self).__init__(*args, **kwargs)
+    super(WeaveModel, self).__init__(*args, **kwargs)

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1159,3 +1159,13 @@ class GraphConvTensorGraph(GraphConvModel):
   def __init__(self, *args, **kwargs):
 
     super(GraphConvTensorGraph, self).__init__(*args, **kwargs)
+
+
+
+class WeaveTensorGraph(WeaveTensorModel):
+
+  warnings.warn(TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph"), FutureWarning)
+
+  def __init__(self, *args, **kwargs):
+
+    super(WeaveTensorModel, self).__init__(*args, **kwargs)

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1149,13 +1149,13 @@ class MPNNTensorGraph(TensorGraph):
 
 import warnings
 
-TENSORGRAPH_DEPRECATION = "{} is deprecated and has been renamed to GraphConvModel and will be removed in DeepChem 3.0."
+TENSORGRAPH_DEPRECATION = "{} is deprecated and has been renamed to {} and will be removed in DeepChem 3.0."
 
 
 class GraphConvTensorGraph(GraphConvModel):
 
   warnings.warn(
-      TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph"), FutureWarning)
+      TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph", "GraphConvModel"), FutureWarning)
 
   def __init__(self, *args, **kwargs):
 
@@ -1165,7 +1165,7 @@ class GraphConvTensorGraph(GraphConvModel):
 class WeaveTensorGraph(WeaveModel):
 
   warnings.warn(
-      TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph"), FutureWarning)
+      TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph", "WeaveModel"), FutureWarning)
 
   def __init__(self, *args, **kwargs):
 

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1154,17 +1154,18 @@ TENSORGRAPH_DEPRECATION = "{} is deprecated and has been renamed to GraphConvMod
 
 class GraphConvTensorGraph(GraphConvModel):
 
-  warnings.warn(TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph"), FutureWarning)
+  warnings.warn(
+      TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph"), FutureWarning)
 
   def __init__(self, *args, **kwargs):
 
     super(GraphConvTensorGraph, self).__init__(*args, **kwargs)
 
 
-
 class WeaveTensorGraph(WeaveTensorModel):
 
-  warnings.warn(TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph"), FutureWarning)
+  warnings.warn(
+      TENSORGRAPH_DEPRECATION.format("WeaveTensorGraph"), FutureWarning)
 
   def __init__(self, *args, **kwargs):
 

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -20,7 +20,7 @@ from deepchem.models.tensorgraph.tensor_graph import TensorGraph
 from deepchem.trans import undo_transforms
 
 
-class WeaveTensorGraph(TensorGraph):
+class WeaveTensorModel(TensorGraph):
 
   def __init__(self,
                n_tasks,
@@ -52,7 +52,7 @@ class WeaveTensorGraph(TensorGraph):
     self.n_hidden = n_hidden
     self.n_graph_feat = n_graph_feat
     self.mode = mode
-    super(WeaveTensorGraph, self).__init__(**kwargs)
+    super(WeaveTensorModel, self).__init__(**kwargs)
     self.build_graph()
 
   def build_graph(self):
@@ -183,7 +183,7 @@ class WeaveTensorGraph(TensorGraph):
         yield feed_dict
 
   def predict_on_generator(self, generator, transformers=[], outputs=None):
-    out = super(WeaveTensorGraph, self).predict_on_generator(
+    out = super(WeaveTensorModel, self).predict_on_generator(
         generator, transformers=[], outputs=outputs)
     if outputs is None:
       outputs = self.outputs
@@ -1149,12 +1149,12 @@ class MPNNTensorGraph(TensorGraph):
 
 import warnings
 
+TENSORGRAPH_DEPRECATION = "{} is deprecated and has been renamed to GraphConvModel and will be removed in DeepChem 3.0."
+
 
 class GraphConvTensorGraph(GraphConvModel):
 
-  warnings.warn(
-      "GraphConvTensorGraph is deprecated and has been renamed to GraphConvModel and will be removed in DeepChem 3.0.",
-      FutureWarning)
+  warnings.warn(TENSORGRAPH_DEPRECATION.format("GraphConvTensorGraph"), FutureWarning)
 
   def __init__(self, *args, **kwargs):
 

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -8,7 +8,7 @@ from deepchem.models import GraphConvModel
 from deepchem.models import TensorGraph
 from deepchem.molnet.load_function.delaney_datasets import load_delaney
 from deepchem.models.tensorgraph.layers import ReduceSum, L2Loss
-from deepchem.models import WeaveTensorModel
+from deepchem.models import WeaveModel
 from deepchem.feat import ConvMolFeaturizer
 
 
@@ -137,7 +137,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'Weave', num_tasks=1)
 
     batch_size = 50
-    model = WeaveTensorModel(
+    model = WeaveModel(
         len(tasks), batch_size=batch_size, mode='regression', use_queue=False)
 
     model.fit(dataset, nb_epoch=1)

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -8,7 +8,7 @@ from deepchem.models import GraphConvModel
 from deepchem.models import TensorGraph
 from deepchem.molnet.load_function.delaney_datasets import load_delaney
 from deepchem.models.tensorgraph.layers import ReduceSum, L2Loss
-from deepchem.models import WeaveTensorGraph
+from deepchem.models import WeaveTensorModel
 from deepchem.feat import ConvMolFeaturizer
 
 
@@ -137,7 +137,7 @@ class TestGraphModels(unittest.TestCase):
         'regression', 'Weave', num_tasks=1)
 
     batch_size = 50
-    model = WeaveTensorGraph(
+    model = WeaveTensorModel(
         len(tasks), batch_size=batch_size, mode='regression', use_queue=False)
 
     model.fit(dataset, nb_epoch=1)

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -698,7 +698,7 @@ class TestOverfit(test_util.TensorFlowTestCase):
     n_feat = 128
     batch_size = 10
 
-    model = dc.models.WeaveTensorGraph(
+    model = dc.models.WeaveTensorModel(
         n_tasks,
         n_atom_feat=n_atom_feat,
         n_pair_feat=n_pair_feat,
@@ -738,7 +738,7 @@ class TestOverfit(test_util.TensorFlowTestCase):
     n_feat = 128
     batch_size = 10
 
-    model = dc.models.WeaveTensorGraph(
+    model = dc.models.WeaveTensorModel(
         n_tasks,
         n_atom_feat=n_atom_feat,
         n_pair_feat=n_pair_feat,

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -698,7 +698,7 @@ class TestOverfit(test_util.TensorFlowTestCase):
     n_feat = 128
     batch_size = 10
 
-    model = dc.models.WeaveTensorModel(
+    model = dc.models.WeaveModel(
         n_tasks,
         n_atom_feat=n_atom_feat,
         n_pair_feat=n_pair_feat,
@@ -738,7 +738,7 @@ class TestOverfit(test_util.TensorFlowTestCase):
     n_feat = 128
     batch_size = 10
 
-    model = dc.models.WeaveTensorModel(
+    model = dc.models.WeaveModel(
         n_tasks,
         n_atom_feat=n_atom_feat,
         n_pair_feat=n_pair_feat,

--- a/deepchem/molnet/run_benchmark_models.py
+++ b/deepchem/molnet/run_benchmark_models.py
@@ -242,7 +242,7 @@ def benchmark_classification(train_dataset,
     n_graph_feat = hyper_parameters['n_graph_feat']
     n_pair_feat = hyper_parameters['n_pair_feat']
 
-    model = deepchem.models.WeaveTensorGraph(
+    model = deepchem.models.WeaveTensorModel(
         len(tasks),
         n_atom_feat=n_features,
         n_pair_feat=n_pair_feat,
@@ -577,7 +577,7 @@ def benchmark_regression(train_dataset,
     n_graph_feat = hyper_parameters['n_graph_feat']
     n_pair_feat = hyper_parameters['n_pair_feat']
 
-    model = deepchem.models.WeaveTensorGraph(
+    model = deepchem.models.WeaveTensorModel(
         len(tasks),
         n_atom_feat=n_features,
         n_pair_feat=n_pair_feat,

--- a/deepchem/molnet/run_benchmark_models.py
+++ b/deepchem/molnet/run_benchmark_models.py
@@ -242,7 +242,7 @@ def benchmark_classification(train_dataset,
     n_graph_feat = hyper_parameters['n_graph_feat']
     n_pair_feat = hyper_parameters['n_pair_feat']
 
-    model = deepchem.models.WeaveTensorModel(
+    model = deepchem.models.WeaveModel(
         len(tasks),
         n_atom_feat=n_features,
         n_pair_feat=n_pair_feat,
@@ -577,7 +577,7 @@ def benchmark_regression(train_dataset,
     n_graph_feat = hyper_parameters['n_graph_feat']
     n_pair_feat = hyper_parameters['n_pair_feat']
 
-    model = deepchem.models.WeaveTensorModel(
+    model = deepchem.models.WeaveModel(
         len(tasks),
         n_atom_feat=n_features,
         n_pair_feat=n_pair_feat,

--- a/examples/delaney/delaney_tensorgraph_weave.py
+++ b/examples/delaney/delaney_tensorgraph_weave.py
@@ -25,7 +25,7 @@ n_pair_feat = 14
 batch_size = 64
 n_feat = 128
 
-model = dc.models.WeaveTensorModel(
+model = dc.models.WeaveModel(
     len(delaney_tasks),
     batch_size=batch_size,
     learning_rate=1e-3,

--- a/examples/delaney/delaney_tensorgraph_weave.py
+++ b/examples/delaney/delaney_tensorgraph_weave.py
@@ -25,7 +25,7 @@ n_pair_feat = 14
 batch_size = 64
 n_feat = 128
 
-model = dc.models.WeaveTensorGraph(
+model = dc.models.WeaveTensorModel(
     len(delaney_tasks),
     batch_size=batch_size,
     learning_rate=1e-3,

--- a/examples/tox21/tox21_tensorgraph_weave.py
+++ b/examples/tox21/tox21_tensorgraph_weave.py
@@ -25,7 +25,7 @@ n_pair_feat = 14
 batch_size = 64
 n_feat = 128
 
-model = dc.models.WeaveTensorModel(
+model = dc.models.WeaveModel(
     len(tox21_tasks),
     batch_size=batch_size,
     learning_rate=1e-3,

--- a/examples/tox21/tox21_tensorgraph_weave.py
+++ b/examples/tox21/tox21_tensorgraph_weave.py
@@ -25,7 +25,7 @@ n_pair_feat = 14
 batch_size = 64
 n_feat = 128
 
-model = dc.models.WeaveTensorGraph(
+model = dc.models.WeaveTensorModel(
     len(tox21_tasks),
     batch_size=batch_size,
     learning_rate=1e-3,


### PR DESCRIPTION
This branch will be used for renaming `WeaveTensorGraph` to `WeaveTensorModel`, per the issue [here](https://github.com/deepchem/deepchem/issues/1138).