### PR TITLE
Spell HingeLoss Correctly

### DIFF
--- a/deepchem/models/tensorgraph/tests/test_layers_eager.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_eager.py
@@ -976,5 +976,5 @@ class TestLayersEager(test_util.TensorFlowTestCase):
         n_logits = 1
         logits = np.random.rand(n_logits).astype(np.float32)
         labels = np.random.rand(n_labels).astype(np.float32)
-        result = layers.Hingeloss()(labels, logits)
+        result = layers.HingeLoss()(labels, logits)
         assert result.shape == (n_labels,)


### PR DESCRIPTION
Fix merge conflict of adding eager layer tests at the same time as renaming HingeLoss.