### PR TITLE
Support for eager mode in TensorGraph

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -104,8 +104,29 @@ class Layer(object):
       return self.clone(in_layers)
     raise ValueError('%s does not implement shared()' % self.__class__.__name__)
 
-  def __call__(self, *in_layers, **kwargs):
-    return self.create_tensor(in_layers=in_layers, set_tensors=False, **kwargs)
+  def __call__(self, *inputs, **kwargs):
+    """Execute the layer in eager mode to compute its output as a function of inputs.
+
+    If the layer defines any variables, they are created the first time it is invoked.
+
+    Arbitrary keyword arguments may be specified after the list of inputs.  Most
+    layers do not expect or use any additional arguments, but there are a few
+    significant cases.
+
+    - Recurrent layers usually accept an argument `initial_state` which can be
+      used to specify the initial state for the recurrent cell.  When this
+      argument is omitted, they use a default initial state, usually all zeros.
+    - A few layers behave differently during training than during inference,
+      such as Dropout and CombineMeanStd.  You can specify a boolean value with
+      the `training` argument to tell it which mode it is being called in.
+
+    Parameters
+    ----------
+    inputs: tensors
+      the inputs to pass to the layer.  The values may be tensors, numpy arrays,
+      or anything else that can be converted to tensors of the correct shape.
+    """
+    return self.create_tensor(in_layers=inputs, set_tensors=False, **kwargs)
 
   @property
   def shape(self):

--- a/deepchem/models/tensorgraph/model_ops.py
+++ b/deepchem/models/tensorgraph/model_ops.py
@@ -23,12 +23,12 @@ def _to_tensor(x, dtype):
   return x
 
 
-def create_variable(value, dtype=None, name=None):
+def create_variable(value, dtype=None, name=None, trainable=True):
   """Create a tf.Variable or tfe.Variable, depending on the current mode."""
   if tfe.in_eager_mode():
-    return tfe.Variable(value, dtype=dtype, name=name)
+    return tfe.Variable(value, dtype=dtype, name=name, trainable=trainable)
   else:
-    return tf.Variable(value, dtype=dtype, name=name)
+    return tf.Variable(value, dtype=dtype, name=name, trainable=trainable)
 
 
 def ones(shape, dtype=None, name=None):

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -325,7 +325,7 @@ class TensorGraph(Model):
           feed_dict[initial_state] = zero_state
         yield feed_dict
 
-  def __call__(self, *inputs, outputs=None):
+  def __call__(self, *inputs, **kwargs):
     """Execute the model in eager mode to compute outputs as a function of inputs.
 
     This is very similar to predict_on_batch(), except that it returns the outputs
@@ -341,7 +341,7 @@ class TensorGraph(Model):
       may be tensors, numpy arrays, or anything else that can be converted to
       tensors of the correct shape.
     outputs: list of Layers
-      the output layers to compute.  If this is None, self.outputs is used
+      the output layers to compute.  If this is omitted, self.outputs is used
       (that is, all outputs that have been added by calling add_output()).
 
     Returns
@@ -351,7 +351,11 @@ class TensorGraph(Model):
     if len(inputs) != len(self.features):
       raise ValueError('Expected %d inputs, received %d' % len(self.features),
                        len(inputs))
-    if outputs is None:
+    # TODO Once we drop Python 2 support, turn outputs into a proper keyword arg
+    # instead of using the **kwargs hack.
+    if 'outputs' in kwargs:
+      outputs = kwargs['outputs']
+    else:
       outputs = self.outputs
     feed_dict = dict(zip(self.features, inputs))
     results = self._run_graph(outputs, feed_dict, False)

--- a/deepchem/models/tensorgraph/tests/test_layers_eager.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_eager.py
@@ -713,7 +713,7 @@ class TestLayersEager(test_util.TensorFlowTestCase):
         test_out, support_out = layer(test, support)
         assert test_out.shape == (n_test, n_feat)
         assert support_out.shape == (n_support, n_feat)
-        assert len(layer.variables) == 5
+        assert len(layer.variables) == 7
 
   def test_iter_ref_lstm_embedding(self):
     """Test invoking AttnLSTMEmbedding in eager mode."""
@@ -730,7 +730,7 @@ class TestLayersEager(test_util.TensorFlowTestCase):
         test_out, support_out = layer(test, support)
         assert test_out.shape == (n_test, n_feat)
         assert support_out.shape == (n_support, n_feat)
-        assert len(layer.variables) == 8
+        assert len(layer.variables) == 12
 
   def test_batch_norm(self):
     """Test invoking BatchNorm in eager mode."""
@@ -976,5 +976,5 @@ class TestLayersEager(test_util.TensorFlowTestCase):
         n_logits = 1
         logits = np.random.rand(n_logits).astype(np.float32)
         labels = np.random.rand(n_labels).astype(np.float32)
-        result = layers.Hingeloss()(labels, logits)
+        result = layers.HingeLoss()(labels, logits)
         assert result.shape == (n_labels,)

--- a/deepchem/models/tensorgraph/tests/test_tensor_graph.py
+++ b/deepchem/models/tensorgraph/tests/test_tensor_graph.py
@@ -16,6 +16,8 @@ from deepchem.models.tensorgraph.layers import Feature, Label
 from deepchem.models.tensorgraph.layers import ReduceSquareDifference, Add
 from deepchem.models.tensorgraph.tensor_graph import TensorGraph
 from deepchem.models.tensorgraph.optimizers import GradientDescent, ExponentialDecay
+import tensorflow.contrib.eager as tfe
+from tensorflow.python.eager import context
 
 
 class TestTensorGraph(unittest.TestCase):
@@ -41,6 +43,11 @@ class TestTensorGraph(unittest.TestCase):
     tg.fit(dataset, nb_epoch=1000)
     prediction = np.squeeze(tg.predict_on_batch(X))
     assert_true(np.all(np.isclose(prediction, y, atol=0.4)))
+
+  def test_single_task_classifier_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_single_task_classifier()
 
   @flaky
   def test_multi_task_classifier(self):
@@ -86,6 +93,12 @@ class TestTensorGraph(unittest.TestCase):
       y_pred = predictions[i]
       assert_true(np.all(np.isclose(y_pred, y_real, atol=0.6)))
 
+  @flaky
+  def test_multi_task_classifier_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_multi_task_classifier()
+
   def test_single_task_regressor(self):
     n_data_points = 20
     n_features = 2
@@ -102,6 +115,11 @@ class TestTensorGraph(unittest.TestCase):
     tg.fit(dataset, nb_epoch=1000)
     prediction = np.squeeze(tg.predict_on_batch(X))
     assert_true(np.all(np.isclose(prediction, y, atol=3.0)))
+
+  def test_single_task_regressor_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_single_task_regressor()
 
   def test_multi_task_regressor(self):
     n_data_points = 20
@@ -144,6 +162,11 @@ class TestTensorGraph(unittest.TestCase):
       y_real = ys[i].X
       y_pred = predictions[i]
       assert_true(np.all(np.isclose(y_pred, y_real, atol=1.5)))
+
+  def test_multi_task_regressor_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_multi_task_regressor()
 
   @flaky
   def test_no_queue(self):
@@ -193,6 +216,12 @@ class TestTensorGraph(unittest.TestCase):
     prediction2 = np.squeeze(tg1.predict_on_batch(X))
     assert_true(np.all(np.isclose(prediction, prediction2, atol=0.01)))
 
+  @flaky
+  def test_set_optimizer_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_set_optimizer()
+
   def test_tensorboard(self):
     n_data_points = 20
     n_features = 2
@@ -221,6 +250,11 @@ class TestTensorGraph(unittest.TestCase):
     file_size = os.stat(event_file).st_size
     assert_true(file_size > 0)
 
+  def test_tensorboard_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_tensorboard()
+
   def test_save_load(self):
     n_data_points = 20
     n_features = 2
@@ -247,6 +281,11 @@ class TestTensorGraph(unittest.TestCase):
     tg1 = TensorGraph.load_from_dir(dirpath)
     prediction2 = np.squeeze(tg1.predict_on_batch(X))
     assert_true(np.all(np.isclose(prediction, prediction2, atol=0.01)))
+
+  def test_save_load_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_save_load()
 
   def test_shared_layer(self):
     n_data_points = 20
@@ -325,6 +364,11 @@ class TestTensorGraph(unittest.TestCase):
       value = tg.predict_on_batch(np.array([0]), outputs=o)
       assert np.array_equal(e, value)
 
+  def test_operators_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_operators()
+
   def test_initialize_variable(self):
     """Test methods for initializing a variable."""
     # Set by variable constructor.
@@ -339,10 +383,17 @@ class TestTensorGraph(unittest.TestCase):
     # Set by set_variable_initial_values().
 
     tg = dc.models.TensorGraph(use_queue=False)
+    features = Feature(shape=(None, 1))
     tg.set_loss(Dense(1, in_layers=features))
+    var = Variable([10.0])
     var.set_variable_initial_values([[15.0]])
     tg.add_output(var)
     assert tg.predict_on_batch(np.zeros((1, 1))) == [15.0]
+
+  def test_initialize_variable_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_initialize_variable()
 
   def test_copy_layers(self):
     """Test copying layers."""
@@ -363,9 +414,17 @@ class TestTensorGraph(unittest.TestCase):
     assert copy.in_layers[1] == replacements[constant]
     variables = tg.get_layer_variables(dense)
     with tg._get_tf("Graph").as_default():
-      values = tg.session.run(variables)
+      if tfe.in_eager_mode():
+        values = [v.numpy() for v in variables]
+      else:
+        values = tg.session.run(variables)
     for v1, v2 in zip(values, copy.in_layers[0].variable_values):
       assert np.array_equal(v1, v2)
+
+  def test_copy_layers_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_copy_layers()
 
   def test_copy_layers_shared(self):
     """Test copying layers with shared variables."""
@@ -432,3 +491,8 @@ class TestTensorGraph(unittest.TestCase):
         1.0, tg.predict_on_batch(data, outputs=var1)[0], places=4)
     self.assertAlmostEqual(
         0.0, tg.predict_on_batch(data, outputs=var2)[0], places=4)
+
+  def test_submodels_eager(self):
+    with context.eager_mode():
+      with tfe.IsolateTest():
+        self.test_submodels()


### PR DESCRIPTION
Some features still aren't supported, but this is basically functional now.  For many scripts that just use DeepChem models in a straightforward way, you can now add `tfe.enable_eager_execution()` at the top, and the whole script will continue to work exactly as it did before.

As part of the necessary support, I've simplified how we handle pickling layers.  If a layer defines extra fields that can't be pickled, you no longer have to override `none_tensors()` and `set_tensors()`.  Instead, just add the field names to `_non_pickle_fields` and everything gets handled automatically.  Some layers were also storing tensors and variables into fields of the layer when there was no need (and doing it even when `set_tensors` was `False`).  I've tried to clean those up.