### PR TITLE
[WIP] Refactor graph models

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -371,7 +371,7 @@ class TensorWrapper(Layer):
   def __init__(self, out_tensor, **kwargs):
     super(TensorWrapper, self).__init__(**kwargs)
     self.out_tensor = out_tensor
-    self._shape = out_tensor.get_shape().as_list()
+    self._shape = tuple(out_tensor.get_shape().as_list())
 
   def create_tensor(self, in_layers=None, **kwargs):
     """Take no actions."""
@@ -2529,6 +2529,11 @@ class GraphConv(Layer):
     self.num_deg = 2 * max_deg + (1 - min_deg)
     self.activation_fn = activation_fn
     super(GraphConv, self).__init__(**kwargs)
+    try:
+      parent_shape = self.in_layers[0].shape
+      self._shape = (parent_shape[0], out_channel)
+    except:
+      pass
 
   def _create_variables(self, in_channels):
     # Generate the nb_affine weights and biases
@@ -2640,6 +2645,10 @@ class GraphPool(Layer):
     self.min_degree = min_degree
     self.max_degree = max_degree
     super(GraphPool, self).__init__(**kwargs)
+    try:
+      self._shape = self.in_layers[0].shape
+    except:
+      pass
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     inputs = self._get_input_tensors(in_layers)
@@ -2689,6 +2698,11 @@ class GraphGather(Layer):
     self.batch_size = batch_size
     self.activation_fn = activation_fn
     super(GraphGather, self).__init__(**kwargs)
+    try:
+      parent_shape = self.in_layers[0].shape
+      self._shape = (batch_size, 2 * parent_shape[1])
+    except:
+      pass
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     inputs = self._get_input_tensors(in_layers)


### PR DESCRIPTION
This fixes the problems that were discussed in #1218.  So far I've only changed GraphConvModel.  If the changes look good to everyone, I'll make similar changes to the other graph models.  Here are the effects of these changes:

- Uncertainty prediction is now implemented.
- I added a `n_classes` option for classification models.  Before it was hardcoded to only allow two classes.
- Training should be faster for multitask models with lots of tasks.
- All prediction methods produce consistent (and hopefully now correct!) outputs.
- Dropout should work better than before.

There's some API inconsistency between the graph models and fully connected models.  MultiTaskClassifier and MultiTaskRegressor have an argument called `dropouts` (plural) which can be either a float (use the same dropout rate for all layers) or a list (specify the rate separately for all layers).  It defaults to 0.5.  In contrast, GraphConvModel and PetroskiSuchModel have an argument called `dropout` (singular) which can only be a float.  It defaults to 0.0.  And then WeaveModel, DTNNModel, DAGModel, and MPNNModel don't support dropout at all.  Should I change these to be more consistent?  In particular,

- Should I add dropout to the models that don't currently support it?
- Should I allow you to specify a list rather than a float?
- Should I change the argument name to `dropouts`?
- Should I change the default value to 0.5?