### PR TITLE
Fix for graph conv regression

### DIFF
--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -865,6 +865,7 @@ class GraphConvModel(TensorGraph):
     return self.evaluate_generator(
         self.default_generator(dataset, predict=True),
         metrics,
+        transformers=transformers,
         labels=self.my_labels,
         weights=[self.my_task_weights],
         per_task_metrics=per_task_metrics)

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -6,7 +6,7 @@ import deepchem
 from deepchem.data import NumpyDataset
 from deepchem.models import GraphConvModel
 from deepchem.models import TensorGraph
-from deepchem.molnet.load_function.delaney_datasets import load_delaney, load_bace
+from deepchem.molnet.load_function.delaney_datasets import load_delaney, load_bace_classification
 from deepchem.models.tensorgraph.layers import ReduceSum, L2Loss
 from deepchem.models import WeaveModel
 from deepchem.feat import ConvMolFeaturizer

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -6,7 +6,7 @@ import deepchem
 from deepchem.data import NumpyDataset
 from deepchem.models import GraphConvModel
 from deepchem.models import TensorGraph
-from deepchem.molnet.load_function.delaney_datasets import load_delaney, load_bace_classification
+from deepchem.molnet import load_bace_classification, load_delaney
 from deepchem.models.tensorgraph.layers import ReduceSum, L2Loss
 from deepchem.models import WeaveModel
 from deepchem.feat import ConvMolFeaturizer
@@ -20,7 +20,7 @@ class TestGraphModels(unittest.TestCase):
                   num_tasks=2):
     data_points = 10
     if mode == 'classification':
-      tasks, all_dataset, transformers = load_bace(featurizer)
+      tasks, all_dataset, transformers = load_bace_classification(featurizer)
     else:
       tasks, all_dataset, transformers = load_delaney(featurizer)
 

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -19,7 +19,11 @@ class TestGraphModels(unittest.TestCase):
                   featurizer='GraphConv',
                   num_tasks=2):
     data_points = 10
-    tasks, all_dataset, transformers = load_delaney(featurizer)
+    if mode == 'classification':
+      tasks, all_dataset, transformers = load_bace(featurizer)
+    else:
+      tasks, all_dataset, transformers = load_delaney(featurizer)
+
     train, valid, test = all_dataset
     for i in range(1, num_tasks):
       tasks.append("random_task")

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -6,7 +6,7 @@ import deepchem
 from deepchem.data import NumpyDataset
 from deepchem.models import GraphConvModel
 from deepchem.models import TensorGraph
-from deepchem.molnet.load_function.delaney_datasets import load_delaney
+from deepchem.molnet.load_function.delaney_datasets import load_delaney, load_bace
 from deepchem.models.tensorgraph.layers import ReduceSum, L2Loss
 from deepchem.models import WeaveModel
 from deepchem.feat import ConvMolFeaturizer

--- a/examples/delaney/delaney_graph_conv.py
+++ b/examples/delaney/delaney_graph_conv.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 
-from models import GraphConvModel
+from deepchem.models import GraphConvModel
 
 np.random.seed(123)
 import tensorflow as tf


### PR DESCRIPTION
This PR fixes

- Missing `transformers` argument in `evaluate` function (causing wrong metric values for RMSE, MAE, etc.)

- Wrong dataset in `test_graph_conv_model`