### PR TITLE
Dropout for DAG

### DIFF
--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -366,6 +366,9 @@ class DAGModel(TensorGraph):
                n_atom_feat=75,
                n_graph_feat=30,
                n_outputs=30,
+               layer_sizes=[100],
+               layer_sizes_gather=[100],
+               dropout=None,
                mode="classification",
                **kwargs):
     """
@@ -381,6 +384,12 @@ class DAGModel(TensorGraph):
               Number of features for atom in the graph
             n_outputs: int, optional
               Number of features for each molecule
+            layer_sizes: list of int, optional
+              Structure of hidden layer(s) in DAG propagation step
+            layer_sizes_gather: list of int, optional
+              Structure of hidden layer(s) in DAG gather step
+            dropout: None or float
+              Dropout probability, applied after each propagation step and gather step
             mode: str
               Either "classification" or "regression" for type of model.
             """
@@ -389,6 +398,9 @@ class DAGModel(TensorGraph):
     self.n_atom_feat = n_atom_feat
     self.n_graph_feat = n_graph_feat
     self.n_outputs = n_outputs
+    self.layer_sizes = layer_sizes
+    self.layer_sizes_gather = layer_sizes_gather
+    self.dropout = dropout
     self.mode = mode
     super(DAGModel, self).__init__(**kwargs)
     self.build_graph()
@@ -410,6 +422,8 @@ class DAGModel(TensorGraph):
         n_graph_feat=self.n_graph_feat,
         n_atom_feat=self.n_atom_feat,
         max_atoms=self.max_atoms,
+        layer_sizes=self.layer_sizes,
+        dropout=self.dropout,
         batch_size=self.batch_size,
         in_layers=[
             self.atom_features, self.parents, self.calculation_orders,
@@ -419,6 +433,8 @@ class DAGModel(TensorGraph):
         n_graph_feat=self.n_graph_feat,
         n_outputs=self.n_outputs,
         max_atoms=self.max_atoms,
+        layer_sizes=self.layer_sizes_gather,
+        dropout=self.dropout,
         in_layers=[dag_layer1, self.membership])
 
     costs = []


### PR DESCRIPTION
This PR adds:

- Fix some doc strings and arguments in `DAGLayer`

- Initial support for dropout in DAG model

Due to the special structure of DAG, the dropout structure added here is a stepwise process that happens on each step(propagate through one directed edge). Another approach is only doing dropout on  the outputs, or equivalently the last step of propagation. Comments and suggestions on the potential structure choice here are very welcomed!

