### PR TITLE
Fix OSX install

### DIFF
--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -25,6 +25,7 @@ unamestr=`uname`
 if [[ "$unamestr" == 'Darwin' ]]; then
    source activate root
    conda install -y -q conda=4.3.25
+   source activate $envname
 fi
 
 conda install -y -q -c omnia pdbfixer=1.4


### PR DESCRIPTION
We weren't resetting to the new environment after downgrading root.  I don't know how this happened :(.  We need to get install tests running on OSX images on circle-ci so this doesn't happen again.