### PR TITLE
Added a list cast to gaussian_process.py to work with Python 3

### DIFF
--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -90,7 +90,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
 
     assert len(metric) == 1, 'Only use one metric'
     hyper_parameters = params_dict
-    hp_list = hyper_parameters.keys()
+    hp_list = list(hyper_parameters.keys())
     for hp in hp_invalid_list:
       if hp in hp_list:
         hp_list.remove(hp)


### PR DESCRIPTION
In the method hyperparam_search in the class GaussianProcessHyperparamOpt, the following lines generate an AttributeError: 'dict_keys' object has no attribute 'remove'

hyper_parameters = params_dict
hp_list = hyper_parameters.keys()
for hp in hp_invalid_list:
  if hp in hp_list:
    hp_list.remove(hp)
In Python 3, dict.keys() produces a view object, rather than a list, as Python 2 does: https://docs.python.org/3/library/stdtypes.html#dict-views
This view object has no method remove. Fixed by casting this as a list:
hp_list = list(hyper_parameters.keys())