### PR TITLE
Add Minimum Separation to Hinge Loss

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -13,6 +13,10 @@ from deepchem.models.tensorgraph.model_ops import create_variable
 import tensorflow.contrib.eager as tfe
 import math
 
+from tensorflow.python.ops import math_ops
+from tensorflow.python.ops import array_ops
+from tensorflow.python.ops import nn_ops
+
 
 class Layer(object):
   layer_number_dict = {}
@@ -4610,7 +4614,15 @@ class HingeLoss(Layer):
   The output is a weighted loss tensor of same shape as labels.
   """
 
-  def __init__(self, in_layers=None, **kwargs):
+  def __init__(self, in_layers=None, separation=1.0, **kwargs):
+    """
+    Parameters
+    ----------
+    separation: float
+      The absolute minimum value of logits to not incur a sample loss
+    kwargs
+    """
+    self.separation = separation
     super(HingeLoss, self).__init__(in_layers, **kwargs)
     try:
       self._shape = self.in_layers[1].shape
@@ -4622,9 +4634,12 @@ class HingeLoss(Layer):
     if len(inputs) != 2:
       raise ValueError()
     labels, logits = inputs[0], inputs[1]
-    reduction = tf.losses.Reduction
-    out_tensor = tf.losses.hinge_loss(
-        labels=labels, logits=logits, reduction=reduction.NONE)
+
+    all_ones = array_ops.ones_like(labels)
+    labels = math_ops.subtract(2 * labels, all_ones)
+    seperation = all_ones * self.separation
+    out_tensor = nn_ops.relu(
+        math_ops.subtract(seperation, math_ops.multiply(labels, logits)))
     if set_tensors:
       self.out_tensor = out_tensor
     return out_tensor

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -891,14 +891,16 @@ class TestLayers(test_util.TensorFlowTestCase):
       assert irv_reg.eval() >= 0
 
   def test_hingeloss(self):
+    separation = 0.25
+    labels = [1, 1, 0, 0]
+    logits = [.3, .1, -0.3, -0.1]
+    losses = np.array([0, 0.15, 0, 0.15], dtype=np.float32)
 
-    labels = 1
-    logits = 1
-    logits_tensor = np.random.rand(logits)
-    labels_tensor = np.random.rand(labels)
     with self.test_session() as sess:
-      logits_tensor = tf.convert_to_tensor(logits_tensor, dtype=tf.float32)
-      labels_tensor = tf.convert_to_tensor(labels_tensor, dtype=tf.float32)
-      out_tensor = HingeLoss()(labels_tensor, logits_tensor)
+      logits_tensor = tf.convert_to_tensor(logits, dtype=tf.float32)
+      labels_tensor = tf.convert_to_tensor(labels, dtype=tf.float32)
+      out_tensor = HingeLoss(separation=separation)(labels_tensor,
+                                                    logits_tensor)
       out_tensor = out_tensor.eval()
-      assert out_tensor.shape == (labels,)
+      retval = np.all(losses == np.array(out_tensor))
+      self.assertTrue(retval)


### PR DESCRIPTION
Something the author did in ScScore is change the minimum separation of the hinge-loss from 1.0 to 0.25 for ScScore.

Since the scores range from 1-5 this meant that there could be more levels of differentiation for compounds in the reaction set.  This is an important hyper parameter to tune if you are doing synthetic feasibility over a large reaction corpus.