### PR TITLE
NumpyDataset does not reshape its arrays

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -308,13 +308,8 @@ class NumpyDataset(Dataset):
 
   def __init__(self, X, y=None, w=None, ids=None, n_tasks=1):
     n_samples = len(X)
-    # The -1 indicates that y will be reshaped to have length -1
     if n_samples > 0:
-      if y is not None:
-        y = np.reshape(y, (n_samples, -1))
-        if w is not None:
-          w = np.reshape(w, (n_samples, -1))
-      else:
+      if y is None:
         # Set labels to be zero, with zero weights
         y = np.zeros((n_samples, n_tasks))
         w = np.zeros_like(y)
@@ -322,6 +317,12 @@ class NumpyDataset(Dataset):
       ids = np.arange(n_samples)
     if w is None:
       w = np.ones_like(y)
+    if not isinstance(X, np.ndarray):
+      X = np.array(X)
+    if not isinstance(y, np.ndarray):
+      y = np.array(y)
+    if not isinstance(w, np.ndarray):
+      w = np.array(w)
     self._X = X
     self._y = y
     self._w = w

--- a/deepchem/data/supports.py
+++ b/deepchem/data/supports.py
@@ -85,10 +85,10 @@ def get_task_dataset_minus_support(dataset, support, task):
   # Get task specific entries
   w_task = w[:, task]
   X_task = X[w_task != 0]
-  y_task = y[w_task != 0, task]
+  y_task = np.expand_dims(y[w_task != 0, task], 1)
   ids_task = ids[w_task != 0]
   # Now just get weights for this task
-  w_task = w[w_task != 0, task]
+  w_task = np.expand_dims(w[w_task != 0, task], 1)
 
   return NumpyDataset(X_task, y_task, w_task, ids_task)
 
@@ -99,10 +99,10 @@ def get_task_dataset(dataset, task):
   # Get task specific entries
   w_task = w[:, task]
   X_task = X[w_task != 0]
-  y_task = y[w_task != 0, task]
+  y_task = np.expand_dims(y[w_task != 0, task], 1)
   ids_task = ids[w_task != 0]
   # Now just get weights for this task
-  w_task = w[w_task != 0, task]
+  w_task = np.expand_dims(w[w_task != 0, task], 1)
 
   return NumpyDataset(X_task, y_task, w_task, ids_task)
 
@@ -234,8 +234,12 @@ def get_task_support(dataset, n_episodes, n_pos, n_neg, task, log_every_n=50):
       X = np.vstack([dataset.X[pos_inds], dataset.X[neg_inds]])
     else:
       X = np.concatenate([dataset.X[pos_inds], dataset.X[neg_inds]])
-    y = np.concatenate([dataset.y[pos_inds, task], dataset.y[neg_inds, task]])
-    w = np.concatenate([dataset.w[pos_inds, task], dataset.w[neg_inds, task]])
+    y = np.expand_dims(
+        np.concatenate([dataset.y[pos_inds, task], dataset.y[neg_inds, task]]),
+        1)
+    w = np.expand_dims(
+        np.concatenate([dataset.w[pos_inds, task], dataset.w[neg_inds, task]]),
+        1)
     ids = np.concatenate([dataset.ids[pos_inds], dataset.ids[neg_inds]])
     supports.append(NumpyDataset(X, y, w, ids))
   return supports

--- a/deepchem/models/tensorgraph/models/symmetry_function_regression.py
+++ b/deepchem/models/tensorgraph/models/symmetry_function_regression.py
@@ -203,7 +203,7 @@ class ANIRegression(TensorGraph):
       numpy array of shape (a, 3) where a <= max_atoms and
       dtype is float-like
     atomic_nums: np.array
-      numpy array of shape (a,) where a is the same as that of X. 
+      numpy array of shape (a,) where a is the same as that of X.
     constraints: unused
       This parameter is mainly for compatibility purposes for scipy optimize
 
@@ -223,7 +223,8 @@ class ANIRegression(TensorGraph):
     Z[:A.shape[0], :A.shape[1]] = A
     X = Z
     dd = dc.data.NumpyDataset(
-        np.array(X).reshape((1, self.max_atoms, 4)), np.array(0), np.array(1))
+        np.array(X).reshape((1, self.max_atoms, 4)), np.zeros((1, 1)),
+        np.ones((1, 1)))
     return self.predict(dd)[0]
 
   def grad_one(self, X, atomic_nums, constraints=None):
@@ -236,7 +237,7 @@ class ANIRegression(TensorGraph):
       numpy array of shape (a, 3) where a <= max_atoms and
       dtype is float-like
     atomic_nums: np.array
-      numpy array of shape (a,) where a is the same as that of X. 
+      numpy array of shape (a,) where a is the same as that of X.
     constraints: np.array
       numpy array of indices of X used for constraining a subset
       of the atoms of the molecule.
@@ -278,7 +279,7 @@ class ANIRegression(TensorGraph):
       numpy array of shape (a, 3) where a <= max_atoms and
       dtype is float-like
     atomic_nums: np.array
-      numpy array of shape (a,) where a is the same as that of X. 
+      numpy array of shape (a,) where a is the same as that of X.
 
     Returns
     -------
@@ -295,9 +296,7 @@ class ANIRegression(TensorGraph):
         jac=self.grad_one,
         method="BFGS",
         tol=1e-6,
-        options={
-            'disp': True
-        })
+        options={'disp': True})
 
     return res.x.reshape((num_atoms, 3))
 

--- a/deepchem/models/tensorgraph/models/symmetry_function_regression.py
+++ b/deepchem/models/tensorgraph/models/symmetry_function_regression.py
@@ -296,7 +296,9 @@ class ANIRegression(TensorGraph):
         jac=self.grad_one,
         method="BFGS",
         tol=1e-6,
-        options={'disp': True})
+        options={
+            'disp': True
+        })
 
     return res.x.reshape((num_atoms, 3))
 

--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -115,7 +115,7 @@ class TestGraphModels(unittest.TestCase):
         mol.SetProp("atom %08d %s" % (atom.GetIdx(), atom_feature_name),
                     str(val))
         atom_features.append(np.random.normal())
-      y.append(np.sum(atom_features))
+      y.append([np.sum(atom_features)])
 
     featurizer = ConvMolFeaturizer(atom_properties=[atom_feature_name])
     X = featurizer.featurize(dataset.X)

--- a/deepchem/models/tensorgraph/models/test_symmetry_functions.py
+++ b/deepchem/models/tensorgraph/models/test_symmetry_functions.py
@@ -27,7 +27,7 @@ class TestANIRegression(unittest.TestCase):
         [0, 0, 0, 0],
     ]])
 
-    y = np.array([2.0, 1.1])
+    y = np.array([[2.0], [1.1]])
 
     layer_structures = [128, 128, 64]
     atom_number_cases = [1, 6, 7, 8]

--- a/deepchem/models/tensorgraph/tests/test_estimators.py
+++ b/deepchem/models/tensorgraph/tests/test_estimators.py
@@ -201,7 +201,7 @@ class TestEstimators(unittest.TestCase):
     # Create a dataset and an input function for processing it.
 
     X = np.random.rand(n_samples, n_features)
-    y = [0.5 for x in range(n_samples)]
+    y = np.array([[0.5] for x in range(n_samples)])
     dataset = dc.data.NumpyDataset(X, y)
 
     def input_fn(epochs):

--- a/deepchem/models/tensorgraph/tests/test_sequential.py
+++ b/deepchem/models/tensorgraph/tests/test_sequential.py
@@ -41,7 +41,7 @@ class TestSequential(unittest.TestCase):
     n_data_points = 20
     n_features = 2
     X = np.random.rand(n_data_points, n_features)
-    y = [0.5 for x in range(n_data_points)]
+    y = [[0.5] for x in range(n_data_points)]
     dataset = dc.data.NumpyDataset(X, y)
     model = dc.models.Sequential(loss="mse", learning_rate=0.01)
     model.add(Dense(out_channels=1))

--- a/deepchem/models/tensorgraph/tests/test_tensor_graph.py
+++ b/deepchem/models/tensorgraph/tests/test_tensor_graph.py
@@ -103,7 +103,7 @@ class TestTensorGraph(unittest.TestCase):
     n_data_points = 20
     n_features = 2
     X = np.random.rand(n_data_points, n_features)
-    y = [0.5 for x in range(n_data_points)]
+    y = [[0.5] for x in range(n_data_points)]
     dataset = NumpyDataset(X, y)
     features = Feature(shape=(None, n_features))
     dense = Dense(out_channels=1, in_layers=[features])

--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -33,6 +33,7 @@ class TestGeneralize(unittest.TestCase):
 
     dataset = sklearn.datasets.load_diabetes()
     X, y = dataset.data, dataset.target
+    y = np.expand_dims(y, 1)
     frac_train = .7
     n_samples = len(X)
     n_train = int(frac_train * n_samples)
@@ -59,6 +60,7 @@ class TestGeneralize(unittest.TestCase):
     np.random.seed(123)
     dataset = sklearn.datasets.load_diabetes()
     X, y = dataset.data, dataset.target
+    y = np.expand_dims(y, 1)
 
     frac_train = .7
     n_samples = len(X)


### PR DESCRIPTION
Fixes #1216.  I had to fix a bunch of tests that were relying on the old behavior (passing in a 1D array for `y` and assuming it would get reshaped to 2D).