### PR TITLE
Automatically set an appropriate minimum sequence length of TextCNNModel

### DIFF
--- a/deepchem/models/tensorgraph/models/test_textcnnmodel.py
+++ b/deepchem/models/tensorgraph/models/test_textcnnmodel.py
@@ -1,0 +1,14 @@
+import unittest
+from deepchem.models import TextCNNModel
+from deepchem.models.tensorgraph.models.text_cnn import default_dict
+
+
+class TestTextCNNModel(unittest.TestCase):
+
+  def test_set_length(self):
+    model = TextCNNModel(1, default_dict, 1)
+    self.assertEqual(model.seq_length, max(model.kernel_sizes))
+
+    large_length = 500
+    model = TextCNNModel(1, default_dict, large_length)
+    self.assertEqual(model.seq_length, large_length)

--- a/deepchem/models/tensorgraph/models/text_cnn.py
+++ b/deepchem/models/tensorgraph/models/text_cnn.py
@@ -111,7 +111,7 @@ class TextCNNModel(TensorGraph):
     """
     self.n_tasks = n_tasks
     self.char_dict = char_dict
-    self.seq_length = seq_length
+    self.seq_length = max(seq_length, max(kernel_sizes))
     self.n_embedding = n_embedding
     self.kernel_sizes = kernel_sizes
     self.num_filters = num_filters


### PR DESCRIPTION
Automatically set an appropriate minimum sequence length of TextCNNModel

Set it to max of kernel sizes and user defined sizes.