### PR TITLE
[WIP] Generalize Sequence Encoding

### DIFF
--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -9,6 +9,7 @@ __license__ = "MIT"
 
 import os
 import unittest
+
 import deepchem as dc
 
 
@@ -26,7 +27,8 @@ class TestFASTALoader(unittest.TestCase):
                               "../../data/tests/example.fasta")
     loader = dc.data.FASTALoader()
     sequences = loader.featurize(input_file)
+
     # example.fasta contains 3 sequences each of length 58.
-    # The one-hot encoding turns base-pairs into vectors of length 4.
-    # There is one "image channel")
-    assert sequences.X.shape == (3, 4, 58, 1)
+    # The one-hot encoding turns base-pairs into vectors of length 5 (ATCGN).
+    # There is one "image channel".
+    assert sequences.X.shape == (3, 5, 58, 1)

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -187,6 +187,15 @@ def encode_fasta_sequence(fname, letters='ATCGN'):
 
   return seq_one_hot_encode(np.array(sequences), letters)
 
+def encode_sequence(fname, letters='ATCGN', file_type="fasta"):
+
+    # TODO: if None, then get from the filename
+    sequences = []
+    for seq in SeqIO.parse(fname, file_type):
+        sequences.append(str(seq.seq).upper())
+
+    return seq_one_hot_encode(np.array(sequences), letters)
+
 # This could just be ambiguous_dna_letters, but that would be much higher dim.
 class IUPACUnambiguousDNAWithN(Alphabet):
     letters = unambiguous_dna_letters + "N"

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -110,14 +110,15 @@ def load_csv_files(filenames, shard_size=None, verbose=True):
 def seq_one_hot_encode(sequences, letters='ATCGN'):
   """One hot encodes list of genomic sequences.
 
-  Sequences encoded have shape (N_sequences, 4, sequence_length, 1).
-  Here 4 is for the 4 basepairs (ACGT) present in genomic sequences.
+  Sequences encoded have shape (N_sequences, N_letters, sequence_length, 1).
   These sequences will be processed as images with one color channel.
 
   Parameters
   ----------
   sequences: np.ndarray
     Array of genetic sequences
+  letters: str
+    String with the set of possible letters in the sequences.
 
   Raises
   ------
@@ -126,7 +127,7 @@ def seq_one_hot_encode(sequences, letters='ATCGN'):
 
   Returns
   -------
-  np.ndarray: Shape (N_sequences, 4, sequence_length, 1).
+  np.ndarray: Shape (N_sequences, N_letters, sequence_length, 1).
   """
 
   # The label encoder is given characters for ACGTN
@@ -168,9 +169,11 @@ def _seq_to_encoded(seq, letter_encoder, alphabet_length, sequence_length):
   return b
 
 
-# This could just be ambiguous_dna_letters, but that would be much higher dim.
 class IUPACUnambiguousDNAWithN(Alphabet):
-  letters = unambiguous_dna_letters + "N"
+  """
+  A deepchem specific DNA Alphabet with the 4 main letters and N.
+  """
+  letters = "ACGTN"
 
 
 def encode_fasta_sequence(fname):
@@ -181,6 +184,10 @@ def encode_fasta_sequence(fname):
   ----------
   fname: str
     Filename of fasta file.
+
+  Returns
+  -------
+  np.ndarray: Shape (N_sequences, 4, sequence_length, 1).
   """
 
   dna_alphabet = IUPACUnambiguousDNAWithN()
@@ -188,12 +195,27 @@ def encode_fasta_sequence(fname):
 
 
 def encode_bio_sequence(fname, file_type="fasta", alphabet=None):
-  # np.ndarray: Shape (N_sequences, 4, sequence_length, 1).
+  """
+  Loads a sequence file and returns an array of one-hot sequences.
+
+  Parameters
+  ----------
+  fname: str
+    Filename of fasta file.
+  file_type: str
+    The type of file encoding to process, e.g. fasta or fastq, this
+    is passed to Biopython.SeqIO.parse.
+  alphabet: Bio.Alphabet.Alphabet
+    A Biopython Alphabet, which should have a letter class property.
+
+  Returns
+  -------
+  np.ndarray: Shape (N_sequences, N_letters, sequence_length, 1).
+  """
 
   if alphabet is None:
     alphabet = IUPACUnambiguousDNAWithN()
 
-  # TODO: if None, then get from the filename
   sequences = SeqIO.parse(fname, file_type, alphabet)
   return seq_one_hot_encode(sequences, alphabet.letters)
 

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -16,9 +16,6 @@ import numpy as np
 import os
 import deepchem
 from rdkit import Chem
-from Bio.Data.IUPACData import unambiguous_dna_letters
-from Bio.Alphabet import Alphabet
-from Bio import SeqIO
 
 
 def log(string, verbose=True):
@@ -169,13 +166,6 @@ def _seq_to_encoded(seq, letter_encoder, alphabet_length, sequence_length):
   return b
 
 
-class IUPACUnambiguousDNAWithN(Alphabet):
-  """
-  A deepchem specific DNA Alphabet with the 4 main letters and N.
-  """
-  letters = "ACGTN"
-
-
 def encode_fasta_sequence(fname):
   """
   Loads fasta file and returns an array of one-hot sequences.
@@ -187,14 +177,13 @@ def encode_fasta_sequence(fname):
 
   Returns
   -------
-  np.ndarray: Shape (N_sequences, 4, sequence_length, 1).
+  np.ndarray: Shape (N_sequences, 5, sequence_length, 1).
   """
 
-  dna_alphabet = IUPACUnambiguousDNAWithN()
-  return encode_bio_sequence(fname, "fasta", dna_alphabet)
+  return encode_bio_sequence(fname)
 
 
-def encode_bio_sequence(fname, file_type="fasta", alphabet=None):
+def encode_bio_sequence(fname, file_type="fasta", letters="ATCGN"):
   """
   Loads a sequence file and returns an array of one-hot sequences.
 
@@ -205,19 +194,18 @@ def encode_bio_sequence(fname, file_type="fasta", alphabet=None):
   file_type: str
     The type of file encoding to process, e.g. fasta or fastq, this
     is passed to Biopython.SeqIO.parse.
-  alphabet: Bio.Alphabet.Alphabet
-    A Biopython Alphabet, which should have a letter class property.
+  letters: str
+    The set of letters that the sequences consist of, e.g. ATCG.
 
   Returns
   -------
   np.ndarray: Shape (N_sequences, N_letters, sequence_length, 1).
   """
 
-  if alphabet is None:
-    alphabet = IUPACUnambiguousDNAWithN()
+  from Bio import SeqIO
 
-  sequences = SeqIO.parse(fname, file_type, alphabet)
-  return seq_one_hot_encode(sequences, alphabet.letters)
+  sequences = SeqIO.parse(fname, file_type)
+  return seq_one_hot_encode(sequences, letters)
 
 
 def save_metadata(tasks, metadata_df, data_dir):

--- a/deepchem/utils/test/data/example.fasta
+++ b/deepchem/utils/test/data/example.fasta
@@ -1,0 +1,4 @@
+>seq0
+AC
+>seq1
+GA

--- a/deepchem/utils/test/data/example.fasta
+++ b/deepchem/utils/test/data/example.fasta
@@ -1,4 +1,4 @@
 >seq0
-AC
+XY
 >seq1
-GA
+ZX

--- a/deepchem/utils/test/data/example.fastq
+++ b/deepchem/utils/test/data/example.fastq
@@ -1,0 +1,8 @@
+@seq0
+XY
++
+hh
+@seq1
+ZX
++
+hh

--- a/deepchem/utils/test/test_seq.py
+++ b/deepchem/utils/test/test_seq.py
@@ -11,7 +11,6 @@ import unittest
 import os
 
 import numpy as np
-from Bio.Alphabet import Alphabet
 
 import deepchem as dc
 

--- a/deepchem/utils/test/test_seq.py
+++ b/deepchem/utils/test/test_seq.py
@@ -32,3 +32,14 @@ class TestSeq(unittest.TestCase):
     except ValueError:
       thrown = True
     assert thrown
+
+  def test_encode_sequence_with_biopython(self):
+      fname = "./data/example.fasta"
+
+      encoded_seqs = dc.utils.save.encode_sequence_with_biopython(fname)
+      expected = np.array([
+        [[0, 0], [1, 0], [0, 0], [0, 1], [0, 0]],
+        [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0]],
+      ])
+
+      np.testing.assert_array_equal(expected, encoded_seqs)

--- a/deepchem/utils/test/test_seq.py
+++ b/deepchem/utils/test/test_seq.py
@@ -20,26 +20,24 @@ class TestSeq(unittest.TestCase):
   def test_one_hot_simple(self):
     sequences = np.array(["ACGT", "GATA", "CGCG"])
     sequences = dc.utils.save.seq_one_hot_encode(sequences)
-    assert sequences.shape == (3, 4, 4, 1)
+    self.assertEqual(sequences.shape, (3, 5, 4, 1))
 
   def test_one_hot_mismatch(self):
     # One sequence has length longer than others. This should throw a
-    # value error.
-    thrown = False
-    try:
+    # ValueError.
+
+    with self.assertRaises(ValueError):
       sequences = np.array(["ACGTA", "GATA", "CGCG"])
       sequences = dc.utils.save.seq_one_hot_encode(sequences)
-    except ValueError:
-      thrown = True
-    assert thrown
 
-  def test_encode_sequence_with_biopython(self):
-      fname = "./data/example.fasta"
+  def test_encode_fasta_sequence(self):
+    fname = "./data/example.fasta"
 
-      encoded_seqs = dc.utils.save.encode_sequence_with_biopython(fname)
-      expected = np.array([
-        [[0, 0], [1, 0], [0, 0], [0, 1], [0, 0]],
-        [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0]],
-      ])
+    encoded_seqs = dc.utils.save.encode_fasta_sequence(fname)
+    expected = np.expand_dims(
+        np.array([
+            [[0, 0], [1, 0], [0, 0], [0, 1], [0, 0]],
+            [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0]],
+        ]), -1)
 
-      np.testing.assert_array_equal(expected, encoded_seqs)
+    np.testing.assert_array_equal(expected, encoded_seqs)

--- a/deepchem/utils/test/test_seq.py
+++ b/deepchem/utils/test/test_seq.py
@@ -15,9 +15,7 @@ from Bio.Alphabet import Alphabet
 
 import deepchem as dc
 
-
-class MockAlphabet(Alphabet):
-  letters = "XYZ"
+LETTERS = "XYZ"
 
 
 class TestSeq(unittest.TestCase):
@@ -46,8 +44,7 @@ class TestSeq(unittest.TestCase):
     # Test it's possible to load a sequence with an aribrary alphabet from a fasta file.
     fname = os.path.join(self.current_dir, "./data/example.fasta")
 
-    encoded_seqs = dc.utils.save.encode_bio_sequence(
-        fname, alphabet=MockAlphabet())
+    encoded_seqs = dc.utils.save.encode_bio_sequence(fname, letters=LETTERS)
     expected = np.expand_dims(
         np.array([
             [[1, 0], [0, 1], [0, 0]],
@@ -60,7 +57,7 @@ class TestSeq(unittest.TestCase):
     fname = os.path.join(self.current_dir, "./data/example.fastq")
 
     encoded_seqs = dc.utils.save.encode_bio_sequence(
-        fname, file_type="fastq", alphabet=MockAlphabet())
+        fname, file_type="fastq", letters=LETTERS)
 
     expected = np.expand_dims(
         np.array([

--- a/deepchem/utils/test/test_seq.py
+++ b/deepchem/utils/test/test_seq.py
@@ -7,15 +7,27 @@ from __future__ import unicode_literals
 __author__ = "Bharath Ramsundar"
 __license__ = "MIT"
 
-import numpy as np
 import unittest
+import os
+
+import numpy as np
+from Bio.Alphabet import Alphabet
+
 import deepchem as dc
+
+
+class MockAlphabet(Alphabet):
+  letters = "XYZ"
 
 
 class TestSeq(unittest.TestCase):
   """
   Tests sequence handling utilities.
   """
+
+  def setUp(self):
+    super(TestSeq, self).setUp()
+    self.current_dir = os.path.dirname(os.path.abspath(__file__))
 
   def test_one_hot_simple(self):
     sequences = np.array(["ACGT", "GATA", "CGCG"])
@@ -31,13 +43,29 @@ class TestSeq(unittest.TestCase):
       sequences = dc.utils.save.seq_one_hot_encode(sequences)
 
   def test_encode_fasta_sequence(self):
-    fname = "./data/example.fasta"
+    # Test it's possible to load a sequence with an aribrary alphabet from a fasta file.
+    fname = os.path.join(self.current_dir, "./data/example.fasta")
 
-    encoded_seqs = dc.utils.save.encode_fasta_sequence(fname)
+    encoded_seqs = dc.utils.save.encode_bio_sequence(
+        fname, alphabet=MockAlphabet())
     expected = np.expand_dims(
         np.array([
-            [[0, 0], [1, 0], [0, 0], [0, 1], [0, 0]],
-            [[1, 0], [0, 1], [0, 0], [0, 0], [0, 0]],
+            [[1, 0], [0, 1], [0, 0]],
+            [[0, 1], [0, 0], [1, 0]],
+        ]), -1)
+
+    np.testing.assert_array_equal(expected, encoded_seqs)
+
+  def test_encode_fastq_sequence(self):
+    fname = os.path.join(self.current_dir, "./data/example.fastq")
+
+    encoded_seqs = dc.utils.save.encode_bio_sequence(
+        fname, file_type="fastq", alphabet=MockAlphabet())
+
+    expected = np.expand_dims(
+        np.array([
+            [[1, 0], [0, 1], [0, 0]],
+            [[0, 1], [0, 0], [1, 0]],
         ]), -1)
 
     np.testing.assert_array_equal(expected, encoded_seqs)

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -47,4 +47,5 @@ conda install -y -q -c conda-forge jupyter=1.0.0
 conda install -y -q -c conda-forge pbr=3.1.1
 conda install -y -q -c rdkit rdkit=2017.09.1
 conda install -y -q -c conda-forge setuptools=39.0.1
+conda install -y -q -c conda-forge biopython=1.71
 yes | pip install $tensorflow==1.6.0


### PR DESCRIPTION
This is a WIP PR related to the issue #1268. The PR aims to expand the variety of sequences which can be handled. Just to get feedback, I put three quick implementation ideas in the 3 different commits. 

238935e0d11270cde22c8165226e5754b671b13a -- this option uses Biopython to parse the file, so one could work with other file types (e.g. fastq), and does the one-hot encoding as the sequences are being read (i.e. `seq_one_hot_encode` could go away). `encode_fasta_sequence` could delegate to this for backwards compatibility.

A biopython alphabet is supplied which is used for the letters to encode, but certainly could imagine just passing the letters.

7cd554cef40151b0c2e303c2a2582b06044cc2ad -- this option doesn't use Biopython and just requires a `letters` argument figure out the dimensions of the encoding. One thing I'm not sure here about is in the return of `seq_one_hot_encode` the first four values of the 3rd index are kept. If this was done to keep only ATCG, then I'm not sure how to generalized it to amino acids or other sequences.

84fe50e8c2632793e92660d42f22bb317bb08284 -- this option is somewhere in between in that it uses Biopython to parse the file, and thus there's the option of reading in more types, but doesn't modify the `seq_one_hot_encode` function much (though note this diff is in reference to the last, which does have updates to `seq_one_hot_encode` to generalize the letters support).

I'm generally a fan of 1 or 3 as it would open up functionality to different file encodings and different sequence types. Once that's decided on, I'll get tests and style up to snuff. Thanks!