### PR TITLE
Single conda-forge install

### DIFF
--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -29,24 +29,24 @@ if [[ "$unamestr" == 'Darwin' ]]; then
 fi
 
 conda install -y -q -c omnia pdbfixer=1.4
-conda install -y -q -c conda-forge joblib=0.11
-conda install -y -q -c conda-forge six=1.11.0
 conda install -y -q -c deepchem mdtraj=1.9.1
-conda install -y -q -c conda-forge scikit-learn=0.19.1
-conda install -y -q -c conda-forge networkx=2.1
-conda install -y -q -c conda-forge pillow=5.0.0
-conda install -y -q -c conda-forge pandas=0.22.0
-conda install -y -q -c conda-forge nose=1.3.7
-conda install -y -q -c conda-forge nose-timer=0.7.0
-conda install -y -q -c conda-forge flaky=3.3.0
-conda install -y -q -c conda-forge zlib=1.2.11
-conda install -y -q -c conda-forge requests=2.18.4
-conda install -y -q -c conda-forge xgboost=0.6a2
-conda install -y -q -c conda-forge simdna=0.4.2
-conda install -y -q -c conda-forge jupyter=1.0.0
-conda install -y -q -c conda-forge pbr=3.1.1
 conda install -y -q -c rdkit rdkit=2017.09.1
-conda install -y -q -c conda-forge setuptools=39.0.1
-conda install -y -q -c conda-forge biopython=1.71
-conda install -y -q -c conda-forge numpy=1.14
+conda install -y -q -c conda-forge joblib=0.11 \
+    six=1.11.0 \
+    scikit-learn=0.19.1 \
+    networkx=2.1 \
+    pillow=5.0.0 \
+    pandas=0.22.0 \
+    nose=1.3.7 \
+    nose-timer=0.7.0 \
+    flaky=3.3.0 \
+    zlib=1.2.11 \
+    requests=2.18.4 \
+    xgboost=0.6a2 \
+    simdna=0.4.2 \
+    jupyter=1.0.0 \
+    pbr=3.1.1 \
+    setuptools=39.0.1 \
+    biopython=1.71 \
+    numpy=1.14
 yes | pip install $tensorflow==1.6.0


### PR DESCRIPTION
Install all deps from conda-forge with a single install command.

The dependency graph checking algorithm from conda got slower so only hitting it once significantly speeds up the install.