### PR TITLE
Fix qm7_sklearn.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ target/
 
 # Vim swap
 *.swp
+

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 # IDE files
 .idea
 *.iml
+
+# Vim swap
+*.swp

--- a/examples/qm7/qm7_sklearn.py
+++ b/examples/qm7/qm7_sklearn.py
@@ -5,41 +5,17 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-import os
-import deepchem as dc
 import numpy as np
-import shutil
+np.random.seed(123)
+import tensorflow as tf
+tf.set_random_seed(123)
+import deepchem as dc
 from sklearn.kernel_ridge import KernelRidge
 
-np.random.seed(123)
+tasks, datasets, transformers = dc.molnet.load_qm7(
+    featurizer='CoulombMatrix', split='stratified', move_mean=False)
 
-base_dir = "/tmp/gdb7_sklearn"
-data_dir = os.path.join(base_dir, "dataset")
-model_dir = os.path.join(base_dir, "model")
-train_dir = os.path.join(base_dir, "train")
-test_dir = os.path.join(base_dir, "test")
-if os.path.exists(base_dir):
-  shutil.rmtree(base_dir)
-os.makedirs(base_dir)
-
-max_num_atoms = 23
-featurizers = dc.feat.CoulombMatrixEig(max_num_atoms)
-input_file = "gdb7.sdf"
-tasks = ["u0_atom"]
-smiles_field = "smiles"
-mol_field = "mol"
-
-featurizer = dc.data.SDFLoader(tasks, smiles_field=smiles_field, mol_field=mol_field, featurizer=featurizers)
-dataset = featurizer.featurize(input_file, data_dir)
-random_splitter = dc.splits.RandomSplitter()
-train_dataset, test_dataset = random_splitter.train_test_split(dataset, train_dir, test_dir, frac_train=0.8)
-#transformers = [dc.trans.NormalizationTransformer(transform_X=True, dataset=train_dataset), dc.trans.NormalizationTransformer(transform_y=True, dataset=train_dataset)]
-transformers = [dc.trans.NormalizationTransformer(transform_y=True, dataset=train_dataset)]
-
-for transformer in transformers:
-    train_dataset = transformer.transform(train_dataset)
-for transformer in transformers:
-    test_dataset = transformer.transform(test_dataset)
+train, valid, test = datasets
 
 regression_metric = dc.metrics.Metric(dc.metrics.mean_absolute_error, mode="regression")
 
@@ -47,19 +23,19 @@ def model_builder(model_dir):
   sklearn_model = KernelRidge(
       kernel="rbf", alpha=5e-4, gamma=0.008)
   return dc.models.SklearnModel(sklearn_model, model_dir)
-model = dc.models.SingletaskToMultitask(tasks, model_builder, model_dir)
+model = dc.models.SingletaskToMultitask(tasks, model_builder)
 
 # Fit trained model
-model.fit(train_dataset)
+model.fit(train)
 model.save()
 
-train_evaluator = dc.utils.evaluate.Evaluator(model, train_dataset, transformers)
+train_evaluator = dc.utils.evaluate.Evaluator(model, train, transformers)
 train_scores = train_evaluator.compute_model_performance([regression_metric])
 
 print("Train scores [kcal/mol]")
 print(train_scores)
 
-test_evaluator = dc.utils.evaluate.Evaluator(model, test_dataset, transformers)
+test_evaluator = dc.utils.evaluate.Evaluator(model, test, transformers)
 test_scores = test_evaluator.compute_model_performance([regression_metric])
 
 print("Validation scores [kcal/mol]")

--- a/examples/qm7/qm7_sklearn.py
+++ b/examples/qm7/qm7_sklearn.py
@@ -17,12 +17,15 @@ tasks, datasets, transformers = dc.molnet.load_qm7(
 
 train, valid, test = datasets
 
-regression_metric = dc.metrics.Metric(dc.metrics.mean_absolute_error, mode="regression")
+regression_metric = dc.metrics.Metric(
+    dc.metrics.mean_absolute_error, mode="regression")
+
 
 def model_builder(model_dir):
-  sklearn_model = KernelRidge(
-      kernel="rbf", alpha=5e-4, gamma=0.008)
+  sklearn_model = KernelRidge(kernel="rbf", alpha=5e-4, gamma=0.008)
   return dc.models.SklearnModel(sklearn_model, model_dir)
+
+
 model = dc.models.SingletaskToMultitask(tasks, model_builder)
 
 # Fit trained model


### PR DESCRIPTION
Fixes the broken example `qm7_sklearn.py` by shifting the example to use `dc.molnet` instead of attempting to featurize dataset on the fly.

Fixes a broken example from:

https://github.com/deepchem/deepchem/issues/1297

Also, adds `.swp` vim swap files to `.gitignore`