### PR TITLE
Use the queue

### DIFF
--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -598,7 +598,6 @@ class GraphConvModel(TensorGraph):
     self.mode = mode
     self.dense_layer_size = dense_layer_size
     self.graph_conv_layers = graph_conv_layers
-    kwargs['use_queue'] = False
     self.number_atom_features = number_atom_features
     self.n_classes = n_classes
     self.uncertainty = uncertainty

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -355,8 +355,8 @@ class DTNNModel(TensorGraph):
           start = start + num_atoms[im]
         feed_dict[self.atom_number] = np.concatenate(atom_number)
         distance = np.concatenate(distance, 0)
-        feed_dict[self.distance] = np.exp(-np.square(distance - self.steps) /
-                                          (2 * self.step_size**2))
+        feed_dict[self.distance] = np.exp(
+            -np.square(distance - self.steps) / (2 * self.step_size**2))
         feed_dict[self.distance_membership_i] = np.concatenate(
             distance_membership_i)
         feed_dict[self.distance_membership_j] = np.concatenate(


### PR DESCRIPTION
For a while tensorflow has allowed a variable 0th dimension in it's FIFO queue.  This was stopping us from using it for the GraphConv Model which uses atom_id as the 0th dimension which is variable per batch.

This PR stops disabling the queue.  It corresponds to a ~10% speedup wall time for Graph Convolutions on a gtx 1080ti.  The GPU here can go faster than my processor queening.  The real pain point is ConvMol#agglomerate_mols.

Still it is a 1 line change for a 10% speedup for one of the most used models of the package.