### PR TITLE
Allow moving saved models

### DIFF
--- a/deepchem/models/tensorgraph/models/test_graph_models.py
+++ b/deepchem/models/tensorgraph/models/test_graph_models.py
@@ -79,7 +79,7 @@ class TestGraphModels(unittest.TestCase):
     fname = tfile.name
     tfile.close()
 
-    model.save(save_dir=fname)
+    model.save(snapshot_dir=fname)
     model = TensorGraph.load_from_dir(fname)
     scores2 = model.evaluate(dataset, [metric], transformers)
     assert np.allclose(scores['mean-roc_auc_score'],

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -838,6 +838,17 @@ class TensorGraph(Model):
     return result
 
   def save(self, save_dir=None):
+    """
+    Parameters
+    ----------
+    save_dir: str
+    filepath to save model to
+    all subfolders must exist
+
+    Returns
+    -------
+
+    """
     # Remove out_tensor from the object to be pickled
     must_restore = False
     tensor_objects = self.tensor_objects

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -1,5 +1,6 @@
 import collections
 import os
+import shutil
 import pickle
 import threading
 import time
@@ -836,7 +837,7 @@ class TensorGraph(Model):
           result[i] = self.get_pickling_errors(state[i], seen)
     return result
 
-  def save(self):
+  def save(self, save_dir=None):
     # Remove out_tensor from the object to be pickled
     must_restore = False
     tensor_objects = self.tensor_objects
@@ -885,6 +886,8 @@ class TensorGraph(Model):
     self.rnn_final_states = rnn_final_states
     self.rnn_zero_states = rnn_zero_states
     self.session = session
+    if save_dir is not None:
+      shutil.copytree(self.model_dir, save_dir)
 
   def evaluate_generator(self,
                          feed_dict_generator,

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -837,12 +837,14 @@ class TensorGraph(Model):
           result[i] = self.get_pickling_errors(state[i], seen)
     return result
 
-  def save(self, save_dir=None):
+  def save(self, snapshot_dir=None):
     """
     Parameters
     ----------
-    save_dir: str
-    filepath to save model to
+    snapshot_dir: str
+    This will create a snapshot of the model, with all weights being set
+    The current model_dir will not move and all future saves will continue
+    to happen on self.model_dir
     all subfolders must exist
 
     Returns
@@ -897,8 +899,8 @@ class TensorGraph(Model):
     self.rnn_final_states = rnn_final_states
     self.rnn_zero_states = rnn_zero_states
     self.session = session
-    if save_dir is not None:
-      shutil.copytree(self.model_dir, save_dir)
+    if snapshot_dir is not None:
+      shutil.copytree(self.model_dir, snapshot_dir)
 
   def evaluate_generator(self,
                          feed_dict_generator,


### PR DESCRIPTION
Add arg to save to specify saving to a filepath.

Can be helpful if playing around in a jupyter notebook and deciding to save a model after construction.