### PR TITLE
Adding automated install for Py36 runtime

### DIFF
--- a/examples/notebooks/graph_convolutional_networks_for_tox21_on_colab.ipynb
+++ b/examples/notebooks/graph_convolutional_networks_for_tox21_on_colab.ipynb
@@ -12,11 +12,12 @@
           "file_id": "https://github.com/deepchem/deepchem/blob/master/examples/notebooks/graph_convolutional_networks_for_tox21.ipynb",
           "timestamp": 1533163451822
         }
-      ]
+      ],
+      "collapsed_sections": []
     },
     "kernelspec": {
-      "name": "python2",
-      "display_name": "Python 2"
+      "name": "python3",
+      "display_name": "Python 3"
     },
     "accelerator": "GPU"
   },
@@ -29,14 +30,14 @@
       "cell_type": "markdown",
       "source": [
         "# Graph Convolutions For Tox21 on Google Colaboratory\n",
-        "In this notebook, we first show how to install DeepChem on a Colab with Py27/GPU runtime. We then explore the use of TensorGraph to create graph convolutional models with DeepChem. In particular, we will build a graph convolutional network on the Tox21 dataset.\n",
+        "In this notebook, we first show how to install DeepChem on a Colab with Py27 or Py36 runtime. We then explore the use of TensorGraph to create graph convolutional models with DeepChem. In particular, we will build a graph convolutional network on the Tox21 dataset.\n",
         "\n",
         "Let's start with installing DeepChem."
       ]
     },
     {
       "metadata": {
-        "id": "6O-Qzof0swOA",
+        "id": "LGu5G1SY9hzv",
         "colab_type": "code",
         "colab": {
           "autoexec": {
@@ -47,15 +48,55 @@
       },
       "cell_type": "code",
       "source": [
-        "!apt-get install -y libxrender-dev\n",
-        "!apt-get install python-rdkit librdkit1 rdkit-data       # Install RDkit\n",
+        "%%bash\n",
+        "PYV=`python -c \"import sys;t='{v[0]}.{v[1]}'.format(v=list(sys.version_info[:2]));sys.stdout.write(t)\";`\n",
+        "echo \"Python version $PYV detected\"\n",
+        "if [ $PYV == \"2.7\" ]\n",
+        "then\n",
+        "  # Installing DeepChem for Python 2.7.\n",
+        "  apt-get install -y libxrender-dev\n",
+        "  apt-get install python-rdkit librdkit1 rdkit-data       # Install RDkit\n",
         "\n",
-        "!pip install joblib simdna\n",
+        "  pip install joblib simdna\n",
         "\n",
-        "!git clone https://github.com/deepchem/deepchem.git      # Clone deepchem source code from GitHub\n",
-        "!cd deepchem && python setup.py install  \n",
+        "  git clone https://github.com/deepchem/deepchem.git      # Clone deepchem source code from GitHub\n",
+        "  cd deepchem && python setup.py install  \n",
         "\n",
-        "!ls -la /usr/local/lib/python2.7/dist-packages/deepchem/"
+        "  ls -la /usr/local/lib/python2.7/dist-packages/deepchem/\n",
+        "else\n",
+        "  # Installing DeepChem for Python 3.6 using MiniConda.\n",
+        "  wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O anaconda.sh;\n",
+        "  chmod +x anaconda.sh\n",
+        "  bash ./anaconda.sh -b -f -p /usr/local\n",
+        "  conda install -y --prefix /usr/local -c conda-forge rdkit joblib simdna\n",
+        "\n",
+        "  git clone https://github.com/deepchem/deepchem.git      # Clone deepchem source code from GitHub\n",
+        "  cd deepchem && python setup.py install\n",
+        "  ls -la /usr/local/lib/python3.6/site-packages/deepchem\n",
+        "fi"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "U3cX2OcRKhfC",
+        "colab_type": "code",
+        "colab": {
+          "autoexec": {
+            "startup": false,
+            "wait_interval": 0
+          }
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "# Last step of installing DeepChem under Python 3.6\n",
+        "\n",
+        "import sys\n",
+        "if sys.version_info[0] >= 3:\n",
+        "    sys.path.append('/usr/local/lib/python3.6/site-packages/')\n",
+        "sys.path"
       ],
       "execution_count": 0,
       "outputs": []
@@ -69,7 +110,7 @@
       "source": [
         "Let's start with some basic imports to see if the install was successful. \n",
         "\n",
-        "Note: Sometimes it is necessary to restart the runtime once after the inital install. After restarting, continue from the cell below."
+        "Note: Sometimes it is necessary to restart the runtime once after the initial install. After restarting, continue from the cell below."
       ]
     },
     {
@@ -508,24 +549,6 @@
       "source": [
         "Success! The model we've constructed behaves nearly identically to `GraphConvModel`. If you're looking to build your own custom models, you can follow the example we've provided here to do so. We hope to see exciting constructions from your end soon!"
       ]
-    },
-    {
-      "metadata": {
-        "id": "Gj9xFEv5qO8F",
-        "colab_type": "code",
-        "colab": {
-          "autoexec": {
-            "startup": false,
-            "wait_interval": 0
-          }
-        }
-      },
-      "cell_type": "code",
-      "source": [
-        ""
-      ],
-      "execution_count": 0,
-      "outputs": []
     }
   ]
 }


### PR DESCRIPTION
Small refinement of yesterdays Deepchem colaboratory. Now Deepchem can be installed for py27 and py36 runtimes. With both runtime types, the Colab can be successfully exercised to the bottom cell. The py36 install instructions are based on Karl Leswing's suggestions.


