### PR TITLE
Fix Binary Classification Metrics Metrics

### DIFF
--- a/deepchem/hyper/tests/test_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_hyperparam_opt.py
@@ -140,7 +140,7 @@ class TestHyperparamOpt(unittest.TestCase):
 
     transformers = []
     metric = dc.metrics.Metric(
-        dc.metrics.matthews_corrcoef, np.mean, mode="classification")
+        dc.metrics.roc_auc_score, np.mean, mode="classification")
     params_dict = {"layer_sizes": [(10,), (100,)]}
 
     def model_builder(model_params, model_dir):

--- a/deepchem/metrics/__init__.py
+++ b/deepchem/metrics/__init__.py
@@ -20,11 +20,11 @@ from scipy.stats import pearsonr
 def to_one_hot(y, n_classes=2):
   """Transforms label vector into one-hot encoding.
 
-  Turns y into vector of shape [n_samples, 2] (assuming binary labels).
+    Turns y into vector of shape [n_samples, 2] (assuming binary labels).
 
-  y: np.ndarray
-    A vector of shape [n_samples, 1]
-  """
+    y: np.ndarray
+      A vector of shape [n_samples, 1]
+    """
   n_samples = np.shape(y)[0]
   y_hot = np.zeros((n_samples, n_classes))
   y_hot[np.arange(n_samples), y.astype(np.int64)] = 1
@@ -34,9 +34,9 @@ def to_one_hot(y, n_classes=2):
 def from_one_hot(y, axis=1):
   """Transorms label vector from one-hot encoding.
 
-  y: np.ndarray
-    A vector of shape [n_samples, num_classes]
-  """
+    y: np.ndarray
+      A vector of shape [n_samples, num_classes]
+    """
   return np.argmax(y, axis=axis)
 
 
@@ -84,25 +84,25 @@ def pearson_r2_score(y, y_pred):
 
 def jaccard_index(y, y_pred):
   """Computes Jaccard Index which is the Intersection Over Union metric
-     which is commonly used in image segmentation tasks
+       which is commonly used in image segmentation tasks
 
-    Parameters
-    ----------
-    y: ground truth array
-    y_pred: predicted array
-  """
+      Parameters
+      ----------
+      y: ground truth array
+      y_pred: predicted array
+    """
   return jaccard_similarity_score(y, y_pred)
 
 
 def pixel_error(y, y_pred):
   """defined as 1 - the maximal F-score of pixel similarity,
-     or squared Euclidean distance between the original and the result labels.
+       or squared Euclidean distance between the original and the result labels.
 
-    Parameters
-    ----------
-    y: ground truth array
-    y_pred: predicted array
-  """
+      Parameters
+      ----------
+      y: ground truth array
+      y_pred: predicted array
+    """
   return 1 - f1_score(y, y_pred)
 
 
@@ -129,21 +129,21 @@ def mae_score(y_true, y_pred):
 def kappa_score(y_true, y_pred):
   """Calculate Cohen's kappa for classification tasks.
 
-  See https://en.wikipedia.org/wiki/Cohen%27s_kappa
+    See https://en.wikipedia.org/wiki/Cohen%27s_kappa
 
-  Note that this implementation of Cohen's kappa expects binary labels.
+    Note that this implementation of Cohen's kappa expects binary labels.
 
-  Args:
-    y_true: Numpy array containing true values.
-    y_pred: Numpy array containing predicted values.
+    Args:
+      y_true: Numpy array containing true values.
+      y_pred: Numpy array containing predicted values.
 
-  Returns:
-    kappa: Numpy array containing kappa for each classification task.
+    Returns:
+      kappa: Numpy array containing kappa for each classification task.
 
-  Raises:
-    AssertionError: If y_true and y_pred are not the same size, or if class
-      labels are not in [0, 1].
-  """
+    Raises:
+      AssertionError: If y_true and y_pred are not the same size, or if class
+        labels are not in [0, 1].
+    """
   assert len(y_true) == len(y_pred), 'Number of examples does not match.'
   yt = np.asarray(y_true, dtype=int)
   yp = np.asarray(y_pred, dtype=int)
@@ -173,13 +173,13 @@ class Metric(object):
                mode=None,
                compute_energy_metric=False):
     """
-    Args:
-      metric: function that takes args y_true, y_pred (in that order) and
-              computes desired score.
-      task_averager: If not None, should be a function that averages metrics
-              across tasks. For example, task_averager=np.mean. If task_averager
-              is provided, this task will be inherited as a multitask metric.
-    """
+        Args:
+          metric: function that takes args y_true, y_pred (in that order) and
+                  computes desired score.
+          task_averager: If not None, should be a function that averages metrics
+                  across tasks. For example, task_averager=np.mean. If task_averager
+                  is provided, this task will be inherited as a multitask metric.
+        """
     self.metric = metric
     self.task_averager = task_averager
     self.is_multitask = (self.task_averager is not None)
@@ -207,6 +207,11 @@ class Metric(object):
       else:
         raise ValueError("Must specify mode for new metric.")
     assert mode in ["classification", "regression"]
+    if self.metric.__name__ in [
+        "accuracy_score", "balanced_accuracy_score", "recall_score",
+        "matthews_corrcoef"
+    ] and threshold is None:
+      self.threshold = 0.5
     self.mode = mode
     # The convention used is that the first task is the metric.
     # TODO(rbharath, joegomes): This doesn't seem like it should be hard-coded as
@@ -223,25 +228,25 @@ class Metric(object):
                      per_task_metrics=False):
     """Compute a performance metric for each task.
 
-    Parameters
-    ----------
-    y_true: np.ndarray
-      An np.ndarray containing true values for each task.
-    y_pred: np.ndarray
-      An np.ndarray containing predicted values for each task.
-    w: np.ndarray, optional
-      An np.ndarray containing weights for each datapoint.
-    n_classes: int, optional
-      Number of classes in data for classification tasks.
-    filter_nans: bool, optional
-      Remove NaN values in computed metrics
-    per_task_metrics: bool, optional
-      If true, return computed metric for each task on multitask dataset.
+        Parameters
+        ----------
+        y_true: np.ndarray
+          An np.ndarray containing true values for each task.
+        y_pred: np.ndarray
+          An np.ndarray containing predicted values for each task.
+        w: np.ndarray, optional
+          An np.ndarray containing weights for each datapoint.
+        n_classes: int, optional
+          Number of classes in data for classification tasks.
+        filter_nans: bool, optional
+          Remove NaN values in computed metrics
+        per_task_metrics: bool, optional
+          If true, return computed metric for each task on multitask dataset.
 
-    Returns
-    -------
-    A numpy nd.array containing metric values for each task.
-    """
+        Returns
+        -------
+        A numpy nd.array containing metric values for each task.
+        """
     n_samples = y_true.shape[0]
     expected_dims = (3 if self.mode == "classification" else 2)
     if len(y_pred.shape) < expected_dims:
@@ -293,6 +298,7 @@ class Metric(object):
     Raises:
       NotImplementedError: If metric_str is not in METRICS.
     """
+
     y_true = np.array(np.squeeze(y_true[w != 0]))
     y_pred = np.array(np.squeeze(y_pred[w != 0]))
 
@@ -304,7 +310,8 @@ class Metric(object):
     if not y_true.size:
       return np.nan
     if self.threshold is not None:
-      y_pred = np.greater(y_pred, threshold)
+      y_pred = y_pred[:, 1]
+      y_pred = np.greater(y_pred, self.threshold)
     if len(y_true.shape) == 0:
       y_true = np.expand_dims(y_true, 0)
     if len(y_pred.shape) == 0:


### PR DESCRIPTION
Some metrics from sklearn do not accept [p_true, p_false] labels and instead require the user to set a threshold.

This does the thresholding for those metrics before final calculation.