### PR TITLE
#1317: Added get_layer_weights to tensorgraph

### DIFF
--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -2,6 +2,7 @@
 from __future__ import division
 import random
 import string
+import warnings
 from collections import Sequence
 from copy import deepcopy
 

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -974,11 +974,11 @@ class TensorGraph(Model):
 
   def get_layer_variables(self, layer):
     """Get the list of trainable variables in a layer of the graph."""
-    if tfe.in_eager_mode():
-      return layer.variables
     if not self.built:
       self.build()
     with self._get_tf("Graph").as_default():
+      if tfe.in_eager_mode():
+        return layer.variables
       if layer.variable_scope == '':
         return []
       return tf.get_collection(
@@ -988,11 +988,12 @@ class TensorGraph(Model):
     """Get the variable values associated with a given layer """
 
     layer_variables = self.get_layer_variables(layer)
-    if tfe.in_eager_mode():
-      return [v.numpy() for v in layer_variables]
-    if len(layer_variables) == 0:
-      return []
-    return self.session.run(layer_variables)
+    with self._get_tf("Graph").as_default():
+      if tfe.in_eager_mode():
+        return [v.numpy() for v in layer_variables]
+      if len(layer_variables) == 0:
+        return []
+      return self.session.run(layer_variables)
 
   def get_variables(self):
     """Get the list of all trainable variables in the graph."""

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -984,6 +984,16 @@ class TensorGraph(Model):
       return tf.get_collection(
           tf.GraphKeys.TRAINABLE_VARIABLES, scope=layer.variable_scope)
 
+  def get_layer_weights(self, layer):
+
+    layer_variables = self.get_layer_variables(layer)
+    if tfe.in_eager_mode():
+      return layer_variables
+    if len(layer_variables) == 0:
+      return []
+    layer_weights = self.session.run(layer_variables)
+    return layer_weights
+
   def get_variables(self):
     """Get the list of all trainable variables in the graph."""
     if not self.built:

--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -984,15 +984,15 @@ class TensorGraph(Model):
       return tf.get_collection(
           tf.GraphKeys.TRAINABLE_VARIABLES, scope=layer.variable_scope)
 
-  def get_layer_weights(self, layer):
+  def get_layer_variable_values(self, layer):
+    """Get the variable values associated with a given layer """
 
     layer_variables = self.get_layer_variables(layer)
     if tfe.in_eager_mode():
-      return layer_variables
+      return [v.numpy() for v in layer_variables]
     if len(layer_variables) == 0:
       return []
-    layer_weights = self.session.run(layer_variables)
-    return layer_weights
+    return self.session.run(layer_variables)
 
   def get_variables(self):
     """Get the list of all trainable variables in the graph."""

--- a/deepchem/models/tensorgraph/tests/test_tensor_graph.py
+++ b/deepchem/models/tensorgraph/tests/test_tensor_graph.py
@@ -585,7 +585,7 @@ class TestTensorGraph(unittest.TestCase):
     tg.add_output(var)
     expected = [10.0, 12.0]
     obtained = tg.get_layer_variable_values(var)[0]
-    np.testing.assert_array_almost_equal(expected, obtained)
+    np.testing.assert_array_equal(expected, obtained)
 
     # Test for shapes (normal mode)
     tg = dc.models.TensorGraph()
@@ -596,22 +596,23 @@ class TestTensorGraph(unittest.TestCase):
     obtained_shape = tg.get_layer_variable_values(output)[0].shape
     assert expected_shape == obtained_shape
 
+  def test_get_layer_variable_values_eager(self):
+    """Tests to get variable values associated with a layer in eager mode"""
+
     with context.eager_mode():
       # Test for correct value return (eager mode)
       tg = dc.models.TensorGraph()
       var = Variable([10.0, 12.0])
       tg.add_output(var)
-      tg.build()
       expected = [10.0, 12.0]
       obtained = tg.get_layer_variable_values(var)[0]
-      np.testing.assert_array_almost_equal(expected, obtained)
+      np.testing.assert_array_equal(expected, obtained)
 
       # Test for shape (eager mode)
       tg = dc.models.TensorGraph()
       input_tensor = Input(shape=(10, 100))
       output = Dense(out_channels=20, in_layers=[input_tensor])
       tg.add_output(output)
-      tg.build()
       expected_shape = (100, 20)
       obtained_shape = tg.get_layer_variable_values(output)[0].shape
       assert expected_shape == obtained_shape


### PR DESCRIPTION
Addressing #1317, this PR adds in the get_layer_weights convenience to Tensorgraph

Tasks left/Questions:
1. Do I add tests for this, since there are no tests present for `get_layer_variables`
2. Should the biases also be returned? For visualization examples, the weights seem to have more importance.