### PR TITLE
#1185: SDF loader should load tasks from SDF File

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -291,7 +291,7 @@ class SDFLoader(DataLoader):
 
   def get_shards(self, input_files, shard_size):
     """Defines a generator which returns data for each shard"""
-    return load_sdf_files(input_files, self.clean_mols, self.tasks)
+    return load_sdf_files(input_files, self.clean_mols, tasks=self.tasks)
 
   def featurize_shard(self, shard):
     """Featurizes a shard of an input dataframe."""

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -284,13 +284,14 @@ class SDFLoader(DataLoader):
   def __init__(self, tasks, clean_mols=False, **kwargs):
     super(SDFLoader, self).__init__(tasks, **kwargs)
     self.clean_mols = clean_mols
+    self.tasks = tasks
     self.smiles_field = "smiles"
     self.mol_field = "mol"
     self.id_field = "smiles"
 
   def get_shards(self, input_files, shard_size):
     """Defines a generator which returns data for each shard"""
-    return load_sdf_files(input_files, self.clean_mols)
+    return load_sdf_files(input_files, self.clean_mols, self.tasks)
 
   def featurize_shard(self, shard):
     """Featurizes a shard of an input dataframe."""

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -81,19 +81,21 @@ def load_sdf_files(input_files, clean_mols, tasks=[]):
     suppl = Chem.SDMolSupplier(str(input_file), clean_mols, False, False)
     df_rows = []
     for ind, mol in enumerate(suppl):
-      if mol is not None:
-        smiles = Chem.MolToSmiles(mol)
-        df_row = [ind, smiles, mol]
+      if mol is None:
+        continue
+      smiles = Chem.MolToSmiles(mol)
+      df_row = [ind, smiles, mol]
+      if not has_csv:  # Get task targets from .sdf file
         for task in tasks:
           df_row.append(mol.GetProp(str(task)))
-        df_rows.append(df_row)
-    mol_df = pd.DataFrame(
-        df_rows, columns=('mol_id', 'smiles', 'mol') + tuple(tasks))
-    # Tasks are stored either in .sdf.csv file
+      df_rows.append(df_row)
     if has_csv:
+      mol_df = pd.DataFrame(df_rows, columns=('mol_id', 'smiles', 'mol'))
       raw_df = next(load_csv_files([input_file + ".csv"], shard_size=None))
       dataframes.append(pd.concat([mol_df, raw_df], axis=1, join='inner'))
     else:
+      mol_df = pd.DataFrame(
+        df_rows, columns=('mol_id', 'smiles', 'mol') + tuple(tasks))
       dataframes.append(mol_df)
   return dataframes
 

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -95,7 +95,7 @@ def load_sdf_files(input_files, clean_mols, tasks=[]):
       dataframes.append(pd.concat([mol_df, raw_df], axis=1, join='inner'))
     else:
       mol_df = pd.DataFrame(
-        df_rows, columns=('mol_id', 'smiles', 'mol') + tuple(tasks))
+          df_rows, columns=('mol_id', 'smiles', 'mol') + tuple(tasks))
       dataframes.append(mol_df)
   return dataframes
 


### PR DESCRIPTION
This PR addresses #1185:
- Checks if file *.sdf.csv exists
- If *.sdf.csv exists, maintain old path for backwards compatibility
- If it does not exist, look up the "tasks" in the SDF file itself, with `mol.getProp()`