### PR TITLE
Make simdna a soft dependency

### DIFF
--- a/deepchem/metrics/genomic_metrics.py
+++ b/deepchem/metrics/genomic_metrics.py
@@ -28,6 +28,7 @@ def get_motif_scores(encoded_sequences,
   If max_scores and return_positions, (N_sequences, 2*num_motifs*max_scores)
   array with max scores and their positions.
   """
+  import simdna
   from simdna import synthetic
   loaded_motifs = synthetic.LoadedEncodeMotifs(
       simdna.ENCODE_MOTIFS_PATH, pseudocountProb=0.001)

--- a/deepchem/metrics/genomic_metrics.py
+++ b/deepchem/metrics/genomic_metrics.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 from deepchem.data import NumpyDataset
-from deepchem.utils.genomics import loaded_motifs
 from scipy.signal import correlate2d
 
 
@@ -29,6 +28,9 @@ def get_motif_scores(encoded_sequences,
   If max_scores and return_positions, (N_sequences, 2*num_motifs*max_scores)
   array with max scores and their positions.
   """
+  from simdna import synthetic
+  loaded_motifs = synthetic.LoadedEncodeMotifs(
+      simdna.ENCODE_MOTIFS_PATH, pseudocountProb=0.001)
   num_samples, _, seq_length, _ = encoded_sequences.shape
   scores = np.ones((num_samples, len(motif_names), seq_length))
   for j, motif_name in enumerate(motif_names):

--- a/deepchem/molnet/dnasim.py
+++ b/deepchem/molnet/dnasim.py
@@ -35,6 +35,7 @@ def simple_motif_embedding(motif_name, seq_length, num_seqs, GC_fraction):
   embedding_arr: 1darray
       Array of embedding objects.
   """
+  import simdna
   from simdna import synthetic
   if motif_name is None:
     embedders = []
@@ -72,6 +73,7 @@ def motif_density(motif_name,
   """
   Returns sequences with motif density, along with embeddings array.
   """
+  import simdna
   from simdna import synthetic
   loaded_motifs = synthetic.LoadedEncodeMotifs(
       simdna.ENCODE_MOTIFS_PATH, pseudocountProb=0.001)
@@ -238,28 +240,29 @@ def simulate_motif_density_localization(motif_name, seq_length, center_size,
 def simulate_multi_motif_embedding(motif_names, seq_length, min_num_motifs,
                                    max_num_motifs, num_seqs, GC_fraction):
   """
-    Generates data for multi motif recognition task.
+  Generates data for multi motif recognition task.
 
-    Parameters
-    ----------
-    motif_names : list
-        List of strings.
-    seq_length : int
-    min_num_motifs : int
-    max_num_motifs : int
-    num_seqs : int
-    GC_fraction : float
+  Parameters
+  ----------
+  motif_names : list
+      List of strings.
+  seq_length : int
+  min_num_motifs : int
+  max_num_motifs : int
+  num_seqs : int
+  GC_fraction : float
 
-    Returns
-    -------
-    sequence_arr : 1darray
-        Contains sequence strings.
-    y : ndarray
-        Contains labels for each motif.
-    embedding_arr: 1darray
-        Array of embedding objects.
-    """
+  Returns
+  -------
+  sequence_arr : 1darray
+      Contains sequence strings.
+  y : ndarray
+      Contains labels for each motif.
+  embedding_arr: 1darray
+      Array of embedding objects.
+  """
 
+  import simdna
   from simdna import synthetic
   loaded_motifs = synthetic.LoadedEncodeMotifs(
       simdna.ENCODE_MOTIFS_PATH, pseudocountProb=0.001)
@@ -369,6 +372,7 @@ def simulate_heterodimer_grammar(motif1, motif2, seq_length, min_spacing,
     embedding_arr: list
         List of embedding objects.
     """
+  import simdna
   from simdna import synthetic
   loaded_motifs = synthetic.LoadedEncodeMotifs(
       simdna.ENCODE_MOTIFS_PATH, pseudocountProb=0.001)

--- a/deepchem/utils/genomics.py
+++ b/deepchem/utils/genomics.py
@@ -1,12 +1,7 @@
 """
 Genomic data handling utilities.
 """
-import simdna
-from simdna.synthetic import LoadedEncodeMotifs
 import numpy as np
-
-loaded_motifs = LoadedEncodeMotifs(
-    simdna.ENCODE_MOTIFS_PATH, pseudocountProb=0.001)
 
 
 def seq_one_hot_encode(sequences, letters='ATCGN'):


### PR DESCRIPTION
This PR makes all `simdna` import internal to functions. The goal for this change is to reduce the number of DeepChem hard dependencies so install becomes easier.