### PR TITLE
Make six a soft dependency

### DIFF
--- a/deepchem/feat/tests/test_rdkit_grid_features.py
+++ b/deepchem/feat/tests/test_rdkit_grid_features.py
@@ -2,7 +2,6 @@
 Test rdkit_grid_featurizer module.
 """
 import os
-from six import integer_types
 import unittest
 
 import numpy as np
@@ -102,6 +101,7 @@ class TestHelperFunctions(unittest.TestCase):
       self.assertAlmostEqual(rgf.angle_between(v1, -v1), np.pi)
 
   def test_hash_ecfp(self):
+    from six import integer_types
     for power in (2, 16, 64):
       for _ in range(10):
         string = random_string(10)
@@ -111,6 +111,7 @@ class TestHelperFunctions(unittest.TestCase):
         self.assertGreaterEqual(string_hash, 0)
 
   def test_hash_ecfp_pair(self):
+    from six import integer_types
     for power in (2, 16, 64):
       for _ in range(10):
         string1 = random_string(10)

--- a/deepchem/models/tensorgraph/activations.py
+++ b/deepchem/models/tensorgraph/activations.py
@@ -4,7 +4,6 @@ Activations for models.
 from __future__ import division
 from __future__ import unicode_literals
 
-import six
 import tensorflow as tf
 from deepchem.models.tensorgraph import model_ops
 from deepchem.models.tensorgraph.model_ops import get_ndim
@@ -38,7 +37,8 @@ def get_from_module(identifier,
   Raises
   ------
   ValueError: if the identifier cannot be found.
- """
+  """
+  import six
   if isinstance(identifier, six.string_types):
     res = module_params.get(identifier)
     if not res:

--- a/deepchem/models/tensorgraph/models/graph_models.py
+++ b/deepchem/models/tensorgraph/models/graph_models.py
@@ -1,7 +1,6 @@
 import collections
 
 import numpy as np
-import six
 import tensorflow as tf
 
 from deepchem.data import NumpyDataset, pad_features


### PR DESCRIPTION
[Six](https://pypi.org/project/six/) is a python 2/3 compatibility library we use in a few places. This PR makes this a soft dependency. (The dependency could perhaps be removed entirely in a future PR).