### PR TITLE
#1473: make_estimator for TextCNN

### DIFF
--- a/deepchem/models/tensorgraph/graph_layers.py
+++ b/deepchem/models/tensorgraph/graph_layers.py
@@ -338,7 +338,6 @@ class DTNNEmbedding(Layer):
     self.build()
 
     atom_number = in_layers[0].out_tensor
-    atom_number = tf.cast(atom_number, dtype=tf.int32)
     atom_features = tf.nn.embedding_lookup(self.embedding_list, atom_number)
     out_tensor = atom_features
     if set_tensors:

--- a/deepchem/models/tensorgraph/models/text_cnn.py
+++ b/deepchem/models/tensorgraph/models/text_cnn.py
@@ -239,7 +239,12 @@ class TextCNNModel(TensorGraph):
     """Creates tensors for inputs."""
     tensors = dict()
     for layer, column in zip(self.features, feature_columns):
-      tensors[layer] = tf.feature_column.input_layer(features, [column])
+      feature_col = tf.feature_column.input_layer(features, [column])
+      if column.dtype != feature_col.dtype:
+        feature_col = tf.cast(feature_col, column.dtype)
+      if len(column.shape) < 1:
+        feature_col = tf.reshape(feature_col, shape=[tf.shape(feature_col)[0]])
+      tensors[layer] = feature_col
     if weight_column is not None:
       tensors[self.task_weights[0]] = tf.feature_column.input_layer(
           features, [weight_column])

--- a/deepchem/models/tensorgraph/tests/test_estimators.py
+++ b/deepchem/models/tensorgraph/tests/test_estimators.py
@@ -296,7 +296,7 @@ class TestEstimators(unittest.TestCase):
 
     np.random.seed(123)
     smile_ids = ["CCCCC", "CCC(=O)O", "CCC", "CC(=O)O", "O=C=O"]
-    X = [model.smiles_to_seq(smile) for smile in smile_ids]
+    X = smile_ids
     y = np.zeros((n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
     dataset = NumpyDataset(X, y, w, smile_ids)
@@ -307,7 +307,8 @@ class TestEstimators(unittest.TestCase):
     def input_fn(epochs):
       x, y, weights = dataset.make_iterator(
           batch_size=n_samples, epochs=epochs).get_next()
-      return {'x': x, 'weights': weights}, y
+      smiles_seq = tf.py_func(model.smiles_to_seq_batch, inp=[x], Tout=tf.int32)
+      return {'x': smiles_seq, 'weights': weights}, y
 
     # Create an estimator from it.
     x_col = tf.feature_column.numeric_column(
@@ -342,7 +343,7 @@ class TestEstimators(unittest.TestCase):
 
     np.random.seed(123)
     smile_ids = ["CCCCC", "CCC(=O)O", "CCC", "CC(=O)O", "O=C=O"]
-    X = [model.smiles_to_seq(smile) for smile in smile_ids]
+    X = smile_ids
     y = np.zeros((n_samples, n_tasks, 1), dtype=np.float32)
     w = np.ones((n_samples, n_tasks))
     dataset = NumpyDataset(X, y, w, smile_ids)
@@ -350,10 +351,12 @@ class TestEstimators(unittest.TestCase):
     def input_fn(epochs):
       x, y, weights = dataset.make_iterator(
           batch_size=n_samples, epochs=epochs).get_next()
-      return {'x': x, 'weights': weights}, y
+      smiles_seq = tf.py_func(model.smiles_to_seq_batch, inp=[x], Tout=tf.int32)
+      return {'x': smiles_seq, 'weights': weights}, y
 
     # Create an estimator from it.
-    x_col = tf.feature_column.numeric_column('x', shape=(seq_length,))
+    x_col = tf.feature_column.numeric_column(
+        'x', shape=(seq_length,), dtype=tf.int32)
     weight_col = tf.feature_column.numeric_column('weights', shape=(n_tasks,))
     metrics = {'error': tf.metrics.mean_absolute_error}
     estimator = model.make_estimator(


### PR DESCRIPTION
A few changes to the TextCNN code merged earlier:
1. Moved `smiles_to_seq` to the `input_fn` definition
2. Removed the `tf.cast` usage from DTNNEmbedding, added dtypes to feature columns.

Note: `dataset.make_iterator` does not return ids, while the `default_generator` in TextCNN uses `dataset.ids` for computing `smiles_to_seq`. Estimator test is designed by setting X to ids. 