### PR TITLE
#1142: make_estimator - ANIRegression, BPSymmetryFunctionRegression

### DIFF
--- a/deepchem/models/tensorgraph/models/symmetry_function_regression.py
+++ b/deepchem/models/tensorgraph/models/symmetry_function_regression.py
@@ -218,7 +218,8 @@ class ANIRegression(TensorGraph):
       flags = np.sign(np.array(X[:upper_lim, :, 0]))
       atom_flags = np.stack([flags]*self.max_atoms, axis=2)*\
           np.stack([flags]*self.max_atoms, axis=1)
-      feed_dict[self.atom_flags] = atom_flags.reshape(-1, self.max_atoms * self.max_atoms)
+      feed_dict[self.atom_flags] = atom_flags.reshape(
+          -1, self.max_atoms * self.max_atoms)
       atom_numbers = np.array(X[:upper_lim, :, 0], dtype=int)
       feed_dict[self.atom_numbers] = atom_numbers
       atom_feats = np.array(X[:upper_lim, :, :], dtype=float)

--- a/deepchem/models/tensorgraph/symmetry_functions.py
+++ b/deepchem/models/tensorgraph/symmetry_functions.py
@@ -46,7 +46,11 @@ class DistanceMatrix(Layer):
     # Calculate pairwise distance
     d = tf.sqrt(tf.reduce_sum(tf.square(tensor1 - tensor2), axis=3))
     # Masking for valid atom index
-    self.out_tensor = d * tf.to_float(atom_flags)
+    out_tensor = d * tf.to_float(atom_flags)
+    if set_tensors:
+      self.out_tensor = out_tensor
+
+    return out_tensor
 
 
 class DistanceCutoff(Layer):
@@ -79,7 +83,11 @@ class DistanceCutoff(Layer):
     d = 0.5 * (tf.cos(np.pi * d / self.Rc) + 1)
     out_tensor = d * d_flag
     out_tensor = out_tensor * tf.expand_dims((1 - tf.eye(self.max_atoms)), 0)
-    self.out_tensor = out_tensor
+    out_tensor = out_tensor
+
+    if set_tensors:
+      self.out_tensor = out_tensor
+    return out_tensor
 
 
 class RadialSymmetry(Layer):
@@ -142,9 +150,14 @@ class RadialSymmetry(Layer):
             tf.expand_dims(atom_number_embedded[:, :, atom_type], axis=1),
             axis=3)
         out_tensors.append(tf.reduce_sum(out_tensor * selected_atoms, axis=2))
-      self.out_tensor = tf.concat(out_tensors, axis=2)
+      out_tensor = tf.concat(out_tensors, axis=2)
     else:
-      self.out_tensor = tf.reduce_sum(out_tensor, axis=2)
+      out_tensor = tf.reduce_sum(out_tensor, axis=2)
+
+    if set_tensors:
+      self.out_tensor = out_tensor
+
+    return out_tensor
 
 
 class AngularSymmetry(Layer):
@@ -227,8 +240,13 @@ class AngularSymmetry(Layer):
     out_tensor = tf.pow(1 + lambd * tf.cos(theta), zeta) * \
                  tf.exp(-ita * (tf.square(R_ij) + tf.square(R_ik) + tf.square(R_jk))) * \
                  f_R_ij * f_R_ik * f_R_jk
-    self.out_tensor = tf.reduce_sum(out_tensor, axis=[2, 3]) * \
+    out_tensor = tf.reduce_sum(out_tensor, axis=[2, 3]) * \
                       tf.pow(tf.constant(2.), 1 - tf.reshape(self.zeta, (1, 1, -1)))
+
+    if set_tensors:
+      self.out_tensor = out_tensor
+
+    return out_tensor
 
 
 class AngularSymmetryMod(Layer):
@@ -345,9 +363,14 @@ class AngularSymmetryMod(Layer):
               tf.expand_dims(selected_atoms, axis=1), axis=4)
           out_tensors.append(
               tf.reduce_sum(out_tensor * selected_atoms, axis=[2, 3]))
-      self.out_tensor = tf.concat(out_tensors, axis=2)
+      out_tensor = tf.concat(out_tensors, axis=2)
     else:
-      self.out_tensor = tf.reduce_sum(out_tensor, axis=[2, 3])
+      out_tensor = tf.reduce_sum(out_tensor, axis=[2, 3])
+
+    if set_tensors:
+      self.out_tensor = out_tensor
+
+    return out_tensor
 
 
 class BPFeatureMerge(Layer):
@@ -369,7 +392,12 @@ class BPFeatureMerge(Layer):
 
     out_tensor = tf.concat(
         [atom_embedding, radial_symmetry, angular_symmetry], axis=2)
-    self.out_tensor = out_tensor * atom_flags[:, :, 0:1]
+    out_tensor = out_tensor * atom_flags[:, :, 0:1]
+
+    if set_tensors:
+      self.out_tensor = out_tensor
+
+    return out_tensor
 
 
 class BPGather(Layer):
@@ -389,6 +417,8 @@ class BPGather(Layer):
 
     out_tensor = tf.reduce_sum(out_tensor * flags[:, :, 0:1], axis=1)
     self.out_tensor = out_tensor
+
+    return out_tensor
 
 
 class AtomicDifferentiatedDense(Layer):
@@ -453,7 +483,12 @@ class AtomicDifferentiatedDense(Layer):
       output = tf.reshape(output * tf.expand_dims(mask, 2),
                           (-1, self.max_atoms, self.out_channels))
       outputs.append(output)
-    self.out_tensor = tf.add_n(outputs)
+    out_tensor = tf.add_n(outputs)
+
+    if set_tensors:
+      self.out_tensor = out_tensor
+
+    return out_tensor
 
   def none_tensors(self):
     w, b, out_tensor = self.W, self.b, self.out_tensor

--- a/deepchem/models/tensorgraph/tests/test_estimators.py
+++ b/deepchem/models/tensorgraph/tests/test_estimators.py
@@ -467,7 +467,7 @@ class TestEstimators(unittest.TestCase):
     input_file = os.path.join(current_dir, "example_DTNN.mat")
     dataset = loadmat(input_file)
 
-    num_vals_to_use = 5
+    num_vals_to_use = 20
 
     np.random.seed(123)
     X = dataset['X'][:num_vals_to_use]

--- a/deepchem/models/tensorgraph/tests/test_estimators.py
+++ b/deepchem/models/tensorgraph/tests/test_estimators.py
@@ -467,9 +467,11 @@ class TestEstimators(unittest.TestCase):
     input_file = os.path.join(current_dir, "example_DTNN.mat")
     dataset = loadmat(input_file)
 
+    num_vals_to_use = 5
+
     np.random.seed(123)
-    X = dataset['X']
-    y = dataset['T'].astype(np.float32)
+    X = dataset['X'][:num_vals_to_use]
+    y = dataset['T'][:num_vals_to_use].astype(np.float32)
     w = np.ones_like(y)
     dataset = dc.data.NumpyDataset(X, y, w, ids=None)
     n_tasks = y.shape[1]
@@ -526,4 +528,151 @@ class TestEstimators(unittest.TestCase):
     estimator.train(input_fn=lambda: input_fn(100, 250))
 
     results = estimator.evaluate(input_fn=lambda: input_fn(n_samples, 1))
+    assert results['error'] < 0.1
+
+  def test_bpsymm_regression_model(self):
+    """Test creating an estimator for BPSymmetry Regression model."""
+    tasks, dataset, transformers = dc.molnet.load_qm7_from_mat(
+        featurizer='BPSymmetryFunction', move_mean=False)
+
+    num_samples_to_use = 5
+    train, _, _ = dataset
+    X = train.X[:num_samples_to_use]
+    y = train.y[:num_samples_to_use]
+    w = train.w[:num_samples_to_use]
+    ids = train.ids[:num_samples_to_use]
+
+    dataset = dc.data.NumpyDataset(X, y, w, ids)
+
+    max_atoms = 23
+    batch_size = 16
+    layer_structures = [128, 128, 64]
+
+    ANItransformer = dc.trans.ANITransformer(
+        max_atoms=max_atoms, atomic_number_differentiated=False)
+    dataset = ANItransformer.transform(dataset)
+    n_feat = ANItransformer.get_num_feats() - 1
+
+    model = dc.models.BPSymmetryFunctionRegression(
+        len(tasks),
+        max_atoms,
+        n_feat,
+        layer_structures=layer_structures,
+        batch_size=batch_size,
+        learning_rate=0.001,
+        use_queue=False,
+        mode="regression")
+
+    metrics = {'error': tf.metrics.mean_absolute_error}
+
+    def input_fn(epochs):
+      X, y, w = dataset.make_iterator(
+          batch_size=batch_size, epochs=epochs).get_next()
+      atom_feats, atom_flags = tf.py_func(
+          model.compute_features_on_batch, [X], Tout=[tf.float32, tf.float32])
+      atom_feats = tf.reshape(
+          atom_feats,
+          shape=(tf.shape(atom_feats)[0], model.max_atoms * model.n_feat))
+      atom_flags = tf.reshape(
+          atom_flags,
+          shape=(tf.shape(atom_flags)[0], model.max_atoms * model.max_atoms))
+
+      features = dict()
+      features['atom_feats'] = atom_feats
+      features['atom_flags'] = atom_flags
+      features['weights'] = w
+      return features, y
+
+    atom_feats = tf.feature_column.numeric_column(
+        'atom_feats', shape=(max_atoms * n_feat,), dtype=tf.float32)
+    atom_flags = tf.feature_column.numeric_column(
+        'atom_flags', shape=(max_atoms * max_atoms), dtype=tf.float32)
+    weight_col = tf.feature_column.numeric_column(
+        'weights', shape=(len(tasks),), dtype=tf.float32)
+
+    estimator = model.make_estimator(
+        feature_columns=[atom_feats, atom_flags],
+        weight_column=weight_col,
+        metrics=metrics)
+    estimator.train(input_fn=lambda: input_fn(100))
+    results = estimator.evaluate(input_fn=lambda: input_fn(1))
+
+    assert results['error'] < 0.1
+
+  def test_ani_regression(self):
+    """Test creating an estimator for ANI Regression."""
+
+    max_atoms = 4
+
+    X = np.array(
+        [[
+            [1, 5.0, 3.2, 1.1],
+            [6, 1.0, 3.4, -1.1],
+            [1, 2.3, 3.4, 2.2],
+            [0, 0, 0, 0],
+        ], [
+            [8, 2.0, -1.4, -1.1],
+            [7, 6.3, 2.4, 3.2],
+            [0, 0, 0, 0],
+            [0, 0, 0, 0],
+        ]],
+        dtype=np.float32)
+
+    y = np.array([[2.0], [1.1]], dtype=np.float32)
+
+    layer_structures = [128, 128, 64]
+    atom_number_cases = [1, 6, 7, 8]
+
+    kwargs = {
+        "n_tasks": 1,
+        "max_atoms": max_atoms,
+        "layer_structures": layer_structures,
+        "atom_number_cases": atom_number_cases,
+        "batch_size": 2,
+        "learning_rate": 0.001,
+        "use_queue": False,
+        "mode": "regression"
+    }
+
+    model = dc.models.ANIRegression(**kwargs)
+    dataset = dc.data.NumpyDataset(X, y, n_tasks=1)
+
+    metrics = {'error': tf.metrics.mean_absolute_error}
+
+    def input_fn(epochs):
+      X, y, w = dataset.make_iterator(batch_size=2, epochs=epochs).get_next()
+      atom_feats, atom_numbers, atom_flags = tf.py_func(
+          model.compute_features_on_batch, [X],
+          Tout=[tf.float32, tf.int32, tf.float32])
+      atom_feats = tf.reshape(
+          atom_feats, shape=(tf.shape(atom_feats)[0], model.max_atoms * 4))
+      atom_numbers = tf.reshape(
+          atom_numbers, shape=(tf.shape(atom_numbers)[0], model.max_atoms))
+      atom_flags = tf.reshape(
+          atom_flags,
+          shape=(tf.shape(atom_flags)[0], model.max_atoms * model.max_atoms))
+
+      features = dict()
+      features['atom_feats'] = atom_feats
+      features['atom_numbers'] = atom_numbers
+      features['atom_flags'] = atom_flags
+      features['weights'] = w
+      return features, y
+
+    atom_feats = tf.feature_column.numeric_column(
+        'atom_feats', shape=(max_atoms * 4,), dtype=tf.float32)
+    atom_numbers = tf.feature_column.numeric_column(
+        'atom_numbers', shape=(max_atoms,), dtype=tf.int32)
+    atom_flags = tf.feature_column.numeric_column(
+        'atom_flags', shape=(max_atoms * max_atoms), dtype=tf.float32)
+    weight_col = tf.feature_column.numeric_column(
+        'weights', shape=(kwargs["n_tasks"],), dtype=tf.float32)
+
+    estimator = model.make_estimator(
+        feature_columns=[atom_feats, atom_numbers, atom_flags],
+        weight_column=weight_col,
+        metrics=metrics)
+    estimator.train(input_fn=lambda: input_fn(100))
+
+    results = estimator.evaluate(input_fn=lambda: input_fn(1))
     assert results['error'] < 0.1

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -51,7 +51,7 @@ def load_qm7_from_mat(featurizer='CoulombMatrix',
       )
     dataset = scipy.io.loadmat(dataset_file)
     X = np.concatenate([np.expand_dims(dataset['Z'], 2), dataset['R']], axis=2)
-    y = dataset['T']
+    y = dataset['T'].reshape(-1, 1)  # scipy.io.loadmat puts samples on axis 1
     w = np.ones_like(y)
     dataset = deepchem.data.DiskDataset.from_numpy(X, y, w, ids=None)
   else:


### PR DESCRIPTION
This PR adds in make estimator support for ANIRegression and BPSymmetryFunctionRegression.

Changes made:
1. Added `return out_tensor` for all Layers in `dc.models.tensorgraph.symmetry_functions`
2. Change shapes of the Feature layers to be compatible with `tf.feature_column.input_layer`
3. Tests added for `ANIRegression` and `BPSymmetryFunctionRegression`
4. Changes to `ANIRegression.grad_one` to deal with Feature layer shape changes
5. Fix shape errors in `load_qm7_from_mat`

Based on the discussion in #1142, it looks like all graph models that take molecules as input and compute features on them, do not work with `tf.py_func`. Hence, the graph models `WeaveTensorGraph`, `DAGTensorGraph`, `GraphConvTensorGraph`, `PetroskiSuchTensorGraph`, `MPNNTensorGraph`  cannot be changed to have `make_estimator` support.
