### PR TITLE
Fix loading of MUV with `reload = False`

### DIFF
--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -76,8 +76,8 @@ def load_muv(featurizer='ECFP', split='index', reload=True, K=4):
     all_dataset = fold_datasets
   else:
     train, valid, test = splitter.train_valid_test_split(dataset)
-  if reload:
-    deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
-                                             transformers)
     all_dataset = (train, valid, test)
+    if reload:
+      deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
+                                               transformers)
   return MUV_tasks, all_dataset, transformers


### PR DESCRIPTION
The `if reload` branch at the end of the MUV loader looks to me like it was incorrectly indented. If `load_muv` was called with `reload=False`, loading would fail out because `all_dataset` was not defined. I nested the `if reload` branch in by one because it didn't look to me like it would properly execute if split was done by task -- not sure if this is semantically correct or if there needs to be an alternate way of handling reload when `train`/`val`/`test` are not available.