### PR TITLE
Added attr-slow for the AtomicConvFeaturizer test

### DIFF
--- a/deepchem/feat/tests/test_graph_features.py
+++ b/deepchem/feat/tests/test_graph_features.py
@@ -11,6 +11,7 @@ __license__ = "MIT"
 import unittest
 import os
 import numpy as np
+from nose.plugins.attrib import attr
 from deepchem.feat.graph_features import ConvMolFeaturizer, AtomicConvFeaturizer
 
 
@@ -96,6 +97,7 @@ class TestConvMolFeaturizer(unittest.TestCase):
 
 class TestAtomicConvFeaturizer(unittest.TestCase):
 
+  @attr("slow")
   def test_feature_generation(self):
     """Test if featurization works using AtomicConvFeaturizer."""
     dir_path = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
Adds `@attr("slow")` for the AtomicConvFeaturizer test. Just like other Atomic conv tests, it just tries to check if the featurizer works properly, and has no other assertions.