### PR TITLE
For DiskDataset: fix bug of move(); make output of create_dataset() clear

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -562,6 +562,7 @@ class DiskDataset(Dataset):
 
     metadata_rows = []
     time1 = time.time()
+    print("Writing just created dataset to temp files of disk...")
     for shard_num, (X, y, w, ids) in enumerate(shard_generator):
       basename = "shard-%d" % shard_num
       metadata_rows.append(
@@ -646,7 +647,14 @@ class DiskDataset(Dataset):
 
   def move(self, new_data_dir):
     """Moves dataset to new directory."""
-    shutil.move(self.data_dir, new_data_dir)
+    files = [os.path.join(self.data_dir, i) for i in os.listdir(self.data_dir)]
+    new_files = [os.path.join(new_data_dir, i) for i in os.listdir(self.data_dir)]
+    if not os.path.exists(new_data_dir):
+      os.makedirs(new_data_dir)
+    for i in range(len(files)):
+      if not os.path.exists(new_files[i]):
+        os.mknod(new_files[i])
+      shutil.move(files[i], new_files[i])
     self.data_dir = new_data_dir
 
   def get_task_names(self):


### PR DESCRIPTION
**It fixs bug of DiskDataset.move() and makes output of DiskDataset.create_dataset() clear.**

I felt confused when using `load_pdbbind()` of `deepchem.molnet.load_function.pdbbind_datasets.py`.

### For addition in line 565

When using load funtion first time, I saw the output above:

> Featurizing Complexes
TIMING: dataset construction took 3.837 s
Loading dataset from disk.
Featurization complete.
TIMING: dataset construction took 3.738 s
Loading dataset from disk.
TIMING: dataset construction took 1.257 s
Loading dataset from disk.
TIMING: dataset construction took 2.201 s
Loading dataset from disk.

I felt strange because there were dataset already saved in my disk but it was my first time to use the load funtion. So I want to add this message to make it clear.

`Writing just created dataset to temp files of disk...`

### For modification in method `move()`

It should move **all files** in the `self.data_dir` into `new_data_dir`, but it moves **the folder** `self.data_dir` into `new_data_dir`.

> shutil.move(src, dst, copy_function=copy2)
Recursively move a file or directory (src) to another location (dst) and return the destination.
> If the destination is an existing directory, then src is moved inside that directory.

This will cause some problems, one of which is the newly generated dataset can **not** overwrite the previously saved dataset.