### PR TITLE
fix bug of load_pdbbind() and add new features

### DIFF
--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -147,19 +147,32 @@ def load_pdbbind(reload=True,
                  split_seed=None,
                  save_dir=None,
                  save_timestamp=False):
-  """Load and featurize raw PDBBind dataset.
-  
-  Parameters
-  ----------
-  data_dir: String, optional
-    Specifies the data directory to store the featurized dataset.
-  split: Str
-    Either "random" or "index"
-  feat: Str
-    Either "grid" or "atomic" for grid and atomic featurizations.
-  subset: Str
-    Only "core" or "refined" for now.
-  """
+    """Load raw PDBBind dataset by featurization and split.
+
+    Parameters
+    ----------
+    reload: Bool, optional
+        Reload saved featurized and splitted dataset or not.
+    data_dir: Str, optional
+        Specifies the directory storing the raw dataset.
+    load_binding_pocket: Bool, optional
+        Load binding pocket or full protein.
+    subset: Str
+        Specifies which subset of PDBBind, only "core" or "refined" for now.
+    featurizer: Str
+        Either "grid" or "atomic" for grid and atomic featurizations.
+    split: Str
+        Either "random" or "index".
+    split_seed: Int, optional
+        Specifies the random seed for splitter.
+    save_dir: Str, optional
+        Specifies the directory to store the featurized and splitted dataset when
+        reload is False. If reload is True, it will load saved dataset inside save_dir. 
+    save_timestamp: Bool, optional
+        Save featurized and splitted dataset with timestamp or not. Set it as True
+        when running similar or same jobs simultaneously on multiple compute nodes.
+    """
+
   pdbbind_tasks = ["-logKd/Ki"]
 
     deepchem_dir = deepchem.utils.get_data_dir()

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -305,8 +305,11 @@ def load_pdbbind(reload=True,
   # Delete labels for failing elements
   labels = np.delete(labels, failures)
   labels = labels.reshape((len(labels), 1))
-  dataset = deepchem.data.DiskDataset.from_numpy(features, labels)
-  print('Featurization complete.')
+  ids = np.delete(pdbs, failures)
+
+  print("\nConstruct dataset excluding failing featurization elements...")
+  dataset = deepchem.data.DiskDataset.from_numpy(features, y=labels, ids=ids)
+
   # No transformations of data
   transformers = []
 

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -145,7 +145,8 @@ def load_pdbbind(reload=True,
                  featurizer="grid",
                  split="random",
                  split_seed=None,
-                 save_dir=None):
+                 save_dir=None,
+                 save_timestamp=False):
   """Load and featurize raw PDBBind dataset.
   
   Parameters
@@ -175,6 +176,11 @@ def load_pdbbind(reload=True,
     else:
         save_folder = os.path.join(
             save_dir, "full_protein-%s-%s-%s" % (subset, featurizer, split))
+
+    if save_timestamp:
+        save_folder = "%s-%s-%s" % (
+            save_folder, time.strftime("%Y%m%d", time.localtime()),
+            re.search("\.(.*)", str(time.time())).group(1))
 
     if reload:
         if not os.path.exists(save_folder):

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -14,7 +14,6 @@ import time
 import deepchem
 import numpy as np
 import pandas as pd
-import logging
 import tarfile
 from deepchem.feat import rdkit_grid_featurizer as rgf
 from deepchem.feat.atomic_coordinates import ComplexNeighborListFragmentAtomicCoordinates

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -144,6 +144,7 @@ def load_pdbbind(reload=True,
                  load_binding_pocket=False,
                  featurizer="grid",
                  split="random",
+                 split_seed=None,
                  save_dir=None):
   """Load and featurize raw PDBBind dataset.
   
@@ -312,6 +313,9 @@ def load_pdbbind(reload=True,
   print('Featurization complete.')
   # No transformations of data
   transformers = []
+
+    # Split dataset
+    print("\nSplit dataset...\n")
   if split == None:
     return pdbbind_tasks, (dataset, None, None), transformers
 
@@ -322,7 +326,9 @@ def load_pdbbind(reload=True,
       'random': deepchem.splits.RandomSplitter(),
   }
   splitter = splitters[split]
-  train, valid, test = splitter.train_valid_test_split(dataset)
+    train, valid, test = splitter.train_valid_test_split(
+        dataset, seed=split_seed)
+
   all_dataset = (train, valid, test)
   print("\nSaving dataset to \"%s\" ..." % save_folder)
   deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,


### PR DESCRIPTION
**This includes several commits for different purposes.**

### 1. fix bug that PDB files do not match with labels

The old code use `INDEX_core_name.2013` for extracting PDB IDs of complexes and `INDEX_core_data.2013` for binding data(labels). The problems is that the order of records in these two index files are different. Features and labels form the dataset in order so it causes that features from PDB files do not match with labels in the dataset.

I use `INDEX_core_data.2013` for extracting both PDB IDs of complexes and labels in **commit 
218c7b3** to fix the bug.

### 2. logical problems of reloading and saving featurized and splitted dataset

In old codes, `save_dataset_to_disk()` will only work when `reload` is `Ture`. But if so, `load_pdbbind()` will load saved dataset in disk and retuern datasets before `save_dataset_to_disk()`.

I separate codes for reloading and saving dataset in  **commit 4ac2910**. Users can also specify the directories for storing raw dataset and processed dataset.

### 3. add timestamp parameter for parallel computing

I run multiple jobs of training ACNN model with PDBbind dataset. I saw the error which said `pickle data was truncated` when the script tried to save dataset to disk. It was because parallel jobs wrote data to the same pickle file.

I use the timestamp as suffix of floder names for saving dataset. Add this parameter in **commit 0de2398**.

### 4. some slight modifications

- remove line 17 that is duplicated with line 8 of the old code (commit 79441c4)
- add explicit random seed parameter for conveniently using splitter (commit 47e3d28)
- use PDB ID of complexes as IDs in dataset instead of numbers in the old codes for conveniently debugging (commit ac94dca)
- merge duplicated codes for building `atomic` and `atomic_conv` featurizers (commit b39a589)
- modify function description (commit de0ef76)

This comment is too long indeed. Please review codes and give some feedback, thanks!