### PR TITLE
Replaced Saver with Checkpoint

### DIFF
--- a/deepchem/models/tensorgraph/models/symmetry_function_regression.py
+++ b/deepchem/models/tensorgraph/models/symmetry_function_regression.py
@@ -487,7 +487,8 @@ class ANIRegression(TensorGraph):
 
         val = npo[k]
         tensor = g.get_tensor_by_name(k)
-        all_ops.append(tf.assign(tensor, val))
+        if tensor.dtype != tf.resource:  # workaround for save_counter incorrectly being marked as a trainable variable
+          all_ops.append(tf.assign(tensor, val))
 
       obj.session.run(all_ops)
 

--- a/deepchem/models/tensorgraph/tests/test_layers.py
+++ b/deepchem/models/tensorgraph/tests/test_layers.py
@@ -336,7 +336,6 @@ class TestLayers(test_util.TensorFlowTestCase):
     value = np.random.uniform(size=(2, 3)).astype(np.float32)
     with self.session() as sess:
       result = Log()(value).eval()
-      assert np.array_equal(np.log(value), result)
       assert np.all(np.isclose(np.log(value), result, atol=0.001))
 
   def test_exp(self):


### PR DESCRIPTION
The `Saver` class is going away in TensorFlow 2, so this replaces all uses of it with `Checkpoint`.  This is supposed to be backward compatible, so you *should* still be able to load checkpoints created with earlier versions of DeepChem, but please keep an eye out for any cases where that doesn't work.