### PR TITLE
Convert TensorGraph layers to Keras layers

### DIFF
--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -1,0 +1,1589 @@
+import tensorflow as tf
+import numpy as np
+import collections
+from deepchem.models.tensorgraph import model_ops, initializations, activations
+
+class InteratomicL2Distances(tf.keras.layers.Layer):
+  """Compute (squared) L2 Distances between atoms given neighbors."""
+
+  def __init__(self, N_atoms, M_nbrs, ndim, **kwargs):
+    super(InteratomicL2Distances, self).__init__(**kwargs)
+    self.N_atoms = N_atoms
+    self.M_nbrs = M_nbrs
+    self.ndim = ndim
+
+  def call(self, inputs):
+    if len(inputs) != 2:
+      raise ValueError("InteratomicDistances requires coords,nbr_list")
+    coords, nbr_list = (inputs[0], inputs[1])
+    N_atoms, M_nbrs, ndim = self.N_atoms, self.M_nbrs, self.ndim
+    # Shape (N_atoms, M_nbrs, ndim)
+    nbr_coords = tf.gather(coords, nbr_list)
+    # Shape (N_atoms, M_nbrs, ndim)
+    tiled_coords = tf.tile(
+        tf.reshape(coords, (N_atoms, 1, ndim)), (1, M_nbrs, 1))
+    # Shape (N_atoms, M_nbrs)
+    return tf.reduce_sum((tiled_coords - nbr_coords)**2, axis=2)
+
+class GraphConv(tf.keras.layers.Layer):
+
+  def __init__(self,
+               out_channel,
+               min_deg=0,
+               max_deg=10,
+               activation_fn=None,
+               **kwargs):
+    super(GraphConv, self).__init__(**kwargs)
+    self.out_channel = out_channel
+    self.min_degree = min_deg
+    self.max_degree = max_deg
+    self.activation_fn = activation_fn
+
+  def build(self, input_shape):
+    # Generate the nb_affine weights and biases
+    num_deg = 2 * self.max_degree + (1 - self.min_degree)
+    self.W_list = [
+        self.add_weight(name='kernel', shape=(int(input_shape[0][-1]), self.out_channel), initializer='glorot_uniform', trainable=True)
+        for k in range(num_deg)
+    ]
+    self.b_list = [
+        self.add_weight(name='bias', shape=(self.out_channel,), initializer='zeros', trainable=True)
+        for k in range(num_deg)
+    ]
+
+  def call(self, inputs):
+
+    # Extract atom_features
+    atom_features = inputs[0]
+
+    # Extract graph topology
+    deg_slice = inputs[1]
+    deg_adj_lists = inputs[3:]
+
+    W = iter(self.W_list)
+    b = iter(self.b_list)
+
+    # Sum all neighbors using adjacency matrix
+    deg_summed = self.sum_neigh(atom_features, deg_adj_lists)
+
+    # Get collection of modified atom features
+    new_rel_atoms_collection = (self.max_degree + 1 - self.min_degree) * [None]
+
+    for deg in range(1, self.max_degree + 1):
+      # Obtain relevant atoms for this degree
+      rel_atoms = deg_summed[deg - 1]
+
+      # Get self atoms
+      begin = tf.stack([deg_slice[deg - self.min_degree, 0], 0])
+      size = tf.stack([deg_slice[deg - self.min_degree, 1], -1])
+      self_atoms = tf.slice(atom_features, begin, size)
+
+      # Apply hidden affine to relevant atoms and append
+      rel_out = tf.matmul(rel_atoms, next(W)) + next(b)
+      self_out = tf.matmul(self_atoms, next(W)) + next(b)
+      out = rel_out + self_out
+
+      new_rel_atoms_collection[deg - self.min_degree] = out
+
+    # Determine the min_deg=0 case
+    if self.min_degree == 0:
+      deg = 0
+
+      begin = tf.stack([deg_slice[deg - self.min_degree, 0], 0])
+      size = tf.stack([deg_slice[deg - self.min_degree, 1], -1])
+      self_atoms = tf.slice(atom_features, begin, size)
+
+      # Only use the self layer
+      out = tf.matmul(self_atoms, next(W)) + next(b)
+
+      new_rel_atoms_collection[deg - self.min_degree] = out
+
+    # Combine all atoms back into the list
+    atom_features = tf.concat(axis=0, values=new_rel_atoms_collection)
+
+    if self.activation_fn is not None:
+      atom_features = self.activation_fn(atom_features)
+
+    return atom_features
+
+  def sum_neigh(self, atoms, deg_adj_lists):
+    """Store the summed atoms by degree"""
+    deg_summed = self.max_degree * [None]
+
+    # Tensorflow correctly processes empty lists when using concat
+    for deg in range(1, self.max_degree + 1):
+      gathered_atoms = tf.gather(atoms, deg_adj_lists[deg - 1])
+      # Sum along neighbors as well as self, and store
+      summed_atoms = tf.reduce_sum(gathered_atoms, 1)
+      deg_summed[deg - 1] = summed_atoms
+
+    return deg_summed
+
+
+class GraphPool(tf.keras.layers.Layer):
+
+  def __init__(self, min_degree=0, max_degree=10, **kwargs):
+    super(GraphPool, self).__init__(**kwargs)
+    self.min_degree = min_degree
+    self.max_degree = max_degree
+
+  def call(self, inputs):
+    atom_features = inputs[0]
+    deg_slice = inputs[1]
+    deg_adj_lists = inputs[3:]
+
+    # Perform the mol gather
+    # atom_features = graph_pool(atom_features, deg_adj_lists, deg_slice,
+    #                            self.max_degree, self.min_degree)
+
+    deg_maxed = (self.max_degree + 1 - self.min_degree) * [None]
+
+    # Tensorflow correctly processes empty lists when using concat
+
+    for deg in range(1, self.max_degree + 1):
+      # Get self atoms
+      begin = tf.stack([deg_slice[deg - self.min_degree, 0], 0])
+      size = tf.stack([deg_slice[deg - self.min_degree, 1], -1])
+      self_atoms = tf.slice(atom_features, begin, size)
+
+      # Expand dims
+      self_atoms = tf.expand_dims(self_atoms, 1)
+
+      # always deg-1 for deg_adj_lists
+      gathered_atoms = tf.gather(atom_features, deg_adj_lists[deg - 1])
+      gathered_atoms = tf.concat(axis=1, values=[self_atoms, gathered_atoms])
+
+      maxed_atoms = tf.reduce_max(gathered_atoms, 1)
+      deg_maxed[deg - self.min_degree] = maxed_atoms
+
+    if self.min_degree == 0:
+      begin = tf.stack([deg_slice[0, 0], 0])
+      size = tf.stack([deg_slice[0, 1], -1])
+      self_atoms = tf.slice(atom_features, begin, size)
+      deg_maxed[0] = self_atoms
+
+    return tf.concat(axis=0, values=deg_maxed)
+
+
+class GraphGather(tf.keras.layers.Layer):
+
+  def __init__(self, batch_size, activation_fn=None, **kwargs):
+    super(GraphGather, self).__init__(**kwargs)
+    self.batch_size = batch_size
+    self.activation_fn = activation_fn
+
+  def call(self, inputs):
+    # x = [atom_features, deg_slice, membership, deg_adj_list placeholders...]
+    atom_features = inputs[0]
+
+    # Extract graph topology
+    membership = inputs[2]
+
+    assert self.batch_size > 1, "graph_gather requires batches larger than 1"
+
+    sparse_reps = tf.unsorted_segment_sum(atom_features, membership,
+                                          self.batch_size)
+    max_reps = tf.unsorted_segment_max(atom_features, membership,
+                                       self.batch_size)
+    mol_features = tf.concat(axis=1, values=[sparse_reps, max_reps])
+
+    if self.activation_fn is not None:
+      mol_features = self.activation_fn(mol_features)
+    return mol_features
+
+
+class LSTMStep(tf.keras.layers.Layer):
+  """Layer that performs a single step LSTM update.
+
+  This layer performs a single step LSTM update. Note that it is *not*
+  a full LSTM recurrent network. The LSTMStep layer is useful as a
+  primitive for designing layers such as the AttnLSTMEmbedding or the
+  IterRefLSTMEmbedding below.
+  """
+
+  def __init__(self,
+               output_dim,
+               input_dim,
+               init_fn=initializations.glorot_uniform,
+               inner_init_fn=initializations.orthogonal,
+               activation_fn=activations.tanh,
+               inner_activation_fn=activations.hard_sigmoid,
+               **kwargs):
+    """
+    Parameters
+    ----------
+    output_dim: int
+      Dimensionality of output vectors.
+    input_dim: int
+      Dimensionality of input vectors.
+    init_fn: object
+      TensorFlow initialization to use for W.
+    inner_init_fn: object
+      TensorFlow initialization to use for U.
+    activation_fn: object
+      TensorFlow activation to use for output.
+    inner_activation_fn: object
+      TensorFlow activation to use for inner steps.
+    """
+
+    super(LSTMStep, self).__init__(**kwargs)
+    self.init = init_fn
+    self.inner_init = inner_init_fn
+    self.output_dim = output_dim
+    # No other forget biases supported right now.
+    self.activation = activation_fn
+    self.inner_activation = inner_activation_fn
+    self.input_dim = input_dim
+
+  def get_initial_states(self, input_shape):
+    return [model_ops.zeros(input_shape), model_ops.zeros(input_shape)]
+
+  def build(self, input_shape):
+    """Constructs learnable weights for this layer."""
+    init = self.init
+    inner_init = self.inner_init
+    self.W = init((self.input_dim, 4 * self.output_dim))
+    self.U = inner_init((self.output_dim, 4 * self.output_dim))
+
+    self.b = tf.Variable(
+        np.hstack((np.zeros(self.output_dim), np.ones(self.output_dim),
+                   np.zeros(self.output_dim), np.zeros(self.output_dim))),
+        dtype=tf.float32)
+
+  def call(self, inputs):
+    """Execute this layer on input tensors.
+
+    Parameters
+    ----------
+    inputs: list
+      List of three tensors (x, h_tm1, c_tm1). h_tm1 means "h, t-1".
+
+    Returns
+    -------
+    list
+      Returns h, [h, c]
+    """
+    activation = self.activation
+    inner_activation = self.inner_activation
+    x, h_tm1, c_tm1 = inputs
+
+    # Taken from Keras code [citation needed]
+    z = model_ops.dot(x, self.W) + model_ops.dot(h_tm1, self.U) + self.b
+
+    z0 = z[:, :self.output_dim]
+    z1 = z[:, self.output_dim:2 * self.output_dim]
+    z2 = z[:, 2 * self.output_dim:3 * self.output_dim]
+    z3 = z[:, 3 * self.output_dim:]
+
+    i = inner_activation(z0)
+    f = inner_activation(z1)
+    c = f * c_tm1 + i * activation(z2)
+    o = inner_activation(z3)
+
+    h = o * activation(c)
+    return h, [h, c]
+
+
+def _cosine_dist(x, y):
+  """Computes the inner product (cosine distance) between two tensors.
+
+  Parameters
+  ----------
+  x: tf.Tensor
+    Input Tensor
+  y: tf.Tensor
+    Input Tensor
+  """
+  denom = (
+      model_ops.sqrt(model_ops.sum(tf.square(x)) * model_ops.sum(tf.square(y)))
+      + model_ops.epsilon())
+  return model_ops.dot(x, tf.transpose(y)) / denom
+
+
+class AttnLSTMEmbedding(tf.keras.layers.Layer):
+  """Implements AttnLSTM as in matching networks paper.
+
+  The AttnLSTM embedding adjusts two sets of vectors, the "test" and
+  "support" sets. The "support" consists of a set of evidence vectors.
+  Think of these as the small training set for low-data machine
+  learning.  The "test" consists of the queries we wish to answer with
+  the small amounts ofavailable data. The AttnLSTMEmbdding allows us to
+  modify the embedding of the "test" set depending on the contents of
+  the "support".  The AttnLSTMEmbedding is thus a type of learnable
+  metric that allows a network to modify its internal notion of
+  distance.
+
+  References:
+  Matching Networks for One Shot Learning
+  https://arxiv.org/pdf/1606.04080v1.pdf
+
+  Order Matters: Sequence to sequence for sets
+  https://arxiv.org/abs/1511.06391
+  """
+
+  def __init__(self, n_test, n_support, n_feat, max_depth, **kwargs):
+    """
+    Parameters
+    ----------
+    n_support: int
+      Size of support set.
+    n_test: int
+      Size of test set.
+    n_feat: int
+      Number of features per atom
+    max_depth: int
+      Number of "processing steps" used by sequence-to-sequence for sets model.
+    """
+    super(AttnLSTMEmbedding, self).__init__(**kwargs)
+
+    self.max_depth = max_depth
+    self.n_test = n_test
+    self.n_support = n_support
+    self.n_feat = n_feat
+
+  def build(self, input_shape):
+    n_feat = self.n_feat
+    self.lstm = LSTMStep(n_feat, 2 * n_feat)
+    self.q_init = model_ops.zeros([self.n_test, n_feat])
+    self.states_init = self.lstm.get_initial_states([self.n_test, n_feat])
+
+  def call(self, inputs):
+    """Execute this layer on input tensors.
+
+    Parameters
+    ----------
+    inputs: list
+      List of two tensors (X, Xp). X should be of shape (n_test,
+      n_feat) and Xp should be of shape (n_support, n_feat) where
+      n_test is the size of the test set, n_support that of the support
+      set, and n_feat is the number of per-atom features.
+
+    Returns
+    -------
+    list
+      Returns two tensors of same shape as input. Namely the output
+      shape will be [(n_test, n_feat), (n_support, n_feat)]
+    """
+    if len(inputs) != 2:
+      raise ValueError("AttnLSTMEmbedding layer must have exactly two parents")
+    # x is test set, xp is support set.
+    x, xp = inputs
+
+    # Get initializations
+    q = self.q_init
+    states = self.states_init
+
+    for d in range(self.max_depth):
+      # Process using attention
+      # Eqn (4), appendix A.1 of Matching Networks paper
+      e = _cosine_dist(x + q, xp)
+      a = tf.nn.softmax(e)
+      r = model_ops.dot(a, xp)
+
+      # Generate new attention states
+      y = model_ops.concatenate([q, r], axis=1)
+      q, states = self.lstm([y]+states)
+    return [x + q, xp]
+
+
+class IterRefLSTMEmbedding(tf.keras.layers.Layer):
+  """Implements the Iterative Refinement LSTM.
+
+  Much like AttnLSTMEmbedding, the IterRefLSTMEmbedding is another type
+  of learnable metric which adjusts "test" and "support." Recall that
+  "support" is the small amount of data available in a low data machine
+  learning problem, and that "test" is the query. The AttnLSTMEmbedding
+  only modifies the "test" based on the contents of the support.
+  However, the IterRefLSTM modifies both the "support" and "test" based
+  on each other. This allows the learnable metric to be more malleable
+  than that from AttnLSTMEmbeding.
+  """
+
+  def __init__(self, n_test, n_support, n_feat, max_depth, **kwargs):
+    """
+    Unlike the AttnLSTM model which only modifies the test vectors
+    additively, this model allows for an additive update to be
+    performed to both test and support using information from each
+    other.
+
+    Parameters
+    ----------
+    n_support: int
+      Size of support set.
+    n_test: int
+      Size of test set.
+    n_feat: int
+      Number of input atom features
+    max_depth: int
+      Number of LSTM Embedding layers.
+    """
+    super(IterRefLSTMEmbedding, self).__init__(**kwargs)
+    self.max_depth = max_depth
+    self.n_test = n_test
+    self.n_support = n_support
+    self.n_feat = n_feat
+
+  def build(self, input_shape):
+    n_feat = self.n_feat
+
+    # Support set lstm
+    self.support_lstm = LSTMStep(n_feat, 2 * n_feat)
+    self.q_init = model_ops.zeros([self.n_support, n_feat])
+    self.support_states_init = self.support_lstm.get_initial_states(
+        [self.n_support, n_feat])
+
+    # Test lstm
+    self.test_lstm = LSTMStep(n_feat, 2 * n_feat)
+    self.p_init = model_ops.zeros([self.n_test, n_feat])
+    self.test_states_init = self.test_lstm.get_initial_states([self.n_test, n_feat])
+
+  def call(self, inputs):
+    """Execute this layer on input tensors.
+
+    Parameters
+    ----------
+    inputs: list
+      List of two tensors (X, Xp). X should be of shape (n_test, n_feat) and
+      Xp should be of shape (n_support, n_feat) where n_test is the size of
+      the test set, n_support that of the support set, and n_feat is the number
+      of per-atom features.
+
+    Returns
+    -------
+    list
+      Returns two tensors of same shape as input. Namely the output shape will
+      be [(n_test, n_feat), (n_support, n_feat)]
+    """
+    if len(inputs) != 2:
+      raise ValueError(
+          "IterRefLSTMEmbedding layer must have exactly two parents")
+    x, xp = inputs
+
+    # Get initializations
+    p = self.p_init
+    q = self.q_init
+    # Rename support
+    z = xp
+    states = self.support_states_init
+    x_states = self.test_states_init
+
+    for d in range(self.max_depth):
+      # Process support xp using attention
+      e = _cosine_dist(z + q, xp)
+      a = tf.nn.softmax(e)
+      # Get linear combination of support set
+      r = model_ops.dot(a, xp)
+
+      # Process test x using attention
+      x_e = _cosine_dist(x + p, z)
+      x_a = tf.nn.softmax(x_e)
+      s = model_ops.dot(x_a, z)
+
+      # Generate new support attention states
+      qr = model_ops.concatenate([q, r], axis=1)
+      q, states = self.support_lstm([qr]+states)
+
+      # Generate new test attention states
+      ps = model_ops.concatenate([p, s], axis=1)
+      p, x_states = self.test_lstm([ps]+x_states)
+
+      # Redefine
+      z = r
+
+    return [x + p, xp + q]
+
+
+class WeightedLinearCombo(tf.keras.layers.Layer):
+  """Computes a weighted linear combination of input layers, with the weights defined by trainable variables."""
+
+  def __init__(self, std=0.3, **kwargs):
+    super(WeightedLinearCombo, self).__init__(**kwargs)
+    self.std = std
+
+  def build(self, input_shape):
+    init = tf.keras.initializers.RandomNormal(stddev=self.std)
+    self.input_weights = [
+        self.add_weight('weight_%d' % (i+1), (1,), initializer=init, trainable=True)
+        for i in range(len(input_shape))
+    ]
+
+  def call(self, inputs):
+    out_tensor = None
+    for in_tensor, w in zip(inputs, self.input_weights):
+      if out_tensor is None:
+        out_tensor = w * in_tensor
+      else:
+        out_tensor += w * in_tensor
+    return out_tensor
+
+
+class VinaFreeEnergy(tf.keras.layers.Layer):
+  """Computes free-energy as defined by Autodock Vina.
+
+  TODO(rbharath): Make this layer support batching.
+  """
+
+  def __init__(self,
+               N_atoms,
+               M_nbrs,
+               ndim,
+               nbr_cutoff,
+               start,
+               stop,
+               stddev=.3,
+               Nrot=1,
+               **kwargs):
+    super(VinaFreeEnergy, self).__init__(**kwargs)
+    self.stddev = stddev
+    # Number of rotatable bonds
+    # TODO(rbharath): Vina actually sets this per-molecule. See if makes
+    # a difference.
+    self.Nrot = Nrot
+    self.N_atoms = N_atoms
+    self.M_nbrs = M_nbrs
+    self.ndim = ndim
+    self.nbr_cutoff = nbr_cutoff
+    self.start = start
+    self.stop = stop
+
+  def build(self, input_shape):
+    self.weighted_combo = WeightedLinearCombo()
+    self.w = tf.Variable(tf.random_normal((1,), stddev=self.stddev))
+
+  def cutoff(self, d, x):
+    out_tensor = tf.where(d < 8, x, tf.zeros_like(x))
+    return out_tensor
+
+  def nonlinearity(self, c, w):
+    """Computes non-linearity used in Vina."""
+    out_tensor = c / (1 + w * self.Nrot)
+    return w, out_tensor
+
+  def repulsion(self, d):
+    """Computes Autodock Vina's repulsion interaction term."""
+    out_tensor = tf.where(d < 0, d**2, tf.zeros_like(d))
+    return out_tensor
+
+  def hydrophobic(self, d):
+    """Computes Autodock Vina's hydrophobic interaction term."""
+    out_tensor = tf.where(d < 0.5, tf.ones_like(d),
+                          tf.where(d < 1.5, 1.5 - d, tf.zeros_like(d)))
+    return out_tensor
+
+  def hydrogen_bond(self, d):
+    """Computes Autodock Vina's hydrogen bond interaction term."""
+    out_tensor = tf.where(
+        d < -0.7, tf.ones_like(d),
+        tf.where(d < 0, (1.0 / 0.7) * (0 - d), tf.zeros_like(d)))
+    return out_tensor
+
+  def gaussian_first(self, d):
+    """Computes Autodock Vina's first Gaussian interaction term."""
+    out_tensor = tf.exp(-(d / 0.5)**2)
+    return out_tensor
+
+  def gaussian_second(self, d):
+    """Computes Autodock Vina's second Gaussian interaction term."""
+    out_tensor = tf.exp(-((d - 3) / 2)**2)
+    return out_tensor
+
+  def call(self, inputs):
+    """
+    Parameters
+    ----------
+    X: tf.Tensor of shape (N, d)
+      Coordinates/features.
+    Z: tf.Tensor of shape (N)
+      Atomic numbers of neighbor atoms.
+
+    Returns
+    -------
+    layer: tf.Tensor of shape (B)
+      The free energy of each complex in batch
+    """
+    X = inputs[0]
+    Z = inputs[1]
+
+    # TODO(rbharath): This layer shouldn't be neighbor-listing. Make
+    # neighbors lists an argument instead of a part of this layer.
+    nbr_list = NeighborList(self.N_atoms, self.M_nbrs, self.ndim,
+                            self.nbr_cutoff, self.start, self.stop)(X)
+
+    # Shape (N, M)
+    dists = InteratomicL2Distances(self.N_atoms, self.M_nbrs,
+                                   self.ndim)([X, nbr_list])
+
+    repulsion = self.repulsion(dists)
+    hydrophobic = self.hydrophobic(dists)
+    hbond = self.hydrogen_bond(dists)
+    gauss_1 = self.gaussian_first(dists)
+    gauss_2 = self.gaussian_second(dists)
+
+    # Shape (N, M)
+    interactions = self.weighted_combo([repulsion, hydrophobic, hbond, gauss_1,
+                                  gauss_2])
+
+    # Shape (N, M)
+    thresholded = self.cutoff(dists, interactions)
+
+    weight, free_energies = self.nonlinearity(thresholded, self.w)
+    return tf.reduce_sum(free_energies)
+
+
+class NeighborList(tf.keras.layers.Layer):
+  """Computes a neighbor-list in Tensorflow.
+
+  Neighbor-lists (also called Verlet Lists) are a tool for grouping atoms which
+  are close to each other spatially
+
+  TODO(rbharath): Make this layer support batching.
+  """
+
+  def __init__(self, N_atoms, M_nbrs, ndim, nbr_cutoff, start, stop, **kwargs):
+    """
+    Parameters
+    ----------
+    N_atoms: int
+      Maximum number of atoms this layer will neighbor-list.
+    M_nbrs: int
+      Maximum number of spatial neighbors possible for atom.
+    ndim: int
+      Dimensionality of space atoms live in. (Typically 3D, but sometimes will
+      want to use higher dimensional descriptors for atoms).
+    nbr_cutoff: float
+      Length in Angstroms (?) at which atom boxes are gridded.
+    """
+    super(NeighborList, self).__init__(**kwargs)
+    self.N_atoms = N_atoms
+    self.M_nbrs = M_nbrs
+    self.ndim = ndim
+    # Number of grid cells
+    n_cells = int(((stop - start) / nbr_cutoff)**ndim)
+    self.n_cells = n_cells
+    self.nbr_cutoff = nbr_cutoff
+    self.start = start
+    self.stop = stop
+
+  def call(self, inputs):
+    if isinstance(inputs, collections.Sequence):
+      if len(inputs) != 1:
+        raise ValueError("NeighborList can only have one input")
+      inputs = inputs[0]
+    if len(inputs.get_shape()) != 2:
+      # TODO(rbharath): Support batching
+      raise ValueError("Parent tensor must be (num_atoms, ndum)")
+    return self.compute_nbr_list(inputs)
+
+  def compute_nbr_list(self, coords):
+    """Get closest neighbors for atoms.
+
+    Needs to handle padding for atoms with no neighbors.
+
+    Parameters
+    ----------
+    coords: tf.Tensor
+      Shape (N_atoms, ndim)
+
+    Returns
+    -------
+    nbr_list: tf.Tensor
+      Shape (N_atoms, M_nbrs) of atom indices
+    """
+    # Shape (n_cells, ndim)
+    cells = self.get_cells()
+
+    # List of length N_atoms, each element of different length uniques_i
+    nbrs = self.get_atoms_in_nbrs(coords, cells)
+    padding = tf.fill((self.M_nbrs,), -1)
+    padded_nbrs = [tf.concat([unique_nbrs, padding], 0) for unique_nbrs in nbrs]
+
+    # List of length N_atoms, each element of different length uniques_i
+    # List of length N_atoms, each a tensor of shape
+    # (uniques_i, ndim)
+    nbr_coords = [tf.gather(coords, atom_nbrs) for atom_nbrs in nbrs]
+
+    # Add phantom atoms that exist far outside the box
+    coord_padding = tf.cast(
+        tf.fill((self.M_nbrs, self.ndim), 2 * self.stop), tf.float32)
+    padded_nbr_coords = [
+        tf.concat([nbr_coord, coord_padding], 0) for nbr_coord in nbr_coords
+    ]
+
+    # List of length N_atoms, each of shape (1, ndim)
+    atom_coords = tf.split(coords, self.N_atoms)
+    # TODO(rbharath): How does distance need to be modified here to
+    # account for periodic boundary conditions?
+    # List of length N_atoms each of shape (M_nbrs)
+    padded_dists = [
+        tf.reduce_sum((atom_coord - padded_nbr_coord)**2, axis=1)
+        for (atom_coord,
+             padded_nbr_coord) in zip(atom_coords, padded_nbr_coords)
+    ]
+
+    padded_closest_nbrs = [
+        tf.nn.top_k(-padded_dist, k=self.M_nbrs)[1]
+        for padded_dist in padded_dists
+    ]
+
+    # N_atoms elts of size (M_nbrs,) each
+    padded_neighbor_list = [
+        tf.gather(padded_atom_nbrs, padded_closest_nbr)
+        for (padded_atom_nbrs,
+             padded_closest_nbr) in zip(padded_nbrs, padded_closest_nbrs)
+    ]
+
+    neighbor_list = tf.stack(padded_neighbor_list)
+
+    return neighbor_list
+
+  def get_atoms_in_nbrs(self, coords, cells):
+    """Get the atoms in neighboring cells for each cells.
+
+    Returns
+    -------
+    atoms_in_nbrs = (N_atoms, n_nbr_cells, M_nbrs)
+    """
+    # Shape (N_atoms, 1)
+    cells_for_atoms = self.get_cells_for_atoms(coords, cells)
+
+    # Find M_nbrs atoms closest to each cell
+    # Shape (n_cells, M_nbrs)
+    closest_atoms = self.get_closest_atoms(coords, cells)
+
+    # Associate each cell with its neighbor cells. Assumes periodic boundary
+    # conditions, so does wrapround. O(constant)
+    # Shape (n_cells, n_nbr_cells)
+    neighbor_cells = self.get_neighbor_cells(cells)
+
+    # Shape (N_atoms, n_nbr_cells)
+    neighbor_cells = tf.squeeze(tf.gather(neighbor_cells, cells_for_atoms))
+
+    # Shape (N_atoms, n_nbr_cells, M_nbrs)
+    atoms_in_nbrs = tf.gather(closest_atoms, neighbor_cells)
+
+    # Shape (N_atoms, n_nbr_cells*M_nbrs)
+    atoms_in_nbrs = tf.reshape(atoms_in_nbrs, [self.N_atoms, -1])
+
+    # List of length N_atoms, each element length uniques_i
+    nbrs_per_atom = tf.split(atoms_in_nbrs, self.N_atoms)
+    uniques = [
+        tf.unique(tf.squeeze(atom_nbrs))[0] for atom_nbrs in nbrs_per_atom
+    ]
+
+    # TODO(rbharath): FRAGILE! Uses fact that identity seems to be the first
+    # element removed to remove self from list of neighbors. Need to verify
+    # this holds more broadly or come up with robust alternative.
+    uniques = [unique[1:] for unique in uniques]
+
+    return uniques
+
+  def get_closest_atoms(self, coords, cells):
+    """For each cell, find M_nbrs closest atoms.
+
+    Let N_atoms be the number of atoms.
+
+    Parameters
+    ----------
+    coords: tf.Tensor
+      (N_atoms, ndim) shape.
+    cells: tf.Tensor
+      (n_cells, ndim) shape.
+
+    Returns
+    -------
+    closest_inds: tf.Tensor
+      Of shape (n_cells, M_nbrs)
+    """
+    N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells, self.ndim,
+                                      self.M_nbrs)
+    # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
+    tiled_cells = tf.reshape(
+        tf.tile(cells, (1, N_atoms)), (N_atoms * n_cells, ndim))
+
+    # Shape (N_atoms*n_cells, ndim) after tile
+    tiled_coords = tf.tile(coords, (n_cells, 1))
+
+    # Shape (N_atoms*n_cells)
+    coords_vec = tf.reduce_sum((tiled_coords - tiled_cells)**2, axis=1)
+    # Shape (n_cells, N_atoms)
+    coords_norm = tf.reshape(coords_vec, (n_cells, N_atoms))
+
+    # Find k atoms closest to this cell. Notice negative sign since
+    # tf.nn.top_k returns *largest* not smallest.
+    # Tensor of shape (n_cells, M_nbrs)
+    closest_inds = tf.nn.top_k(-coords_norm, k=M_nbrs)[1]
+
+    return closest_inds
+
+  def get_cells_for_atoms(self, coords, cells):
+    """Compute the cells each atom belongs to.
+
+    Parameters
+    ----------
+    coords: tf.Tensor
+      Shape (N_atoms, ndim)
+    cells: tf.Tensor
+      (n_cells, ndim) shape.
+    Returns
+    -------
+    cells_for_atoms: tf.Tensor
+      Shape (N_atoms, 1)
+    """
+    N_atoms, n_cells, ndim = self.N_atoms, self.n_cells, self.ndim
+    n_cells = int(n_cells)
+    # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
+    tiled_cells = tf.tile(cells, (N_atoms, 1))
+
+    # Shape (N_atoms*n_cells, 1) after tile
+    tiled_coords = tf.reshape(
+        tf.tile(coords, (1, n_cells)), (n_cells * N_atoms, ndim))
+    coords_vec = tf.reduce_sum((tiled_coords - tiled_cells)**2, axis=1)
+    coords_norm = tf.reshape(coords_vec, (N_atoms, n_cells))
+
+    closest_inds = tf.nn.top_k(-coords_norm, k=1)[1]
+    return closest_inds
+
+  def _get_num_nbrs(self):
+    """Get number of neighbors in current dimensionality space."""
+    ndim = self.ndim
+    if ndim == 1:
+      n_nbr_cells = 3
+    elif ndim == 2:
+      # 9 neighbors in 2-space
+      n_nbr_cells = 9
+    # TODO(rbharath): Shoddy handling of higher dimensions...
+    elif ndim >= 3:
+      # Number of cells for cube in 3-space is
+      n_nbr_cells = 27  # (26 faces on Rubik's cube for example)
+    return n_nbr_cells
+
+  def get_neighbor_cells(self, cells):
+    """Compute neighbors of cells in grid.
+
+    # TODO(rbharath): Do we need to handle periodic boundary conditions
+    properly here?
+    # TODO(rbharath): This doesn't handle boundaries well. We hard-code
+    # looking for n_nbr_cells neighbors, which isn't right for boundary cells in
+    # the cube.
+
+    Parameters
+    ----------
+    cells: tf.Tensor
+      (n_cells, ndim) shape.
+    Returns
+    -------
+    nbr_cells: tf.Tensor
+      (n_cells, n_nbr_cells)
+    """
+    ndim, n_cells = self.ndim, self.n_cells
+    n_nbr_cells = self._get_num_nbrs()
+    # Tile cells to form arrays of size (n_cells*n_cells, ndim)
+    # Two tilings (a, b, c, a, b, c, ...) vs. (a, a, a, b, b, b, etc.)
+    # Tile (a, a, a, b, b, b, etc.)
+    tiled_centers = tf.reshape(
+        tf.tile(cells, (1, n_cells)), (n_cells * n_cells, ndim))
+    # Tile (a, b, c, a, b, c, ...)
+    tiled_cells = tf.tile(cells, (n_cells, 1))
+
+    coords_vec = tf.reduce_sum((tiled_centers - tiled_cells)**2, axis=1)
+    coords_norm = tf.reshape(coords_vec, (n_cells, n_cells))
+    closest_inds = tf.nn.top_k(-coords_norm, k=n_nbr_cells)[1]
+
+    return closest_inds
+
+  def get_cells(self):
+    """Returns the locations of all grid points in box.
+
+    Suppose start is -10 Angstrom, stop is 10 Angstrom, nbr_cutoff is 1.
+    Then would return a list of length 20^3 whose entries would be
+    [(-10, -10, -10), (-10, -10, -9), ..., (9, 9, 9)]
+
+    Returns
+    -------
+    cells: tf.Tensor
+      (n_cells, ndim) shape.
+    """
+    start, stop, nbr_cutoff = self.start, self.stop, self.nbr_cutoff
+    mesh_args = [tf.range(start, stop, nbr_cutoff) for _ in range(self.ndim)]
+    return tf.cast(
+        tf.reshape(
+            tf.transpose(tf.stack(tf.meshgrid(*mesh_args))),
+            (self.n_cells, self.ndim)), tf.float32)
+
+
+class AtomicConvolution(tf.keras.layers.Layer):
+
+  def __init__(self,
+               atom_types=None,
+               radial_params=list(),
+               boxsize=None,
+               **kwargs):
+    """Atomic convoluation layer
+
+    N = max_num_atoms, M = max_num_neighbors, B = batch_size, d = num_features
+    l = num_radial_filters * num_atom_types
+
+    Parameters
+    ----------
+    atom_types: list or None
+      Of length a, where a is number of atom types for filtering.
+    radial_params: list
+      Of length l, where l is number of radial filters learned.
+    boxsize: float or None
+      Simulation box length [Angstrom].
+    """
+    super(AtomicConvolution, self).__init__(**kwargs)
+    self.boxsize = boxsize
+    self.radial_params = radial_params
+    self.atom_types = atom_types
+
+  def build(self, input_shape):
+    vars = []
+    for i in range(3):
+      val = np.array([p[i] for p in self.radial_params]).reshape((-1, 1, 1, 1))
+      vars.append(tf.Variable(val, dtype=tf.float32))
+    self.rc = vars[0]
+    self.rs = vars[1]
+    self.re = vars[2]
+
+  def call(self, inputs):
+    """
+    Parameters
+    ----------
+    X: tf.Tensor of shape (B, N, d)
+      Coordinates/features.
+    Nbrs: tf.Tensor of shape (B, N, M)
+      Neighbor list.
+    Nbrs_Z: tf.Tensor of shape (B, N, M)
+      Atomic numbers of neighbor atoms.
+
+    Returns
+    -------
+    layer: tf.Tensor of shape (B, N, l)
+      A new tensor representing the output of the atomic conv layer
+    """
+    X = inputs[0]
+    Nbrs = tf.cast(inputs[1], tf.int32)
+    Nbrs_Z = inputs[2]
+
+    # N: Maximum number of atoms
+    # M: Maximum number of neighbors
+    # d: Number of coordinates/features/filters
+    # B: Batch Size
+    N = X.get_shape()[-2].value
+    d = X.get_shape()[-1].value
+    M = Nbrs.get_shape()[-1].value
+    B = X.get_shape()[0].value
+
+    # Compute the distances and radial symmetry functions.
+    D = self.distance_tensor(X, Nbrs, self.boxsize, B, N, M, d)
+    R = self.distance_matrix(D)
+    R = tf.reshape(R, [1] + R.shape.as_list())
+    rsf = self.radial_symmetry_function(R, self.rc, self.rs, self.re)
+
+    if not self.atom_types:
+      cond = tf.cast(tf.not_equal(Nbrs_Z, 0), tf.float32)
+      cond = tf.reshape(cond, R.shape)
+      layer = tf.reduce_sum(cond * rsf, 3)
+    else:
+      sym = []
+      for j in range(len(self.atom_types)):
+        cond = tf.cast(tf.equal(Nbrs_Z, self.atom_types[j]), tf.float32)
+        cond = tf.reshape(cond, R.shape)
+        sym.append(tf.reduce_sum(cond * rsf, 3))
+      layer = tf.concat(sym, 0)
+
+    layer = tf.transpose(layer, [1, 2, 0])  # (l, B, N) -> (B, N, l)
+    m, v = tf.nn.moments(layer, axes=[0])
+    return tf.nn.batch_normalization(layer, m, v, None, None, 1e-3)
+
+  def radial_symmetry_function(self, R, rc, rs, e):
+    """Calculates radial symmetry function.
+
+    B = batch_size, N = max_num_atoms, M = max_num_neighbors, d = num_filters
+
+    Parameters
+    ----------
+    R: tf.Tensor of shape (B, N, M)
+      Distance matrix.
+    rc: float
+      Interaction cutoff [Angstrom].
+    rs: float
+      Gaussian distance matrix mean.
+    e: float
+      Gaussian distance matrix width.
+
+    Returns
+    -------
+    retval: tf.Tensor of shape (B, N, M)
+      Radial symmetry function (before summation)
+    """
+    K = self.gaussian_distance_matrix(R, rs, e)
+    FC = self.radial_cutoff(R, rc)
+    return tf.multiply(K, FC)
+
+  def radial_cutoff(self, R, rc):
+    """Calculates radial cutoff matrix.
+
+    B = batch_size, N = max_num_atoms, M = max_num_neighbors
+
+    Parameters
+    ----------
+      R [B, N, M]: tf.Tensor
+        Distance matrix.
+      rc: tf.Variable
+        Interaction cutoff [Angstrom].
+
+    Returns
+    -------
+      FC [B, N, M]: tf.Tensor
+        Radial cutoff matrix.
+    """
+    T = 0.5 * (tf.cos(np.pi * R / (rc)) + 1)
+    E = tf.zeros_like(T)
+    cond = tf.less_equal(R, rc)
+    FC = tf.where(cond, T, E)
+    return FC
+
+  def gaussian_distance_matrix(self, R, rs, e):
+    """Calculates gaussian distance matrix.
+
+    B = batch_size, N = max_num_atoms, M = max_num_neighbors
+
+    Parameters
+    ----------
+      R [B, N, M]: tf.Tensor
+        Distance matrix.
+      rs: tf.Variable
+        Gaussian distance matrix mean.
+      e: tf.Variable
+        Gaussian distance matrix width (e = .5/std**2).
+
+    Returns
+    -------
+      retval [B, N, M]: tf.Tensor
+        Gaussian distance matrix.
+    """
+    return tf.exp(-e * (R - rs)**2)
+
+  def distance_tensor(self, X, Nbrs, boxsize, B, N, M, d):
+    """Calculates distance tensor for batch of molecules.
+
+    B = batch_size, N = max_num_atoms, M = max_num_neighbors, d = num_features
+
+    Parameters
+    ----------
+    X: tf.Tensor of shape (B, N, d)
+      Coordinates/features tensor.
+    Nbrs: tf.Tensor of shape (B, N, M)
+      Neighbor list tensor.
+    boxsize: float or None
+      Simulation box length [Angstrom].
+
+    Returns
+    -------
+    D: tf.Tensor of shape (B, N, M, d)
+      Coordinates/features distance tensor.
+    """
+    D = []
+    for coords, neighbors in zip(tf.unstack(X), tf.unstack(Nbrs)):
+      flat_neighbors = tf.reshape(neighbors, [-1])
+      neighbor_coords = tf.gather(coords, flat_neighbors)
+      neighbor_coords = tf.reshape(neighbor_coords, [N, M, d])
+      D.append(neighbor_coords - tf.expand_dims(coords, 1))
+    D = tf.stack(D)
+    if boxsize is not None:
+      boxsize = tf.reshape(boxsize, [1, 1, 1, d])
+      D -= tf.round(D / boxsize) * boxsize
+    return D
+
+  def distance_matrix(self, D):
+    """Calcuates the distance matrix from the distance tensor
+
+    B = batch_size, N = max_num_atoms, M = max_num_neighbors, d = num_features
+
+    Parameters
+    ----------
+    D: tf.Tensor of shape (B, N, M, d)
+      Distance tensor.
+
+    Returns
+    -------
+    R: tf.Tensor of shape (B, N, M)
+       Distance matrix.
+    """
+    R = tf.reduce_sum(tf.multiply(D, D), 3)
+    R = tf.sqrt(R)
+    return R
+
+
+class AlphaShareLayer(tf.keras.layers.Layer):
+  """
+  Part of a sluice network. Adds alpha parameters to control
+  sharing between the main and auxillary tasks
+
+  Factory method AlphaShare should be used for construction
+
+  Parameters
+  ----------
+  in_layers: list of Layers or tensors
+    tensors in list must be the same size and list must include two or more tensors
+
+  Returns
+  -------
+  out_tensor: a tensor with shape [len(in_layers), x, y] where x, y were the original layer dimensions
+  Distance matrix.
+  """
+
+  def __init__(self, **kwargs):
+    super(AlphaShareLayer, self).__init__(**kwargs)
+
+  def build(self, input_shape):
+    n_alphas = 2*len(input_shape)
+    self.alphas = tf.Variable(
+          tf.random_normal([n_alphas, n_alphas]), name='alphas')
+
+  def call(self, inputs):
+    # check that there isnt just one or zero inputs
+    if len(inputs) <= 1:
+      raise ValueError("AlphaShare must have more than one input")
+    self.num_outputs = len(inputs)
+    # create subspaces
+    subspaces = []
+    original_cols = int(inputs[0].get_shape()[-1].value)
+    subspace_size = int(original_cols / 2)
+    for input_tensor in inputs:
+      subspaces.append(tf.reshape(input_tensor[:, :subspace_size], [-1]))
+      subspaces.append(tf.reshape(input_tensor[:, subspace_size:], [-1]))
+    n_alphas = len(subspaces)
+    subspaces = tf.reshape(tf.stack(subspaces), [n_alphas, -1])
+    subspaces = tf.matmul(self.alphas, subspaces)
+
+    # concatenate subspaces, reshape to size of original input, then stack
+    # such that out_tensor has shape (2,?,original_cols)
+    count = 0
+    out_tensors = []
+    tmp_tensor = []
+    for row in range(n_alphas):
+      tmp_tensor.append(tf.reshape(subspaces[row,], [-1, subspace_size]))
+      count += 1
+      if (count == 2):
+        out_tensors.append(tf.concat(tmp_tensor, 1))
+        tmp_tensor = []
+        count = 0
+    return out_tensors
+
+
+class SluiceLoss(tf.keras.layers.Layer):
+  """
+  Calculates the loss in a Sluice Network
+  Every input into an AlphaShare should be used in SluiceLoss
+  """
+
+  def __init__(self, **kwargs):
+    super(SluiceLoss, self).__init__(**kwargs)
+
+  def call(self, inputs):
+    temp = []
+    subspaces = []
+    # creates subspaces the same way it was done in AlphaShare
+    for input_tensor in inputs:
+      subspace_size = int(input_tensor.get_shape()[-1].value / 2)
+      subspaces.append(input_tensor[:, :subspace_size])
+      subspaces.append(input_tensor[:, subspace_size:])
+      product = tf.matmul(tf.transpose(subspaces[0]), subspaces[1])
+      subspaces = []
+      # calculate squared Frobenius norm
+      temp.append(tf.reduce_sum(tf.pow(product, 2)))
+    return tf.reduce_sum(temp)
+
+
+class BetaShare(tf.keras.layers.Layer):
+  """
+  Part of a sluice network. Adds beta params to control which layer
+  outputs are used for prediction
+
+  Parameters
+  ----------
+  in_layers: list of Layers or tensors
+    tensors in list must be the same size and list must include two or more tensors
+
+  Returns
+  -------
+  output_layers: list of Layers or tensors with same size as in_layers
+    Distance matrix.
+  """
+
+  def __init__(self, **kwargs):
+    super(BetaShare, self).__init__(**kwargs)
+
+  def build(self, input_shape):
+    n_betas = len(input_shape)
+    self.betas = tf.Variable(tf.random_normal([1, n_betas]), name='betas')
+
+  def call(self, inputs):
+    """
+    Size of input layers must all be the same
+    """
+    subspaces = []
+    original_cols = int(inputs[0].get_shape()[-1].value)
+    for input_tensor in inputs:
+      subspaces.append(tf.reshape(input_tensor, [-1]))
+    n_betas = len(inputs)
+    subspaces = tf.reshape(tf.stack(subspaces), [n_betas, -1])
+    out_tensor = tf.matmul(self.betas, subspaces)
+    return tf.reshape(out_tensor, [-1, original_cols])
+
+
+class ANIFeat(tf.keras.layers.Layer):
+  """Performs transform from 3D coordinates to ANI symmetry functions
+  """
+
+  def __init__(self,
+               max_atoms=23,
+               radial_cutoff=4.6,
+               angular_cutoff=3.1,
+               radial_length=32,
+               angular_length=8,
+               atom_cases=[1, 6, 7, 8, 16],
+               atomic_number_differentiated=True,
+               coordinates_in_bohr=True,
+               **kwargs):
+    """
+    Only X can be transformed
+    """
+    super(ANIFeat, self).__init__(**kwargs)
+    self.max_atoms = max_atoms
+    self.radial_cutoff = radial_cutoff
+    self.angular_cutoff = angular_cutoff
+    self.radial_length = radial_length
+    self.angular_length = angular_length
+    self.atom_cases = atom_cases
+    self.atomic_number_differentiated = atomic_number_differentiated
+    self.coordinates_in_bohr = coordinates_in_bohr
+
+  def call(self, inputs):
+    """
+    In layers should be of shape dtype tf.float32, (None, self.max_atoms, 4)
+
+    """
+    atom_numbers = tf.cast(inputs[0][:, :, 0], tf.int32)
+    flags = tf.sign(atom_numbers)
+    flags = tf.cast(
+        tf.expand_dims(flags, 1) * tf.expand_dims(flags, 2), tf.float32)
+    coordinates = inputs[0][:, :, 1:]
+    if self.coordinates_in_bohr:
+      coordinates = coordinates * 0.52917721092
+
+    d = self.distance_matrix(coordinates, flags)
+
+    d_radial_cutoff = self.distance_cutoff(d, self.radial_cutoff, flags)
+    d_angular_cutoff = self.distance_cutoff(d, self.angular_cutoff, flags)
+
+    radial_sym = self.radial_symmetry(d_radial_cutoff, d, atom_numbers)
+    angular_sym = self.angular_symmetry(d_angular_cutoff, d, atom_numbers,
+                                        coordinates)
+    return tf.concat(
+        [
+            tf.cast(tf.expand_dims(atom_numbers, 2), tf.float32), radial_sym,
+            angular_sym
+        ],
+        axis=2)
+
+  def distance_matrix(self, coordinates, flags):
+    """ Generate distance matrix """
+    # (TODO YTZ:) faster, less memory intensive way
+    # r = tf.reduce_sum(tf.square(coordinates), 2)
+    # r = tf.expand_dims(r, -1)
+    # inner = 2*tf.matmul(coordinates, tf.transpose(coordinates, perm=[0,2,1]))
+    # # inner = 2*tf.matmul(coordinates, coordinates, transpose_b=True)
+
+    # d = r - inner + tf.transpose(r, perm=[0,2,1])
+    # d = tf.nn.relu(d) # fix numerical instabilities about diagonal
+    # d = tf.sqrt(d) # does this have negative elements? may be unstable for diagonals
+
+    max_atoms = self.max_atoms
+    tensor1 = tf.stack([coordinates] * max_atoms, axis=1)
+    tensor2 = tf.stack([coordinates] * max_atoms, axis=2)
+
+    # Calculate pairwise distance
+    d = tf.sqrt(
+        tf.reduce_sum(tf.squared_difference(tensor1, tensor2), axis=3) + 1e-7)
+
+    d = d * flags
+    return d
+
+  def distance_cutoff(self, d, cutoff, flags):
+    """ Generate distance matrix with trainable cutoff """
+    # Cutoff with threshold Rc
+    d_flag = flags * tf.sign(cutoff - d)
+    d_flag = tf.nn.relu(d_flag)
+    d_flag = d_flag * tf.expand_dims((1 - tf.eye(self.max_atoms)), 0)
+    d = 0.5 * (tf.cos(np.pi * d / cutoff) + 1)
+    return d * d_flag
+    # return d
+
+  def radial_symmetry(self, d_cutoff, d, atom_numbers):
+    """ Radial Symmetry Function """
+    embedding = tf.eye(np.max(self.atom_cases) + 1)
+    atom_numbers_embedded = tf.nn.embedding_lookup(embedding, atom_numbers)
+
+    Rs = np.linspace(0., self.radial_cutoff, self.radial_length)
+    ita = np.ones_like(Rs) * 3 / (Rs[1] - Rs[0])**2
+    Rs = tf.cast(np.reshape(Rs, (1, 1, 1, -1)), tf.float32)
+    ita = tf.cast(np.reshape(ita, (1, 1, 1, -1)), tf.float32)
+    length = ita.get_shape().as_list()[-1]
+
+    d_cutoff = tf.stack([d_cutoff] * length, axis=3)
+    d = tf.stack([d] * length, axis=3)
+
+    out = tf.exp(-ita * tf.square(d - Rs)) * d_cutoff
+    if self.atomic_number_differentiated:
+      out_tensors = []
+      for atom_type in self.atom_cases:
+        selected_atoms = tf.expand_dims(
+            tf.expand_dims(atom_numbers_embedded[:, :, atom_type], axis=1),
+            axis=3)
+        out_tensors.append(tf.reduce_sum(out * selected_atoms, axis=2))
+      return tf.concat(out_tensors, axis=2)
+    else:
+      return tf.reduce_sum(out, axis=2)
+
+  def angular_symmetry(self, d_cutoff, d, atom_numbers, coordinates):
+    """ Angular Symmetry Function """
+
+    max_atoms = self.max_atoms
+    embedding = tf.eye(np.max(self.atom_cases) + 1)
+    atom_numbers_embedded = tf.nn.embedding_lookup(embedding, atom_numbers)
+
+    Rs = np.linspace(0., self.angular_cutoff, self.angular_length)
+    ita = 3 / (Rs[1] - Rs[0])**2
+    thetas = np.linspace(0., np.pi, self.angular_length)
+    zeta = float(self.angular_length**2)
+
+    ita, zeta, Rs, thetas = np.meshgrid(ita, zeta, Rs, thetas)
+    zeta = tf.cast(np.reshape(zeta, (1, 1, 1, 1, -1)), tf.float32)
+    ita = tf.cast(np.reshape(ita, (1, 1, 1, 1, -1)), tf.float32)
+    Rs = tf.cast(np.reshape(Rs, (1, 1, 1, 1, -1)), tf.float32)
+    thetas = tf.cast(np.reshape(thetas, (1, 1, 1, 1, -1)), tf.float32)
+    length = zeta.get_shape().as_list()[-1]
+
+    # tf.stack issues again...
+    vector_distances = tf.stack([coordinates] * max_atoms, 1) - tf.stack(
+        [coordinates] * max_atoms, 2)
+    R_ij = tf.stack([d] * max_atoms, axis=3)
+    R_ik = tf.stack([d] * max_atoms, axis=2)
+    f_R_ij = tf.stack([d_cutoff] * max_atoms, axis=3)
+    f_R_ik = tf.stack([d_cutoff] * max_atoms, axis=2)
+
+    # Define angle theta = arccos(R_ij(Vector) dot R_ik(Vector)/R_ij(distance)/R_ik(distance))
+    vector_mul = tf.reduce_sum(tf.stack([vector_distances] * max_atoms, axis=3) * \
+                               tf.stack([vector_distances] * max_atoms, axis=2), axis=4)
+    vector_mul = vector_mul * tf.sign(f_R_ij) * tf.sign(f_R_ik)
+    theta = tf.acos(tf.math.divide(vector_mul, R_ij * R_ik + 1e-5))
+
+    R_ij = tf.stack([R_ij] * length, axis=4)
+    R_ik = tf.stack([R_ik] * length, axis=4)
+    f_R_ij = tf.stack([f_R_ij] * length, axis=4)
+    f_R_ik = tf.stack([f_R_ik] * length, axis=4)
+    theta = tf.stack([theta] * length, axis=4)
+
+    out_tensor = tf.pow((1. + tf.cos(theta - thetas)) / 2., zeta) * \
+                 tf.exp(-ita * tf.square((R_ij + R_ik) / 2. - Rs)) * f_R_ij * f_R_ik * 2
+
+    if self.atomic_number_differentiated:
+      out_tensors = []
+      for id_j, atom_type_j in enumerate(self.atom_cases):
+        for atom_type_k in self.atom_cases[id_j:]:
+          selected_atoms = tf.stack([atom_numbers_embedded[:, :, atom_type_j]] * max_atoms, axis=2) * \
+                           tf.stack([atom_numbers_embedded[:, :, atom_type_k]] * max_atoms, axis=1)
+          selected_atoms = tf.expand_dims(
+              tf.expand_dims(selected_atoms, axis=1), axis=4)
+          out_tensors.append(
+              tf.reduce_sum(out_tensor * selected_atoms, axis=(2, 3)))
+      return tf.concat(out_tensors, axis=2)
+    else:
+      return tf.reduce_sum(out_tensor, axis=(2, 3))
+
+  def get_num_feats(self):
+    n_feat = self.outputs.get_shape().as_list()[-1]
+    return n_feat
+
+
+class GraphEmbedPoolLayer(tf.keras.layers.Layer):
+  """
+  GraphCNNPool Layer from Robust Spatial Filtering with Graph Convolutional Neural Networks
+  https://arxiv.org/abs/1703.00792
+
+  This is a learnable pool operation
+  It constructs a new adjacency matrix for a graph of specified number of nodes.
+
+  This differs from our other pool opertions which set vertices to a function value
+  without altering the adjacency matrix.
+
+  $V_{emb} = SpatialGraphCNN({V_{in}})$\\
+  $V_{out} = \sigma(V_{emb})^{T} * V_{in}$
+  $A_{out} = V_{emb}^{T} * A_{in} * V_{emb}$
+
+  """
+
+  def __init__(self, num_vertices, **kwargs):
+    self.num_vertices = num_vertices
+    super(GraphEmbedPoolLayer, self).__init__(**kwargs)
+
+  def build(self, input_shape):
+    no_features = int(input_shape[0][-1])
+    self.W = tf.Variable(
+        tf.truncated_normal(
+            [no_features, self.num_vertices], stddev=1.0 / np.sqrt(no_features)),
+        name='weights',
+        dtype=tf.float32)
+    self.b = tf.Variable(tf.constant(0.1), name='bias', dtype=tf.float32)
+
+  def call(self, inputs):
+    """
+    Parameters
+    ----------
+    num_filters: int
+      Number of filters to have in the output
+
+    in_layers: list of Layers or tensors
+      [V, A, mask]
+      V are the vertex features must be of shape (batch, vertex, channel)
+
+      A are the adjacency matrixes for each graph
+        Shape (batch, from_vertex, adj_matrix, to_vertex)
+
+      mask is optional, to be used when not every graph has the
+      same number of vertices
+
+    Returns: tf.tensor
+    Returns a tf.tensor with a graph convolution applied
+    The shape will be (batch, vertex, self.num_filters)
+    """
+    if len(inputs) == 3:
+      V, A, mask = inputs
+    else:
+      V, A = inputs
+      mask = None
+    factors = self.embedding_factors(V)
+
+    if mask is not None:
+      factors = tf.multiply(factors, mask)
+    factors = self.softmax_factors(factors)
+
+    result = tf.matmul(factors, V, transpose_a=True)
+
+    result_A = tf.reshape(A, (tf.shape(A)[0], -1, tf.shape(A)[-1]))
+    result_A = tf.matmul(result_A, factors)
+    result_A = tf.reshape(result_A, (tf.shape(A)[0], tf.shape(A)[-1], -1))
+    result_A = tf.matmul(factors, result_A, transpose_a=True)
+    result_A = tf.reshape(result_A, (tf.shape(A)[0], self.num_vertices,
+                                     A.get_shape()[2].value, self.num_vertices))
+    return result, result_A
+
+  def embedding_factors(self, V):
+    no_features = V.get_shape()[-1].value
+    V_reshape = tf.reshape(V, (-1, no_features))
+    s = tf.slice(tf.shape(V), [0], [len(V.get_shape()) - 1])
+    s = tf.concat([s, tf.stack([self.num_vertices])], 0)
+    result = tf.reshape(tf.matmul(V_reshape, self.W) + self.b, s)
+    return result
+
+  def softmax_factors(self, V, axis=1):
+    max_value = tf.reduce_max(V, axis=axis, keepdims=True)
+    exp = tf.exp(tf.subtract(V, max_value))
+    prob = tf.math.divide(exp, tf.reduce_sum(exp, axis=axis, keepdims=True))
+    return prob
+
+
+class GraphCNN(tf.keras.layers.Layer):
+  """
+  GraphCNN Layer from Robust Spatial Filtering with Graph Convolutional Neural Networks
+  https://arxiv.org/abs/1703.00792
+
+  Spatial-domain convolutions can be defined as
+  H = h_0I + h_1A + h_2A^2 + ... + hkAk, H ∈ R**(N×N)
+
+  We approximate it by
+  H ≈ h_0I + h_1A
+
+  We can define a convolution as applying multiple these linear filters
+  over edges of different types (think up, down, left, right, diagonal in images)
+  Where each edge type has its own adjacency matrix
+  H ≈ h_0I + h_1A_1 + h_2A_2 + . . . h_(L−1)A_(L−1)
+
+  V_out = \sum_{c=1}^{C} H^{c} V^{c} + b
+  """
+
+  def __init__(self, num_filters, **kwargs):
+    """
+    Parameters
+    ----------
+    num_filters: int
+      Number of filters to have in the output
+
+    in_layers: list of Layers or tensors
+      [V, A, mask]
+      V are the vertex features must be of shape (batch, vertex, channel)
+
+      A are the adjacency matrixes for each graph
+        Shape (batch, from_vertex, adj_matrix, to_vertex)
+
+      mask is optional, to be used when not every graph has the
+      same number of vertices
+
+    Returns: tf.tensor
+    Returns a tf.tensor with a graph convolution applied
+    The shape will be (batch, vertex, self.num_filters)
+    """
+    super(GraphCNN, self).__init__(**kwargs)
+    self.num_filters = num_filters
+
+  def build(self, input_shape):
+    no_features = int(input_shape[0][2])
+    no_A = int(input_shape[1][2])
+    self.W = tf.Variable(
+        tf.truncated_normal(
+            [no_features * no_A, self.num_filters],
+            stddev=np.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
+        name='weights',
+        dtype=tf.float32)
+    self.W_I = tf.Variable(
+        tf.truncated_normal(
+            [no_features, self.num_filters],
+            stddev=np.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
+        name='weights_I',
+        dtype=tf.float32)
+    self.b = tf.Variable(tf.constant(0.1), name='bias', dtype=tf.float32)
+
+  def call(self, inputs):
+    if len(inputs) == 3:
+      V, A, mask = inputs
+    else:
+      V, A = inputs
+    no_A = A.get_shape()[2].value
+    no_features = V.get_shape()[2].value
+    n = self.graphConvolution(V, A)
+    A_shape = tf.shape(A)
+    n = tf.reshape(n, [-1, A_shape[1], no_A * no_features])
+    return self.batch_mat_mult(n, self.W) + self.batch_mat_mult(V, self.W_I) + self.b
+
+  def graphConvolution(self, V, A):
+    no_A = A.get_shape()[2].value
+    no_features = V.get_shape()[2].value
+    A_shape = tf.shape(A)
+    A_reshape = tf.reshape(A, tf.stack([-1, A_shape[1] * no_A, A_shape[1]]))
+    n = tf.matmul(A_reshape, V)
+    return tf.reshape(n, [-1, A_shape[1], no_A, no_features])
+
+  def batch_mat_mult(self, A, B):
+    A_shape = tf.shape(A)
+    A_reshape = tf.reshape(A, [-1, A_shape[-1]])
+    # So the Tensor has known dimensions
+    if B.get_shape()[1] == None:
+      axis_2 = -1
+    else:
+      axis_2 = B.get_shape()[1]
+    result = tf.matmul(A_reshape, B)
+    return tf.reshape(result, tf.stack([A_shape[0], A_shape[1], axis_2]))

--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import tensorflow as tf
 import numpy as np
 import collections

--- a/deepchem/models/tensorgraph/graph_layers.py
+++ b/deepchem/models/tensorgraph/graph_layers.py
@@ -10,14 +10,15 @@ from __future__ import unicode_literals
 
 import numpy as np
 import tensorflow as tf
+import deepchem.models.layers
 from deepchem.models.tensorgraph import activations
 from deepchem.models.tensorgraph import initializations
 from deepchem.models.tensorgraph import model_ops
-from deepchem.models.tensorgraph.layers import Layer, LayerSplitter
+from deepchem.models.tensorgraph.layers import Layer, LayerSplitter, KerasLayer
 from deepchem.models.tensorgraph.layers import convert_to_layers
 
 
-class WeaveLayer(Layer):
+class WeaveLayer(KerasLayer):
   """ TensorGraph style implementation
   Note: Use WeaveLayerFactory to construct this layer
   """
@@ -64,8 +65,6 @@ class WeaveLayer(Layer):
     self.n_hidden_PA = n_hidden_PA
     self.n_hidden_AP = n_hidden_AP
     self.n_hidden_PP = n_hidden_PP
-    self.n_hidden_A = n_hidden_AA + n_hidden_PA
-    self.n_hidden_P = n_hidden_AP + n_hidden_PP
 
     self.n_atom_input_feat = n_atom_input_feat
     self.n_pair_input_feat = n_pair_input_feat
@@ -73,121 +72,25 @@ class WeaveLayer(Layer):
     self.n_pair_output_feat = n_pair_output_feat
     self.W_AP, self.b_AP, self.W_PP, self.b_PP, self.W_P, self.b_P = None, None, None, None, None, None
 
-  def build(self):
-    """ Construct internal trainable weights.
-
-        TODO(rbharath): Need to make this not set instance variables to
-        follow style in other layers.
-        """
-    init = initializations.get(self.init)  # Set weight initialization
-
-    self.W_AA = init([self.n_atom_input_feat, self.n_hidden_AA])
-    self.b_AA = model_ops.zeros(shape=[
-        self.n_hidden_AA,
-    ])
-
-    self.W_PA = init([self.n_pair_input_feat, self.n_hidden_PA])
-    self.b_PA = model_ops.zeros(shape=[
-        self.n_hidden_PA,
-    ])
-
-    self.W_A = init([self.n_hidden_A, self.n_atom_output_feat])
-    self.b_A = model_ops.zeros(shape=[
-        self.n_atom_output_feat,
-    ])
-
-    self.trainable_weights = [
-        self.W_AA, self.b_AA, self.W_PA, self.b_PA, self.W_A, self.b_A
-    ]
-    if self.update_pair:
-      self.W_AP = init([self.n_atom_input_feat * 2, self.n_hidden_AP])
-      self.b_AP = model_ops.zeros(shape=[
-          self.n_hidden_AP,
-      ])
-
-      self.W_PP = init([self.n_pair_input_feat, self.n_hidden_PP])
-      self.b_PP = model_ops.zeros(shape=[
-          self.n_hidden_PP,
-      ])
-
-      self.W_P = init([self.n_hidden_P, self.n_pair_output_feat])
-      self.b_P = model_ops.zeros(shape=[
-          self.n_pair_output_feat,
-      ])
-
-      self.trainable_weights.extend(
-          [self.W_AP, self.b_AP, self.W_PP, self.b_PP, self.W_P, self.b_P])
+  def _build_layer(self):
+    return deepchem.models.layers.WeaveLayer(
+        self.n_atom_input_feat, self.n_pair_input_feat, self.n_atom_output_feat,
+        self.n_pair_output_feat, self.n_hidden_AA, self.n_hidden_PA,
+        self.n_hidden_AP, self.n_hidden_PP, self.update_pair, self.init,
+        self.activation)
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
     """Creates weave tensors.
 
     parent layers: [atom_features, pair_features], pair_split, atom_to_pair
     """
-    activation = activations.get(self.activation)  # Get activations
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    self.build()
-
-    atom_features = in_layers[0].out_tensor
-    pair_features = in_layers[1].out_tensor
-
-    pair_split = in_layers[2].out_tensor
-    atom_to_pair = in_layers[3].out_tensor
-
-    AA = tf.matmul(atom_features, self.W_AA) + self.b_AA
-    AA = activation(AA)
-    PA = tf.matmul(pair_features, self.W_PA) + self.b_PA
-    PA = activation(PA)
-    PA = tf.segment_sum(PA, pair_split)
-
-    A = tf.matmul(tf.concat([AA, PA], 1), self.W_A) + self.b_A
-    A = activation(A)
-
-    if self.update_pair:
-      AP_ij = tf.matmul(
-          tf.reshape(
-              tf.gather(atom_features, atom_to_pair),
-              [-1, 2 * self.n_atom_input_feat]), self.W_AP) + self.b_AP
-      AP_ij = activation(AP_ij)
-      AP_ji = tf.matmul(
-          tf.reshape(
-              tf.gather(atom_features, tf.reverse(atom_to_pair, [1])),
-              [-1, 2 * self.n_atom_input_feat]), self.W_AP) + self.b_AP
-      AP_ji = activation(AP_ji)
-
-      PP = tf.matmul(pair_features, self.W_PP) + self.b_PP
-      PP = activation(PP)
-      P = tf.matmul(tf.concat([AP_ij + AP_ji, PP], 1), self.W_P) + self.b_P
-      P = activation(P)
-    else:
-      P = pair_features
-
-    self.out_tensors = [A, P]
+    output = super(WeaveLayer, self).create_tensor(
+        in_layers=in_layers, set_tensors=set_tensors, **kwargs)
     if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = A
-    return self.out_tensors
-
-  def none_tensors(self):
-    W_AP, b_AP, W_PP, W_PP, W_P, b_P = self.W_AP, self.b_AP, self.W_PP, self.W_PP, self.W_P, self.b_P
-    self.W_AP, self.b_AP, self.W_PP, self.b_PP, self.W_P, self.b_P = None, None, None, None, None, None
-
-    W_AA, b_AA, W_PA, b_PA, W_A, b_A = self.W_AA, self.b_AA, self.W_PA, self.b_PA, self.W_A, self.b_A
-    self.W_AA, self.b_AA, self.W_PA, self.b_PA, self.W_A, self.b_A = None, None, None, None, None, None
-
-    out_tensor, out_tensors, trainable_weights, variables = self.out_tensor, self.out_tensors, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.out_tensors, self.trainable_weights, self.trainable_variables = None, [], [], []
-
-    return W_AP, b_AP, W_PP, W_PP, W_P, b_P, \
-           W_AA, b_AA, W_PA, b_PA, W_A, b_A, \
-           out_tensor, out_tensors, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.W_AP, self.b_AP, self.W_PP, self.W_PP, self.W_P, self.b_P, \
-    self.W_AA, self.b_AA, self.W_PA, self.b_PA, self.W_A, self.b_A, \
-    self.out_tensor, self.out_tensors, self.trainable_weights, self.trainable_variables = tensor
+      self.out_tensors = output
+      self.out_tensor = output[0]
+      self._non_pickle_fields.append('out_tensors')
+    return output
 
 
 def WeaveLayerFactory(**kwargs):
@@ -195,7 +98,7 @@ def WeaveLayerFactory(**kwargs):
   return [LayerSplitter(i, in_layers=weaveLayer) for i in range(2)]
 
 
-class WeaveGather(Layer):
+class WeaveGather(KerasLayer):
   """ TensorGraph style implementation
   """
 
@@ -226,79 +129,20 @@ class WeaveGather(Layer):
     self.n_input = n_input
     self.batch_size = batch_size
     self.gaussian_expand = gaussian_expand
-    self.init = initializations.get(init)  # Set weight initialization
-    self.activation = activations.get(activation)  # Get activations
+    self.init = init
+    self.activation = activation
     self.epsilon = epsilon
     self.momentum = momentum
     self.W, self.b = None, None
     super(WeaveGather, self).__init__(**kwargs)
 
-  def build(self):
-    if self.gaussian_expand:
-      self.W = self.init([self.n_input * 11, self.n_input])
-      self.b = model_ops.zeros(shape=[
-          self.n_input,
-      ])
-      self.trainable_weights = self.W + self.b
-    else:
-      self.trainable_weights = None
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    parent layers: atom_features, atom_split
-    """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    self.build()
-    outputs = in_layers[0].out_tensor
-    atom_split = in_layers[1].out_tensor
-
-    if self.gaussian_expand:
-      outputs = self.gaussian_histogram(outputs)
-
-    output_molecules = tf.segment_sum(outputs, atom_split)
-
-    if self.gaussian_expand:
-      output_molecules = tf.matmul(output_molecules, self.W) + self.b
-      output_molecules = self.activation(output_molecules)
-
-    out_tensor = output_molecules
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def gaussian_histogram(self, x):
-    gaussian_memberships = [(-1.645, 0.283), (-1.080, 0.170), (-0.739, 0.134),
-                            (-0.468, 0.118), (-0.228, 0.114), (0., 0.114),
-                            (0.228, 0.114), (0.468, 0.118), (0.739, 0.134),
-                            (1.080, 0.170), (1.645, 0.283)]
-    dist = [
-        tf.contrib.distributions.Normal(p[0], p[1])
-        for p in gaussian_memberships
-    ]
-    dist_max = [dist[i].prob(gaussian_memberships[i][0]) for i in range(11)]
-    outputs = [dist[i].prob(x) / dist_max[i] for i in range(11)]
-    outputs = tf.stack(outputs, axis=2)
-    outputs = outputs / tf.reduce_sum(outputs, axis=2, keepdims=True)
-    outputs = tf.reshape(outputs, [-1, self.n_input * 11])
-    return outputs
-
-  def none_tensors(self):
-    W, b = self.W, self.b
-    self.W, self.b = None, None
-
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return W, b, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.W, self.b, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.WeaveGather(
+        self.batch_size, self.n_input, self.gaussian_expand, self.init,
+        self.activation, self.epsilon, self.momentum)
 
 
-class DTNNEmbedding(Layer):
+class DTNNEmbedding(KerasLayer):
   """ TensorGraph style implementation
   """
 
@@ -319,44 +163,15 @@ class DTNNEmbedding(Layer):
         """
     self.n_embedding = n_embedding
     self.periodic_table_length = periodic_table_length
-    self.init = initializations.get(init)  # Set weight initialization
-
+    self.init = init
     super(DTNNEmbedding, self).__init__(**kwargs)
 
-  def build(self):
-    self.embedding_list = self.init(
-        [self.periodic_table_length, self.n_embedding])
-    self.trainable_weights = [self.embedding_list]
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    parent layers: atom_number
-    """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-    self.build()
-
-    atom_number = in_layers[0].out_tensor
-    atom_features = tf.nn.embedding_lookup(self.embedding_list, atom_number)
-    out_tensor = atom_features
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = atom_features
-    return out_tensor
-
-  def none_tensors(self):
-    embedding_list = self.embedding_list
-    self.embedding_list = None
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return embedding_list, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.embedding_list, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.DTNNEmbedding(
+        self.n_embedding, self.periodic_table_length, self.init)
 
 
-class DTNNStep(Layer):
+class DTNNStep(KerasLayer):
   """ TensorGraph style implementation
   """
 
@@ -384,74 +199,17 @@ class DTNNStep(Layer):
     self.n_embedding = n_embedding
     self.n_distance = n_distance
     self.n_hidden = n_hidden
-    self.init = initializations.get(init)  # Set weight initialization
-    self.activation = activations.get(activation)  # Get activations
-
+    self.init = init
+    self.activation = activation
     super(DTNNStep, self).__init__(**kwargs)
 
-  def build(self):
-    self.W_cf = self.init([self.n_embedding, self.n_hidden])
-    self.W_df = self.init([self.n_distance, self.n_hidden])
-    self.W_fc = self.init([self.n_hidden, self.n_embedding])
-    self.b_cf = model_ops.zeros(shape=[
-        self.n_hidden,
-    ])
-    self.b_df = model_ops.zeros(shape=[
-        self.n_hidden,
-    ])
-
-    self.trainable_weights = [
-        self.W_cf, self.W_df, self.W_fc, self.b_cf, self.b_df
-    ]
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    parent layers: atom_features, distance, distance_membership_i, distance_membership_j
-    """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    self.build()
-    atom_features = in_layers[0].out_tensor
-    distance = in_layers[1].out_tensor
-    distance_membership_i = in_layers[2].out_tensor
-    distance_membership_j = in_layers[3].out_tensor
-    distance_hidden = tf.matmul(distance, self.W_df) + self.b_df
-    atom_features_hidden = tf.matmul(atom_features, self.W_cf) + self.b_cf
-    outputs = tf.multiply(
-        distance_hidden, tf.gather(atom_features_hidden, distance_membership_j))
-
-    # for atom i in a molecule m, this step multiplies together distance info of atom pair(i,j)
-    # and embeddings of atom j(both gone through a hidden layer)
-    outputs = tf.matmul(outputs, self.W_fc)
-    outputs = self.activation(outputs)
-
-    output_ii = tf.multiply(self.b_df, atom_features_hidden)
-    output_ii = tf.matmul(output_ii, self.W_fc)
-    output_ii = self.activation(output_ii)
-
-    # for atom i, sum the influence from all other atom j in the molecule
-    outputs = tf.segment_sum(outputs,
-                             distance_membership_i) - output_ii + atom_features
-    out_tensor = outputs
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def none_tensors(self):
-    W_cf, W_df, W_fc, b_cf, b_df = self.W_cf, self.W_df, self.W_fc, self.b_cf, self.b_df
-    self.W_cf, self.W_df, self.W_fc, self.b_cf, self.b_df = None, None, None, None, None
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return W_cf, W_df, W_fc, b_cf, b_df, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.W_cf, self.W_df, self.W_fc, self.b_cf, self.b_df, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.DTNNStep(self.n_embedding, self.n_distance,
+                                           self.n_hidden, self.init,
+                                           self.activation)
 
 
-class DTNNGather(Layer):
+class DTNNGather(KerasLayer):
   """ TensorGraph style implementation
   """
 
@@ -481,62 +239,14 @@ class DTNNGather(Layer):
     self.n_outputs = n_outputs
     self.layer_sizes = layer_sizes
     self.output_activation = output_activation
-    self.init = initializations.get(init)  # Set weight initialization
-    self.activation = activations.get(activation)  # Get activations
-
+    self.init = init
+    self.activation = activation
     super(DTNNGather, self).__init__(**kwargs)
 
-  def build(self):
-    self.W_list = []
-    self.b_list = []
-    prev_layer_size = self.n_embedding
-    for i, layer_size in enumerate(self.layer_sizes):
-      self.W_list.append(self.init([prev_layer_size, layer_size]))
-      self.b_list.append(model_ops.zeros(shape=[
-          layer_size,
-      ]))
-      prev_layer_size = layer_size
-    self.W_list.append(self.init([prev_layer_size, self.n_outputs]))
-    self.b_list.append(model_ops.zeros(shape=[
-        self.n_outputs,
-    ]))
-    prev_layer_size = self.n_outputs
-
-    self.trainable_weights = self.W_list + self.b_list
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    parent layers: atom_features, atom_membership
-    """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    self.build()
-    output = in_layers[0].out_tensor
-    atom_membership = in_layers[1].out_tensor
-    for i, W in enumerate(self.W_list[:-1]):
-      output = tf.matmul(output, W) + self.b_list[i]
-      output = self.activation(output)
-    output = tf.matmul(output, self.W_list[-1]) + self.b_list[-1]
-    if self.output_activation:
-      output = self.activation(output)
-    output = tf.segment_sum(output, atom_membership)
-    out_tensor = output
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def none_tensors(self):
-    W_list, b_list = self.W_list, self.b_list
-    self.W_list, self.b_list = [], []
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return W_list, b_list, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.W_list, self.b_list, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.DTNNGather(
+        self.n_embedding, self.n_outputs, self.layer_sizes,
+        self.output_activation, self.init, self.activation)
 
 
 class DTNNExtract(Layer):
@@ -555,7 +265,7 @@ class DTNNExtract(Layer):
     return out_tensor
 
 
-class DAGLayer(Layer):
+class DAGLayer(KerasLayer):
   """ TensorGraph style implementation
   """
 
@@ -593,8 +303,8 @@ class DAGLayer(Layer):
         """
     super(DAGLayer, self).__init__(**kwargs)
 
-    self.init = initializations.get(init)  # Set weight initialization
-    self.activation = activations.get(activation)  # Get activations
+    self.init = init
+    self.activation = activation
     self.layer_sizes = layer_sizes
     self.dropout = dropout
     self.max_atoms = max_atoms
@@ -605,121 +315,13 @@ class DAGLayer(Layer):
     self.n_outputs = n_graph_feat
     self.n_atom_feat = n_atom_feat
 
-  def build(self):
-    """"Construct internal trainable weights.
-        """
-
-    self.W_list = []
-    self.b_list = []
-    prev_layer_size = self.n_inputs
-    for layer_size in self.layer_sizes:
-      self.W_list.append(self.init([prev_layer_size, layer_size]))
-      self.b_list.append(model_ops.zeros(shape=[
-          layer_size,
-      ]))
-      prev_layer_size = layer_size
-    self.W_list.append(self.init([prev_layer_size, self.n_outputs]))
-    self.b_list.append(model_ops.zeros(shape=[
-        self.n_outputs,
-    ]))
-
-    self.trainable_weights = self.W_list + self.b_list
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    parent layers: atom_features, parents, calculation_orders, calculation_masks, n_atoms
-    """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    # Add trainable weights
-    self.build()
-
-    atom_features = in_layers[0].out_tensor
-    # each atom corresponds to a graph, which is represented by the `max_atoms*max_atoms` int32 matrix of index
-    # each gragh include `max_atoms` of steps(corresponding to rows) of calculating graph features
-    parents = in_layers[1].out_tensor
-    # target atoms for each step: (batch_size*max_atoms) * max_atoms
-    calculation_orders = in_layers[2].out_tensor
-    calculation_masks = in_layers[3].out_tensor
-
-    n_atoms = in_layers[4].out_tensor
-    # initialize graph features for each graph
-    graph_features_initial = tf.zeros((self.max_atoms * self.batch_size,
-                                       self.max_atoms + 1, self.n_graph_feat))
-    # initialize graph features for each graph
-    # another row of zeros is generated for padded dummy atoms
-    graph_features = tf.Variable(graph_features_initial, trainable=False)
-
-    for count in range(self.max_atoms):
-      # `count`-th step
-      # extracting atom features of target atoms: (batch_size*max_atoms) * n_atom_features
-      mask = calculation_masks[:, count]
-      current_round = tf.boolean_mask(calculation_orders[:, count], mask)
-      batch_atom_features = tf.gather(atom_features, current_round)
-
-      # generating index for graph features used in the inputs
-      index = tf.stack(
-          [
-              tf.reshape(
-                  tf.stack(
-                      [tf.boolean_mask(tf.range(n_atoms), mask)] *
-                      (self.max_atoms - 1),
-                      axis=1), [-1]),
-              tf.reshape(tf.boolean_mask(parents[:, count, 1:], mask), [-1])
-          ],
-          axis=1)
-      # extracting graph features for parents of the target atoms, then flatten
-      # shape: (batch_size*max_atoms) * [(max_atoms-1)*n_graph_features]
-      batch_graph_features = tf.reshape(
-          tf.gather_nd(graph_features, index),
-          [-1, (self.max_atoms - 1) * self.n_graph_feat])
-
-      # concat into the input tensor: (batch_size*max_atoms) * n_inputs
-      batch_inputs = tf.concat(
-          axis=1, values=[batch_atom_features, batch_graph_features])
-      # DAGgraph_step maps from batch_inputs to a batch of graph_features
-      # of shape: (batch_size*max_atoms) * n_graph_features
-      # representing the graph features of target atoms in each graph
-      batch_outputs = self.DAGgraph_step(batch_inputs, self.W_list, self.b_list,
-                                         **kwargs)
-
-      # index for targe atoms
-      target_index = tf.stack([tf.range(n_atoms), parents[:, count, 0]], axis=1)
-      target_index = tf.boolean_mask(target_index, mask)
-      # update the graph features for target atoms
-      graph_features = tf.scatter_nd_update(graph_features, target_index,
-                                            batch_outputs)
-
-    out_tensor = batch_outputs
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def DAGgraph_step(self, batch_inputs, W_list, b_list, **kwargs):
-    outputs = batch_inputs
-    for idw, W in enumerate(W_list):
-      outputs = tf.nn.xw_plus_b(outputs, W, b_list[idw])
-      outputs = self.activation(outputs)
-      training = kwargs['training'] if 'training' in kwargs else 1.0
-      if not self.dropout is None:
-        outputs = tf.nn.dropout(outputs, rate=self.dropout * training)
-    return outputs
-
-  def none_tensors(self):
-    W_list, b_list = self.W_list, self.b_list
-    self.W_list, self.b_list = [], []
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return W_list, b_list, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.W_list, self.b_list, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.DAGLayer(
+        self.n_graph_feat, self.n_atom_feat, self.max_atoms, self.layer_sizes,
+        self.init, self.activation, self.dropout, self.batch_size)
 
 
-class DAGGather(Layer):
+class DAGGather(KerasLayer):
   """ TensorGraph style implementation
   """
 
@@ -753,82 +355,21 @@ class DAGGather(Layer):
           Dropout probability in the hidden layer(s).
         """
     super(DAGGather, self).__init__(**kwargs)
-
-    self.init = initializations.get(init)  # Set weight initialization
-    self.activation = activations.get(activation)  # Get activations
+    self.init = init
+    self.activation = activation
     self.layer_sizes = layer_sizes
     self.dropout = dropout
     self.max_atoms = max_atoms
     self.n_graph_feat = n_graph_feat
     self.n_outputs = n_outputs
 
-  def build(self):
-    """"Construct internal trainable weights.
-        """
-
-    self.W_list = []
-    self.b_list = []
-    prev_layer_size = self.n_graph_feat
-    for layer_size in self.layer_sizes:
-      self.W_list.append(self.init([prev_layer_size, layer_size]))
-      self.b_list.append(model_ops.zeros(shape=[
-          layer_size,
-      ]))
-      prev_layer_size = layer_size
-    self.W_list.append(self.init([prev_layer_size, self.n_outputs]))
-    self.b_list.append(model_ops.zeros(shape=[
-        self.n_outputs,
-    ]))
-
-    self.trainable_weights = self.W_list + self.b_list
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    parent layers: atom_features, membership
-    """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    # Add trainable weights
-    self.build()
-
-    # Extract atom_features
-    atom_features = in_layers[0].out_tensor
-    membership = in_layers[1].out_tensor
-    # Extract atom_features
-    graph_features = tf.segment_sum(atom_features, membership)
-    # sum all graph outputs
-    outputs = self.DAGgraph_step(graph_features, self.W_list, self.b_list,
-                                 **kwargs)
-    out_tensor = outputs
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def DAGgraph_step(self, batch_inputs, W_list, b_list, **kwargs):
-    outputs = batch_inputs
-    for idw, W in enumerate(W_list):
-      outputs = tf.nn.xw_plus_b(outputs, W, b_list[idw])
-      outputs = self.activation(outputs)
-      training = kwargs['training'] if 'training' in kwargs else 1.0
-      if not self.dropout is None:
-        outputs = tf.nn.dropout(outputs, rate=self.dropout * training)
-    return outputs
-
-  def none_tensors(self):
-    W_list, b_list = self.W_list, self.b_list
-    self.W_list, self.b_list = [], []
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return W_list, b_list, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.W_list, self.b_list, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.DAGGather(
+        self.n_graph_feat, self.n_outputs, self.max_atoms, self.layer_sizes,
+        self.init, self.activation, self.dropout)
 
 
-class MessagePassing(Layer):
+class MessagePassing(KerasLayer):
   """ General class for MPNN
   default structures built according to https://arxiv.org/abs/1511.06391 """
 
@@ -857,219 +398,32 @@ class MessagePassing(Layer):
     self.n_hidden = n_hidden
     super(MessagePassing, self).__init__(**kwargs)
 
-  def build(self, pair_features, n_pair_features):
-    if self.message_fn == 'enn':
-      # Default message function: edge network, update function: GRU
-      # more options to be implemented
-      self.message_function = EdgeNetwork(pair_features, n_pair_features,
-                                          self.n_hidden)
-    if self.update_fn == 'gru':
-      self.update_function = GatedRecurrentUnit(self.n_hidden)
-    self.trainable_weights = self.message_function.trainable_weights + \
-                             self.update_function.trainable_weights
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """ Perform T steps of message passing """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    # Extract atom_features
-    atom_features = in_layers[0].out_tensor
-    pair_features = in_layers[1].out_tensor
-    atom_to_pair = in_layers[2].out_tensor
-    n_atom_features = atom_features.get_shape().as_list()[-1]
-    n_pair_features = pair_features.get_shape().as_list()[-1]
-    # Add trainable weights
-    self.build(pair_features, n_pair_features)
-
-    if n_atom_features < self.n_hidden:
-      pad_length = self.n_hidden - n_atom_features
-      out = tf.pad(atom_features, ((0, 0), (0, pad_length)), mode='CONSTANT')
-    elif n_atom_features > self.n_hidden:
-      raise ValueError("Too large initial feature vector")
-    else:
-      out = atom_features
-
-    for i in range(self.T):
-      message = self.message_function.forward(out, atom_to_pair)
-      out = self.update_function.forward(out, message)
-
-    out_tensor = out
-
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def none_tensors(self):
-    message_tensors = self.message_function.none_tensors()
-    update_tensors = self.update_function.none_tensors()
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return message_tensors, update_tensors, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    message_tensors, update_tensors, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
-    self.message_function.set_tensors(message_tensors)
-    self.update_function.set_tensors(update_tensors)
+  def _build_layer(self):
+    return deepchem.models.layers.MessagePassing(self.T, self.message_fn,
+                                                 self.update_fn, self.n_hidden)
 
 
-class EdgeNetwork(object):
-  """ Submodule for Message Passing """
-
-  def __init__(self,
-               pair_features,
-               n_pair_features=8,
-               n_hidden=100,
-               init='glorot_uniform'):
-    self.n_pair_features = n_pair_features
-    self.n_hidden = n_hidden
-    self.init = initializations.get(init)
-    W = self.init([n_pair_features, n_hidden * n_hidden])
-    b = model_ops.zeros(shape=(n_hidden * n_hidden,))
-    self.A = tf.nn.xw_plus_b(pair_features, W, b)
-    self.A = tf.reshape(self.A, (-1, n_hidden, n_hidden))
-    self.trainable_weights = [W, b]
-
-  def forward(self, atom_features, atom_to_pair):
-    out = tf.expand_dims(tf.gather(atom_features, atom_to_pair[:, 1]), 2)
-    out = tf.squeeze(tf.matmul(self.A, out), axis=2)
-    out = tf.segment_sum(out, atom_to_pair[:, 0])
-    return out
-
-  def none_tensors(self):
-    A = self.A
-    self.A = None,
-    trainable_weights = self.trainable_weights
-    self.trainable_weights = []
-    return A, trainable_weights
-
-  def set_tensors(self, tensor):
-    self.A, self.trainable_weights = tensor
-
-
-class GatedRecurrentUnit(object):
-  """ Submodule for Message Passing """
-
-  def __init__(self, n_hidden=100, init='glorot_uniform'):
-    self.n_hidden = n_hidden
-    self.init = initializations.get(init)
-    Wz = self.init([n_hidden, n_hidden])
-    Wr = self.init([n_hidden, n_hidden])
-    Wh = self.init([n_hidden, n_hidden])
-    Uz = self.init([n_hidden, n_hidden])
-    Ur = self.init([n_hidden, n_hidden])
-    Uh = self.init([n_hidden, n_hidden])
-    bz = model_ops.zeros(shape=(n_hidden,))
-    br = model_ops.zeros(shape=(n_hidden,))
-    bh = model_ops.zeros(shape=(n_hidden,))
-    self.trainable_weights = [Wz, Wr, Wh, Uz, Ur, Uh, bz, br, bh]
-
-  def forward(self, inputs, messages):
-    z = tf.nn.sigmoid(tf.matmul(messages, self.trainable_weights[0]) + \
-                      tf.matmul(inputs, self.trainable_weights[3]) + \
-                      self.trainable_weights[6])
-    r = tf.nn.sigmoid(tf.matmul(messages, self.trainable_weights[1]) + \
-                      tf.matmul(inputs, self.trainable_weights[4]) + \
-                      self.trainable_weights[7])
-    h = (1 - z) * tf.nn.tanh(tf.matmul(messages, self.trainable_weights[2]) + \
-                             tf.matmul(inputs * r, self.trainable_weights[5]) + \
-                             self.trainable_weights[8]) + z * inputs
-    return h
-
-  def none_tensors(self):
-    trainable_weights = self.trainable_weights
-    self.trainable_weights = []
-    return trainable_weights
-
-  def set_tensors(self, tensor):
-    self.trainable_weights = tensor
-
-
-class SetGather(Layer):
+class SetGather(KerasLayer):
   """ set2set gather layer for graph-based model
   model using this layer must set pad_batches=True """
 
   def __init__(self, M, batch_size, n_hidden=100, init='orthogonal', **kwargs):
     """
-        Parameters
-        ----------
-        M: int
-          Number of LSTM steps
-        batch_size: int
-          Number of samples in a batch(all batches must have same size)
-        n_hidden: int, optional
-          number of hidden units in the passing phase
-        """
-
+    Parameters
+    ----------
+    M: int
+      Number of LSTM steps
+    batch_size: int
+      Number of samples in a batch(all batches must have same size)
+    n_hidden: int, optional
+      number of hidden units in the passing phase
+    """
     self.M = M
     self.batch_size = batch_size
     self.n_hidden = n_hidden
-    self.init = initializations.get(init)
+    self.init = init
     super(SetGather, self).__init__(**kwargs)
 
-  def build(self):
-    self.U = self.init((2 * self.n_hidden, 4 * self.n_hidden))
-    self.b = tf.Variable(
-        np.concatenate((np.zeros(self.n_hidden), np.ones(self.n_hidden),
-                        np.zeros(self.n_hidden), np.zeros(self.n_hidden))),
-        dtype=tf.float32)
-    self.trainable_weights = [self.U, self.b]
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """ Perform M steps of set2set gather,
-        detailed descriptions in: https://arxiv.org/abs/1511.06391 """
-    if in_layers is None:
-      in_layers = self.in_layers
-    in_layers = convert_to_layers(in_layers)
-
-    self.build()
-    # Extract atom_features
-    atom_features = in_layers[0].out_tensor
-    atom_split = in_layers[1].out_tensor
-
-    self.c = tf.zeros((self.batch_size, self.n_hidden))
-    self.h = tf.zeros((self.batch_size, self.n_hidden))
-
-    for i in range(self.M):
-      q_expanded = tf.gather(self.h, atom_split)
-      e = tf.reduce_sum(atom_features * q_expanded, 1)
-      e_mols = tf.dynamic_partition(e, atom_split, self.batch_size)
-      # Add another value(~-Inf) to prevent error in softmax
-      e_mols = [
-          tf.concat([e_mol, tf.constant([-1000.])], 0) for e_mol in e_mols
-      ]
-      a = tf.concat([tf.nn.softmax(e_mol)[:-1] for e_mol in e_mols], 0)
-      r = tf.segment_sum(tf.reshape(a, [-1, 1]) * atom_features, atom_split)
-      # Model using this layer must set pad_batches=True
-      q_star = tf.concat([self.h, r], axis=1)
-      self.h, self.c = self.LSTMStep(q_star, self.c)
-
-    out_tensor = q_star
-    if set_tensors:
-      self.trainable_variables = self.trainable_weights
-      self.out_tensor = out_tensor
-    return out_tensor
-
-  def LSTMStep(self, h, c, x=None):
-    # Perform one step of LSTM
-    z = tf.nn.xw_plus_b(h, self.U, self.b)
-    i = tf.nn.sigmoid(z[:, :self.n_hidden])
-    f = tf.nn.sigmoid(z[:, self.n_hidden:2 * self.n_hidden])
-    o = tf.nn.sigmoid(z[:, 2 * self.n_hidden:3 * self.n_hidden])
-    z3 = z[:, 3 * self.n_hidden:]
-    c_out = f * c + i * tf.nn.tanh(z3)
-    h_out = o * tf.nn.tanh(c_out)
-
-    return h_out, c_out
-
-  def none_tensors(self):
-    U, b, c, h = self.U, self.b, self.c, self.h
-    self.U, self.b, self.c, self.h = None, None, None, None
-    out_tensor, trainable_weights, variables = self.out_tensor, self.trainable_weights, self.trainable_variables
-    self.out_tensor, self.trainable_weights, self.trainable_variables = None, [], []
-    return U, b, c, h, out_tensor, trainable_weights, variables
-
-  def set_tensors(self, tensor):
-    self.U, self.b, self.c, self.h, self.out_tensor, self.trainable_weights, self.trainable_variables = tensor
+  def _build_layer(self):
+    return deepchem.models.layers.SetGather(self.M, self.batch_size,
+                                            self.n_hidden, self.init)

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -6,10 +6,11 @@ import warnings
 from collections import Sequence
 from copy import deepcopy
 
+import deepchem.models.layers
 import tensorflow as tf
 import numpy as np
 
-from deepchem.models.tensorgraph import model_ops, initializations, regularizers, activations
+from deepchem.models.tensorgraph import model_ops, initializations, activations
 import math
 
 from tensorflow.python.ops import math_ops
@@ -402,15 +403,11 @@ def convert_to_layers(in_layers):
   return layers
 
 
-class SharedLayer(Layer):
-  """A Layer that can share variables with another layer via a common internal Keras layer.
-
-  This abstract class can be used as a parent for any layer that implements
-  shared() by this mechanism.  It exists to avoid duplicated code.
-  """
+class KerasLayer(Layer):
+  """A Layer that is implemented internally by Keras layer."""
 
   def __init__(self, **kwargs):
-    super(SharedLayer, self).__init__(**kwargs)
+    super(KerasLayer, self).__init__(**kwargs)
     self._layer = None
     self._shared_with = None
 
@@ -433,6 +430,18 @@ class SharedLayer(Layer):
   def _build_layer(self):
     raise NotImplementedError("Subclasses must implement this")
 
+  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
+    inputs = self._get_input_tensors(in_layers)
+    layer = self._get_layer(set_tensors)
+    out_tensor = layer(inputs)
+    if set_tensors:
+      self.out_tensor = out_tensor
+      self.trainable_variables = layer.trainable_variables
+    if tf.executing_eagerly() and not self._built:
+      self._built = True
+      self.trainable_variables = layer.trainable_variables
+    return out_tensor
+
 
 def _conv_size(width, size, stride, padding):
   """Compute the output size of a convolutional layer."""
@@ -444,7 +453,7 @@ def _conv_size(width, size, stride, padding):
     raise ValueError('Unknown padding type: %s' % padding)
 
 
-class Conv1D(SharedLayer):
+class Conv1D(KerasLayer):
   """A 1D convolution on the input.
 
   This layer expects its input to be a three dimensional tensor of shape (batch size, width, # channels).
@@ -587,7 +596,7 @@ class Conv1D(SharedLayer):
     return out_tensor
 
 
-class Dense(SharedLayer):
+class Dense(KerasLayer):
 
   def __init__(self,
                out_channels,
@@ -1682,7 +1691,7 @@ class Exp(Layer):
     return out_tensor
 
 
-class InteratomicL2Distances(Layer):
+class InteratomicL2Distances(KerasLayer):
   """Compute (squared) L2 Distances between atoms given neighbors."""
 
   def __init__(self, N_atoms, M_nbrs, ndim, **kwargs):
@@ -1691,23 +1700,9 @@ class InteratomicL2Distances(Layer):
     self.ndim = ndim
     super(InteratomicL2Distances, self).__init__(**kwargs)
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-    if len(inputs) != 2:
-      raise ValueError("InteratomicDistances requires coords,nbr_list")
-    coords, nbr_list = (inputs[0], inputs[1])
-    N_atoms, M_nbrs, ndim = self.N_atoms, self.M_nbrs, self.ndim
-    # Shape (N_atoms, M_nbrs, ndim)
-    nbr_coords = tf.gather(coords, nbr_list)
-    # Shape (N_atoms, M_nbrs, ndim)
-    tiled_coords = tf.tile(
-        tf.reshape(coords, (N_atoms, 1, ndim)), (1, M_nbrs, 1))
-    # Shape (N_atoms, M_nbrs)
-    dists = tf.reduce_sum((tiled_coords - nbr_coords)**2, axis=2)
-    out_tensor = dists
-    if set_tensors:
-      self.out_tensor = out_tensor
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.InteratomicL2Distances(
+        self.N_atoms, self.M_nbrs, self.ndim)
 
 
 class SparseSoftMaxCrossEntropy(Layer):
@@ -1925,7 +1920,7 @@ class ReduceSquareDifference(Layer):
     return out_tensor
 
 
-class Conv2D(SharedLayer):
+class Conv2D(KerasLayer):
   """A 2D convolution on the input.
 
   This layer expects its input to be a four dimensional tensor of shape (batch size, height, width, # channels).
@@ -2025,7 +2020,7 @@ class Conv2D(SharedLayer):
     return out_tensor
 
 
-class Conv3D(SharedLayer):
+class Conv3D(KerasLayer):
   """A 3D convolution on the input.
 
   This layer expects its input to be a five dimensional tensor of shape
@@ -2129,7 +2124,7 @@ class Conv3D(SharedLayer):
     return out_tensor
 
 
-class Conv2DTranspose(SharedLayer):
+class Conv2DTranspose(KerasLayer):
   """A transposed 2D convolution on the input.
 
   This layer is typically used for upsampling in a deconvolutional network.  It
@@ -2225,7 +2220,7 @@ class Conv2DTranspose(SharedLayer):
     return out_tensor
 
 
-class Conv3DTranspose(SharedLayer):
+class Conv3DTranspose(KerasLayer):
   """A transposed 3D convolution on the input.
 
   This layer is typically used for upsampling in a deconvolutional network.  It
@@ -2510,7 +2505,7 @@ class InputFifoQueue(Layer):
     self._non_pickle_fields += ['queue', 'out_tensors', 'close_op']
 
 
-class GraphConv(Layer):
+class GraphConv(KerasLayer):
 
   def __init__(self,
                out_channel,
@@ -2521,7 +2516,6 @@ class GraphConv(Layer):
     self.out_channel = out_channel
     self.min_degree = min_deg
     self.max_degree = max_deg
-    self.num_deg = 2 * max_deg + (1 - min_deg)
     self.activation_fn = activation_fn
     super(GraphConv, self).__init__(**kwargs)
     try:
@@ -2530,112 +2524,12 @@ class GraphConv(Layer):
     except:
       pass
 
-  def _create_variables(self, in_channels):
-    # Generate the nb_affine weights and biases
-    W_list = [
-        initializations.glorot_uniform(
-            [in_channels, self.out_channel], name='kernel')
-        for k in range(self.num_deg)
-    ]
-    b_list = [
-        model_ops.zeros(shape=[
-            self.out_channel,
-        ], name='bias') for k in range(self.num_deg)
-    ]
-    return (W_list, b_list)
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-    # in_layers = [atom_features, deg_slice, membership, deg_adj_list placeholders...]
-    in_channels = inputs[0].get_shape()[-1].value
-    if tf.executing_eagerly():
-      if not self._built:
-        W_list, b_list = self._create_variables(in_channels)
-        self.trainable_variables = W_list + b_list
-        self._built = True
-      else:
-        W_list = self.trainable_variables[:self.num_deg]
-        b_list = self.trainable_variables[self.num_deg:]
-    else:
-      W_list, b_list = self._create_variables(in_channels)
-
-    # Extract atom_features
-    atom_features = inputs[0]
-
-    # Extract graph topology
-    deg_slice = inputs[1]
-    deg_adj_lists = inputs[3:]
-
-    # Perform the mol conv
-    # atom_features = graph_conv(atom_features, deg_adj_lists, deg_slice,
-    #                            self.max_deg, self.min_deg, W_list,
-    #                            b_list)
-
-    W = iter(W_list)
-    b = iter(b_list)
-
-    # Sum all neighbors using adjacency matrix
-    deg_summed = self.sum_neigh(atom_features, deg_adj_lists)
-
-    # Get collection of modified atom features
-    new_rel_atoms_collection = (self.max_degree + 1 - self.min_degree) * [None]
-
-    for deg in range(1, self.max_degree + 1):
-      # Obtain relevant atoms for this degree
-      rel_atoms = deg_summed[deg - 1]
-
-      # Get self atoms
-      begin = tf.stack([deg_slice[deg - self.min_degree, 0], 0])
-      size = tf.stack([deg_slice[deg - self.min_degree, 1], -1])
-      self_atoms = tf.slice(atom_features, begin, size)
-
-      # Apply hidden affine to relevant atoms and append
-      rel_out = tf.matmul(rel_atoms, next(W)) + next(b)
-      self_out = tf.matmul(self_atoms, next(W)) + next(b)
-      out = rel_out + self_out
-
-      new_rel_atoms_collection[deg - self.min_degree] = out
-
-    # Determine the min_deg=0 case
-    if self.min_degree == 0:
-      deg = 0
-
-      begin = tf.stack([deg_slice[deg - self.min_degree, 0], 0])
-      size = tf.stack([deg_slice[deg - self.min_degree, 1], -1])
-      self_atoms = tf.slice(atom_features, begin, size)
-
-      # Only use the self layer
-      out = tf.matmul(self_atoms, next(W)) + next(b)
-
-      new_rel_atoms_collection[deg - self.min_degree] = out
-
-    # Combine all atoms back into the list
-    atom_features = tf.concat(axis=0, values=new_rel_atoms_collection)
-
-    if self.activation_fn is not None:
-      atom_features = self.activation_fn(atom_features)
-
-    out_tensor = atom_features
-    if set_tensors:
-      self.out_tensor = out_tensor
-      self.trainable_variables = W_list + b_list
-    return out_tensor
-
-  def sum_neigh(self, atoms, deg_adj_lists):
-    """Store the summed atoms by degree"""
-    deg_summed = self.max_degree * [None]
-
-    # Tensorflow correctly processes empty lists when using concat
-    for deg in range(1, self.max_degree + 1):
-      gathered_atoms = tf.gather(atoms, deg_adj_lists[deg - 1])
-      # Sum along neighbors as well as self, and store
-      summed_atoms = tf.reduce_sum(gathered_atoms, 1)
-      deg_summed[deg - 1] = summed_atoms
-
-    return deg_summed
+  def _build_layer(self):
+    return deepchem.models.layers.GraphConv(self.out_channel, self.min_degree,
+                                            self.max_degree, self.activation_fn)
 
 
-class GraphPool(Layer):
+class GraphPool(KerasLayer):
 
   def __init__(self, min_degree=0, max_degree=10, **kwargs):
     self.min_degree = min_degree
@@ -2646,49 +2540,11 @@ class GraphPool(Layer):
     except:
       pass
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-    atom_features = inputs[0]
-    deg_slice = inputs[1]
-    deg_adj_lists = inputs[3:]
-
-    # Perform the mol gather
-    # atom_features = graph_pool(atom_features, deg_adj_lists, deg_slice,
-    #                            self.max_degree, self.min_degree)
-
-    deg_maxed = (self.max_degree + 1 - self.min_degree) * [None]
-
-    # Tensorflow correctly processes empty lists when using concat
-
-    for deg in range(1, self.max_degree + 1):
-      # Get self atoms
-      begin = tf.stack([deg_slice[deg - self.min_degree, 0], 0])
-      size = tf.stack([deg_slice[deg - self.min_degree, 1], -1])
-      self_atoms = tf.slice(atom_features, begin, size)
-
-      # Expand dims
-      self_atoms = tf.expand_dims(self_atoms, 1)
-
-      # always deg-1 for deg_adj_lists
-      gathered_atoms = tf.gather(atom_features, deg_adj_lists[deg - 1])
-      gathered_atoms = tf.concat(axis=1, values=[self_atoms, gathered_atoms])
-
-      maxed_atoms = tf.reduce_max(gathered_atoms, 1)
-      deg_maxed[deg - self.min_degree] = maxed_atoms
-
-    if self.min_degree == 0:
-      begin = tf.stack([deg_slice[0, 0], 0])
-      size = tf.stack([deg_slice[0, 1], -1])
-      self_atoms = tf.slice(atom_features, begin, size)
-      deg_maxed[0] = self_atoms
-
-    out_tensor = tf.concat(axis=0, values=deg_maxed)
-    if set_tensors:
-      self.out_tensor = out_tensor
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.GraphPool(self.min_degree, self.max_degree)
 
 
-class GraphGather(Layer):
+class GraphGather(KerasLayer):
 
   def __init__(self, batch_size, activation_fn=None, **kwargs):
     self.batch_size = batch_size
@@ -2700,32 +2556,12 @@ class GraphGather(Layer):
     except:
       pass
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-
-    # x = [atom_features, deg_slice, membership, deg_adj_list placeholders...]
-    atom_features = inputs[0]
-
-    # Extract graph topology
-    membership = inputs[2]
-
-    assert self.batch_size > 1, "graph_gather requires batches larger than 1"
-
-    sparse_reps = tf.unsorted_segment_sum(atom_features, membership,
-                                          self.batch_size)
-    max_reps = tf.unsorted_segment_max(atom_features, membership,
-                                       self.batch_size)
-    mol_features = tf.concat(axis=1, values=[sparse_reps, max_reps])
-
-    if self.activation_fn is not None:
-      mol_features = self.activation_fn(mol_features)
-    out_tensor = mol_features
-    if set_tensors:
-      self.out_tensor = out_tensor
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.GraphGather(self.batch_size,
+                                              self.activation_fn)
 
 
-class LSTMStep(Layer):
+class LSTMStep(KerasLayer):
   """Layer that performs a single step LSTM update.
 
   This layer performs a single step LSTM update. Note that it is *not*
@@ -2770,85 +2606,20 @@ class LSTMStep(Layer):
     self.inner_activation = inner_activation_fn
     self.input_dim = input_dim
 
-  def get_initial_states(self, input_shape):
-    return [model_ops.zeros(input_shape), model_ops.zeros(input_shape)]
-
-  def _create_variables(self):
-    """Constructs learnable weights for this layer."""
-    init = self.init
-    inner_init = self.inner_init
-    W = init((self.input_dim, 4 * self.output_dim))
-    U = inner_init((self.output_dim, 4 * self.output_dim))
-
-    b = tf.Variable(
-        np.hstack((np.zeros(self.output_dim), np.ones(self.output_dim),
-                   np.zeros(self.output_dim), np.zeros(self.output_dim))),
-        dtype=tf.float32)
-    return [W, U, b]
+  def _build_layer(self):
+    return deepchem.models.layers.LSTMStep(
+        self.output_dim, self.input_dim, self.init, self.inner_init,
+        self.activation, self.inner_activation)
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """Execute this layer on input tensors.
-
-    Parameters
-    ----------
-    in_layers: list
-      List of three tensors (x, h_tm1, c_tm1). h_tm1 means "h, t-1".
-
-    Returns
-    -------
-    list
-      Returns h, [h + c]
-    """
-    activation = self.activation
-    inner_activation = self.inner_activation
-
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables = self._create_variables()
-        self._built = True
-      W, U, b = self.trainable_variables
-    else:
-      W, U, b = self._create_variables()
-    inputs = self._get_input_tensors(in_layers)
-    x, h_tm1, c_tm1 = inputs
-
-    # Taken from Keras code [citation needed]
-    z = model_ops.dot(x, W) + model_ops.dot(h_tm1, U) + b
-
-    z0 = z[:, :self.output_dim]
-    z1 = z[:, self.output_dim:2 * self.output_dim]
-    z2 = z[:, 2 * self.output_dim:3 * self.output_dim]
-    z3 = z[:, 3 * self.output_dim:]
-
-    i = inner_activation(z0)
-    f = inner_activation(z1)
-    c = f * c_tm1 + i * activation(z2)
-    o = inner_activation(z3)
-
-    h = o * activation(c)
-
+    result = super(LSTMStep, self).create_tensor(in_layers, set_tensors,
+                                                 **kwargs)
     if set_tensors:
-      self.out_tensor = h
-    return h, [h, c]
+      self.out_tensor = result[0]
+    return result
 
 
-def _cosine_dist(x, y):
-  """Computes the inner product (cosine distance) between two tensors.
-
-  Parameters
-  ----------
-  x: tf.Tensor
-    Input Tensor
-  y: tf.Tensor
-    Input Tensor
-  """
-  denom = (
-      model_ops.sqrt(model_ops.sum(tf.square(x)) * model_ops.sum(tf.square(y)))
-      + model_ops.epsilon())
-  return model_ops.dot(x, tf.transpose(y)) / denom
-
-
-class AttnLSTMEmbedding(Layer):
+class AttnLSTMEmbedding(KerasLayer):
   """Implements AttnLSTM as in matching networks paper.
 
   The AttnLSTM embedding adjusts two sets of vectors, the "test" and
@@ -2889,76 +2660,24 @@ class AttnLSTMEmbedding(Layer):
     self.n_support = n_support
     self.n_feat = n_feat
 
-  def _create_variables(self):
-    n_feat = self.n_feat
-    lstm = LSTMStep(n_feat, 2 * n_feat)
-    q_init = model_ops.zeros([self.n_test, n_feat])
-    r_init = model_ops.zeros([self.n_test, n_feat])
-    states_init = lstm.get_initial_states([self.n_test, n_feat])
-    return (lstm, q_init, r_init, states_init)
+  def _build_layer(self):
+    return deepchem.models.layers.AttnLSTMEmbedding(self.n_test, self.n_support,
+                                                    self.n_feat, self.max_depth)
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """Execute this layer on input tensors.
-
-    Parameters
-    ----------
-    in_layers: list
-      List of two tensors (X, Xp). X should be of shape (n_test,
-      n_feat) and Xp should be of shape (n_support, n_feat) where
-      n_test is the size of the test set, n_support that of the support
-      set, and n_feat is the number of per-atom features.
-
-    Returns
-    -------
-    list
-      Returns two tensors of same shape as input. Namely the output
-      shape will be [(n_test, n_feat), (n_support, n_feat)]
-    """
     inputs = self._get_input_tensors(in_layers)
-    if len(inputs) != 2:
-      raise ValueError("AttnLSTMEmbedding layer must have exactly two parents")
-    # x is test set, xp is support set.
-    x, xp = inputs
-
-    if tf.executing_eagerly():
-      if not self._built:
-        self._lstm, self.q_init, self.r_init, self.states_init = self._create_variables(
-        )
-        self._non_pickle_fields += ['_lstm', 'q_init', 'r_init', 'states_init']
-      lstm = self._lstm
-      q_init = self.q_init
-      r_init = self.r_init
-      states_init = self.states_init
-    else:
-      lstm, q_init, r_init, states_init = self._create_variables()
-
-    ### Performs computations
-
-    # Get initializations
-    q = q_init
-    states = states_init
-
-    for d in range(self.max_depth):
-      # Process using attention
-      # Eqn (4), appendix A.1 of Matching Networks paper
-      e = _cosine_dist(x + q, xp)
-      a = tf.nn.softmax(e)
-      r = model_ops.dot(a, xp)
-
-      # Generate new attention states
-      y = model_ops.concatenate([q, r], axis=1)
-      q, states = lstm(y, *states)
-
+    layer = self._get_layer(set_tensors)
+    result = layer(inputs)
     if set_tensors:
-      self.out_tensor = xp
+      self.out_tensor = result[1]
+      self.trainable_variables = layer.trainable_variables + layer.states_init
     if tf.executing_eagerly() and not self._built:
       self._built = True
-      self.trainable_variables = lstm.trainable_variables + [q_init, r_init
-                                                            ] + states_init
-    return [x + q, xp]
+      self.trainable_variables = layer.trainable_variables + layer.states_init
+    return result
 
 
-class IterRefLSTMEmbedding(Layer):
+class IterRefLSTMEmbedding(KerasLayer):
   """Implements the Iterative Refinement LSTM.
 
   Much like AttnLSTMEmbedding, the IterRefLSTMEmbedding is another type
@@ -2996,104 +2715,21 @@ class IterRefLSTMEmbedding(Layer):
     self.n_support = n_support
     self.n_feat = n_feat
 
-  def _create_variables(self):
-    n_feat = self.n_feat
-
-    # Support set lstm
-    support_lstm = LSTMStep(n_feat, 2 * n_feat)
-    q_init = model_ops.zeros([self.n_support, n_feat])
-    support_states_init = support_lstm.get_initial_states(
-        [self.n_support, n_feat])
-
-    # Test lstm
-    test_lstm = LSTMStep(n_feat, 2 * n_feat)
-    p_init = model_ops.zeros([self.n_test, n_feat])
-    test_states_init = test_lstm.get_initial_states([self.n_test, n_feat])
-    return (support_lstm, q_init, support_states_init, test_lstm, p_init,
-            test_states_init)
+  def _build_layer(self):
+    return deepchem.models.layers.IterRefLSTMEmbedding(
+        self.n_test, self.n_support, self.n_feat, self.max_depth)
 
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """Execute this layer on input tensors.
-
-    Parameters
-    ----------
-    in_layers: list
-      List of two tensors (X, Xp). X should be of shape (n_test, n_feat) and
-      Xp should be of shape (n_support, n_feat) where n_test is the size of
-      the test set, n_support that of the support set, and n_feat is the number
-      of per-atom features.
-
-    Returns
-    -------
-    list
-      Returns two tensors of same shape as input. Namely the output shape will
-      be [(n_test, n_feat), (n_support, n_feat)]
-    """
-    if tf.executing_eagerly():
-      if not self._built:
-        self._support_lstm, self.q_init, self.support_states_init, self._test_lstm, self.p_init, self.test_states_init = self._create_variables(
-        )
-        self._non_pickle_fields += [
-            '_support_lstm', 'q_init', 'support_states_init', '_test_lstm',
-            'p_init', 'test_states_init'
-        ]
-      support_lstm = self._support_lstm
-      q_init = self.q_init
-      support_states_init = self.support_states_init
-      test_lstm = self._test_lstm
-      p_init = self.p_init
-      test_states_init = self.test_states_init
-    else:
-      support_lstm, q_init, support_states_init, test_lstm, p_init, test_states_init = self._create_variables(
-      )
-
-    # self.build()
     inputs = self._get_input_tensors(in_layers)
-    if len(inputs) != 2:
-      raise ValueError(
-          "IterRefLSTMEmbedding layer must have exactly two parents")
-    x, xp = inputs
-
-    # Get initializations
-    p = p_init
-    q = q_init
-    # Rename support
-    z = xp
-    states = support_states_init
-    x_states = test_states_init
-
-    for d in range(self.max_depth):
-      # Process support xp using attention
-      e = _cosine_dist(z + q, xp)
-      a = tf.nn.softmax(e)
-      # Get linear combination of support set
-      r = model_ops.dot(a, xp)
-
-      # Process test x using attention
-      x_e = _cosine_dist(x + p, z)
-      x_a = tf.nn.softmax(x_e)
-      s = model_ops.dot(x_a, z)
-
-      # Generate new support attention states
-      qr = model_ops.concatenate([q, r], axis=1)
-      q, states = support_lstm(qr, *states)
-
-      # Generate new test attention states
-      ps = model_ops.concatenate([p, s], axis=1)
-      p, x_states = test_lstm(ps, *x_states)
-
-      # Redefine
-      z = r
-
+    layer = self._get_layer(set_tensors)
+    result = layer(inputs)
     if set_tensors:
-      self.out_tensor = xp
+      self.out_tensor = result[1]
+      self.trainable_variables = layer.trainable_variables + layer.support_states_init + layer.test_states_init
     if tf.executing_eagerly() and not self._built:
-      self.trainable_variables = support_lstm.trainable_variables + test_lstm.trainable_variables + [
-          q_init, p_init
-      ] + support_states_init + test_states_init
       self._built = True
-
-    return [x + p, xp + q]
+      self.trainable_variables = layer.trainable_variables + layer.support_states_init + layer.test_states_init
+    return result
 
 
 class BatchNorm(Layer):
@@ -3201,7 +2837,7 @@ class WeightedError(Layer):
     return out_tensor
 
 
-class VinaFreeEnergy(Layer):
+class VinaFreeEnergy(KerasLayer):
   """Computes free-energy as defined by Autodock Vina.
 
   TODO(rbharath): Make this layer support batching.
@@ -3230,149 +2866,28 @@ class VinaFreeEnergy(Layer):
     self.stop = stop
     super(VinaFreeEnergy, self).__init__(**kwargs)
 
-  def _build_layers(self):
-    weighted_combo = WeightedLinearCombo()
-    w = tf.Variable(tf.random_normal((1,), stddev=self.stddev))
-    return (weighted_combo, w)
-
-  def cutoff(self, d, x):
-    out_tensor = tf.where(d < 8, x, tf.zeros_like(x))
-    return out_tensor
-
-  def nonlinearity(self, c, w):
-    """Computes non-linearity used in Vina."""
-    out_tensor = c / (1 + w * self.Nrot)
-    return w, out_tensor
-
-  def repulsion(self, d):
-    """Computes Autodock Vina's repulsion interaction term."""
-    out_tensor = tf.where(d < 0, d**2, tf.zeros_like(d))
-    return out_tensor
-
-  def hydrophobic(self, d):
-    """Computes Autodock Vina's hydrophobic interaction term."""
-    out_tensor = tf.where(d < 0.5, tf.ones_like(d),
-                          tf.where(d < 1.5, 1.5 - d, tf.zeros_like(d)))
-    return out_tensor
-
-  def hydrogen_bond(self, d):
-    """Computes Autodock Vina's hydrogen bond interaction term."""
-    out_tensor = tf.where(
-        d < -0.7, tf.ones_like(d),
-        tf.where(d < 0, (1.0 / 0.7) * (0 - d), tf.zeros_like(d)))
-    return out_tensor
-
-  def gaussian_first(self, d):
-    """Computes Autodock Vina's first Gaussian interaction term."""
-    out_tensor = tf.exp(-(d / 0.5)**2)
-    return out_tensor
-
-  def gaussian_second(self, d):
-    """Computes Autodock Vina's second Gaussian interaction term."""
-    out_tensor = tf.exp(-((d - 3) / 2)**2)
-    return out_tensor
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    Parameters
-    ----------
-    X: tf.Tensor of shape (N, d)
-      Coordinates/features.
-    Z: tf.Tensor of shape (N)
-      Atomic numbers of neighbor atoms.
-
-    Returns
-    -------
-    layer: tf.Tensor of shape (B)
-      The free energy of each complex in batch
-    """
-    inputs = self._get_input_tensors(in_layers)
-    X = inputs[0]
-    Z = inputs[1]
-
-    if tf.executing_eagerly():
-      if not self._built:
-        self._weighted_combo, self._w = self._build_layers()
-        self._non_pickle_fields += ['_weighted_combo', '_w']
-      weighted_combo = self._weighted_combo
-      w = self._w
-    else:
-      weighted_combo, w = self._build_layers()
-
-    # TODO(rbharath): This layer shouldn't be neighbor-listing. Make
-    # neighbors lists an argument instead of a part of this layer.
-    nbr_list = NeighborList(self.N_atoms, self.M_nbrs, self.ndim,
-                            self.nbr_cutoff, self.start, self.stop)(X)
-
-    # Shape (N, M)
-    dists = InteratomicL2Distances(self.N_atoms, self.M_nbrs,
-                                   self.ndim)(X, nbr_list)
-
-    repulsion = self.repulsion(dists)
-    hydrophobic = self.hydrophobic(dists)
-    hbond = self.hydrogen_bond(dists)
-    gauss_1 = self.gaussian_first(dists)
-    gauss_2 = self.gaussian_second(dists)
-
-    # Shape (N, M)
-    interactions = weighted_combo(repulsion, hydrophobic, hbond, gauss_1,
-                                  gauss_2)
-
-    # Shape (N, M)
-    thresholded = self.cutoff(dists, interactions)
-
-    weight, free_energies = self.nonlinearity(thresholded, w)
-    free_energy = ReduceSum()(free_energies)
-
-    out_tensor = free_energy
-    if set_tensors:
-      self.out_tensor = out_tensor
-      self.trainable_variables = weighted_combo.trainable_variables + [w]
-    if tf.executing_eagerly() and not self._built:
-      self.trainable_variables = weighted_combo.trainable_variables + [w]
-      self._built = True
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.VinaFreeEnergy(
+        self.N_atoms, self.M_nbrs, self.ndim, self.nbr_cutoff, self.start,
+        self.stop, self.stddev, self.Nrot)
 
 
-class WeightedLinearCombo(Layer):
+class WeightedLinearCombo(KerasLayer):
   """Computes a weighted linear combination of input layers, with the weights defined by trainable variables."""
 
   def __init__(self, in_layers=None, std=.3, **kwargs):
     self.std = std
-    super(WeightedLinearCombo, self).__init__(in_layers, **kwargs)
+    super(WeightedLinearCombo, self).__init__(int_layers=in_layers, **kwargs)
     try:
       self._shape = tuple(self.in_layers[0].shape)
     except:
       pass
 
-  def _create_variables(self, inputs):
-    return [
-        tf.Variable(tf.random_normal([1], stddev=self.std))
-        for i in range(len(inputs))
-    ]
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers, True)
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables = self._create_variables(inputs)
-        self._built = True
-      weights = self.trainable_variables
-    else:
-      weights = self._create_variables(inputs)
-    out_tensor = None
-    for in_tensor, w in zip(inputs, weights):
-      if out_tensor is None:
-        out_tensor = w * in_tensor
-      else:
-        out_tensor += w * in_tensor
-    if set_tensors:
-      self.out_tensor = out_tensor
-      self.trainable_variables = weights
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.WeightedLinearCombo(self.std)
 
 
-class NeighborList(Layer):
+class NeighborList(KerasLayer):
   """Computes a neighbor-list in Tensorflow.
 
   Neighbor-lists (also called Verlet Lists) are a tool for grouping atoms which
@@ -3406,20 +2921,10 @@ class NeighborList(Layer):
     self.stop = stop
     super(NeighborList, self).__init__(**kwargs)
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """Creates tensors associated with neighbor-listing."""
-    inputs = self._get_input_tensors(in_layers)
-    if len(inputs) != 1:
-      raise ValueError("NeighborList can only have one input")
-    parent = inputs[0]
-    if len(parent.get_shape()) != 2:
-      # TODO(rbharath): Support batching
-      raise ValueError("Parent tensor must be (num_atoms, ndum)")
-    coords = parent
-    out_tensor = self.compute_nbr_list(coords)
-    if set_tensors:
-      self.out_tensor = out_tensor
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.NeighborList(self.N_atoms, self.M_nbrs,
+                                               self.ndim, self.nbr_cutoff,
+                                               self.start, self.stop)
 
   def compute_nbr_list(self, coords):
     """Get closest neighbors for atoms.
@@ -3436,52 +2941,7 @@ class NeighborList(Layer):
     nbr_list: tf.Tensor
       Shape (N_atoms, M_nbrs) of atom indices
     """
-    # Shape (n_cells, ndim)
-    cells = self.get_cells()
-
-    # List of length N_atoms, each element of different length uniques_i
-    nbrs = self.get_atoms_in_nbrs(coords, cells)
-    padding = tf.fill((self.M_nbrs,), -1)
-    padded_nbrs = [tf.concat([unique_nbrs, padding], 0) for unique_nbrs in nbrs]
-
-    # List of length N_atoms, each element of different length uniques_i
-    # List of length N_atoms, each a tensor of shape
-    # (uniques_i, ndim)
-    nbr_coords = [tf.gather(coords, atom_nbrs) for atom_nbrs in nbrs]
-
-    # Add phantom atoms that exist far outside the box
-    coord_padding = tf.cast(
-        tf.fill((self.M_nbrs, self.ndim), 2 * self.stop), tf.float32)
-    padded_nbr_coords = [
-        tf.concat([nbr_coord, coord_padding], 0) for nbr_coord in nbr_coords
-    ]
-
-    # List of length N_atoms, each of shape (1, ndim)
-    atom_coords = tf.split(coords, self.N_atoms)
-    # TODO(rbharath): How does distance need to be modified here to
-    # account for periodic boundary conditions?
-    # List of length N_atoms each of shape (M_nbrs)
-    padded_dists = [
-        tf.reduce_sum((atom_coord - padded_nbr_coord)**2, axis=1)
-        for (atom_coord,
-             padded_nbr_coord) in zip(atom_coords, padded_nbr_coords)
-    ]
-
-    padded_closest_nbrs = [
-        tf.nn.top_k(-padded_dist, k=self.M_nbrs)[1]
-        for padded_dist in padded_dists
-    ]
-
-    # N_atoms elts of size (M_nbrs,) each
-    padded_neighbor_list = [
-        tf.gather(padded_atom_nbrs, padded_closest_nbr)
-        for (padded_atom_nbrs,
-             padded_closest_nbr) in zip(padded_nbrs, padded_closest_nbrs)
-    ]
-
-    neighbor_list = tf.stack(padded_neighbor_list)
-
-    return neighbor_list
+    return self._get_layer(False).compute_nbr_list(coords)
 
   def get_atoms_in_nbrs(self, coords, cells):
     """Get the atoms in neighboring cells for each cells.
@@ -3490,39 +2950,7 @@ class NeighborList(Layer):
     -------
     atoms_in_nbrs = (N_atoms, n_nbr_cells, M_nbrs)
     """
-    # Shape (N_atoms, 1)
-    cells_for_atoms = self.get_cells_for_atoms(coords, cells)
-
-    # Find M_nbrs atoms closest to each cell
-    # Shape (n_cells, M_nbrs)
-    closest_atoms = self.get_closest_atoms(coords, cells)
-
-    # Associate each cell with its neighbor cells. Assumes periodic boundary
-    # conditions, so does wrapround. O(constant)
-    # Shape (n_cells, n_nbr_cells)
-    neighbor_cells = self.get_neighbor_cells(cells)
-
-    # Shape (N_atoms, n_nbr_cells)
-    neighbor_cells = tf.squeeze(tf.gather(neighbor_cells, cells_for_atoms))
-
-    # Shape (N_atoms, n_nbr_cells, M_nbrs)
-    atoms_in_nbrs = tf.gather(closest_atoms, neighbor_cells)
-
-    # Shape (N_atoms, n_nbr_cells*M_nbrs)
-    atoms_in_nbrs = tf.reshape(atoms_in_nbrs, [self.N_atoms, -1])
-
-    # List of length N_atoms, each element length uniques_i
-    nbrs_per_atom = tf.split(atoms_in_nbrs, self.N_atoms)
-    uniques = [
-        tf.unique(tf.squeeze(atom_nbrs))[0] for atom_nbrs in nbrs_per_atom
-    ]
-
-    # TODO(rbharath): FRAGILE! Uses fact that identity seems to be the first
-    # element removed to remove self from list of neighbors. Need to verify
-    # this holds more broadly or come up with robust alternative.
-    uniques = [unique[1:] for unique in uniques]
-
-    return uniques
+    return self._get_layer(False).get_atoms_in_nbrs(coords, cells)
 
   def get_closest_atoms(self, coords, cells):
     """For each cell, find M_nbrs closest atoms.
@@ -3541,26 +2969,7 @@ class NeighborList(Layer):
     closest_inds: tf.Tensor
       Of shape (n_cells, M_nbrs)
     """
-    N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells, self.ndim,
-                                      self.M_nbrs)
-    # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
-    tiled_cells = tf.reshape(
-        tf.tile(cells, (1, N_atoms)), (N_atoms * n_cells, ndim))
-
-    # Shape (N_atoms*n_cells, ndim) after tile
-    tiled_coords = tf.tile(coords, (n_cells, 1))
-
-    # Shape (N_atoms*n_cells)
-    coords_vec = tf.reduce_sum((tiled_coords - tiled_cells)**2, axis=1)
-    # Shape (n_cells, N_atoms)
-    coords_norm = tf.reshape(coords_vec, (n_cells, N_atoms))
-
-    # Find k atoms closest to this cell. Notice negative sign since
-    # tf.nn.top_k returns *largest* not smallest.
-    # Tensor of shape (n_cells, M_nbrs)
-    closest_inds = tf.nn.top_k(-coords_norm, k=M_nbrs)[1]
-
-    return closest_inds
+    return self._get_layer(False).get_closest_atoms(coords, cells)
 
   def get_cells_for_atoms(self, coords, cells):
     """Compute the cells each atom belongs to.
@@ -3576,33 +2985,7 @@ class NeighborList(Layer):
     cells_for_atoms: tf.Tensor
       Shape (N_atoms, 1)
     """
-    N_atoms, n_cells, ndim = self.N_atoms, self.n_cells, self.ndim
-    n_cells = int(n_cells)
-    # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
-    tiled_cells = tf.tile(cells, (N_atoms, 1))
-
-    # Shape (N_atoms*n_cells, 1) after tile
-    tiled_coords = tf.reshape(
-        tf.tile(coords, (1, n_cells)), (n_cells * N_atoms, ndim))
-    coords_vec = tf.reduce_sum((tiled_coords - tiled_cells)**2, axis=1)
-    coords_norm = tf.reshape(coords_vec, (N_atoms, n_cells))
-
-    closest_inds = tf.nn.top_k(-coords_norm, k=1)[1]
-    return closest_inds
-
-  def _get_num_nbrs(self):
-    """Get number of neighbors in current dimensionality space."""
-    ndim = self.ndim
-    if ndim == 1:
-      n_nbr_cells = 3
-    elif ndim == 2:
-      # 9 neighbors in 2-space
-      n_nbr_cells = 9
-    # TODO(rbharath): Shoddy handling of higher dimensions...
-    elif ndim >= 3:
-      # Number of cells for cube in 3-space is
-      n_nbr_cells = 27  # (26 faces on Rubik's cube for example)
-    return n_nbr_cells
+    return self._get_layer(False).get_cells_for_atoms(coords, cells)
 
   def get_neighbor_cells(self, cells):
     """Compute neighbors of cells in grid.
@@ -3622,21 +3005,7 @@ class NeighborList(Layer):
     nbr_cells: tf.Tensor
       (n_cells, n_nbr_cells)
     """
-    ndim, n_cells = self.ndim, self.n_cells
-    n_nbr_cells = self._get_num_nbrs()
-    # Tile cells to form arrays of size (n_cells*n_cells, ndim)
-    # Two tilings (a, b, c, a, b, c, ...) vs. (a, a, a, b, b, b, etc.)
-    # Tile (a, a, a, b, b, b, etc.)
-    tiled_centers = tf.reshape(
-        tf.tile(cells, (1, n_cells)), (n_cells * n_cells, ndim))
-    # Tile (a, b, c, a, b, c, ...)
-    tiled_cells = tf.tile(cells, (n_cells, 1))
-
-    coords_vec = tf.reduce_sum((tiled_centers - tiled_cells)**2, axis=1)
-    coords_norm = tf.reshape(coords_vec, (n_cells, n_cells))
-    closest_inds = tf.nn.top_k(-coords_norm, k=n_nbr_cells)[1]
-
-    return closest_inds
+    return self._get_layer(False).get_neighbor_cells(cells)
 
   def get_cells(self):
     """Returns the locations of all grid points in box.
@@ -3650,12 +3019,7 @@ class NeighborList(Layer):
     cells: tf.Tensor
       (n_cells, ndim) shape.
     """
-    start, stop, nbr_cutoff = self.start, self.stop, self.nbr_cutoff
-    mesh_args = [tf.range(start, stop, nbr_cutoff) for _ in range(self.ndim)]
-    return tf.cast(
-        tf.reshape(
-            tf.transpose(tf.stack(tf.meshgrid(*mesh_args))),
-            (self.n_cells, self.ndim)), tf.float32)
+    return self._get_layer(False).get_cells()
 
 
 class Dropout(Layer):
@@ -3714,7 +3078,7 @@ class WeightDecay(Layer):
     return out_tensor
 
 
-class AtomicConvolution(Layer):
+class AtomicConvolution(KerasLayer):
 
   def __init__(self,
                atom_types=None,
@@ -3742,206 +3106,9 @@ class AtomicConvolution(Layer):
     self.atom_types = atom_types
     super(AtomicConvolution, self).__init__(**kwargs)
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    Parameters
-    ----------
-    X: tf.Tensor of shape (B, N, d)
-      Coordinates/features.
-    Nbrs: tf.Tensor of shape (B, N, M)
-      Neighbor list.
-    Nbrs_Z: tf.Tensor of shape (B, N, M)
-      Atomic numbers of neighbor atoms.
-
-    Returns
-    -------
-    layer: tf.Tensor of shape (B, N, l)
-      A new tensor representing the output of the atomic conv layer
-    """
-    inputs = self._get_input_tensors(in_layers)
-    X = inputs[0]
-    Nbrs = tf.cast(inputs[1], tf.int32)
-    Nbrs_Z = inputs[2]
-
-    # N: Maximum number of atoms
-    # M: Maximum number of neighbors
-    # d: Number of coordinates/features/filters
-    # B: Batch Size
-    N = X.get_shape()[-2].value
-    d = X.get_shape()[-1].value
-    M = Nbrs.get_shape()[-1].value
-    B = X.get_shape()[0].value
-
-    # Create the variables.
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables += self._create_radial_variables()
-      rc, rs, re = self.trainable_variables
-    else:
-      rc, rs, re = self._create_radial_variables()
-
-    # Compute the distances and radial symmetry functions.
-    D = self.distance_tensor(X, Nbrs, self.boxsize, B, N, M, d)
-    R = self.distance_matrix(D)
-    R = tf.reshape(R, [1] + R.shape.as_list())
-    rsf = self.radial_symmetry_function(R, rc, rs, re)
-
-    if not self.atom_types:
-      cond = tf.cast(tf.not_equal(Nbrs_Z, 0), tf.float32)
-      cond = tf.reshape(cond, R.shape)
-      layer = tf.reduce_sum(cond * rsf, 3)
-    else:
-      sym = []
-      for j in range(len(self.atom_types)):
-        cond = tf.cast(tf.equal(Nbrs_Z, self.atom_types[j]), tf.float32)
-        cond = tf.reshape(cond, R.shape)
-        sym.append(tf.reduce_sum(cond * rsf, 3))
-      layer = tf.concat(sym, 0)
-
-    layer = tf.transpose(layer, [1, 2, 0])  # (l, B, N) -> (B, N, l)
-    m, v = tf.nn.moments(layer, axes=[0])
-    out_tensor = tf.nn.batch_normalization(layer, m, v, None, None, 1e-3)
-    if set_tensors:
-      self.out_tensor = out_tensor
-      self.trainable_variables = [rc, rs, re]
-    if tf.executing_eagerly() and not self._built:
-      self._built = True
-    return out_tensor
-
-  def _create_radial_variables(self):
-    vars = []
-    for i in range(3):
-      val = np.array([p[i] for p in self.radial_params]).reshape((-1, 1, 1, 1))
-      vars.append(tf.Variable(val, dtype=tf.float32))
-    return vars
-
-  def radial_symmetry_function(self, R, rc, rs, e):
-    """Calculates radial symmetry function.
-
-    B = batch_size, N = max_num_atoms, M = max_num_neighbors, d = num_filters
-
-    Parameters
-    ----------
-    R: tf.Tensor of shape (B, N, M)
-      Distance matrix.
-    rc: float
-      Interaction cutoff [Angstrom].
-    rs: float
-      Gaussian distance matrix mean.
-    e: float
-      Gaussian distance matrix width.
-
-    Returns
-    -------
-    retval: tf.Tensor of shape (B, N, M)
-      Radial symmetry function (before summation)
-
-    """
-
-    K = self.gaussian_distance_matrix(R, rs, e)
-    FC = self.radial_cutoff(R, rc)
-    return tf.multiply(K, FC)
-
-  def radial_cutoff(self, R, rc):
-    """Calculates radial cutoff matrix.
-
-    B = batch_size, N = max_num_atoms, M = max_num_neighbors
-
-    Parameters
-    ----------
-      R [B, N, M]: tf.Tensor
-        Distance matrix.
-      rc: tf.Variable
-        Interaction cutoff [Angstrom].
-
-    Returns
-    -------
-      FC [B, N, M]: tf.Tensor
-        Radial cutoff matrix.
-
-    """
-
-    T = 0.5 * (tf.cos(np.pi * R / (rc)) + 1)
-    E = tf.zeros_like(T)
-    cond = tf.less_equal(R, rc)
-    FC = tf.where(cond, T, E)
-    return FC
-
-  def gaussian_distance_matrix(self, R, rs, e):
-    """Calculates gaussian distance matrix.
-
-    B = batch_size, N = max_num_atoms, M = max_num_neighbors
-
-    Parameters
-    ----------
-      R [B, N, M]: tf.Tensor
-        Distance matrix.
-      rs: tf.Variable
-        Gaussian distance matrix mean.
-      e: tf.Variable
-        Gaussian distance matrix width (e = .5/std**2).
-
-    Returns
-    -------
-      retval [B, N, M]: tf.Tensor
-        Gaussian distance matrix.
-
-    """
-
-    return tf.exp(-e * (R - rs)**2)
-
-  def distance_tensor(self, X, Nbrs, boxsize, B, N, M, d):
-    """Calculates distance tensor for batch of molecules.
-
-    B = batch_size, N = max_num_atoms, M = max_num_neighbors, d = num_features
-
-    Parameters
-    ----------
-    X: tf.Tensor of shape (B, N, d)
-      Coordinates/features tensor.
-    Nbrs: tf.Tensor of shape (B, N, M)
-      Neighbor list tensor.
-    boxsize: float or None
-      Simulation box length [Angstrom].
-
-    Returns
-    -------
-    D: tf.Tensor of shape (B, N, M, d)
-      Coordinates/features distance tensor.
-
-    """
-    D = []
-    for coords, neighbors in zip(tf.unstack(X), tf.unstack(Nbrs)):
-      flat_neighbors = tf.reshape(neighbors, [-1])
-      neighbor_coords = tf.gather(coords, flat_neighbors)
-      neighbor_coords = tf.reshape(neighbor_coords, [N, M, d])
-      D.append(neighbor_coords - tf.expand_dims(coords, 1))
-    D = tf.stack(D)
-    if boxsize is not None:
-      boxsize = tf.reshape(boxsize, [1, 1, 1, d])
-      D -= tf.round(D / boxsize) * boxsize
-    return D
-
-  def distance_matrix(self, D):
-    """Calcuates the distance matrix from the distance tensor
-
-    B = batch_size, N = max_num_atoms, M = max_num_neighbors, d = num_features
-
-    Parameters
-    ----------
-    D: tf.Tensor of shape (B, N, M, d)
-      Distance tensor.
-
-    Returns
-    -------
-    R: tf.Tensor of shape (B, N, M)
-       Distance matrix.
-
-    """
-
-    R = tf.reduce_sum(tf.multiply(D, D), 3)
-    R = tf.sqrt(R)
-    return R
+  def _build_layer(self):
+    return deepchem.models.layers.AtomicConvolution(
+        self.atom_types, self.radial_params, self.boxsize)
 
 
 def AlphaShare(in_layers=None, **kwargs):
@@ -3968,7 +3135,7 @@ def AlphaShare(in_layers=None, **kwargs):
   return [LayerSplitter(x, in_layers=alpha_share) for x in range(num_outputs)]
 
 
-class AlphaShareLayer(Layer):
+class AlphaShareLayer(KerasLayer):
   """
   Part of a sluice network. Adds alpha parameters to control
   sharing between the main and auxillary tasks
@@ -3989,58 +3156,20 @@ class AlphaShareLayer(Layer):
   def __init__(self, **kwargs):
     super(AlphaShareLayer, self).__init__(**kwargs)
 
+  def _build_layer(self):
+    return deepchem.models.layers.AlphaShareLayer()
+
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-    # check that there isnt just one or zero inputs
-    if len(inputs) <= 1:
-      raise ValueError("AlphaShare must have more than one input")
-    self.num_outputs = len(inputs)
-    # create subspaces
-    subspaces = []
-    original_cols = int(inputs[0].get_shape()[-1].value)
-    subspace_size = int(original_cols / 2)
-    for input_tensor in inputs:
-      subspaces.append(tf.reshape(input_tensor[:, :subspace_size], [-1]))
-      subspaces.append(tf.reshape(input_tensor[:, subspace_size:], [-1]))
-    n_alphas = len(subspaces)
-    subspaces = tf.reshape(tf.stack(subspaces), [n_alphas, -1])
-
-    # create the alpha learnable parameters
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables = [
-            tf.Variable(tf.random_normal([n_alphas, n_alphas]), name='alphas')
-        ]
-        self._built = True
-      alphas = self.trainable_variables[0]
-    else:
-      alphas = tf.Variable(
-          tf.random_normal([n_alphas, n_alphas]), name='alphas')
-
-    subspaces = tf.matmul(alphas, subspaces)
-
-    # concatenate subspaces, reshape to size of original input, then stack
-    # such that out_tensor has shape (2,?,original_cols)
-    count = 0
-    out_tensors = []
-    tmp_tensor = []
-    for row in range(n_alphas):
-      tmp_tensor.append(tf.reshape(subspaces[row,], [-1, subspace_size]))
-      count += 1
-      if (count == 2):
-        out_tensors.append(tf.concat(tmp_tensor, 1))
-        tmp_tensor = []
-        count = 0
-
+    outputs = super(AlphaShareLayer, self).create_tensor(
+        in_layers, set_tensors, **kwargs)
     if set_tensors:
-      self.out_tensor = out_tensors[0]
-      self.out_tensors = out_tensors
-      self.alphas = alphas
-      self._non_pickle_fields += ['out_tensors', 'alphas']
-    return out_tensors
+      self.out_tensor = outputs[0]
+      self.out_tensors = outputs
+      self._non_pickle_fields.append('out_tensors')
+    return outputs
 
 
-class SluiceLoss(Layer):
+class SluiceLoss(KerasLayer):
   """
   Calculates the loss in a Sluice Network
   Every input into an AlphaShare should be used in SluiceLoss
@@ -4049,25 +3178,11 @@ class SluiceLoss(Layer):
   def __init__(self, **kwargs):
     super(SluiceLoss, self).__init__(**kwargs)
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-    temp = []
-    subspaces = []
-    # creates subspaces the same way it was done in AlphaShare
-    for input_tensor in inputs:
-      subspace_size = int(input_tensor.get_shape()[-1].value / 2)
-      subspaces.append(input_tensor[:, :subspace_size])
-      subspaces.append(input_tensor[:, subspace_size:])
-      product = tf.matmul(tf.transpose(subspaces[0]), subspaces[1])
-      subspaces = []
-      # calculate squared Frobenius norm
-      temp.append(tf.reduce_sum(tf.pow(product, 2)))
-    out_tensor = tf.reduce_sum(temp)
-    self.out_tensor = out_tensor
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.SluiceLoss()
 
 
-class BetaShare(Layer):
+class BetaShare(KerasLayer):
   """
   Part of a sluice network. Adds beta params to control which layer
   outputs are used for prediction
@@ -4086,35 +3201,11 @@ class BetaShare(Layer):
   def __init__(self, **kwargs):
     super(BetaShare, self).__init__(**kwargs)
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-        Size of input layers must all be the same
-        """
-    inputs = self._get_input_tensors(in_layers)
-    subspaces = []
-    original_cols = int(inputs[0].get_shape()[-1].value)
-    for input_tensor in inputs:
-      subspaces.append(tf.reshape(input_tensor, [-1]))
-    n_betas = len(inputs)
-    subspaces = tf.reshape(tf.stack(subspaces), [n_betas, -1])
-
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables = [
-            tf.Variable(tf.random_normal([1, n_betas]), name='betas')
-        ]
-        self._built = True
-      betas = self.trainable_variables[0]
-    else:
-      betas = tf.Variable(tf.random_normal([1, n_betas]), name='betas')
-    out_tensor = tf.matmul(betas, subspaces)
-    out_tensor = tf.reshape(out_tensor, [-1, original_cols])
-    if set_tensors:
-      self.out_tensor = out_tensor
-    return out_tensor
+  def _build_layer(self):
+    return deepchem.models.layers.BetaShare()
 
 
-class ANIFeat(Layer):
+class ANIFeat(KerasLayer):
   """Performs transform from 3D coordinates to ANI symmetry functions
   """
 
@@ -4140,161 +3231,13 @@ class ANIFeat(Layer):
     self.atom_cases = atom_cases
     self.atomic_number_differentiated = atomic_number_differentiated
     self.coordinates_in_bohr = coordinates_in_bohr
-    super(ANIFeat, self).__init__(in_layers, **kwargs)
+    super(ANIFeat, self).__init__(in_layers=in_layers, **kwargs)
 
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-    In layers should be of shape dtype tf.float32, (None, self.max_atoms, 4)
-
-    """
-    inputs = self._get_input_tensors(in_layers)[0]
-    atom_numbers = tf.cast(inputs[:, :, 0], tf.int32)
-    flags = tf.sign(atom_numbers)
-    flags = tf.cast(
-        tf.expand_dims(flags, 1) * tf.expand_dims(flags, 2), tf.float32)
-    coordinates = inputs[:, :, 1:]
-    if self.coordinates_in_bohr:
-      coordinates = coordinates * 0.52917721092
-
-    d = self.distance_matrix(coordinates, flags)
-
-    d_radial_cutoff = self.distance_cutoff(d, self.radial_cutoff, flags)
-    d_angular_cutoff = self.distance_cutoff(d, self.angular_cutoff, flags)
-
-    radial_sym = self.radial_symmetry(d_radial_cutoff, d, atom_numbers)
-    angular_sym = self.angular_symmetry(d_angular_cutoff, d, atom_numbers,
-                                        coordinates)
-
-    out_tensor = tf.concat(
-        [
-            tf.cast(tf.expand_dims(atom_numbers, 2), tf.float32), radial_sym,
-            angular_sym
-        ],
-        axis=2)
-
-    if set_tensors:
-      self.out_tensor = out_tensor
-
-    return out_tensor
-
-  def distance_matrix(self, coordinates, flags):
-    """ Generate distance matrix """
-    # (TODO YTZ:) faster, less memory intensive way
-    # r = tf.reduce_sum(tf.square(coordinates), 2)
-    # r = tf.expand_dims(r, -1)
-    # inner = 2*tf.matmul(coordinates, tf.transpose(coordinates, perm=[0,2,1]))
-    # # inner = 2*tf.matmul(coordinates, coordinates, transpose_b=True)
-
-    # d = r - inner + tf.transpose(r, perm=[0,2,1])
-    # d = tf.nn.relu(d) # fix numerical instabilities about diagonal
-    # d = tf.sqrt(d) # does this have negative elements? may be unstable for diagonals
-
-    max_atoms = self.max_atoms
-    tensor1 = tf.stack([coordinates] * max_atoms, axis=1)
-    tensor2 = tf.stack([coordinates] * max_atoms, axis=2)
-
-    # Calculate pairwise distance
-    d = tf.sqrt(
-        tf.reduce_sum(tf.squared_difference(tensor1, tensor2), axis=3) + 1e-7)
-
-    d = d * flags
-    return d
-
-  def distance_cutoff(self, d, cutoff, flags):
-    """ Generate distance matrix with trainable cutoff """
-    # Cutoff with threshold Rc
-    d_flag = flags * tf.sign(cutoff - d)
-    d_flag = tf.nn.relu(d_flag)
-    d_flag = d_flag * tf.expand_dims((1 - tf.eye(self.max_atoms)), 0)
-    d = 0.5 * (tf.cos(np.pi * d / cutoff) + 1)
-    return d * d_flag
-    # return d
-
-  def radial_symmetry(self, d_cutoff, d, atom_numbers):
-    """ Radial Symmetry Function """
-    embedding = tf.eye(np.max(self.atom_cases) + 1)
-    atom_numbers_embedded = tf.nn.embedding_lookup(embedding, atom_numbers)
-
-    Rs = np.linspace(0., self.radial_cutoff, self.radial_length)
-    ita = np.ones_like(Rs) * 3 / (Rs[1] - Rs[0])**2
-    Rs = tf.cast(np.reshape(Rs, (1, 1, 1, -1)), tf.float32)
-    ita = tf.cast(np.reshape(ita, (1, 1, 1, -1)), tf.float32)
-    length = ita.get_shape().as_list()[-1]
-
-    d_cutoff = tf.stack([d_cutoff] * length, axis=3)
-    d = tf.stack([d] * length, axis=3)
-
-    out = tf.exp(-ita * tf.square(d - Rs)) * d_cutoff
-    if self.atomic_number_differentiated:
-      out_tensors = []
-      for atom_type in self.atom_cases:
-        selected_atoms = tf.expand_dims(
-            tf.expand_dims(atom_numbers_embedded[:, :, atom_type], axis=1),
-            axis=3)
-        out_tensors.append(tf.reduce_sum(out * selected_atoms, axis=2))
-      return tf.concat(out_tensors, axis=2)
-    else:
-      return tf.reduce_sum(out, axis=2)
-
-  def angular_symmetry(self, d_cutoff, d, atom_numbers, coordinates):
-    """ Angular Symmetry Function """
-
-    max_atoms = self.max_atoms
-    embedding = tf.eye(np.max(self.atom_cases) + 1)
-    atom_numbers_embedded = tf.nn.embedding_lookup(embedding, atom_numbers)
-
-    Rs = np.linspace(0., self.angular_cutoff, self.angular_length)
-    ita = 3 / (Rs[1] - Rs[0])**2
-    thetas = np.linspace(0., np.pi, self.angular_length)
-    zeta = float(self.angular_length**2)
-
-    ita, zeta, Rs, thetas = np.meshgrid(ita, zeta, Rs, thetas)
-    zeta = tf.cast(np.reshape(zeta, (1, 1, 1, 1, -1)), tf.float32)
-    ita = tf.cast(np.reshape(ita, (1, 1, 1, 1, -1)), tf.float32)
-    Rs = tf.cast(np.reshape(Rs, (1, 1, 1, 1, -1)), tf.float32)
-    thetas = tf.cast(np.reshape(thetas, (1, 1, 1, 1, -1)), tf.float32)
-    length = zeta.get_shape().as_list()[-1]
-
-    # tf.stack issues again...
-    vector_distances = tf.stack([coordinates] * max_atoms, 1) - tf.stack(
-        [coordinates] * max_atoms, 2)
-    R_ij = tf.stack([d] * max_atoms, axis=3)
-    R_ik = tf.stack([d] * max_atoms, axis=2)
-    f_R_ij = tf.stack([d_cutoff] * max_atoms, axis=3)
-    f_R_ik = tf.stack([d_cutoff] * max_atoms, axis=2)
-
-    # Define angle theta = arccos(R_ij(Vector) dot R_ik(Vector)/R_ij(distance)/R_ik(distance))
-    vector_mul = tf.reduce_sum(tf.stack([vector_distances] * max_atoms, axis=3) * \
-                               tf.stack([vector_distances] * max_atoms, axis=2), axis=4)
-    vector_mul = vector_mul * tf.sign(f_R_ij) * tf.sign(f_R_ik)
-    theta = tf.acos(tf.math.divide(vector_mul, R_ij * R_ik + 1e-5))
-
-    R_ij = tf.stack([R_ij] * length, axis=4)
-    R_ik = tf.stack([R_ik] * length, axis=4)
-    f_R_ij = tf.stack([f_R_ij] * length, axis=4)
-    f_R_ik = tf.stack([f_R_ik] * length, axis=4)
-    theta = tf.stack([theta] * length, axis=4)
-
-    out_tensor = tf.pow((1. + tf.cos(theta - thetas)) / 2., zeta) * \
-                 tf.exp(-ita * tf.square((R_ij + R_ik) / 2. - Rs)) * f_R_ij * f_R_ik * 2
-
-    if self.atomic_number_differentiated:
-      out_tensors = []
-      for id_j, atom_type_j in enumerate(self.atom_cases):
-        for atom_type_k in self.atom_cases[id_j:]:
-          selected_atoms = tf.stack([atom_numbers_embedded[:, :, atom_type_j]] * max_atoms, axis=2) * \
-                           tf.stack([atom_numbers_embedded[:, :, atom_type_k]] * max_atoms, axis=1)
-          selected_atoms = tf.expand_dims(
-              tf.expand_dims(selected_atoms, axis=1), axis=4)
-          out_tensors.append(
-              tf.reduce_sum(out_tensor * selected_atoms, axis=(2, 3)))
-      return tf.concat(out_tensors, axis=2)
-    else:
-      return tf.reduce_sum(out_tensor, axis=(2, 3))
-
-  def get_num_feats(self):
-    n_feat = self.outputs.get_shape().as_list()[-1]
-    return n_feat
+  def _build_layer(self):
+    return deepchem.models.layers.ANIFeat(
+        self.max_atoms, self.radial_cutoff, self.angular_cutoff,
+        self.radial_length, self.angular_length, self.atom_cases,
+        self.atomic_number_differentiated, self.coordinates_in_bohr)
 
 
 class LayerSplitter(Layer):
@@ -4324,7 +3267,7 @@ class LayerSplitter(Layer):
     return out_tensor
 
 
-class GraphEmbedPoolLayer(Layer):
+class GraphEmbedPoolLayer(KerasLayer):
   """
   GraphCNNPool Layer from Robust Spatial Filtering with Graph Convolutional Neural Networks
   https://arxiv.org/abs/1703.00792
@@ -4338,103 +3281,23 @@ class GraphEmbedPoolLayer(Layer):
   $V_{emb} = SpatialGraphCNN({V_{in}})$\\
   $V_{out} = \sigma(V_{emb})^{T} * V_{in}$
   $A_{out} = V_{emb}^{T} * A_{in} * V_{emb}$
-
   """
 
   def __init__(self, num_vertices, **kwargs):
     self.num_vertices = num_vertices
     super(GraphEmbedPoolLayer, self).__init__(**kwargs)
 
+  def _build_layer(self):
+    return deepchem.models.layers.GraphEmbedPoolLayer(self.num_vertices)
+
   def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    """
-
-    Parameters
-    ----------
-    num_filters: int
-      Number of filters to have in the output
-
-    in_layers: list of Layers or tensors
-      [V, A, mask]
-      V are the vertex features must be of shape (batch, vertex, channel)
-
-      A are the adjacency matrixes for each graph
-        Shape (batch, from_vertex, adj_matrix, to_vertex)
-
-      mask is optional, to be used when not every graph has the
-      same number of vertices
-
-    Returns: tf.tensor
-    Returns a tf.tensor with a graph convolution applied
-    The shape will be (batch, vertex, self.num_filters)
-    """
-    in_tensors = self._get_input_tensors(in_layers)
-    if len(in_tensors) == 3:
-      V, A, mask = in_tensors
-    else:
-      V, A = in_tensors
-      mask = None
-    factors = self.embedding_factors(
-        V, self.num_vertices, name='%s_Factors' % self.name)
-
-    if mask is not None:
-      factors = tf.multiply(factors, mask)
-    factors = self.softmax_factors(factors)
-
-    result = tf.matmul(factors, V, transpose_a=True)
-
-    result_A = tf.reshape(A, (tf.shape(A)[0], -1, tf.shape(A)[-1]))
-    result_A = tf.matmul(result_A, factors)
-    result_A = tf.reshape(result_A, (tf.shape(A)[0], tf.shape(A)[-1], -1))
-    result_A = tf.matmul(factors, result_A, transpose_a=True)
-    result_A = tf.reshape(result_A, (tf.shape(A)[0], self.num_vertices,
-                                     A.get_shape()[2].value, self.num_vertices))
-    # We do not need the mask because every graph has self.num_vertices vertices now
+    outputs = super(GraphEmbedPoolLayer, self).create_tensor(
+        in_layers, set_tensors, **kwargs)
     if set_tensors:
-      self.out_tensor = result[0]
-      self.out_tensors = [result, result_A]
+      self.out_tensor = outputs[0]
+      self.out_tensors = outputs
       self._non_pickle_fields.append('out_tensors')
-    return result, result_A
-
-  def _create_variables(self, no_features, no_filters, name):
-    W = tf.Variable(
-        tf.truncated_normal(
-            [no_features, no_filters], stddev=1.0 / math.sqrt(no_features)),
-        name='%s_weights' % name,
-        dtype=tf.float32)
-    b = tf.Variable(
-        tf.constant(0.1), name='%s_bias' % self.name, dtype=tf.float32)
-    return [W, b]
-
-  def embedding_factors(self, V, no_filters, name="default"):
-    no_features = V.get_shape()[-1].value
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables = self._create_variables(
-            no_features, no_filters, name)
-        self._built = True
-      W, b = self.trainable_variables
-    else:
-      W, b = self._create_variables(no_features, no_filters, name)
-    V_reshape = tf.reshape(V, (-1, no_features))
-    s = tf.slice(tf.shape(V), [0], [len(V.get_shape()) - 1])
-    s = tf.concat([s, tf.stack([no_filters])], 0)
-    result = tf.reshape(tf.matmul(V_reshape, W) + b, s)
-    return result
-
-  def softmax_factors(self, V, axis=1, name=None):
-    max_value = tf.reduce_max(V, axis=axis, keepdims=True)
-    exp = tf.exp(tf.subtract(V, max_value))
-    prob = tf.math.divide(exp, tf.reduce_sum(exp, axis=axis, keepdims=True))
-    return prob
-
-  def none_tensors(self):
-    out_tensors, out_tensor = self.out_tensors, self.out_tensor
-    self.out_tensors = None
-    self.out_tensor = None
-    return out_tensors, out_tensor
-
-  def set_tensors(self, tensor):
-    self.out_tensors, self.out_tensor = tensor
+    return outputs
 
 
 def GraphCNNPool(num_vertices, **kwargs):
@@ -4442,7 +3305,7 @@ def GraphCNNPool(num_vertices, **kwargs):
   return [LayerSplitter(x, in_layers=gcnnpool_layer) for x in range(2)]
 
 
-class GraphCNN(Layer):
+class GraphCNN(KerasLayer):
   """
   GraphCNN Layer from Robust Spatial Filtering with Graph Convolutional Neural Networks
   https://arxiv.org/abs/1703.00792
@@ -4486,68 +3349,8 @@ class GraphCNN(Layer):
     self.num_filters = num_filters
     super(GraphCNN, self).__init__(**kwargs)
 
-  def _create_variables(self, no_features, no_A):
-    W = tf.Variable(
-        tf.truncated_normal(
-            [no_features * no_A, self.num_filters],
-            stddev=math.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
-        name='%s_weights' % self.name,
-        dtype=tf.float32)
-    W_I = tf.Variable(
-        tf.truncated_normal(
-            [no_features, self.num_filters],
-            stddev=math.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
-        name='%s_weights_I' % self.name,
-        dtype=tf.float32)
-    b = tf.Variable(
-        tf.constant(0.1), name='%s_bias' % self.name, dtype=tf.float32)
-    return [W, W_I, b]
-
-  def create_tensor(self, in_layers=None, set_tensors=True, **kwargs):
-    inputs = self._get_input_tensors(in_layers)
-    if len(inputs) == 3:
-      V, A, mask = inputs
-    else:
-      V, A = inputs
-    no_A = A.get_shape()[2].value
-    no_features = V.get_shape()[2].value
-    if tf.executing_eagerly():
-      if not self._built:
-        self.trainable_variables = self._create_variables(no_features, no_A)
-        self._built = True
-      W, W_I, b = self.trainable_variables
-    else:
-      W, W_I, b = self._create_variables(no_features, no_A)
-
-    n = self.graphConvolution(V, A)
-    A_shape = tf.shape(A)
-    n = tf.reshape(n, [-1, A_shape[1], no_A * no_features])
-    result = self.batch_mat_mult(n, W) + self.batch_mat_mult(V, W_I) + b
-    if set_tensors:
-      self.out_tensor = result
-    return result
-
-  def graphConvolution(self, V, A):
-    no_A = A.get_shape()[2].value
-    no_features = V.get_shape()[2].value
-
-    A_shape = tf.shape(A)
-    A_reshape = tf.reshape(A, tf.stack([-1, A_shape[1] * no_A, A_shape[1]]))
-    n = tf.matmul(A_reshape, V)
-    return tf.reshape(n, [-1, A_shape[1], no_A, no_features])
-
-  def batch_mat_mult(self, A, B):
-    A_shape = tf.shape(A)
-    A_reshape = tf.reshape(A, [-1, A_shape[-1]])
-
-    # So the Tensor has known dimensions
-    if B.get_shape()[1] == None:
-      axis_2 = -1
-    else:
-      axis_2 = B.get_shape()[1]
-    result = tf.matmul(A_reshape, B)
-    result = tf.reshape(result, tf.stack([A_shape[0], A_shape[1], axis_2]))
-    return result
+  def _build_layer(self):
+    return deepchem.models.layers.GraphCNN(self.num_filters)
 
 
 class HingeLoss(Layer):

--- a/deepchem/models/tensorgraph/layers.py
+++ b/deepchem/models/tensorgraph/layers.py
@@ -2841,7 +2841,7 @@ class WeightedLinearCombo(KerasLayer):
 
   def __init__(self, in_layers=None, std=.3, **kwargs):
     self.std = std
-    super(WeightedLinearCombo, self).__init__(int_layers=in_layers, **kwargs)
+    super(WeightedLinearCombo, self).__init__(in_layers=in_layers, **kwargs)
     try:
       self._shape = tuple(self.in_layers[0].shape)
     except:

--- a/deepchem/models/tensorgraph/tests/test_layers_eager.py
+++ b/deepchem/models/tensorgraph/tests/test_layers_eager.py
@@ -593,7 +593,8 @@ class TestLayersEager(test_util.TensorFlowTestCase):
       layer = layers.GraphConv(out_channels)
       result = layer(*args)
       assert result.shape == (n_atoms, out_channels)
-      assert len(layer.trainable_variables) == 2 * layer.num_deg
+      num_deg = 2 * layer.max_degree + (1 - layer.min_degree)
+      assert len(layer.trainable_variables) == 2 * num_deg
 
   def test_graph_pool(self):
     """Test invoking GraphPool in eager mode."""
@@ -665,10 +666,10 @@ class TestLayersEager(test_util.TensorFlowTestCase):
       test_out, support_out = layer(test, support)
       assert test_out.shape == (n_test, n_feat)
       assert support_out.shape == (n_support, n_feat)
-      assert len(layer.trainable_variables) == 7
+      assert len(layer.trainable_variables) == 6
 
   def test_iter_ref_lstm_embedding(self):
-    """Test invoking AttnLSTMEmbedding in eager mode."""
+    """Test invoking IterRefLSTMEmbedding in eager mode."""
     with context.eager_mode():
       max_depth = 5
       n_test = 5


### PR DESCRIPTION
As described in #1461, I've converted all the nontrivial TensorGraph layers to Keras.  They are now in `dc.models.layers`.  The old TensorGraph layers still exist in the same places they were before, but now they're just thin wrappers around the Keras layers.