### PR TITLE
Remove contagious logger setup

### DIFF
--- a/deepchem/models/tensorgraph/tensor_graph.py
+++ b/deepchem/models/tensorgraph/tensor_graph.py
@@ -17,7 +17,6 @@ from deepchem.models.tensorgraph.optimizers import Adam
 from deepchem.trans import undo_transforms
 from deepchem.utils.evaluate import GeneratorEvaluator
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
Doing an 
```python
import deepchem
```

overwrites loggers defined in projects using deepchem because of
```python
logging.basicConfig()
```
in the file `tensor_graph.py`.

Python libraries should not setup the logger themselves. See for instance the section "13.12. Adding Logging to Libraries" of the book "Python cookbook".

This PR removes the corresponding line.