### PR TITLE
Converted progressive multitask models to KerasModel

### DIFF
--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -595,6 +595,28 @@ class Stack(tf.keras.layers.Layer):
     return tf.stack(inputs, axis=self.axis)
 
 
+class Variable(tf.keras.layers.Layer):
+  """Output a trainable value."""
+
+  def __init__(self, initial_value, **kwargs):
+    """Construct a variable layer.
+
+    Parameters
+    ----------
+    initial_value: array or Tensor
+      the initial value the layer should output
+    """
+    super(Variable, self).__init__(**kwargs)
+    self.initial_value = initial_value
+
+  def build(self, input_shape):
+    self.var = tf.Variable(self.initial_value, dtype=self.dtype)
+    self.built = True
+
+  def call(self, inputs):
+    return self.var
+
+
 class VinaFreeEnergy(tf.keras.layers.Layer):
   """Computes free-energy as defined by Autodock Vina.
 

--- a/deepchem/models/losses.py
+++ b/deepchem/models/losses.py
@@ -109,6 +109,21 @@ class SoftmaxCrossEntropy(Loss):
         labels, output, reduction=tf.losses.Reduction.NONE)
 
 
+class SparseSoftmaxCrossEntropy(Loss):
+  """The cross entropy between two probability distributions.
+
+  The labels should have shape (batch_size) or (batch_size, tasks), and be
+  integer class labels.  The outputs have shape (batch_size, classes) or
+  (batch_size, tasks, classes) and be logits that are converted to probabilities
+  using a softmax function.
+  """
+
+  def __call__(self, output, labels):
+    labels = tf.cast(labels, tf.int32)
+    return tf.losses.sparse_softmax_cross_entropy(
+        labels, output, reduction=tf.losses.Reduction.NONE)
+
+
 def _make_shapes_consistent(output, labels):
   """Try to make inputs have the same shape by adding dimensions of size 1."""
   shape1 = output.shape

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -787,18 +787,18 @@ class TestOverfit(test_util.TensorFlowTestCase):
 
     assert scores[regression_metric.name] > .9
 
-  def test_tf_progressive_classification_overfit(self):
-    """Test tf progressive multitask overfits tiny data."""
+  def test_progressive_classification_overfit(self):
+    """Test progressive multitask overfits tiny data."""
     np.random.seed(123)
     n_tasks = 5
     n_samples = 10
-    n_features = 3
+    n_features = 6
 
     # Generate dummy dataset
     np.random.seed(123)
     ids = np.arange(n_samples)
     X = np.random.rand(n_samples, n_features)
-    y = np.ones((n_samples, n_tasks))
+    y = np.random.randint(2, size=(n_samples, n_tasks))
     w = np.ones((n_samples, n_tasks))
 
     dataset = dc.data.NumpyDataset(X, y, w, ids)
@@ -810,31 +810,30 @@ class TestOverfit(test_util.TensorFlowTestCase):
         layer_sizes=[50],
         bypass_layer_sizes=[10],
         dropouts=[0.],
-        learning_rate=0.003,
+        learning_rate=0.002,
         weight_init_stddevs=[.1],
         alpha_init_stddevs=[.02],
-        batch_size=n_samples,
-        use_queue=False)
+        batch_size=n_samples)
 
     # Fit trained model
-    model.fit(dataset, nb_epoch=20)
+    model.fit(dataset, nb_epoch=200)
 
     # Eval model on train
     scores = model.evaluate(dataset, [metric])
     assert scores[metric.name] > .9
 
-  def test_tf_progressive_regression_overfit(self):
-    """Test tf progressive multitask overfits tiny data."""
+  def test_progressive_regression_overfit(self):
+    """Test progressive multitask overfits tiny data."""
     np.random.seed(123)
     n_tasks = 5
     n_samples = 10
-    n_features = 3
+    n_features = 6
 
     # Generate dummy dataset
     np.random.seed(123)
     ids = np.arange(n_samples)
     X = np.random.rand(n_samples, n_features)
-    y = np.ones((n_samples, n_tasks))
+    y = np.random.rand(n_samples, n_tasks)
     w = np.ones((n_samples, n_tasks))
 
     dataset = dc.data.NumpyDataset(X, y, w, ids)
@@ -846,13 +845,13 @@ class TestOverfit(test_util.TensorFlowTestCase):
         layer_sizes=[50],
         bypass_layer_sizes=[10],
         dropouts=[0.],
-        learning_rate=0.003,
+        learning_rate=0.002,
         weight_init_stddevs=[.1],
         alpha_init_stddevs=[.02],
         batch_size=n_samples)
 
     # Fit trained model
-    model.fit(dataset, nb_epoch=20)
+    model.fit(dataset, nb_epoch=200)
 
     # Eval model on train
     scores = model.evaluate(dataset, [metric])


### PR DESCRIPTION
This required some new architecture.  The progressive models made use of submodels in TensorGraph, so I needed some way to replace that functionality.  I considered a few  approaches, including trying to do this with a series of nested tf.keras.Models or just copying over the submodel API.  In the end I decided to do something slightly different: I added `variables` and `loss` arguments to all the fit methods.  So whenever you do fitting, you have an option to restrict it to a subset of variables, or to have it use a different loss function.