### PR TITLE
Swapping Split-Transform order

### DIFF
--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -57,17 +57,17 @@ def load_bace_regression(featurizer='ECFP',
       tasks=bace_tasks, smiles_field="mol", featurizer=featurizer)
 
   dataset = loader.featurize(dataset_file, shard_size=8192)
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.NormalizationTransformer(
-          transform_y=True, dataset=dataset, move_mean=move_mean)
-  ]
+  if split is None:
+    # Initialize transformers
+    transformers = [
+        deepchem.trans.NormalizationTransformer(
+            transform_y=True, dataset=dataset, move_mean=move_mean)
+    ]
 
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
 
-  if split == None:
     return bace_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -76,7 +76,19 @@ def load_bace_regression(featurizer='ECFP',
       'scaffold': deepchem.splits.ScaffoldSplitter()
   }
   splitter = splitters[split]
+  logger.info("About to split data using {} splitter".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  transformers = [
+      deepchem.trans.NormalizationTransformer(
+          transform_y=True, dataset=train, move_mean=move_mean)
+  ]
+
+  logger.info("About to transform data.")
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
@@ -122,25 +134,32 @@ def load_bace_classification(featurizer='ECFP', split='random', reload=True):
       tasks=bace_tasks, smiles_field="mol", featurizer=featurizer)
 
   dataset = loader.featurize(dataset_file, shard_size=8192)
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
 
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
+  if split is None:
+    # Initialize transformers
+    transformers = [
+        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
+    ]
 
-  if split == None:
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
+
     return bace_tasks, (dataset, None, None), transformers
 
-  splitters = {
-      'index': deepchem.splits.IndexSplitter(),
-      'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
-  }
   splitter = splitters[split]
+  logger.info("About to split data using {} splitter".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  transformers = [
+      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
+  ]
+
+  logger.info("About to transform data.")
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -147,6 +147,12 @@ def load_bace_classification(featurizer='ECFP', split='random', reload=True):
 
     return bace_tasks, (dataset, None, None), transformers
 
+  splitters = {
+      'index': deepchem.splits.IndexSplitter(),
+      'random': deepchem.splits.RandomSplitter(),
+      'scaffold': deepchem.splits.ScaffoldSplitter()
+  }
+
   splitter = splitters[split]
   logger.info("About to split data using {} splitter".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)

--- a/deepchem/molnet/load_function/bbbc_datasets.py
+++ b/deepchem/molnet/load_function/bbbc_datasets.py
@@ -139,6 +139,7 @@ def load_bbbc002(split='index', reload=True):
 
   logger.info("About to split dataset with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+  all_dataset = (train, valid, test)
   transformers = []
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/bbbc_datasets.py
+++ b/deepchem/molnet/load_function/bbbc_datasets.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def load_bbbc001(split='index', reload=True):
   """Load BBBC001 dataset
-  
+
   This dataset contains 6 images of human HT29 colon cancer cells. The task is to learn to predict the cell counts in these images. This dataset is too small to serve to train algorithms, but might serve as a good test dataset. https://data.broadinstitute.org/bbbc/BBBC001/
   """
   # Featurize BBBC001 dataset
@@ -57,6 +57,8 @@ def load_bbbc001(split='index', reload=True):
   dataset = deepchem.data.DiskDataset.from_numpy(dataset.X, y)
 
   if split == None:
+    transformers = []
+    logger.info("Split is None, no transformers used for the dataset.")
     return bbbc001_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -67,7 +69,9 @@ def load_bbbc001(split='index', reload=True):
     raise ValueError("Only index and random splits supported.")
   splitter = splitters[split]
 
+  logger.info("About to split dataset with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+  transformers = []
   all_dataset = (train, valid, test)
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
@@ -77,7 +81,7 @@ def load_bbbc001(split='index', reload=True):
 
 def load_bbbc002(split='index', reload=True):
   """Load BBBC002 dataset
-  
+
   This dataset contains data corresponding to 5 samples of Drosophilia Kc167
   cells. There are 10 fields of view for each sample, each an image of size
   512x512. Ground truth labels contain cell counts for this dataset. Full
@@ -121,6 +125,8 @@ def load_bbbc002(split='index', reload=True):
   dataset = deepchem.data.DiskDataset.from_numpy(dataset.X, y, ids=ids)
 
   if split == None:
+    transformers = []
+    logger.info("Split is None, no transformers used for the dataset.")
     return bbbc002_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -131,8 +137,9 @@ def load_bbbc002(split='index', reload=True):
     raise ValueError("Only index and random splits supported.")
   splitter = splitters[split]
 
+  logger.info("About to split dataset with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
-  all_dataset = (train, valid, test)
+  transformers = []
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
                                              transformers)

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -45,16 +45,17 @@ def load_bbbp(featurizer='ECFP', split='random', reload=True):
   loader = deepchem.data.CSVLoader(
       tasks=bbbp_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
 
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
+  if split is None:
+    # Initialize transformers
+    transformers = [
+        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
+    ]
 
-  if split == None:
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
+
     return bbbp_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -63,7 +64,18 @@ def load_bbbp(featurizer='ECFP', split='random', reload=True):
       'scaffold': deepchem.splits.ScaffoldSplitter()
   }
   splitter = splitters[split]
+  logger.info("About to split data with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  # Initialize transformers
+  transformers = [
+      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
+  ]
+
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/cell_counting_datasets.py
+++ b/deepchem/molnet/load_function/cell_counting_datasets.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 def load_cell_counting(split=None, reload=True):
   """Load Cell Counting dataset.
-  
+
   Loads the cell counting dataset from http://www.robots.ox.ac.uk/~vgg/research/counting/index_org.html.
   """
   data_dir = deepchem.utils.get_data_dir()
@@ -43,6 +43,7 @@ def load_cell_counting(split=None, reload=True):
   transformers = []
 
   if split == None:
+    logger.info("Split is None, no transformers used.")
     return cell_counting_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -53,7 +54,9 @@ def load_cell_counting(split=None, reload=True):
     raise ValueError("Only index and random splits supported.")
   splitter = splitters[split]
 
+  logger.info("About to split dataset with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+  transformers = []
   all_dataset = (train, valid, test)
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -54,17 +54,15 @@ def load_clintox(featurizer='ECFP', split='index', reload=True):
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
   # Transform clintox dataset
-  logger.info("About to transform clintox dataset.")
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
+  if split is None:
+    transformers = [
+        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
+    ]
 
-  # Split clintox dataset
-  logger.info("About to split clintox dataset.")
+    logger.info("Split is None, about to transform data.")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
 
-  if split == None:
     return clintox_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -73,7 +71,18 @@ def load_clintox(featurizer='ECFP', split='index', reload=True):
       'scaffold': deepchem.splits.ScaffoldSplitter()
   }
   splitter = splitters[split]
+  logger.info("About to split data with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  transformers = [
+      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
+  ]
+
+  logger.info("About to transform data.")
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/delaney_datasets.py
+++ b/deepchem/molnet/load_function/delaney_datasets.py
@@ -50,17 +50,16 @@ def load_delaney(featurizer='ECFP', split='index', reload=True, move_mean=True):
       tasks=delaney_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.NormalizationTransformer(
-          transform_y=True, dataset=dataset, move_mean=move_mean)
-  ]
+  if split is None:
+    transformers = [
+        deepchem.trans.NormalizationTransformer(
+            transform_y=True, dataset=dataset, move_mean=move_mean)
+    ]
 
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
 
-  if split == None:
     return delaney_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -69,7 +68,19 @@ def load_delaney(featurizer='ECFP', split='index', reload=True, move_mean=True):
       'scaffold': deepchem.splits.ScaffoldSplitter()
   }
   splitter = splitters[split]
+  logger.info("About to split dataset with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  transformers = [
+      deepchem.trans.NormalizationTransformer(
+          transform_y=True, dataset=train, move_mean=move_mean)
+  ]
+
+  logger.info("About to transform data.")
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -50,17 +50,16 @@ def load_hopv(featurizer='ECFP', split='index', reload=True):
       tasks=hopv_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.NormalizationTransformer(
-          transform_y=True, dataset=dataset)
-  ]
-
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
-
   if split == None:
+    transformers = [
+        deepchem.trans.NormalizationTransformer(
+            transform_y=True, dataset=dataset)
+    ]
+
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
+
     return hopv_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -70,7 +69,18 @@ def load_hopv(featurizer='ECFP', split='index', reload=True):
       'butina': deepchem.splits.ButinaSplitter()
   }
   splitter = splitters[split]
+  logger.info("About to split dataset with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  transformers = [
+      deepchem.trans.NormalizationTransformer(transform_y=True, dataset=train)
+  ]
+
+  logger.info("About to transform data.")
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/hppb_datasets.py
+++ b/deepchem/molnet/load_function/hppb_datasets.py
@@ -86,6 +86,7 @@ def load_hppb(featurizer="ECFP",
 
   if split == None:
     logger.info("About to transform the data...")
+    transformers = []
     for transformer in transformers:
       logger.info("Transforming the dataset with transformer ",
                   transformer.__class__.__name__)

--- a/deepchem/molnet/load_function/lipo_datasets.py
+++ b/deepchem/molnet/load_function/lipo_datasets.py
@@ -51,17 +51,16 @@ def load_lipo(featurizer='ECFP', split='index', reload=True, move_mean=True):
       tasks=Lipo_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.NormalizationTransformer(
-          transform_y=True, dataset=dataset, move_mean=move_mean)
-  ]
+  if split is None:
+    transformers = [
+        deepchem.trans.NormalizationTransformer(
+            transform_y=True, dataset=dataset, move_mean=move_mean)
+    ]
 
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
 
-  if split == None:
     return Lipo_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -70,7 +69,19 @@ def load_lipo(featurizer='ECFP', split='index', reload=True, move_mean=True):
       'scaffold': deepchem.splits.ScaffoldSplitter()
   }
   splitter = splitters[split]
+  logger.info("About to split data with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
+
+  transformers = [
+      deepchem.trans.NormalizationTransformer(
+          transform_y=True, dataset=train, move_mean=move_mean)
+  ]
+
+  logger.info("About to transform data.")
+  for transformer in transformers:
+    train = transformer.transform(train)
+    valid = transformer.transform(valid)
+    test = transformer.transform(test)
 
   if reload:
     deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -53,15 +53,15 @@ def load_muv(featurizer='ECFP', split='index', reload=True, K=4):
       tasks=MUV_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
-
   if split == None:
+    transformers = [
+        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
+    ]
+
+    logger.info("Split is None, about to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
+
     return MUV_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -74,10 +74,15 @@ def load_muv(featurizer='ECFP', split='index', reload=True, K=4):
   if split == 'task':
     fold_datasets = splitter.k_fold_split(dataset, K)
     all_dataset = fold_datasets
+    logger.info(
+        "K-Fold split complete. Use the transformers for this dataset on the returned folds."
+    )
+    return MUV_tasks, all_dataset, []
+
   else:
     train, valid, test = splitter.train_valid_test_split(dataset)
     all_dataset = (train, valid, test)
     if reload:
       deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
                                                transformers)
-  return MUV_tasks, all_dataset, transformers
+    return MUV_tasks, all_dataset, transformers


### PR DESCRIPTION
This PR addresses the changes in ordering between split and transform for about half of the files in `dc.molnet`. The remaining ones will be added, once this half has been reviewed. 

In the `muv_datasets.py`, there's an additional `task` based split option available. For the fold datasets returned, there is an indecision on whether to do the transformation ourselves, or allow the user to do it, since the train dataset varies for every fold. Currently, I return an empty list for the transformers and expect the user to use the transformer themselves based on what is used for the rest of the code.

@rbharath, @peastman: Reviews and suggestions requested.