### PR TITLE
ChemNet Fixes and Additions

### DIFF
--- a/deepchem/feat/smiles_featurizers.py
+++ b/deepchem/feat/smiles_featurizers.py
@@ -201,6 +201,9 @@ class SmilesToImage(Featurizer):
       # Compute atom properties
       atom_props = np.array([[atom.GetAtomicNum()] for atom in cmol.GetAtoms()])
 
+      bond_props = bond_props.astype(np.float32)
+      atom_props = atom_props.astype(np.float32)
+
     else:
       # Setup image
       img = np.zeros((self.img_size, self.img_size, 4))
@@ -217,6 +220,13 @@ class SmilesToImage(Featurizer):
           atom.GetExplicitValence(),
           atom.GetHybridization().real,
       ] for atom in cmol.GetAtoms()])
+
+      bond_props = bond_props.astype(np.float32)
+      atom_props = atom_props.astype(np.float32)
+
+      partial_charges = atom_props[:, 1]
+      if np.any(np.isnan(partial_charges)):
+        return []
 
     frac = np.linspace(0, 1, int(1 / self.res * 2))
     # Reshape done for proper broadcast

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -956,7 +956,7 @@ class KerasModel(Model):
       the path to the checkpoint file to load.  If this is None, the most recent
       checkpoint will be chosen automatically.  Call get_checkpoints() to get a
       list of all available checkpoints.
-    restore_from: str, default None
+    model_dir: str, default None
       Directory to restore checkpoint from. If None, use self.model_dir.
     """
     self._ensure_built()

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -947,7 +947,7 @@ class KerasModel(Model):
       model_dir = self.model_dir
     return tf.train.get_checkpoint_state(model_dir).all_model_checkpoint_paths
 
-  def restore(self, checkpoint=None, restore_from=None):
+  def restore(self, checkpoint=None, model_dir=None):
     """Reload the values of all variables from a checkpoint file.
 
     Parameters
@@ -960,10 +960,10 @@ class KerasModel(Model):
       Directory to restore checkpoint from. If None, use self.model_dir.
     """
     self._ensure_built()
-    if restore_from is None:
-      restore_from = self.model_dir
+    if model_dir is None:
+      model_dir = self.model_dir
     if checkpoint is None:
-      checkpoint = tf.train.latest_checkpoint(restore_from)
+      checkpoint = tf.train.latest_checkpoint(model_dir)
     if checkpoint is None:
       raise ValueError('No checkpoint found')
     if tf.executing_eagerly():

--- a/deepchem/molnet/load_function/chembl25_datasets.py
+++ b/deepchem/molnet/load_function/chembl25_datasets.py
@@ -52,6 +52,7 @@ def load_chembl25(featurizer="smiles2seq",
                   save_dir=None,
                   split_seed=None,
                   reload=True,
+                  transformer_type='minmax',
                   **kwargs):
   """Loads the ChEMBL25 dataset, featurizes it, and does a split.
   Parameters
@@ -68,6 +69,8 @@ def load_chembl25(featurizer="smiles2seq",
     Seed to be used for splitting the dataset
   reload: bool, default True
     Whether to reload saved dataset
+  transformer_type: str, default minmax:
+    Transformer to use
   """
   if data_dir is None:
     data_dir = DEFAULT_DIR
@@ -121,10 +124,17 @@ def load_chembl25(featurizer="smiles2seq",
       input_files=[dataset_file], shard_size=10000, data_dir=save_folder)
 
   if split is None:
-    transformer = [
-        dc.trans.NormalizationTransformer(
-            transform_X=False, transform_y=True, dataset=dataset)
-    ]
+    if transformer_type == "minmax":
+      transformers = [
+          dc.trans.MinMaxTransformer(
+              transform_X=False, transform_y=True, dataset=dataset)
+      ]
+    else:
+      transformers = [
+          dc.trans.NormalizationTransformer(
+              transform_X=False, transform_y=True, dataset=dataset)
+      ]
+
     logger.info("Split is None, about to transform dataset.")
     for transformer in transformers:
       dataset = transformer.transform(dataset)
@@ -140,10 +150,17 @@ def load_chembl25(featurizer="smiles2seq",
   splitter = splitters[split]
 
   train, valid, test = splitter.train_valid_test_split(dataset, seed=split_seed)
-  transformers = [
-      dc.trans.NormalizationTransformer(
-          transform_X=False, transform_y=True, dataset=train)
-  ]
+  if transformer_type == "minmax":
+    transformers = [
+        dc.trans.MinMaxTransformer(
+            transform_X=False, transform_y=True, dataset=train)
+    ]
+  else:
+    transformers = [
+        dc.trans.NormalizationTransformer(
+            transform_X=False, transform_y=True, dataset=train)
+    ]
+
   for transformer in transformers:
     train = transformer.transform(train)
     valid = transformer.transform(valid)

--- a/deepchem/molnet/load_function/chembl25_datasets.py
+++ b/deepchem/molnet/load_function/chembl25_datasets.py
@@ -149,7 +149,16 @@ def load_chembl25(featurizer="smiles2seq",
   logger.info("About to split data with {} splitter.".format(split))
   splitter = splitters[split]
 
-  train, valid, test = splitter.train_valid_test_split(dataset, seed=split_seed)
+  frac_train = kwargs.get('frac_train', 4 / 6)
+  frac_valid = kwargs.get('frac_valid', 1 / 6)
+  frac_test = kwargs.get('frac_test', 1 / 6)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      seed=split_seed,
+      frac_train=frac_train,
+      frac_test=frac_test,
+      frac_valid=frac_valid)
   if transformer_type == "minmax":
     transformers = [
         dc.trans.MinMaxTransformer(

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -28,6 +28,8 @@ def load_hiv(featurizer='ECFP',
   if save_dir is None:
     save_dir = DEFAULT_DIR
 
+  hiv_tasks = ["HIV_active"]
+
   save_folder = os.path.join(save_dir, "hiv-featurized", str(featurizer),
                              str(split))
   if featurizer == "smiles2img":
@@ -43,8 +45,6 @@ def load_hiv(featurizer='ECFP',
   dataset_file = os.path.join(data_dir, "HIV.csv")
   if not os.path.exists(dataset_file):
     deepchem.utils.download_url(url=HIV_URL, dest_dir=data_dir)
-
-  hiv_tasks = ["HIV_active"]
 
   if featurizer == 'ECFP':
     featurizer = deepchem.feat.CircularFingerprint(size=1024)

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -10,28 +10,41 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
+HIV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/HIV.csv'
+DEFAULT_DIR = deepchem.utils.get_data_dir()
 
-def load_hiv(featurizer='ECFP', split='index', reload=True, **kwargs):
+
+def load_hiv(featurizer='ECFP',
+             split='index',
+             reload=True,
+             data_dir=None,
+             save_dir=None,
+             **kwargs):
   """Load hiv datasets. Does not do train/test split"""
   # Featurize hiv dataset
   logger.info("About to featurize hiv dataset.")
-  data_dir = deepchem.utils.get_data_dir()
-  if reload:
-    save_dir = os.path.join(data_dir, "hiv/" + featurizer + "/" + str(split))
+  if data_dir is None:
+    data_dir = DEFAULT_DIR
+  if save_dir is None:
+    save_dir = DEFAULT_DIR
 
-  dataset_file = os.path.join(data_dir, "HIV.csv")
-  if not os.path.exists(dataset_file):
-    deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/HIV.csv'
-    )
-
-  hiv_tasks = ["HIV_active"]
+  save_folder = os.path.join(save_dir, "hiv-featurized", str(featurizer),
+                             str(split))
+  if featurizer == "smiles2img":
+    img_spec = kwargs.get("img_spec", "std")
+    save_folder = os.path.join(save_folder, img_spec)
 
   if reload:
     loaded, all_dataset, transformers = deepchem.utils.save.load_dataset_from_disk(
-        save_dir)
+        save_folder)
     if loaded:
       return hiv_tasks, all_dataset, transformers
+
+  dataset_file = os.path.join(data_dir, "HIV.csv")
+  if not os.path.exists(dataset_file):
+    deepchem.utils.download_url(url=HIV_URL, dest_dir=data_dir)
+
+  hiv_tasks = ["HIV_active"]
 
   if featurizer == 'ECFP':
     featurizer = deepchem.feat.CircularFingerprint(size=1024)
@@ -64,10 +77,20 @@ def load_hiv(featurizer='ECFP', split='index', reload=True, **kwargs):
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
       'scaffold': deepchem.splits.ScaffoldSplitter(),
-      'butina': deepchem.splits.ButinaSplitter()
+      'butina': deepchem.splits.ButinaSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split dataset with {} splitter.".format(split))
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   train, valid, test = splitter.train_valid_test_split(dataset)
 
   transformers = [
@@ -81,6 +104,6 @@ def load_hiv(featurizer='ECFP', split='index', reload=True, **kwargs):
     test = transformer.transform(test)
 
   if reload:
-    deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
+    deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,
                                              transformers)
   return hiv_tasks, (train, valid, test), transformers

--- a/deepchem/molnet/load_function/sampl_datasets.py
+++ b/deepchem/molnet/load_function/sampl_datasets.py
@@ -10,35 +10,47 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
+SAMPL_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/SAMPL.csv'
+DEFAULT_DIR = deepchem.utils.get_data_dir()
+
 
 def load_sampl(featurizer='ECFP',
                split='index',
                reload=True,
                move_mean=True,
+               data_dir=None,
+               save_dir=None,
                **kwargs):
   """Load SAMPL datasets."""
   # Featurize SAMPL dataset
   logger.info("About to featurize SAMPL dataset.")
   logger.info("About to load SAMPL dataset.")
-  data_dir = deepchem.utils.get_data_dir()
-  if reload:
-    if move_mean:
-      dir_name = "sampl/" + featurizer + "/" + str(split)
-    else:
-      dir_name = "sampl/" + featurizer + "_mean_unmoved/" + str(split)
-    save_dir = os.path.join(data_dir, dir_name)
+
+  if data_dir is None:
+    data_dir = DEFAULT_DIR
+  if save_dir is None:
+    save_dir = DEFAULT_DIR
+
+  if move_mean:
+    save_folder = os.path.join(data_dir, "sampl-featurized", str(featurizer),
+                               str(split))
+  else:
+    save_folder = os.path.join(data_dir, "sampl-featurized",
+                               str(featurizer) + "_mean_unmoved", str(split))
+
+  if featurizer == "smiles2img":
+    img_spec = kwargs.get("img_spec", "std")
+    save_folder = os.path.join(save_folder, img_spec)
 
   dataset_file = os.path.join(data_dir, "SAMPL.csv")
   if not os.path.exists(dataset_file):
-    deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/SAMPL.csv'
-    )
+    deepchem.utils.download_url(url=SAMPL_URL, dest_dir=data_dir)
 
   SAMPL_tasks = ['expt']
 
   if reload:
     loaded, all_dataset, transformers = deepchem.utils.save.load_dataset_from_disk(
-        save_dir)
+        save_folder)
     if loaded:
       return SAMPL_tasks, all_dataset, transformers
 
@@ -77,6 +89,15 @@ def load_sampl(featurizer='ECFP',
   }
   splitter = splitters[split]
   logger.info("About to split dataset with {} splitter.".format(split))
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   train, valid, test = splitter.train_valid_test_split(dataset)
 
   transformers = [
@@ -91,6 +112,6 @@ def load_sampl(featurizer='ECFP',
     test = transformer.transform(test)
 
   if reload:
-    deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
+    deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,
                                              transformers)
   return SAMPL_tasks, (train, valid, test), transformers

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -10,8 +10,17 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
+TOX21_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/tox21.csv.gz'
+DEFAULT_DIR = deepchem.utils.get_data_dir()
 
-def load_tox21(featurizer='ECFP', split='index', reload=True, K=4, **kwargs):
+
+def load_tox21(featurizer='ECFP',
+               split='index',
+               reload=True,
+               K=4,
+               data_dir=None,
+               save_dir=None,
+               **kwargs):
   """Load Tox21 datasets. Does not do train/test split"""
   # Featurize Tox21 dataset
 
@@ -20,19 +29,26 @@ def load_tox21(featurizer='ECFP', split='index', reload=True, K=4, **kwargs):
       'NR-PPAR-gamma', 'SR-ARE', 'SR-ATAD5', 'SR-HSE', 'SR-MMP', 'SR-p53'
   ]
 
-  data_dir = deepchem.utils.get_data_dir()
+  if data_dir is None:
+    data_dir = DEFAULT_DIR
+  if save_dir is None:
+    save_dir = DEFAULT_DIR
+
+  save_folder = os.path.join(save_dir, "tox21-featurized", str(featurizer),
+                             str(split))
+  if featurizer == "smiles2img":
+    img_spec = kwargs.get("img_spec", "std")
+    save_folder = os.path.join(save_folder, img_spec)
+
   if reload:
-    save_dir = os.path.join(data_dir, "tox21/" + featurizer + "/" + str(split))
     loaded, all_dataset, transformers = deepchem.utils.save.load_dataset_from_disk(
-        save_dir)
+        save_folder)
     if loaded:
       return tox21_tasks, all_dataset, transformers
 
   dataset_file = os.path.join(data_dir, "tox21.csv.gz")
   if not os.path.exists(dataset_file):
-    deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/tox21.csv.gz'
-    )
+    deepchem.utils.download_url(url=TOX21_URL, dest_dir=data_dir)
 
   if featurizer == 'ECFP':
     featurizer = deepchem.feat.CircularFingerprint(size=1024)
@@ -70,16 +86,25 @@ def load_tox21(featurizer='ECFP', split='index', reload=True, K=4, **kwargs):
       'random': deepchem.splits.RandomSplitter(),
       'scaffold': deepchem.splits.ScaffoldSplitter(),
       'butina': deepchem.splits.ButinaSplitter(),
-      'task': deepchem.splits.TaskSplitter()
+      'task': deepchem.splits.TaskSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
   if split == 'task':
     fold_datasets = splitter.k_fold_split(dataset, K)
     all_dataset = fold_datasets
   else:
-    train, valid, test = splitter.train_valid_test_split(dataset)
+    frac_train = kwargs.get("frac_train", 0.8)
+    frac_valid = kwargs.get('frac_valid', 0.1)
+    frac_test = kwargs.get('frac_test', 0.1)
+
+    train, valid, test = splitter.train_valid_test_split(
+        dataset,
+        frac_train=frac_train,
+        frac_valid=frac_valid,
+        frac_test=frac_test)
     all_dataset = (train, valid, test)
     if reload:
-      deepchem.utils.save.save_dataset_to_disk(save_dir, train, valid, test,
+      deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,
                                                transformers)
   return tox21_tasks, all_dataset, transformers

--- a/deepchem/trans/__init__.py
+++ b/deepchem/trans/__init__.py
@@ -16,3 +16,4 @@ from deepchem.trans.transformers import CoulombFitTransformer
 from deepchem.trans.transformers import IRVTransformer
 from deepchem.trans.transformers import DAGTransformer
 from deepchem.trans.transformers import ANITransformer
+from deepchem.trans.transformers import MinMaxTransformer

--- a/deepchem/trans/tests/test_transformers.py
+++ b/deepchem/trans/tests/test_transformers.py
@@ -172,6 +172,93 @@ class TestTransformers(unittest.TestCase):
     # Check that untransform does the right thing.
     np.testing.assert_allclose(log_transformer.untransform(X_t), X)
 
+  def test_y_minmax_transformer(self):
+    """Tests MinMax transformer. """
+    solubility_dataset = dc.data.tests.load_solubility_data()
+    minmax_transformer = dc.trans.MinMaxTransformer(
+        transform_y=True, dataset=solubility_dataset)
+    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y,
+                    solubility_dataset.w, solubility_dataset.ids)
+    solubility_dataset = minmax_transformer.transform(solubility_dataset)
+    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y,
+                            solubility_dataset.w, solubility_dataset.ids)
+
+    # Check ids are unchanged before and after transformation
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+
+    # Check X is unchanged since transform_y is true
+    np.testing.assert_allclose(X, X_t)
+    # Check w is unchanged since transform_y is true
+    np.testing.assert_allclose(w, w_t)
+
+    # Check minimum and maximum values of transformed y are 0 and 1
+    np.testing.assert_allclose(y_t.min(), 0.)
+    np.testing.assert_allclose(y_t.max(), 1.)
+
+    # Check untransform works correctly
+    np.testing.assert_allclose(minmax_transformer.untransform(y_t), y)
+
+    # Test on random example
+    n_samples = 100
+    n_features = 10
+    n_tasks = 10
+
+    X = np.random.randn(n_samples, n_features)
+    y = np.random.randn(n_samples, n_tasks)
+    dataset = dc.data.NumpyDataset(X, y)
+
+    minmax_transformer = dc.trans.MinMaxTransformer(
+        transform_y=True, dataset=dataset)
+    w, ids = dataset.w, dataset.ids
+
+    dataset = minmax_transformer.transform(dataset)
+    X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
+    # Check ids are unchanged before and after transformation
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+
+    # Check X is unchanged since transform_y is true
+    np.testing.assert_allclose(X, X_t)
+    # Check w is unchanged since transform_y is true
+    np.testing.assert_allclose(w, w_t)
+
+    # Check minimum and maximum values of transformed y are 0 and 1
+    np.testing.assert_allclose(y_t.min(), 0.)
+    np.testing.assert_allclose(y_t.max(), 1.)
+
+    # Test if dimensionality expansion is handled correctly by untransform
+    y_t = np.expand_dims(y_t, axis=-1)
+    y_restored = minmax_transformer.untransform(y_t)
+    assert y_restored.shape == y.shape + (1,)
+    np.testing.assert_allclose(np.squeeze(y_restored, axis=-1), y)
+
+  def test_X_minmax_transformer(self):
+    solubility_dataset = dc.data.tests.load_solubility_data()
+    minmax_transformer = dc.trans.MinMaxTransformer(
+        transform_X=True, dataset=solubility_dataset)
+    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y,
+                    solubility_dataset.w, solubility_dataset.ids)
+    solubility_dataset = minmax_transformer.transform(solubility_dataset)
+    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y,
+                            solubility_dataset.w, solubility_dataset.ids)
+
+    # Check ids are unchanged before and after transformation
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+
+    # Check X is unchanged since transform_y is true
+    np.testing.assert_allclose(y, y_t)
+    # Check w is unchanged since transform_y is true
+    np.testing.assert_allclose(w, w_t)
+
+    # Check minimum and maximum values of transformed y are 0 and 1
+    np.testing.assert_allclose(X_t.min(), 0.)
+    np.testing.assert_allclose(X_t.max(), 1.)
+
+    # Check untransform works correctly
+    np.testing.assert_allclose(minmax_transformer.untransform(X_t), X)
+
   def test_y_normalization_transformer(self):
     """Tests normalization transformer."""
     solubility_dataset = dc.data.tests.load_solubility_data()

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -104,15 +104,54 @@ class Transformer(object):
 
 
 class MinMaxTransformer(Transformer):
+  """MinMax transformer transforms the dataset by shifting each axis of X or y
+  (depending on whether transform_X or transform_y is True), except the first one
+  by the minimum value along the axis and dividing the result by the range
+  (maximum value - minimum value) along the axis. This ensures each axis is
+  between 0 and 1. In case of multi-task learning, it ensures each task is given
+  equal importance.
+
+  Given original array A, the transformed array can be written as:
+  A_min = np.min(A, axis=0)
+  A_max = np.max(A, axis=0)
+  A_t = np.nan_to_num((A - A_min)/(A_max - A_min))
+
+  Example:
+  >>> n_samples = 10
+  >>> n_features = 3
+  >>> n_tasks = 1
+  >>> ids = np.arange(n_samples)
+  >>> X = np.random.rand(n_samples, n_features)
+  >>> y = np.zeros((n_samples, n_tasks))
+  >>> w = np.ones((n_samples, n_tasks))
+  >>> dataset = dc.data.NumpyDataset(X, y, w, ids)
+  >>> transformer = dc.trans.MinMaxTransformer(transform_y=True)
+  >>> dataset = transformer.transform(dataset)
+  """
 
   def __init__(self,
                transform_X=False,
                transform_y=False,
                transform_w=False,
                dataset=None):
+    """Initialization of MinMax transformer.
+
+    Parameters
+    ----------
+    transform_X: bool, optional (default False)
+      Whether to transform X
+    transform_y: bool, optional (default False)
+      Whether to transform y
+    transform_w: bool, optional (default False)
+      Whether to transform w
+    dataset: dc.data.Dataset object, optional
+      Dataset to be transformed
+    """
     if transform_X:
-      raise NotImplementedError("MinMax transformer does not work for X yet.")
-    if transform_y:
+      self.X_min = np.min(dataset.X, axis=0)
+      self.X_max = np.max(dataset.X, axis=0)
+
+    elif transform_y:
       self.y_min = np.min(dataset.y, axis=0)
       self.y_max = np.max(dataset.y, axis=0)
 
@@ -126,25 +165,44 @@ class MinMaxTransformer(Transformer):
         dataset=dataset)
 
   def transform(self, dataset, parallel=False):
+    """Transforms the dataset."""
     return super(MinMaxTransformer, self).transform(dataset, parallel=parallel)
 
   def transform_array(self, X, y, w):
     """Transform the data in a set of (X, y, w) arrays."""
     if self.transform_X:
-      raise NotImplementedError("MinMax transformer does not work for X yet")
-    if self.transform_y:
+      X = np.nan_to_num((X - self.X_min) / (self.X_max - self.X_min))
+    elif self.transform_y:
       y = np.nan_to_num((y - self.y_min) / (self.y_max - self.y_min))
     return (X, y, w)
 
   def untransform(self, z):
     """
     Undo transformation on provided data.
+
+    Parameters
+    ----------
+    z: np.ndarray,
+      Transformed X or y array
     """
     if self.transform_X:
-      raise NotImplementedError("MinMax does not work for X yet.")
-    if self.transform_y:
+      X_max = self.X_max
+      X_min = self.X_min
+
+      return z * (X_max - X_min) + X_min
+
+    elif self.transform_y:
       y_min = self.y_min
       y_max = self.y_max
+
+      n_tasks = len(y_min)
+      z_shape = list(z.shape)
+      z_shape.reverse()
+
+      for dim in z_shape:
+        if dim != n_tasks and dim == 1:
+          y_min = np.expand_dims(y_min, -1)
+          y_max = np.expand_dims(y_max, -1)
 
       y = z * (y_max - y_min) + y_min
       return y

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -103,6 +103,53 @@ class Transformer(object):
     return X, y, w
 
 
+class MinMaxTransformer(Transformer):
+
+  def __init__(self,
+               transform_X=False,
+               transform_y=False,
+               transform_w=False,
+               dataset=None):
+    if transform_X:
+      raise NotImplementedError("MinMax transformer does not work for X yet.")
+    if transform_y:
+      self.y_min = np.min(dataset.y, axis=0)
+      self.y_max = np.max(dataset.y, axis=0)
+
+      if len(dataset.y.shape) > 1:
+        assert len(self.y_min) == dataset.y.shape[1]
+
+    super(MinMaxTransformer, self).__init__(
+        transform_X=transform_X,
+        transform_y=transform_y,
+        transform_w=transform_w,
+        dataset=dataset)
+
+  def transform(self, dataset, parallel=False):
+    return super(MinMaxTransformer, self).transform(dataset, parallel=parallel)
+
+  def transform_array(self, X, y, w):
+    """Transform the data in a set of (X, y, w) arrays."""
+    if self.transform_X:
+      raise NotImplementedError("MinMax transformer does not work for X yet")
+    if self.transform_y:
+      y = np.nan_to_num((y - self.y_min) / (self.y_max - self.y_min))
+    return (X, y, w)
+
+  def untransform(self, z):
+    """
+    Undo transformation on provided data.
+    """
+    if self.transform_X:
+      raise NotImplementedError("MinMax does not work for X yet.")
+    if self.transform_y:
+      y_min = self.y_min
+      y_max = self.y_max
+
+      y = z * (y_max - y_min) + y_min
+      return y
+
+
 class NormalizationTransformer(Transformer):
 
   def __init__(self,

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -125,7 +125,7 @@ class MinMaxTransformer(Transformer):
   >>> y = np.zeros((n_samples, n_tasks))
   >>> w = np.ones((n_samples, n_tasks))
   >>> dataset = dc.data.NumpyDataset(X, y, w, ids)
-  >>> transformer = dc.trans.MinMaxTransformer(transform_y=True)
+  >>> transformer = dc.trans.MinMaxTransformer(transform_y=True, dataset=dataset)
   >>> dataset = transformer.transform(dataset)
   """
 


### PR DESCRIPTION
This PR adds in enhancements in line with the ChemNet paper:

**Transformers**:
1. MinMax transformer is added along with tests and documentation - This is the Transformer used in ChemNet pretraining. 

**Tox21, HIV, ChEMBL25, FreeSolv**
1. Train, Valid and test split fractions added in kwargs for all the four datasets
2. RandomStratifiedSplitter added in Tox21 and HIV, since that is used in the paper for original training and fine-tuning.
3. Custom directories for data download and dataset storage for all datasets
4. MinMax transformer has also been added to `dc.molnet.chembl25_datasets`

**Featurizers**:
1. Safeguard against the NaN problem in SmilesToImage featurizer

**KerasModel**
1. Replaced the `print()` statements for losses with logger statements. A large fraction of DeepChem uses loggers, so this would make it more compatible

2. Losses were getting logged only while saving checkpoints. In general, one might want to keep them separate, since the frequencies of monitoring losses vs saving can be different then.

3. Added support for custom directories when saving checkpoints, or restoring existing model, or getting a list of checkpoints. 
