### PR TITLE
First version of pretrained loading

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -1020,8 +1020,6 @@ class KerasModel(Model):
     ----------
     source_model: dc.models.KerasModel
         Source model to create value map from
-    include_top: bool, default True
-        if true, copies the last dense layer
     """
     value_map = {}
     source_vars = source_model.model.trainable_variables
@@ -1044,37 +1042,40 @@ class KerasModel(Model):
                            model_dir=None,
                            include_top=True,
                            **kwargs):
-    """Copies variable values between pretrained model and current model. This
-    method assumes that the variable values of the pretrained model are saved to
-    disk. source_model is a dc.KerasModel with the same architecture as the
-    pretrained model. The variable values are then restored to the source_model.
-    assignment_map is a dictionary mapping the variables from the source model
-    to those in the current model. If no assignment_map is provided, one is made
-    from scratch and assumes the model is composed of several different layers,
-    with the final one being a dense layer. include_top is used to control whether
-    or not the final dense layer is used. The default assignment map is useful in
-    cases where the type of task is different (classification vs regression) and/or
-    number of tasks in the setting.
+    """Copies variable values from a pretrained model. `source_model` can either
+    be a pretrained model or a model with the same architecture. `value_map`
+    is a variable-value dictionary. If no `value_map` is provided, the variable
+    values are restored to the `source_model` from a checkpoint and a default
+    `value_map` is created. `assignment_map` is a dictionary mapping variables
+    from the `source_model` to the current model. If no `assignment_map` is
+    provided, one is made from scratch and assumes the model is composed of
+    several different layers, with the final one being a dense layer. include_top
+    is used to control whether or not the final dense layer is used. The default
+    assignment map is useful in cases where the type of task is different
+    (classification vs regression) and/or number of tasks in the setting.
 
     Parameters
     ----------
     source_model: dc.KerasModel, required
-      Model which has the same topology and architecture as the pretrained
-      model.
+      source_model can either be the pretrained model or a dc.KerasModel with
+      the same architecture as the pretrained model. It is used to restore from
+      a checkpoint, if value_map is None and to create a default assignment map
+      if assignment_map is None
     assignment_map: Dict, default None
-      Dictionary containing layer mapping between source and current model layers
+      Dictionary mapping the source_model variables and current model variables
     value_map: Dict, default None
-      Dictionary containing source model trainable variables mapped to numpy
-      arrays
+      Dictionary containing source_model trainable variables mapped to numpy
+      arrays. If value_map is None, the values are restored and a default
+      variable map is created using the restored values
     checkpoint: str, default None
       the path to the checkpoint file to load.  If this is None, the most recent
       checkpoint will be chosen automatically.  Call get_checkpoints() to get a
-      list of all available checkpoints.
+      list of all available checkpoints
     model_dir: str, default None
       Restore model from custom model directory if needed
     include_top: bool, default True
-        if True, copies the weights and bias associated with the final dense layer.
-        Used only when assignment map is None.
+        if True, copies the weights and bias associated with the final dense
+        layer. Used only when assignment map is None
     """
 
     self._ensure_built()

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -11,7 +11,6 @@ from deepchem.models.losses import Loss
 from deepchem.models.models import Model
 from deepchem.models.tensorgraph.optimizers import Adam
 from deepchem.trans import undo_transforms
-from deepchem.metrics import to_one_hot
 from deepchem.utils.evaluate import GeneratorEvaluator
 
 
@@ -1014,7 +1013,8 @@ class KerasModel(Model):
   def _create_value_map(self, source_model, **kwargs):
     """
     Creates a value map between variables in the source model and their
-    current values. This is used only when a custom value map is missing.
+    current values. This is used only when a custom value map is missing, and
+    assumes the restore method has been called under self.session.
 
     Parameters
     ----------
@@ -1031,6 +1031,7 @@ class KerasModel(Model):
         value_map[source_var] = source_var.numpy()
     else:
       for source_var in source_vars:
+        # self.session is used because restore was called in the same session
         value_map[source_var] = source_var.eval(session=self.session)
 
     return value_map

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -982,21 +982,6 @@ class KerasModel(Model):
       return int(self._global_step)
     return self._global_step.eval(session=self.session)
 
-  def compute_loss(self, dataset, transformers):
-    if self.mode == "regression":
-      y = undo_transforms(dataset.y, transformers=transformers)
-    else:
-      y = to_one_hot(dataset.y.flatten(), self.n_classes).reshape(
-          -1, len(self.n_tasks), self.n_classes)
-    loss_fn = model._loss_fn
-
-    y_pred = self.predict(dataset, transformers=transformers)
-    loss_tensor = loss_fn([y_pred], [y], [dataset.w])
-    if tf.executing_eagerly():
-      return loss_tensor.numpy()
-    else:
-      return self.session.run(loss_tensor)
-
   def _create_assignment_map(self, source_model, include_top=True, **kwargs):
     """
     Creates a default assignment map between variables of source and current model.

--- a/deepchem/models/tests/test_pretrained.py
+++ b/deepchem/models/tests/test_pretrained.py
@@ -131,7 +131,4 @@ class TestPretrained(unittest.TestCase):
     dest_model.fit(self.dataset, nb_epoch=1)
     predictions = np.squeeze(dest_model.predict_on_batch(self.dataset.X))
 
-    # print(tf.train.load_variable("./MLP", 'model/layer_with_weights-0/kernel/.ATTRIBUTES/VARIABLE_VALUE'))
-    # print(tf.train.load_variable("./MLP", 'model/layer_with_weights-1/kernel/.ATTRIBUTES/VARIABLE_VALUE'))
-
     np.testing.assert_array_almost_equal(self.dataset.y, np.round(predictions))

--- a/deepchem/models/tests/test_pretrained.py
+++ b/deepchem/models/tests/test_pretrained.py
@@ -1,0 +1,82 @@
+import os
+import unittest
+import deepchem as dc
+import numpy as np
+import tensorflow as tf
+from tensorflow.python.eager import context
+from tensorflow.keras.layers import Input, Dense
+from deepchem.models.losses import L2Loss
+
+
+class MLP(dc.models.KerasModel):
+
+  def __init__(self, n_tasks=1, feature_dim=100, hidden_layer_size=64,
+               **kwargs):
+    self.feature_dim = feature_dim
+    self.hidden_layer_size = hidden_layer_size
+    self.n_tasks = n_tasks
+
+    model, loss, output_types = self._build_graph()
+    super(MLP, self).__init__(
+        model=model, loss=loss, output_types=output_types, **kwargs)
+
+  def _build_graph(self):
+    inputs = Input(dtype=tf.float32, shape=(self.feature_dim,), name="Input")
+    out1 = Dense(units=self.hidden_layer_size, activation=tf.nn.relu)(inputs)
+
+    final = Dense(units=self.n_tasks)(out1)
+    outputs = [final]
+    output_types = ['prediction']
+    loss = L2Loss()
+
+    model = tf.keras.Model(inputs=[inputs], outputs=outputs)
+    return model, loss, output_types
+
+
+class TestPretrained(unittest.TestCase):
+
+  def setUp(self):
+    model_dir = "./MLP/"
+    self.feature_dim = 2
+    self.hidden_layer_size = 2
+    data_points = 100
+
+    X = np.random.randn(data_points, self.feature_dim)
+    y = np.random.randn(data_points)
+
+    dataset = dc.data.NumpyDataset(X, y)
+
+    model = MLP(
+        hidden_layer_size=self.hidden_layer_size,
+        feature_dim=self.feature_dim,
+        model_dir=model_dir,
+        batch_size=10)
+    model.fit(dataset, nb_epoch=100)
+
+  def test_load_pretrained(self):
+    source_model = MLP(
+        model_dir="./MLP/",
+        feature_dim=self.feature_dim,
+        hidden_layer_size=self.hidden_layer_size)
+    source_model.restore()
+
+    dest_model = MLP(
+        feature_dim=self.feature_dim,
+        hidden_layer_size=self.hidden_layer_size,
+        n_tasks=10)
+
+    assignment_map = dict()
+    dest_variables = dest_model.model.trainable_variables[:
+                                                          -2]  #Excluding the last weight and bias
+
+    for idx, variable in enumerate(dest_variables):
+      source_variable = source_model.model.trainable_variables[idx]
+      assignment_map[source_variable] = variable
+
+    dest_model.load_pretrained(assignment_map=assignment_map)
+
+    for var_old, var_new in assignment_map.items():
+      val_old = dest_model.session.run(var_old)
+      val_new = dest_model.session.run(var_new)
+
+      np.testing.assert_array_almost_equal(val_old, val_new)


### PR DESCRIPTION
This is a starter version for transfer learning from the discussion in #1612.

It is expected that the user gives the correspondence between variables to restore from and variables to restore to. I could not find a way to make variables non-trainable, but @peastman has alllowed only a list of variables to be optimized during training, so that should work.

The future work would be to moving towards making it easier for users to do Transfer Learning. 
One idea would be to have a default setting, where only the last dense layer is replaced, depending on task type and number of tasks, and the rest of the layers are restored as is. For the more advanced users, the current option can be retained.

