### PR TITLE
Stratified splitters, and minor changes for MolNet

### DIFF
--- a/deepchem/models/tensorgraph/models/chemnet_models.py
+++ b/deepchem/models/tensorgraph/models/chemnet_models.py
@@ -280,7 +280,7 @@ class ChemCeption(KerasModel):
     avg_pooling_out = GlobalAveragePooling2D()(inceptionC_out)
 
     if self.mode == "classification":
-      logits = Dense(self.n_tasks * self.n_classes)(rnn_embeddings)
+      logits = Dense(self.n_tasks * self.n_classes)(avg_pooling_out)
       logits = Reshape((self.n_tasks, self.n_classes))(logits)
       if self.n_classes == 2:
         output = Activation(activation='sigmoid')(logits)

--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -90,11 +90,20 @@ def load_bace_regression(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split data using {} splitter".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(
@@ -182,12 +191,21 @@ def load_bace_classification(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
 
   splitter = splitters[split]
   logger.info("About to split data using {} splitter".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)

--- a/deepchem/molnet/load_function/bbbc_datasets.py
+++ b/deepchem/molnet/load_function/bbbc_datasets.py
@@ -43,7 +43,7 @@ def load_bbbc001(split='index',
     save_dir = DEFAULT_DIR
 
   if reload:
-    save_folder = os.path.join(save_dir, "bbbc001-featurized/" + str(split))
+    save_folder = os.path.join(save_dir, "bbbc001-featurized", str(split))
     loaded, all_dataset, transformers = deepchem.utils.save.load_dataset_from_disk(
         save_folder)
     if loaded:
@@ -86,7 +86,15 @@ def load_bbbc001(split='index',
   splitter = splitters[split]
 
   logger.info("About to split dataset with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   transformers = []
   all_dataset = (train, valid, test)
   if reload:
@@ -117,7 +125,7 @@ def load_bbbc002(split='index',
     save_dir = DEFAULT_DIR
 
   if reload:
-    save_folder = os.path.join(save_dir, "bbbc002-featurized/" + str(split))
+    save_folder = os.path.join(save_dir, "bbbc002-featurized", str(split))
     loaded, all_dataset, transformers = deepchem.utils.save.load_dataset_from_disk(
         save_folder)
     if loaded:
@@ -161,7 +169,15 @@ def load_bbbc002(split='index',
   splitter = splitters[split]
 
   logger.info("About to split dataset with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   all_dataset = (train, valid, test)
   transformers = []
   if reload:

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -83,7 +83,15 @@ def load_bbbp(featurizer='ECFP',
   }
   splitter = splitters[split]
   logger.info("About to split data with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   # Initialize transformers
   transformers = [

--- a/deepchem/molnet/load_function/cell_counting_datasets.py
+++ b/deepchem/molnet/load_function/cell_counting_datasets.py
@@ -36,8 +36,7 @@ def load_cell_counting(split=None,
   # For now images are loaded directly by ImageLoader
   featurizer = ""
   if reload:
-    save_folder = os.path.join(save_dir,
-                               "cell_counting-featurized/" + str(split))
+    save_folder = os.path.join(save_dir, "cell_counting-featurized", str(split))
     loaded, all_dataset, transformers = deepchem.utils.save.load_dataset_from_disk(
         save_folder)
     if loaded:
@@ -64,7 +63,15 @@ def load_cell_counting(split=None,
   splitter = splitters[split]
 
   logger.info("About to split dataset with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   transformers = []
   all_dataset = (train, valid, test)
   if reload:

--- a/deepchem/molnet/load_function/chembl25_datasets.py
+++ b/deepchem/molnet/load_function/chembl25_datasets.py
@@ -79,7 +79,7 @@ def load_chembl25(featurizer="smiles2seq",
 
   save_folder = os.path.join(save_dir, "chembl_25-featurized", str(featurizer))
   if featurizer == "smiles2img":
-    img_spec = kwargs.get("img_spec", "engd")
+    img_spec = kwargs.get("img_spec", "std")
     save_folder = os.path.join(save_folder, img_spec)
 
   if reload:
@@ -100,14 +100,21 @@ def load_chembl25(featurizer="smiles2seq",
         dataset_file))
     dc.utils.download_url(url=CHEMBL_URL, dest_dir=data_dir)
 
-  if featurizer == "smiles2seq":
+  if featurizer == 'ECFP':
+    featurizer = deepchem.feat.CircularFingerprint(size=1024)
+  elif featurizer == 'GraphConv':
+    featurizer = deepchem.feat.ConvMolFeaturizer()
+  elif featurizer == 'Weave':
+    featurizer = deepchem.feat.WeaveFeaturizer()
+  elif featurizer == 'Raw':
+    featurizer = deepchem.feat.RawFeaturizer()
+  elif featurizer == "smiles2seq":
     max_len = kwargs.get('max_len', 250)
     pad_len = kwargs.get('pad_len', 10)
     char_to_idx = create_char_to_idx(
         dataset_file, max_len=max_len, smiles_field="smiles")
     featurizer = SmilesToSeq(
         char_to_idx=char_to_idx, max_len=max_len, pad_len=pad_len)
-
   elif featurizer == "smiles2img":
     img_size = kwargs.get("img_size", 80)
     img_spec = kwargs.get("img_spec", "engd")

--- a/deepchem/molnet/load_function/chembl_datasets.py
+++ b/deepchem/molnet/load_function/chembl_datasets.py
@@ -130,12 +130,20 @@ def load_chembl(shard_size=2000,
     splitters = {
         'index': deepchem.splits.IndexSplitter(),
         'random': deepchem.splits.RandomSplitter(),
-        'scaffold': deepchem.splits.ScaffoldSplitter()
+        'scaffold': deepchem.splits.ScaffoldSplitter(),
     }
 
     splitter = splitters[split]
     logger.info("Performing new split.")
-    train, valid, test = splitter.train_valid_test_split(dataset)
+    frac_train = kwargs.get("frac_train", 0.8)
+    frac_valid = kwargs.get('frac_valid', 0.1)
+    frac_test = kwargs.get('frac_test', 0.1)
+
+    train, valid, test = splitter.train_valid_test_split(
+        dataset,
+        frac_train=frac_train,
+        frac_valid=frac_valid,
+        frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(transform_y=True, dataset=train)

--- a/deepchem/molnet/load_function/clearance_datasets.py
+++ b/deepchem/molnet/load_function/clearance_datasets.py
@@ -87,11 +87,20 @@ def load_clearance(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split data with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -25,7 +25,7 @@ def load_clintox(featurizer='ECFP',
   """Load clintox datasets."""
   if data_dir is None:
     data_dir = DEFAULT_DIR
-  else:
+  if save_dir is None:
     save_dir = DEFAULT_DIR
 
   if reload:
@@ -85,7 +85,8 @@ def load_clintox(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split data with {} splitter.".format(split))

--- a/deepchem/molnet/load_function/delaney_datasets.py
+++ b/deepchem/molnet/load_function/delaney_datasets.py
@@ -85,7 +85,8 @@ def load_delaney(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split dataset with {} splitter.".format(split))

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -88,7 +88,15 @@ def load_hopv(featurizer='ECFP',
   }
   splitter = splitters[split]
   logger.info("About to split dataset with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(transform_y=True, dataset=train)

--- a/deepchem/molnet/load_function/hppb_datasets.py
+++ b/deepchem/molnet/load_function/hppb_datasets.py
@@ -106,9 +106,18 @@ def load_hppb(featurizer="ECFP",
       'random': deepchem.splits.RandomSplitter(),
       'scaffold': deepchem.splits.ScaffoldSplitter(),
       'butina': deepchem.splits.ButinaSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
-  train, valid, test = splitter.train_valid_test_split(dataset, seed=split_seed)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   transformers = []
 
   logger.info("About to transform the data...")

--- a/deepchem/molnet/load_function/lipo_datasets.py
+++ b/deepchem/molnet/load_function/lipo_datasets.py
@@ -87,11 +87,20 @@ def load_lipo(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split data with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -88,7 +88,8 @@ def load_muv(featurizer='ECFP',
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
       'scaffold': deepchem.splits.ScaffoldSplitter(),
-      'task': deepchem.splits.TaskSplitter()
+      'task': deepchem.splits.TaskSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
   if split == 'task':
@@ -100,7 +101,15 @@ def load_muv(featurizer='ECFP',
     return MUV_tasks, all_dataset, []
 
   else:
-    train, valid, test = splitter.train_valid_test_split(dataset)
+    frac_train = kwargs.get("frac_train", 0.8)
+    frac_valid = kwargs.get('frac_valid', 0.1)
+    frac_test = kwargs.get('frac_test', 0.1)
+
+    train, valid, test = splitter.train_valid_test_split(
+        dataset,
+        frac_train=frac_train,
+        frac_valid=frac_valid,
+        frac_test=frac_test)
     all_dataset = (train, valid, test)
     if reload:
       deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,

--- a/deepchem/molnet/load_function/nci_datasets.py
+++ b/deepchem/molnet/load_function/nci_datasets.py
@@ -99,7 +99,15 @@ def load_nci(featurizer='ECFP',
   }
   splitter = splitters[split]
   logger.info("About to split data with {} splitter.".format(splitter))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(transform_y=True, dataset=train)

--- a/deepchem/molnet/load_function/pcba_datasets.py
+++ b/deepchem/molnet/load_function/pcba_datasets.py
@@ -140,11 +140,20 @@ def load_pcba_dataset(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split dataset using {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)

--- a/deepchem/molnet/load_function/ppb_datasets.py
+++ b/deepchem/molnet/load_function/ppb_datasets.py
@@ -81,11 +81,20 @@ def load_ppb(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split dataset with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(transform_y=True, dataset=train)

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -104,8 +104,15 @@ def load_qm7_from_mat(featurizer='CoulombMatrix',
     }
 
     splitter = splitters[split]
+    frac_train = kwargs.get("frac_train", 0.8)
+    frac_valid = kwargs.get('frac_valid', 0.1)
+    frac_test = kwargs.get('frac_test', 0.1)
+
     train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(
-        dataset)
+        dataset,
+        frac_train=frac_train,
+        frac_valid=frac_valid,
+        frac_test=frac_test)
 
     transformers = [
         deepchem.trans.NormalizationTransformer(
@@ -155,8 +162,15 @@ def load_qm7b_from_mat(featurizer='CoulombMatrix',
         deepchem.splits.SingletaskStratifiedSplitter(task_number=0)
     }
     splitter = splitters[split]
+    frac_train = kwargs.get("frac_train", 0.8)
+    frac_valid = kwargs.get('frac_valid', 0.1)
+    frac_test = kwargs.get('frac_test', 0.1)
+
     train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(
-        dataset)
+        dataset,
+        frac_train=frac_train,
+        frac_valid=frac_valid,
+        frac_test=frac_test)
 
     transformers = [
         deepchem.trans.NormalizationTransformer(
@@ -211,8 +225,15 @@ def load_qm7(featurizer='CoulombMatrix',
       'stratified': deepchem.splits.SingletaskStratifiedSplitter(task_number=0)
   }
   splitter = splitters[split]
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
   train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(
-      dataset)
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.NormalizationTransformer(

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -101,8 +101,15 @@ def load_qm8(featurizer='CoulombMatrix',
       'stratified': deepchem.splits.SingletaskStratifiedSplitter(task_number=0)
   }
   splitter = splitters[split]
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
   train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(
-      dataset)
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=train_dataset, move_mean=move_mean)

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -104,8 +104,15 @@ def load_qm9(featurizer='CoulombMatrix',
       'stratified': deepchem.splits.SingletaskStratifiedSplitter(task_number=11)
   }
   splitter = splitters[split]
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
   train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(
-      dataset)
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
   transformers = [
       deepchem.trans.NormalizationTransformer(
           transform_y=True, dataset=train_dataset, move_mean=move_mean)

--- a/deepchem/molnet/load_function/sider_datasets.py
+++ b/deepchem/molnet/load_function/sider_datasets.py
@@ -88,14 +88,23 @@ def load_sider(featurizer='ECFP',
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
       'scaffold': deepchem.splits.ScaffoldSplitter(),
-      'task': deepchem.splits.TaskSplitter()
+      'task': deepchem.splits.TaskSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
   if split == 'task':
     fold_datasets = splitter.k_fold_split(dataset, K)
     all_dataset = fold_datasets
   else:
-    train, valid, test = splitter.train_valid_test_split(dataset)
+    frac_train = kwargs.get("frac_train", 0.8)
+    frac_valid = kwargs.get('frac_valid', 0.1)
+    frac_test = kwargs.get('frac_test', 0.1)
+
+    train, valid, test = splitter.train_valid_test_split(
+        dataset,
+        frac_train=frac_train,
+        frac_valid=frac_valid,
+        frac_test=frac_test)
     if reload:
       deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,
                                                transformers)

--- a/deepchem/molnet/load_function/sweetlead_datasets.py
+++ b/deepchem/molnet/load_function/sweetlead_datasets.py
@@ -77,10 +77,19 @@ def load_sweet(featurizer='ECFP',
       'index': dc.splits.IndexSplitter(),
       'random': dc.splits.RandomSplitter(),
       'scaffold': dc.splits.ScaffoldSplitter(),
-      'task': dc.splits.TaskSplitter()
+      'task': dc.splits.TaskSplitter(),
+      'stratified': dc.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   if reload:
     dc.utils.save.save_dataset_to_disk(save_folder, train, valid, test,

--- a/deepchem/molnet/load_function/thermosol_datasets.py
+++ b/deepchem/molnet/load_function/thermosol_datasets.py
@@ -105,9 +105,19 @@ def load_thermosol(featurizer="ECFP",
       'random': deepchem.splits.RandomSplitter(),
       'scaffold': deepchem.splits.ScaffoldSplitter(),
       'butina': deepchem.splits.ButinaSplitter(),
+      'stratified': deepchem.splits.SingletaskStratifiedSplitter()
   }
   splitter = splitters[split]
-  train, valid, test = splitter.train_valid_test_split(dataset, seed=split_seed)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test,
+      seed=split_seed)
   transformers = []
 
   logger.info("About to transform the data...")

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -71,16 +71,16 @@ def load_tox21(featurizer='ECFP',
       tasks=tox21_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
-  # Initialize transformers
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
-
-  logger.info("About to transform data")
-  for transformer in transformers:
-    dataset = transformer.transform(dataset)
-
   if split == None:
+    # Initialize transformers
+    transformers = [
+        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
+    ]
+
+    logger.info("About to transform data")
+    for transformer in transformers:
+      dataset = transformer.transform(dataset)
+
     return tox21_tasks, (dataset, None, None), transformers
 
   splitters = {
@@ -106,6 +106,17 @@ def load_tox21(featurizer='ECFP',
         frac_valid=frac_valid,
         frac_test=frac_test)
     all_dataset = (train, valid, test)
+
+    transformers = [
+        deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
+    ]
+
+    logger.info("About to transform data")
+    for transformer in transformers:
+      train = transformer.transform(train)
+      valid = transformer.transform(valid)
+      test = transformer.transform(test)
+
     if reload:
       deepchem.utils.save.save_dataset_to_disk(save_folder, train, valid, test,
                                                transformers)

--- a/deepchem/molnet/load_function/toxcast_datasets.py
+++ b/deepchem/molnet/load_function/toxcast_datasets.py
@@ -80,11 +80,20 @@ def load_toxcast(featurizer='ECFP',
   splitters = {
       'index': deepchem.splits.IndexSplitter(),
       'random': deepchem.splits.RandomSplitter(),
-      'scaffold': deepchem.splits.ScaffoldSplitter()
+      'scaffold': deepchem.splits.ScaffoldSplitter(),
+      'stratified': deepchem.splits.RandomStratifiedSplitter()
   }
   splitter = splitters[split]
   logger.info("About to split dataset with {} splitter.".format(split))
-  train, valid, test = splitter.train_valid_test_split(dataset)
+  frac_train = kwargs.get("frac_train", 0.8)
+  frac_valid = kwargs.get('frac_valid', 0.1)
+  frac_test = kwargs.get('frac_test', 0.1)
+
+  train, valid, test = splitter.train_valid_test_split(
+      dataset,
+      frac_train=frac_train,
+      frac_valid=frac_valid,
+      frac_test=frac_test)
 
   transformers = [
       deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)


### PR DESCRIPTION
1. Added some options for train-test-split, scaffold and stratified splitters since they follow that split in the paper for MolNet datasets. 
2. Fixed a split and transform issue with Tox21
3. Fixed a bug introduced in previous PR in the ChemCeption model. 