### PR TITLE
DiskDataset.move() would not overwrite an existing dataset

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -649,6 +649,8 @@ class DiskDataset(Dataset):
 
   def move(self, new_data_dir):
     """Moves dataset to new directory."""
+    if os.path.isdir(new_data_dir):
+      shutil.rmtree(new_data_dir)
     shutil.move(self.data_dir, new_data_dir)
     self.data_dir = new_data_dir
 


### PR DESCRIPTION
It uses `shutil.move()` to move the dataset to the new location, but that will not overwrite existing files.  So if there was already a dataset there, the new dataset would effectively be thrown away and suddenly transform into the previous one.  This came up when using the molnet load functions.  For example, if you first loaded a dataset, then loaded it again specifying a different splitting, you would keep getting the original splitting.