### PR TITLE
allow bedroc_score to not require mode

### DIFF
--- a/deepchem/metrics/__init__.py
+++ b/deepchem/metrics/__init__.py
@@ -237,7 +237,7 @@ class Metric(object):
       if self.metric.__name__ in [
           "roc_auc_score", "matthews_corrcoef", "recall_score",
           "accuracy_score", "kappa_score", "precision_score",
-          "balanced_accuracy_score", "prc_auc_score"
+          "balanced_accuracy_score", "prc_auc_score", "bedroc_score",
       ]:
         mode = "classification"
       elif self.metric.__name__ in [


### PR DESCRIPTION
This is a super simple PR.  I just noticed in experimenting with `deepchem` that trying to initialize a `Metric` with `bedroc_score` threw an exception "Must specify mode for new metric".  This patches that.