### PR TITLE
Conda install hangs at solving environment

### DIFF
--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -42,7 +42,7 @@ if [[ "$unamestr" == 'Darwin' ]]; then
 fi
 
 yes | pip install --upgrade pip
-conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
+conda install -y -q --override-channels -c deepchem -c rdkit -c conda-forge -c omnia \
     mdtraj \
     pdbfixer \
     rdkit \


### PR DESCRIPTION
Extracted from: https://github.com/conda/conda/issues/7690#issuecomment-451582942

> https://www.anaconda.com/understanding-and-improving-condas-performance/
> 
> For solve times beyond one or two minutes, it is almost always some problem with metadata that leads conda into awkward loops where there is not a clear "right" answer. For example, things on defaults are built with openssl 1.1.1, whereas things from conda-forge are only starting to be available with that. Because conda-forge doesn't have a complete set of packages using openssl 1.1.1, conda can get into awkward solutions that end up not really converging. Strict channel priority is helpful for forcing these situations to error out quickly instead of churning, though the error messages are not always very helpful.
> 
> If you identify packages that create problems, it is helpful to file issues using the "speed complaint" template. Even if there's nothing conda can do, we can perhaps help fix the metadata in our packages or on conda-forge so that other people don't get stuck.
> 
> by @msarahan at https://github.com/conda/conda/issues/7690#issuecomment-472280902