### PR TITLE
Fixing ButinaSplitter and adding return scaffolds functionality

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -784,7 +784,7 @@ def ClusterFps(fps, cutoff=0.2):
   return cs
 
 
-class ButinaSplitterNew(Splitter):
+class ButinaSplitter(Splitter):
   """
   Class for doing data splits based on the butina clustering of a bulk tanimoto
   fingerprint matrix.

--- a/deepchem/splits/tests/test_butina_splitter.py
+++ b/deepchem/splits/tests/test_butina_splitter.py
@@ -6,7 +6,7 @@ import deepchem as dc
 from deepchem.splits.splitters import ButinaSplitter
 
 
-class TestScaffoldSplitter(TestCase):
+class TestButinaSplitter(TestCase):
 
   def test_scaffolds(self):
     raise NotImplementedError

--- a/deepchem/splits/tests/test_butina_splitter.py
+++ b/deepchem/splits/tests/test_butina_splitter.py
@@ -1,0 +1,12 @@
+import unittest
+from unittest import TestCase
+
+import numpy as np
+import deepchem as dc
+from deepchem.splits.splitters import ButinaSplitter
+
+
+class TestScaffoldSplitter(TestCase):
+
+  def test_scaffolds(self):
+    raise NotImplementedError


### PR DESCRIPTION
Related to issue https://github.com/deepchem/deepchem/issues/1752

I have added `generate_scaffolds()` method that replaces part of the `split()` functionality. More specifically, it returns scaffolds sets that are generated with `ClusterFps()` methods (as in the original code). I will add some tests in the next few days.

There is also an issue here that the class does not seem to be fully implemented:
https://github.com/deepchem/deepchem/blob/03f1709e58830aad084c1afb3fdb4fe28608facb/deepchem/splits/splitters.py#L827-L840

Currently, it works as follows:

1. Generate the scaffolds with `ClusterFps`
2. It assigns each cluster to the validation data as long as the following requirement is met:
https://github.com/deepchem/deepchem/blob/03f1709e58830aad084c1afb3fdb4fe28608facb/deepchem/splits/splitters.py#L836-L840
3. Then, the remaining clusters are assigned to the train data 
4. Return indices of validation and train data

The question here is: what that if statement actually means `if np.all(active_populations):` and what `ys = dataset.y` represents?
The comments in the code mention that the loop continues 

> until  we find an active in all the tasks, otherwise we can't compute a meaningful AUC"

I would suspect that `ys` represents whether a molecule is active or not (1 or 0) but I am not certainly sure.
Also, a problem with this implementation is that we can't control the sizes of the train and validation data. 
https://github.com/deepchem/deepchem/blob/03f1709e58830aad084c1afb3fdb4fe28608facb/deepchem/splits/splitters.py#L793-L801
All arguments besides dataset and cutoff are unused.