### PR TITLE
Update Multitask_Networks_on_MUV.ipynb

### DIFF
--- a/examples/notebooks/Multitask_Networks_on_MUV.ipynb
+++ b/examples/notebooks/Multitask_Networks_on_MUV.ipynb
@@ -357,7 +357,7 @@
     "\n",
     "n_features = train_dataset.get_data_shape()[0]\n",
     "def model_builder(model_params, model_dir):\n",
-    "  model = dc.models.MultitaskClassifier(\n",
+    "  model = dc.models.fcnet.MultitaskClassifier(\n",
     "    len(MUV_tasks), n_features, **model_params)\n",
     "  return model\n",
     "\n",


### PR DESCRIPTION
`dc.models.MultiTaskClassifier()` has changed to `dc.models.fcnet.MultitaskClassifier()`.
Please refer to this Gitter page for more information:
https://gitter.im/deepchem/Lobby?at=5e31cdc4bfe65274eabd06be