### PR TITLE
Travis bump to 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-- '3.5'
-- '3.7'
+- '3.6'
+- '3.8'
 sudo: required
 dist: xenial
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
 - '3.6'
-- '3.8'
+- '3.7'
 sudo: required
 dist: xenial
 install:

--- a/deepchem/feat/tests/test_rdkit_grid_features.py
+++ b/deepchem/feat/tests/test_rdkit_grid_features.py
@@ -101,23 +101,21 @@ class TestHelperFunctions(unittest.TestCase):
       self.assertAlmostEqual(rgf.angle_between(v1, -v1), np.pi)
 
   def test_hash_ecfp(self):
-    from six import integer_types
     for power in (2, 16, 64):
       for _ in range(10):
         string = random_string(10)
         string_hash = rgf.hash_ecfp(string, power)
-        self.assertIsInstance(string_hash, integer_types)
+        self.assertIsInstance(string_hash, int)
         self.assertLess(string_hash, 2**power)
         self.assertGreaterEqual(string_hash, 0)
 
   def test_hash_ecfp_pair(self):
-    from six import integer_types
     for power in (2, 16, 64):
       for _ in range(10):
         string1 = random_string(10)
         string2 = random_string(10)
         pair_hash = rgf.hash_ecfp_pair((string1, string2), power)
-        self.assertIsInstance(pair_hash, integer_types)
+        self.assertIsInstance(pair_hash, int)
         self.assertLess(pair_hash, 2**power)
         self.assertGreaterEqual(pair_hash, 0)
 

--- a/deepchem/trans/tests/test_transformers.py
+++ b/deepchem/trans/tests/test_transformers.py
@@ -7,7 +7,6 @@ from __future__ import unicode_literals
 from deepchem.molnet import load_delaney
 from deepchem.trans.transformers import FeaturizationTransformer
 from deepchem.trans.transformers import DataTransforms
-from tensorflow.examples.tutorials.mnist import input_data
 
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
@@ -18,6 +17,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import deepchem as dc
+import tensorflow as tf
 import scipy.ndimage
 from PIL import Image
 
@@ -33,12 +33,14 @@ class TestTransformers(unittest.TestCase):
     '''
        init to load the MNIST data for DataTransforms Tests
       '''
-    mnist = input_data.read_data_sets("MNIST_data/", one_hot=True)
+    #mnist = input_data.read_data_sets("MNIST_data/", one_hot=True)
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
     # extracting validation set of MNIST for testing the DataTransforms
-    valid = dc.data.NumpyDataset(mnist.validation.images,
-                                 mnist.validation.labels)
+    #valid = dc.data.NumpyDataset(mnist.validation.images,
+    #                             mnist.validation.labels)
+    train = dc.data.NumpyDataset(x_train, y_train)
     # extract only the images (no need of the labels)
-    data = (valid.X)[0]
+    data = (train.X)[0]
     # reshaping the vector to image
     data = np.reshape(data, (28, 28))
     self.d = data

--- a/deepchem/trans/tests/test_transformers.py
+++ b/deepchem/trans/tests/test_transformers.py
@@ -33,11 +33,7 @@ class TestTransformers(unittest.TestCase):
     '''
        init to load the MNIST data for DataTransforms Tests
       '''
-    #mnist = input_data.read_data_sets("MNIST_data/", one_hot=True)
     (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
-    # extracting validation set of MNIST for testing the DataTransforms
-    #valid = dc.data.NumpyDataset(mnist.validation.images,
-    #                             mnist.validation.labels)
     train = dc.data.NumpyDataset(x_train, y_train)
     # extract only the images (no need of the labels)
     data = (train.X)[0]

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -58,7 +58,7 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     requests \
     xgboost \
     simdna \
-    biopython \
     setuptools \
+    biopython \
     numpy
 yes | pip install $tensorflow==2.1.0 tensorflow-probability

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -47,7 +47,6 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     pdbfixer \
     rdkit \
     joblib \
-    six \
     scikit-learn \
     networkx \
     pillow \

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -49,7 +49,6 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     joblib \
     scikit-learn \
     networkx \
-    pillow \
     pandas \
     nose \
     nose-timer \
@@ -57,9 +56,6 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     zlib \
     requests \
     xgboost \
-    simdna \
-    pbr \
     setuptools \
-    biopython \
     numpy
 yes | pip install $tensorflow==2.1.0 tensorflow-probability

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -49,6 +49,7 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     joblib \
     scikit-learn \
     networkx \
+    pillow \
     pandas \
     nose \
     nose-timer \
@@ -56,8 +57,8 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     zlib \
     requests \
     xgboost \
+    simdna \
     biopython \
-    pillow \
     setuptools \
     numpy
 yes | pip install $tensorflow==2.1.0 tensorflow-probability

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -56,6 +56,8 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     zlib \
     requests \
     xgboost \
+    biopython \
+    pillow \
     setuptools \
     numpy
 yes | pip install $tensorflow==2.1.0 tensorflow-probability


### PR DESCRIPTION
This PR bumps travis to run on Python 3.6 and 3.8 in line with discussion in #1771 