### PR TITLE
Removes scikit-learn joblib

### DIFF
--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -5,9 +5,7 @@ from __future__ import print_function
 from __future__ import division
 from __future__ import unicode_literals
 
-# TODO(rbharath): Use standard joblib once old-data has been regenerated.
 import joblib
-from sklearn.externals import joblib as old_joblib
 import gzip
 import json
 import pickle
@@ -219,13 +217,7 @@ def load_from_disk(filename):
   if os.path.splitext(name)[1] == ".pkl":
     return load_pickle_from_disk(filename)
   elif os.path.splitext(name)[1] == ".joblib":
-    try:
-      return joblib.load(filename)
-    except KeyError:
-      # Try older joblib version for legacy files.
-      return old_joblib.load(filename)
-    except ValueError:
-      return old_joblib.load(filename)
+    return joblib.load(filename)
   elif os.path.splitext(name)[1] == ".csv":
     # First line of user-specified CSV *must* be header.
     df = pd.read_csv(filename, header=0)


### PR DESCRIPTION
We used to use scikit-learn's joblib to save scikit-learn models a long while back. This import has been emitting warnings for a long while now. I'm removing this and switching to just regular joblib since I think there are no legacy models we support that need this old functionality. 