### PR TITLE
Remove unnecessary future statements

### DIFF
--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -1,9 +1,6 @@
 """
 Imports all submodules
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __version__ = '2.3.0'
 
 import deepchem.data

--- a/deepchem/data/__init__.py
+++ b/deepchem/data/__init__.py
@@ -1,10 +1,6 @@
 """
 Gathers all datasets in one place for convenient imports
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 # TODO(rbharath): Get rid of * import
 from deepchem.data.datasets import pad_features
 from deepchem.data.datasets import pad_batch

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -1,8 +1,6 @@
 """
 Process an input dataset into a format suitable for machine learning.
 """
-from __future__ import division
-from __future__ import unicode_literals
 import os
 import gzip
 import pandas as pd

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1,8 +1,6 @@
 """
 Contains wrapper class for datasets.
 """
-from __future__ import division
-from __future__ import unicode_literals
 import json
 import os
 import math

--- a/deepchem/data/supports.py
+++ b/deepchem/data/supports.py
@@ -1,9 +1,6 @@
 """
 Sample supports from datasets.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import time
 import numpy as np

--- a/deepchem/data/tests/__init__.py
+++ b/deepchem/data/tests/__init__.py
@@ -1,10 +1,6 @@
 """
 General API for testing dataset objects
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_data_loader.py
+++ b/deepchem/data/tests/test_data_loader.py
@@ -1,9 +1,6 @@
 """
 Tests for FeaturizedSamples class
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -1,9 +1,6 @@
 """
 Tests for dataset creation
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -1,9 +1,6 @@
 """
 Tests that FASTA files can be loaded.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __license__ = "MIT"
 

--- a/deepchem/data/tests/test_image_dataset.py
+++ b/deepchem/data/tests/test_image_dataset.py
@@ -1,9 +1,6 @@
 """
 Tests for ImageDataset class
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_image_loader.py
+++ b/deepchem/data/tests/test_image_loader.py
@@ -1,9 +1,6 @@
 """
 Tests for ImageLoader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import unittest
 import tempfile

--- a/deepchem/data/tests/test_load.py
+++ b/deepchem/data/tests/test_load.py
@@ -1,9 +1,6 @@
 """
 Testing singletask/multitask data loading capabilities.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_merge.py
+++ b/deepchem/data/tests/test_merge.py
@@ -1,9 +1,6 @@
 """
 Testing singletask/multitask dataset merging
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_reload.py
+++ b/deepchem/data/tests/test_reload.py
@@ -1,9 +1,6 @@
 """
 Testing reload.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -1,9 +1,6 @@
 """
 Testing singletask/multitask dataset shuffling 
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/data/tests/test_support_generator.py
+++ b/deepchem/data/tests/test_support_generator.py
@@ -1,9 +1,6 @@
 """
 Simple Tests for Support Generation
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Han Altae-Tran and Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/dock/__init__.py
+++ b/deepchem/dock/__init__.py
@@ -1,10 +1,6 @@
 """
 Imports all submodules 
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.dock.pose_generation import PoseGenerator
 from deepchem.dock.pose_generation import VinaPoseGenerator
 from deepchem.dock.pose_scoring import PoseScorer

--- a/deepchem/dock/binding_pocket.py
+++ b/deepchem/dock/binding_pocket.py
@@ -1,9 +1,6 @@
 """
 Computes putative binding pockets on protein.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2017, Stanford University"
 __license__ = "MIT"

--- a/deepchem/dock/docking.py
+++ b/deepchem/dock/docking.py
@@ -1,9 +1,6 @@
 """
 Docks protein-ligand pairs
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/dock/pose_generation.py
+++ b/deepchem/dock/pose_generation.py
@@ -1,9 +1,6 @@
 """
 Generates protein-ligand docked poses using Autodock Vina.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.utils import mol_xyz_util
 
 __author__ = "Bharath Ramsundar"

--- a/deepchem/dock/pose_scoring.py
+++ b/deepchem/dock/pose_scoring.py
@@ -1,9 +1,6 @@
 """
 Scores protein-ligand poses using DeepChem.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.feat import RdkitGridFeaturizer
 
 __author__ = "Bharath Ramsundar"

--- a/deepchem/dock/tests/test_binding_pocket.py
+++ b/deepchem/dock/tests/test_binding_pocket.py
@@ -1,9 +1,6 @@
 """
 Tests for binding pocket detection.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/dock/tests/test_docking.py
+++ b/deepchem/dock/tests/test_docking.py
@@ -1,9 +1,6 @@
 """
 Tests for Docking 
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/dock/tests/test_pose_generation.py
+++ b/deepchem/dock/tests/test_pose_generation.py
@@ -1,9 +1,6 @@
 """
 Tests for Pose Generation
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/dock/tests/test_pose_scoring.py
+++ b/deepchem/dock/tests/test_pose_scoring.py
@@ -1,9 +1,6 @@
 """
 Tests for Pose Scoring
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -1,10 +1,6 @@
 """
 Making it easy to import in classes.
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/atomic_coordinates.py
+++ b/deepchem/feat/atomic_coordinates.py
@@ -1,9 +1,6 @@
 """
 Atomic coordinate featurizer.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Joseph Gomes and Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/basic.py
+++ b/deepchem/feat/basic.py
@@ -1,9 +1,6 @@
 """
 Basic molecular features.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/binding_pocket_features.py
+++ b/deepchem/feat/binding_pocket_features.py
@@ -1,9 +1,6 @@
 """
 Featurizes proposed binding pockets.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2017, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/coulomb_matrices.py
+++ b/deepchem/feat/coulomb_matrices.py
@@ -3,9 +3,6 @@ Generate coulomb matrices for molecules.
 
 See Montavon et al., _New Journal of Physics_ __15__ (2013) 095003.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/fingerprints.py
+++ b/deepchem/feat/fingerprints.py
@@ -1,9 +1,6 @@
 """
 Topological fingerprints.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Steven Kearnes"
 __copyright__ = "Copyright 2014, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/graph_features.py
+++ b/deepchem/feat/graph_features.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 import numpy as np
 from rdkit import Chem
 

--- a/deepchem/feat/mol_graphs.py
+++ b/deepchem/feat/mol_graphs.py
@@ -1,9 +1,6 @@
 """
 Data Structures used to represented molecules for convolutions.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Han Altae-Tran and Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/nnscore_utils.py
+++ b/deepchem/feat/nnscore_utils.py
@@ -1,9 +1,6 @@
 """
 Helper Classes and Functions for docking fingerprint computation.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar and Jacob Durrant"
 __license__ = "GNU General Public License"
 

--- a/deepchem/feat/raw_featurizer.py
+++ b/deepchem/feat/raw_featurizer.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python2
 # -*- coding: utf-8 -*-
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.feat import Featurizer
 
 

--- a/deepchem/feat/rdkit_grid_featurizer.py
+++ b/deepchem/feat/rdkit_grid_featurizer.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar, Evan Feinberg, and Karl Leswing"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/smiles_featurizers.py
+++ b/deepchem/feat/smiles_featurizers.py
@@ -4,9 +4,6 @@ SmilesToSeq featurizer for Smiles2Vec models taken from https://arxiv.org/abs/17
 SmilesToImage featurizer for ChemCeption models taken from https://arxiv.org/abs/1710.02238
 """
 
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Vignesh Ram Somnath"
 __license__ = "MIT"
 

--- a/deepchem/feat/tests/test_graph_features.py
+++ b/deepchem/feat/tests/test_graph_features.py
@@ -1,9 +1,6 @@
 """
 Tests for ConvMolFeaturizer. 
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Han Altae-Tran and Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/tests/test_mol_graphs.py
+++ b/deepchem/feat/tests/test_mol_graphs.py
@@ -1,9 +1,6 @@
 """
 Tests for Molecular Graph data structures. 
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Han Altae-Tran and Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/feat/tests/test_sdf_reader.py
+++ b/deepchem/feat/tests/test_sdf_reader.py
@@ -1,9 +1,6 @@
 """
 Tests for importing .sdf files
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Joseph Gomes"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -1,9 +1,6 @@
 """
 Contains class for gaussian process hyperparameter optimizations.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import numpy as np
 import tempfile

--- a/deepchem/hyper/tests/test_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_hyperparam_opt.py
@@ -1,9 +1,6 @@
 """
 Integration tests for hyperparam optimization.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/metrics/tests/metrics_test.py
+++ b/deepchem/metrics/tests/metrics_test.py
@@ -1,9 +1,6 @@
 """
 Tests for metricsT.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/metrics/tests/test_genomics.py
+++ b/deepchem/metrics/tests/test_genomics.py
@@ -1,9 +1,6 @@
 """
 Test that genomic metrics work.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import unittest
 import os
 

--- a/deepchem/models/IRV.py
+++ b/deepchem/models/IRV.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import numpy as np
 import tensorflow as tf

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -1,9 +1,6 @@
 """
 Gathers all models in one place for convenient imports
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.models.models import Model
 from deepchem.models.keras_model import KerasModel
 from deepchem.models.sklearn_models import SklearnModel

--- a/deepchem/models/atomic_conv.py
+++ b/deepchem/models/atomic_conv.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Joseph Gomes"
 __copyright__ = "Copyright 2017, Stanford University"
 __license__ = "MIT"

--- a/deepchem/models/callbacks.py
+++ b/deepchem/models/callbacks.py
@@ -2,8 +2,6 @@
 Callback functions that can be invoked while fitting a KerasModel.
 """
 
-from __future__ import print_function
-
 import tensorflow as tf
 import sys
 

--- a/deepchem/models/chemnet_layers.py
+++ b/deepchem/models/chemnet_layers.py
@@ -2,9 +2,6 @@
 Contains implementations of layers used in ChemCeption and Smiles2Vec models.
 """
 
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Vignesh Ram Somnath"
 __license__ = "MIT"
 

--- a/deepchem/models/chemnet_models.py
+++ b/deepchem/models/chemnet_models.py
@@ -3,9 +3,6 @@ Implementation of Smiles2Vec and ChemCeption models as part of the ChemNet
 transfer learning protocol.
 """
 
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Vignesh Ram Somnath"
 __license__ = "MIT"
 

--- a/deepchem/models/fcnet.py
+++ b/deepchem/models/fcnet.py
@@ -1,8 +1,5 @@
 """TensorFlow implementation of fully connected networks.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import warnings
 import time

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -1,9 +1,6 @@
 """
 Contains an abstract base class that supports different ML models.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar and Joseph Gomes"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/models/multitask.py
+++ b/deepchem/models/multitask.py
@@ -1,9 +1,6 @@
 """
 Convenience class that lets singletask models fit on multitask data.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import sklearn
 import tempfile

--- a/deepchem/models/progressive_multitask.py
+++ b/deepchem/models/progressive_multitask.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 import time
 import numpy as np
 import tensorflow as tf

--- a/deepchem/models/robust_multitask.py
+++ b/deepchem/models/robust_multitask.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 import numpy as np
 import tensorflow as tf
 import collections

--- a/deepchem/models/tests/test_api.py
+++ b/deepchem/models/tests/test_api.py
@@ -1,9 +1,6 @@
 """
 Integration tests for singletask vector feature models.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/models/tests/test_atomic_conv.py
+++ b/deepchem/models/tests/test_atomic_conv.py
@@ -1,9 +1,6 @@
 """
 Tests for Atomic Convolutions.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from nose.plugins.attrib import attr
 
 import os

--- a/deepchem/models/tests/test_generalize.py
+++ b/deepchem/models/tests/test_generalize.py
@@ -2,9 +2,6 @@
 Tests to make sure deepchem models can fit models on easy datasets.
 """
 
-from __future__ import division
-from __future__ import unicode_literals
-
 from nose.plugins.attrib import attr
 
 __author__ = "Bharath Ramsundar"

--- a/deepchem/models/tests/test_multitask.py
+++ b/deepchem/models/tests/test_multitask.py
@@ -1,9 +1,6 @@
 """
 Integration tests for multitask datasets.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -1,9 +1,6 @@
 """
 Tests to make sure deepchem models can overfit on tiny datasets.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from nose.plugins.attrib import attr
 
 __author__ = "Bharath Ramsundar"

--- a/deepchem/models/tests/test_predict.py
+++ b/deepchem/models/tests/test_predict.py
@@ -1,9 +1,6 @@
 """
 Tests that deepchem models make deterministic predictions. 
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/models/tests/test_reload.py
+++ b/deepchem/models/tests/test_reload.py
@@ -1,9 +1,6 @@
 """
 Test reload for trained models.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/models/tests/test_singletask_to_multitask.py
+++ b/deepchem/models/tests/test_singletask_to_multitask.py
@@ -1,9 +1,6 @@
 """
 Testing singletask-to-multitask.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/molnet/__init__.py
+++ b/deepchem/molnet/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.molnet.load_function.bace_datasets import load_bace_classification, load_bace_regression
 from deepchem.molnet.load_function.bbbc_datasets import load_bbbc001, load_bbbc002
 from deepchem.molnet.load_function.bbbp_datasets import load_bbbp

--- a/deepchem/molnet/dnasim.py
+++ b/deepchem/molnet/dnasim.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, division, print_function
 from collections import OrderedDict
 import numpy as np
 

--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -1,9 +1,6 @@
 """
 bace dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/bbbc_datasets.py
+++ b/deepchem/molnet/load_function/bbbc_datasets.py
@@ -3,10 +3,6 @@ BBBC Dataset loader.
 
 This file contains image loaders for the BBBC dataset collection (https://data.broadinstitute.org/bbbc/image_sets.html).
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import numpy as np
 import logging

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -1,9 +1,6 @@
 """
 Blood-Brain Barrier Penetration dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/cell_counting_datasets.py
+++ b/deepchem/molnet/load_function/cell_counting_datasets.py
@@ -5,9 +5,6 @@ Loads the cell counting dataset from
 http://www.robots.ox.ac.uk/~vgg/research/counting/index_org.html. Labels aren't
 available for this dataset, so only raw images are provided.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/chembl25_datasets.py
+++ b/deepchem/molnet/load_function/chembl25_datasets.py
@@ -1,10 +1,6 @@
 """
 ChEMBL dataset loader, for training ChemNet
 """
-
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 import numpy as np
 import logging

--- a/deepchem/molnet/load_function/chembl_datasets.py
+++ b/deepchem/molnet/load_function/chembl_datasets.py
@@ -1,9 +1,6 @@
 """
 ChEMBL dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/clearance_datasets.py
+++ b/deepchem/molnet/load_function/clearance_datasets.py
@@ -1,9 +1,6 @@
 """
 clearance dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -2,10 +2,6 @@
 Clinical Toxicity (clintox) dataset loader.
 @author Caleb Geniesse
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/delaney_datasets.py
+++ b/deepchem/molnet/load_function/delaney_datasets.py
@@ -1,9 +1,6 @@
 """
 Delaney dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/factors_datasets.py
+++ b/deepchem/molnet/load_function/factors_datasets.py
@@ -1,10 +1,6 @@
 """
 FACTOR dataset loader
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import time

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -1,9 +1,6 @@
 """
 hiv dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -1,9 +1,6 @@
 """
 HOPV dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/hppb_datasets.py
+++ b/deepchem/molnet/load_function/hppb_datasets.py
@@ -1,10 +1,6 @@
 """
 HPPB Dataset Loader.
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/kaggle_datasets.py
+++ b/deepchem/molnet/load_function/kaggle_datasets.py
@@ -1,9 +1,6 @@
 """
 KAGGLE dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import time

--- a/deepchem/molnet/load_function/kinase_datasets.py
+++ b/deepchem/molnet/load_function/kinase_datasets.py
@@ -1,10 +1,6 @@
 """
 KINASE dataset loader
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import time

--- a/deepchem/molnet/load_function/lipo_datasets.py
+++ b/deepchem/molnet/load_function/lipo_datasets.py
@@ -1,9 +1,6 @@
 """
 Lipophilicity dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -1,9 +1,6 @@
 """
 MUV dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/nci_datasets.py
+++ b/deepchem/molnet/load_function/nci_datasets.py
@@ -3,9 +3,6 @@ NCI dataset loader.
 Original Author - Bharath Ramsundar
 Author - Aneesh Pappu
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/pcba_datasets.py
+++ b/deepchem/molnet/load_function/pcba_datasets.py
@@ -1,9 +1,6 @@
 """
 PCBA dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -1,10 +1,6 @@
 """
 PDBBind dataset loader.
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import logging
 import multiprocessing
 import os

--- a/deepchem/molnet/load_function/ppb_datasets.py
+++ b/deepchem/molnet/load_function/ppb_datasets.py
@@ -1,9 +1,6 @@
 """
 PPB dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -1,9 +1,6 @@
 """
 qm7 dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import numpy as np
 import deepchem

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -1,9 +1,6 @@
 """
 qm8 dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import deepchem
 import logging

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -1,9 +1,6 @@
 """
 qm9 dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/sampl_datasets.py
+++ b/deepchem/molnet/load_function/sampl_datasets.py
@@ -1,9 +1,6 @@
 """
 SAMPL dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/sider_datasets.py
+++ b/deepchem/molnet/load_function/sider_datasets.py
@@ -1,9 +1,6 @@
 """
 SIDER dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/sweetlead_datasets.py
+++ b/deepchem/molnet/load_function/sweetlead_datasets.py
@@ -1,10 +1,6 @@
 """
 SWEET dataset loader.
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import numpy as np
 import shutil

--- a/deepchem/molnet/load_function/thermosol_datasets.py
+++ b/deepchem/molnet/load_function/thermosol_datasets.py
@@ -1,10 +1,6 @@
 """
 Thermodynamic Solubility Dataset Loader
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -1,9 +1,6 @@
 """
 Tox21 dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/toxcast_datasets.py
+++ b/deepchem/molnet/load_function/toxcast_datasets.py
@@ -1,9 +1,6 @@
 """
 TOXCAST dataset loader.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import deepchem

--- a/deepchem/molnet/load_function/uspto_datasets.py
+++ b/deepchem/molnet/load_function/uspto_datasets.py
@@ -3,10 +3,6 @@ Loads synthetic reaction datasets from USPTO.
 
 This file contains loaders for synthetic reaction datasets from the US Patenent Office. http://nextmovesoftware.com/blog/2014/02/27/unleashing-over-a-million-reactions-into-the-wild/.
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import csv
 import logging

--- a/deepchem/molnet/load_function/uv_datasets.py
+++ b/deepchem/molnet/load_function/uv_datasets.py
@@ -1,10 +1,6 @@
 """
 UV Dataset loader
 """
-
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import logging
 import time

--- a/deepchem/molnet/run_benchmark.py
+++ b/deepchem/molnet/run_benchmark.py
@@ -4,9 +4,6 @@ Created on Mon Mar 06 14:25:40 2017
 
 @author: Zhenqin Wu
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import csv

--- a/deepchem/molnet/run_benchmark_low_data.py
+++ b/deepchem/molnet/run_benchmark_low_data.py
@@ -5,10 +5,6 @@ Created on Mon Mar 06 14:25:40 2017
 @author: Zhenqin Wu
 """
 '''
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 import time
 import csv

--- a/deepchem/molnet/run_benchmark_models.py
+++ b/deepchem/molnet/run_benchmark_models.py
@@ -5,9 +5,6 @@ Created on Mon Mar  6 23:41:26 2017
 
 @author: zqwu
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import numpy as np
 import tensorflow as tf
 import deepchem

--- a/deepchem/molnet/tests/test_molnet.py
+++ b/deepchem/molnet/tests/test_molnet.py
@@ -1,9 +1,6 @@
 """
 Tests for molnet function
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import csv
 import tempfile
 import unittest

--- a/deepchem/splits/__init__.py
+++ b/deepchem/splits/__init__.py
@@ -1,9 +1,6 @@
 """
 Gathers all splitters in one place for convenient imports
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 # TODO(rbharath): Get rid of * import
 from deepchem.splits.splitters import *
 from deepchem.splits.splitters import ScaffoldSplitter

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1,9 +1,6 @@
 """
 Contains an abstract base class that supports chemically aware data splits.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import random
 
 __author__ = "Bharath Ramsundar, Aneesh Pappu "

--- a/deepchem/splits/task_splitter.py
+++ b/deepchem/splits/task_splitter.py
@@ -1,9 +1,6 @@
 """
 Contains an abstract base class that supports chemically aware data splits.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -1,9 +1,6 @@
 """
 Tests for splitter objects.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar, Aneesh Pappu"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/splits/tests/test_task_splitter.py
+++ b/deepchem/splits/tests/test_task_splitter.py
@@ -1,9 +1,6 @@
 """
 Tests for splitter objects.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar, Aneesh Pappu"
 __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"

--- a/deepchem/trans/__init__.py
+++ b/deepchem/trans/__init__.py
@@ -1,9 +1,6 @@
 """
 Gathers all transformers in one place for convenient imports
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.trans.transformers import undo_transforms
 from deepchem.trans.transformers import undo_grad_transforms
 from deepchem.trans.transformers import LogTransformer

--- a/deepchem/trans/tests/test_transformers.py
+++ b/deepchem/trans/tests/test_transformers.py
@@ -1,9 +1,6 @@
 """
 Tests for transformer objects.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 from deepchem.molnet import load_delaney
 from deepchem.trans.transformers import FeaturizationTransformer
 from deepchem.trans.transformers import DataTransforms

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -2,9 +2,6 @@
 """
 Contains an abstract base class that supports data transformations.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 import os
 
 import numpy as np

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -1,10 +1,6 @@
 """
 Utility functions to evaluate models on datasets.
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 import csv
 import numpy as np
 import warnings

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -1,10 +1,6 @@
 """
 Simple utils to save and load from disk.
 """
-from __future__ import print_function
-from __future__ import division
-from __future__ import unicode_literals
-
 import joblib
 import gzip
 import json

--- a/deepchem/utils/test/test_seq.py
+++ b/deepchem/utils/test/test_seq.py
@@ -1,9 +1,6 @@
 """
 Tests that sequence handling utilities work.
 """
-from __future__ import division
-from __future__ import unicode_literals
-
 __author__ = "Bharath Ramsundar"
 __license__ = "MIT"
 


### PR DESCRIPTION
Most of the files in the deepchem repo had old `from __future__ import ...` statements. This PR makes a cleanup pass to remove all these old statements.