### PR TITLE
Change install script to python 3.6

### DIFF
--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -19,10 +19,10 @@ fi
 
 if [ -z "$python_version" ]
 then
-    echo "Using python 3.5 by default"
-    export python_version=3.5
+    echo "Using python 3.6 by default"
+    export python_version=3.6
 else
-    echo "Using python "$python_version". But recommended to use python 3.5."
+    echo "Using python "$python_version". But recommended to use python 3.6."
 fi
 
 if [ -z "$1" ];


### PR DESCRIPTION
Changed the install script to use Python 3.6 instead of Python 3.5. 
@rbharath @peastman: Is 3.6 okay, or 3.7 better?