### PR TITLE
Expanding gitignore for dataset files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,35 @@ target/
 # Vim swap
 *.swp
 
+# Dataset files
+datasets/2008-2011_USPTO_reactionSmiles_filtered.zip
+datasets/2008-2011_USPTO_reactionSmiles_filtered/
+datasets/autodock_vina_1_1_2_mac_catalina_64bit/
+datasets/chembl_25-featurized/          
+datasets/chembl_25.csv.gz                 
+datasets/delaney-featurized/  
+datasets/from-pdbbind/                                   
+datasets/kinase/                                         
+datasets/pdbbind/                                        
+datasets/pdbbind_v2015.tar.gz
+datasets/qm7-featurized/ 
+datasets/qm7.csv                                         
+datasets/qm7.mat
+datasets/sider-featurized/
+datasets/sider.csv.gz
+datasets/sweet-featurized/
+datasets/sweet.csv.gz
+datasets/tox21-featurized/
+datasets/toxcast-featurized/
+datasets/toxcast_data.csv.gz
+datasets/gdb8.tar.gz
+datasets/qm8-featurized/
+datasets/qm8.sdf
+datasets/qm8.sdf.csv
+datasets/PDBbind_2019_plain_text_index.tar.gz
+datasets/pdbbind_v2019_NL.tar.gz
+datasets/pdbbind_v2019_PN.tar.gz
+datasets/pdbbind_v2019_PP.tar.gz
+datasets/pdbbind_v2019_other_PL.tar.gz
+datasets/pdbbind_v2019_refined.tar.gz
+datasets/qm8.csv


### PR DESCRIPTION
This is a little cleanup convenience PR that add a few more files to `.gitignore`. It's pulled out of #1792. If you set `DEEPCHEM_DATA_DIR=datasets/` which is a sensible default, you quickly build up files that make your `git status` messy. This PR adds a few more ignore statements to make the status printout cleaner