### PR TITLE
Fix bug in metric computing

### DIFF
--- a/deepchem/metrics/__init__.py
+++ b/deepchem/metrics/__init__.py
@@ -355,6 +355,8 @@ class Metric(object):
     # If there are no nonzero examples, metric is ill-defined.
     if not y_true.size:
       return np.nan
+    if self.threshold is not None and len(y_pred.shape) == 1:
+      y_pred = np.expand_dims(y_pred, 0)
     if self.threshold is not None:
       y_pred = y_pred[:, 1]
       y_pred = np.greater(y_pred, self.threshold)

--- a/deepchem/metrics/tests/metrics_test.py
+++ b/deepchem/metrics/tests/metrics_test.py
@@ -24,19 +24,22 @@ class MetricsTest(googletest.TestCase):
     self.assertAlmostEqual(kappa, expected_kappa)
 
   def test_one_sample(self):
+    """Test that the metrics won't raise error even in an extreme condition
+    where there is only one sample with w > 0.
+    """
     np.random.seed(123)
     n_samples = 2
     y_true = np.array([0, 0])
     y_pred = np.random.rand(n_samples, 2)
     w = np.array([0, 1])
     all_metrics = [
-      dc.metrics.Metric(dc.metrics.recall_score),
-      dc.metrics.Metric(dc.metrics.matthews_corrcoef),
-      dc.metrics.Metric(dc.metrics.roc_auc_score)
+        dc.metrics.Metric(dc.metrics.recall_score),
+        dc.metrics.Metric(dc.metrics.matthews_corrcoef),
+        dc.metrics.Metric(dc.metrics.roc_auc_score)
     ]
     for metric in all_metrics:
       score = metric.compute_singletask_metric(y_true, y_pred, w)
-      self.assertTrue(np.isnan(score) or score==0)
+      self.assertTrue(np.isnan(score) or score == 0)
 
   def test_r2_score(self):
     """Test that R^2 metric passes basic sanity tests"""

--- a/deepchem/metrics/tests/metrics_test.py
+++ b/deepchem/metrics/tests/metrics_test.py
@@ -23,6 +23,21 @@ class MetricsTest(googletest.TestCase):
                                     1.0 - expected_agreement)
     self.assertAlmostEqual(kappa, expected_kappa)
 
+  def test_one_sample(self):
+    np.random.seed(123)
+    n_samples = 2
+    y_true = np.array([0, 0])
+    y_pred = np.random.rand(n_samples, 2)
+    w = np.array([0, 1])
+    all_metrics = [
+      dc.metrics.Metric(dc.metrics.recall_score),
+      dc.metrics.Metric(dc.metrics.matthews_corrcoef),
+      dc.metrics.Metric(dc.metrics.roc_auc_score)
+    ]
+    for metric in all_metrics:
+      score = metric.compute_singletask_metric(y_true, y_pred, w)
+      self.assertTrue(np.isnan(score) or score==0)
+
   def test_r2_score(self):
     """Test that R^2 metric passes basic sanity tests"""
     np.random.seed(123)


### PR DESCRIPTION
When sample number is 1, `y_pred` will be squeezed and `y_pred[:, 1]` will raise error.

The bug was not detected because we only use auc as the metric in classification, which doesn't have a threshold. it will fail when we use other metrics like recall.

There was warning during https://github.com/deepchem/deepchem/blob/26ecc32158d5f62f0e08449e10b958d1401081fd/deepchem/hyper/tests/test_hyperparam_opt.py#L114
but was just ignored.

There might be better solutions but at least now the programme won't raise the error anymore.

To be safer, I just used the condition `self.threshold is not None` to avoid potential mistake in other circumstances (like regression mode). And the warning still exists.
```
Straightforward test of Tensorflow multitask deepchem classification API. ... C:\Anaconda3\envs\dc\lib\site-packages\deepchem\metrics\__init__.py:370: UserWarning: Error calculating metric mean-roc_auc_score: Found input variables with inconsistent numbers of samples: [1, 2]
  warnings.warn("Error calculating metric %s: %s" % (self.name, e))
C:\Anaconda3\envs\dc\lib\site-packages\deepchem\metrics\__init__.py:370: UserWarning: Error calculating metric mean-roc_auc_score: Found input variables with inconsistent numbers of samples: [1, 2]

Test of TensorGraph singletask deepchem classification API. ... C:\Anaconda3\envs\dc\lib\site-packages\deepchem\data\data_loader.py:269: FutureWarning: featurize() is deprecated and has been renamed to create_dataset(). featurize() will be removed in DeepChem 3.0
  FutureWarning)
C:\Anaconda3\envs\dc\lib\site-packages\sklearn\base.py:197: FutureWarning: From version 0.24, get_params will raise an AttributeError if a parameter cannot be retrieved as an instance attribute. Previously it would return None.
  FutureWarning)
C:\Anaconda3\envs\dc\lib\site-packages\deepchem\metrics\__init__.py:370: UserWarning: Error calculating metric matthews_corrcoef: Classification metrics can't handle a mix of continuous and binary targets
  warnings.warn("Error calculating metric %s: %s" % (self.name, e))
C:\Anaconda3\envs\dc\lib\site-packages\deepchem\metrics\__init__.py:370: UserWarning: Error calculating metric recall_score: Classification metrics can't handle a mix of continuous and binary targets
  warnings.warn("Error calculating metric %s: %s" % (self.name, e))
C:\Anaconda3\envs\dc\lib\site-packages\deepchem\metrics\__init__.py:370: UserWarning: Error calculating metric accuracy_score: Classification metrics can't handle a mix of continuous and binary targets
  warnings.warn("Error calculating metric %s: %s" % (self.name, e))
C:\Anaconda3\envs\dc\lib\site-packages\deepchem\metrics\__init__.py:370: UserWarning: Error calculating metric roc_auc_score: Only one class present in y_true. ROC AUC score is not defined in that case.
  warnings.warn("Error calculating metric %s: %s" % (self.name, e))
...
```