### PR TITLE
DiskDataset caches shards in memory

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -949,7 +949,6 @@ class DiskDataset(Dataset):
     self.tasks, self.metadata_df = self.load_metadata()
     self._cached_shards = None
     self._memory_cache_size = 20 * (1 << 20)  # 20 MB
-    self._cache_used = 0
 
   @staticmethod
   def create_dataset(shard_generator, data_dir=None, tasks=[]):
@@ -1598,6 +1597,7 @@ class DiskDataset(Dataset):
     # See if we have a cached copy of this shard.
     if self._cached_shards is None:
       self._cached_shards = [None] * self.get_number_shards()
+      self._cache_used = 0
     if self._cached_shards[i] is not None:
       shard = self._cached_shards[i]
       return (shard.X, shard.y, shard.w, shard.ids)
@@ -1784,7 +1784,6 @@ class DiskDataset(Dataset):
     self._memory_cache_size = size
     if self._cache_used > size:
       self._cached_shards = None
-      self._cache_used = 0
 
   def __len__(self):
     """

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -949,6 +949,7 @@ class DiskDataset(Dataset):
     self.tasks, self.metadata_df = self.load_metadata()
     self._cached_shards = None
     self._memory_cache_size = 20 * (1 << 20)  # 20 MB
+    self._cache_used = 0
 
   @staticmethod
   def create_dataset(shard_generator, data_dir=None, tasks=[]):

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -153,6 +153,8 @@ class Splitter(object):
     else:
       valid_dataset = None
     test_dataset = dataset.select(test_inds, test_dir)
+    if isinstance(train_dataset, DiskDataset):
+      train_dataset.memory_cache_size = 40 * (1 << 20)  # 40 MB
 
     return train_dataset, valid_dataset, test_dataset
 

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -62,7 +62,6 @@ class Transformer(object):
                transform_w=False,
                dataset=None):
     """Initializes transformation based on dataset statistics."""
-    self.dataset = dataset
     self.transform_X = transform_X
     self.transform_y = transform_y
     self.transform_w = transform_w
@@ -482,12 +481,12 @@ class BalancingTransformer(Transformer):
     assert transform_w
 
     # Compute weighting factors from dataset.
-    y = self.dataset.y
-    w = self.dataset.w
+    y = dataset.y
+    w = dataset.w
     # Ensure dataset is binary
     np.testing.assert_allclose(sorted(np.unique(y)), np.array([0., 1.]))
     weights = []
-    for ind, task in enumerate(self.dataset.get_task_names()):
+    for ind, task in enumerate(dataset.get_task_names()):
       task_w = w[:, ind]
       task_y = y[:, ind]
       # Remove labels with zero weights
@@ -505,7 +504,7 @@ class BalancingTransformer(Transformer):
   def transform_array(self, X, y, w):
     """Transform the data in a set of (X, y, w) arrays."""
     w_balanced = np.zeros_like(w)
-    for ind, task in enumerate(self.dataset.get_task_names()):
+    for ind in range(y.shape[1]):
       task_y = y[:, ind]
       task_w = w[:, ind]
       zero_indices = np.logical_and(task_y == 0, task_w != 0)

--- a/deepchem/utils/save.py
+++ b/deepchem/utils/save.py
@@ -292,6 +292,7 @@ def load_dataset_from_disk(save_dir):
   train = deepchem.data.DiskDataset(train_dir)
   valid = deepchem.data.DiskDataset(valid_dir)
   test = deepchem.data.DiskDataset(test_dir)
+  train.memory_cache_size = 40 * (1 << 20)  # 40 MB
   all_dataset = (train, valid, test)
   with open(os.path.join(save_dir, "transformers.pkl"), 'rb') as f:
     transformers = pickle.load(f)


### PR DESCRIPTION
Fixes #1855.

Python doesn't seem to provide any good mechanism for dynamically adjusting the size of the cache without creating a risk that some other part of the program will run out of memory.  So instead I just have each DiskDataset use a fixed amount of memory for its cache.  I made it default to 20 MB, which is large enough to be useful but small enough that it's unlikely to cause problems, even if you have several datasets in memory at once.  You can change it by setting the `memory_cache_size` property.  For large datasets, increasing the size could improve performance a lot.

One idea I've been thinking about is to have all the splitters and molnet loaders increase the cache size for the training set, maybe to 50 MB?  Since you normally make more passes through the training set than the validation or test set, it makes sense to let it use a bit more memory than the others.