### PR TITLE
Fixing Read the Docs Environment

### DIFF
--- a/deepchem/feat/graph_features.py
+++ b/deepchem/feat/graph_features.py
@@ -1,5 +1,4 @@
 import numpy as np
-#from rdkit import Chem
 
 import deepchem as dc
 from deepchem.feat import Featurizer

--- a/deepchem/feat/graph_features.py
+++ b/deepchem/feat/graph_features.py
@@ -1,5 +1,5 @@
 import numpy as np
-from rdkit import Chem
+#from rdkit import Chem
 
 import deepchem as dc
 from deepchem.feat import Featurizer
@@ -55,11 +55,9 @@ possible_atom_list = [
 possible_numH_list = [0, 1, 2, 3, 4]
 possible_valence_list = [0, 1, 2, 3, 4, 5, 6]
 possible_formal_charge_list = [-3, -2, -1, 0, 1, 2, 3]
-possible_hybridization_list = [
-    Chem.rdchem.HybridizationType.SP, Chem.rdchem.HybridizationType.SP2,
-    Chem.rdchem.HybridizationType.SP3, Chem.rdchem.HybridizationType.SP3D,
-    Chem.rdchem.HybridizationType.SP3D2
-]
+# To avoid importing rdkit, this is a placeholder list of the correct
+# length. These will be replaced with rdkit HybridizationType below
+possible_hybridization_list = ["SP", "SP2", "SP3", "SP3D", "SP3D2"]
 possible_number_radical_e_list = [0, 1, 2]
 possible_chirality_list = ['R', 'S']
 
@@ -84,6 +82,14 @@ def get_feature_list(atom):
   atom: RDKit.rdchem.Atom
     Atom to get features for 
   """
+  # Replace the hybridization
+  from rdkit import Chem
+  global possible_hybridization_list
+  possible_hybridization_list = [
+      Chem.rdchem.HybridizationType.SP, Chem.rdchem.HybridizationType.SP2,
+      Chem.rdchem.HybridizationType.SP3, Chem.rdchem.HybridizationType.SP3D,
+      Chem.rdchem.HybridizationType.SP3D2
+  ]
   features = 6 * [0]
   features[0] = safe_index(possible_atom_list, atom.GetSymbol())
   features[1] = safe_index(possible_numH_list, atom.GetTotalNumHs())
@@ -91,6 +97,7 @@ def get_feature_list(atom):
   features[3] = safe_index(possible_formal_charge_list, atom.GetFormalCharge())
   features[4] = safe_index(possible_number_radical_e_list,
                            atom.GetNumRadicalElectrons())
+
   features[5] = safe_index(possible_hybridization_list, atom.GetHybridization())
   return features
 

--- a/deepchem/feat/tests/test_graph_features.py
+++ b/deepchem/feat/tests/test_graph_features.py
@@ -22,7 +22,7 @@ class TestConvMolFeaturizer(unittest.TestCase):
     # Note there is a central nitrogen of degree 4, with 4 carbons
     # of degree 1 (connected only to central nitrogen).
     raw_smiles = ['C[N+](C)(C)C']
-    import rdkit
+    import rdkit.Chem
     mols = [rdkit.Chem.MolFromSmiles(s) for s in raw_smiles]
     featurizer = ConvMolFeaturizer()
     mols = featurizer.featurize(mols)
@@ -70,7 +70,7 @@ class TestConvMolFeaturizer(unittest.TestCase):
   def test_alkane(self):
     """Test on simple alkane"""
     raw_smiles = ['CCC']
-    import rdkit
+    import rdkit.Chem
     mols = [rdkit.Chem.MolFromSmiles(s) for s in raw_smiles]
     featurizer = ConvMolFeaturizer()
     mol_list = featurizer.featurize(mols)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@
 #
 import os
 import sys
+sys.path.insert(0, os.path.abspath('..'))
 
 # -- Project information -----------------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,7 @@
 sphinx_rtd_theme
+numpy
+pandas
+sklearn
+tensorflow
+pillow
+tensorflow_probability


### PR DESCRIPTION
Autodoc was failing on readthedocs due to issues with path and dependencies. This PR attempts to fix this. It turned out rdkit was a hard dependency (as documented in https://github.com/deepchem/deepchem/issues/1528), so this PR also fixes the 1 remaining hard rdkit dependency.