### PR TITLE
fix joblib error for sklearn>0.22

### DIFF
--- a/datasets/construct_pdbbind_df.py
+++ b/datasets/construct_pdbbind_df.py
@@ -6,10 +6,9 @@ from __future__ import print_function
 import pickle
 import os
 import pandas as pd
-from rdkit import Chem
 from glob import glob
 import re
-from sklearn.externals import joblib
+import joblib
 
 
 def extract_labels(pdbbind_label_file):
@@ -39,6 +38,7 @@ def construct_df(pdb_stem_directory, pdbbind_label_file, pdbbind_df_joblib):
     of strings per line in file, ligand mol2 as a list of strings per line in
     mol2 file, and a "label" containing the experimental measurement.
   """
+  from rdkit import Chem
   labels = extract_labels(pdbbind_label_file)
   df_rows = []
   os.chdir(pdb_stem_directory)

--- a/datasets/construct_pdbbind_df.py
+++ b/datasets/construct_pdbbind_df.py
@@ -27,6 +27,7 @@ def extract_labels(pdbbind_label_file):
       labels[line[0]] = line[3]
   return labels
 
+
 def construct_df(pdb_stem_directory, pdbbind_label_file, pdbbind_df_joblib):
   """
   Takes as input a stem directory containing subdirectories with ligand
@@ -58,7 +59,7 @@ def construct_df(pdb_stem_directory, pdbbind_label_file, pdbbind_df_joblib):
         ligand_mol2 = f
 
     print("Extracted Input Files:")
-    print (ligand_pdb, protein_pdb, ligand_mol2)
+    print(ligand_pdb, protein_pdb, ligand_mol2)
     if not ligand_pdb or not protein_pdb or not ligand_mol2:
       raise ValueError("Required files not present for %s" % pdb_dir)
     ligand_pdb_path = os.path.join(pdb_dir, ligand_pdb)
@@ -84,11 +85,14 @@ def construct_df(pdb_stem_directory, pdbbind_label_file, pdbbind_df_joblib):
     smiles = Chem.MolToSmiles(ligand_mol)
     complex_id = "%s%s" % (pdb_id, smiles)
     label = labels[pdb_id]
-    df_rows.append([pdb_id, smiles, complex_id, protein_pdb_lines,
-                    ligand_pdb_lines, ligand_mol2_lines, label])
+    df_rows.append([
+        pdb_id, smiles, complex_id, protein_pdb_lines, ligand_pdb_lines,
+        ligand_mol2_lines, label
+    ])
 
-  pdbbind_df = pd.DataFrame(df_rows, columns=('pdb_id', 'smiles', 'complex_id',
-                                              'protein_pdb', 'ligand_pdb',
-                                              'ligand_mol2', 'label'))
+  pdbbind_df = pd.DataFrame(df_rows,
+                            columns=('pdb_id', 'smiles', 'complex_id',
+                                     'protein_pdb', 'ligand_pdb', 'ligand_mol2',
+                                     'label'))
 
   joblib.dump(pdbbind_df, pdbbind_df_joblib)


### PR DESCRIPTION
I replace `sklearn.externals.joblib` to `joblib` and  move `rdkit` dependency inside the function.