### PR TITLE
[WIP] Adding inorganic crystal featurizers

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ DeepChem has a number of "soft" requirements. These are packages which are neede
 
 - [BioPython](https://biopython.org/wiki/Documentation)
 - [OpenAI Gym](https://gym.openai.com/)
+- [matminer](https://hackingmaterials.lbl.gov/matminer/)
 - [MDTraj](http://mdtraj.org/)
 - [NetworkX](https://networkx.github.io/documentation/stable/index.html)
 - [OpenMM](http://openmm.org/)
 - [PDBFixer](https://github.com/pandegroup/pdbfixer)
 - [Pillow](https://pypi.org/project/Pillow/)
 - [pyGPGO](https://pygpgo.readthedocs.io/en/latest/)
+- [Pymatgen](https://pymatgen.org/)
 - [PyTorch](https://pytorch.org/)
 - [RDKit](http://www.rdkit.org/docs/Install.html)
 - [simdna](https://github.com/kundajelab/simdna)
@@ -209,7 +211,7 @@ sudo apt-get install -y libxrender-dev
 
 ## Getting Started
 
-The DeepChem project maintains an extensive colelction of [tutorials](https://github.com/deepchem/deepchem/tree/master/examples/tutorials). All tutorials are designed to be run on Google colab (or locally if you prefer). Tutorials are arranged in a suggested learning sequence which will take you from beginner to proficient at molecular machine learning and computational biology more broadly.
+The DeepChem project maintains an extensive collection of [tutorials](https://github.com/deepchem/deepchem/tree/master/examples/tutorials). All tutorials are designed to be run on Google colab (or locally if you prefer). Tutorials are arranged in a suggested learning sequence which will take you from beginner to proficient at molecular machine learning and computational biology more broadly.
 
 After working through the tutorials, you can also go through other [examples](https://github.com/deepchem/deepchem/tree/master/examples). To apply `deepchem` to a new problem, try starting from one of the existing examples or tutorials and modifying it step by step to work with your new use-case. If you have questions or comments you can raise them on our [gitter](https://gitter.im/deepchem/Lobby).
 

--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -23,3 +23,4 @@ from deepchem.feat.atomic_coordinates import AtomicCoordinates
 from deepchem.feat.atomic_coordinates import NeighborListComplexAtomicCoordinates
 from deepchem.feat.adjacency_fingerprints import AdjacencyFingerprint
 from deepchem.feat.smiles_featurizers import SmilesToSeq, SmilesToImage
+from deepchem.feat.materials_featurizers import ChemicalFingerprint, SineCoulombMatrix, StructureGraphFeaturizer

--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -23,4 +23,4 @@ from deepchem.feat.atomic_coordinates import AtomicCoordinates
 from deepchem.feat.atomic_coordinates import NeighborListComplexAtomicCoordinates
 from deepchem.feat.adjacency_fingerprints import AdjacencyFingerprint
 from deepchem.feat.smiles_featurizers import SmilesToSeq, SmilesToImage
-from deepchem.feat.materials_featurizers import ChemicalFingerprint, SineCoulombMatrix, StructureGraphFeaturizer
+from deepchem.feat.materials_featurizers import ElementPropertyFingerprint, SineCoulombMatrix, StructureGraphFeaturizer

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -17,7 +17,7 @@ class ChemicalFingerprint(Featurizer):
   based on elemental stoichiometry. E.g., the average electronegativity
   of atoms in a crystal structure. The chemical fingerprint is a 
   vector of these statistics. For a full list of properties and statistics,
-  see ElementProperty(data_source).feature_labels().
+  see ``matminer.featurizers.composition.ElementProperty(data_source).feature_labels()``.
 
   This featurizer requires the optional dependencies pymatgen and
   matminer. It may be useful when only crystal compositions are available
@@ -55,6 +55,12 @@ class ChemicalFingerprint(Featurizer):
     ----------
     comp : str
       Reduced formula of crystal.
+
+    Returns
+    -------
+    feats: np.ndarray
+      Vector of properties and statistics derived from chemical
+      stoichiometry.
 
     """
 
@@ -118,7 +124,13 @@ class SineCoulombMatrix(Featurizer):
     Parameters
     ----------
     struct : dict
-      pymatgen structure dictionary
+      Json-serializable dictionary representation of pymatgen.core.structure
+      https://pymatgen.org/pymatgen.core.structure.html
+
+    Returns
+    -------
+    features: np.ndarray
+      2D sine Coulomb matrix, or 1D matrix eigenvalues. 
 
     """
 
@@ -136,7 +148,16 @@ class SineCoulombMatrix(Featurizer):
 
     Parameters
     ----------
-    s : pymatgen structure
+    s : pymatgen.core.structure
+      A periodic crystal composed of a lattice and a sequence of atomic
+      sites with 3D coordinates and elements.
+
+    Returns
+    -------
+    eigs: np.ndarray
+      1D matrix eigenvalues. 
+    sine_mat: np.ndarray
+      2D sine Coulomb matrix.
 
     """
 
@@ -167,7 +188,8 @@ class SineCoulombMatrix(Featurizer):
       eigs, _ = np.linalg.eig(sine_mat)
       zeros = np.zeros((self.max_atoms,))
       zeros[:len(eigs)] = eigs
-      return zeros
+      eigs = zeros
+      return eigs
     else:
       sine_mat = pad_array(sine_mat, self.max_atoms)
       return sine_mat
@@ -216,7 +238,13 @@ class StructureGraphFeaturizer(Featurizer):
     Parameters
     ----------
     struct : dict
-      pymatgen structure dictionary.
+      Json-serializable dictionary representation of pymatgen.core.structure
+      https://pymatgen.org/pymatgen.core.structure.html
+
+    Returns
+    -------
+    feats: tuple
+      atomic numbers, nodes, and edges in networkx.classes.multidigraph.MultiDiGraph format.
 
     """
 
@@ -235,7 +263,14 @@ class StructureGraphFeaturizer(Featurizer):
 
     Parameters
     ----------
-    struct : pymatgen structure
+    struct : pymatgen.core.structure
+      A periodic crystal composed of a lattice and a sequence of atomic
+      sites with 3D coordinates and elements.
+
+    Returns
+    -------
+    feats: tuple
+      atomic numbers, nodes, and edges in networkx.classes.multidigraph.MultiDiGraph format.
     
     """
 
@@ -244,7 +279,7 @@ class StructureGraphFeaturizer(Featurizer):
     atom_features = np.array([site.specie.Z for site in struct], dtype='int32')
 
     sg = StructureGraph.with_local_env_strategy(struct, self.strategy)
-    nodes = np.asarray(sg.graph.nodes)
-    edges = np.asarray(sg.graph.edges)
+    nodes = np.array(list(sg.graph.nodes))
+    edges = np.array(list(sg.graph.edges))
 
     return (atom_features, nodes, edges)

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -135,7 +135,8 @@ class SineCoulombMatrix(Featurizer):
     Returns
     -------
     features: np.ndarray
-      2D sine Coulomb matrix, or 1D matrix eigenvalues. 
+      2D sine Coulomb matrix with shape (max_atoms, max_atoms),
+      or 1D matrix eigenvalues with shape (max_atoms,). 
 
     """
 
@@ -243,8 +244,6 @@ class StructureGraphFeaturizer(Featurizer):
       atomic numbers, filtered interatomic distance tensor, and neighbor ids
     
     """
-
-    from pymatgen.analysis.graphs import StructureGraph
 
     atom_features = np.array([site.specie.Z for site in struct], dtype='int32')
 

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -8,9 +8,9 @@ from deepchem.feat import Featurizer
 from deepchem.utils import pad_array
 
 
-class ChemicalFingerprint(Featurizer):
+class ElementPropertyFingerprint(Featurizer):
   """
-  Chemical fingerprint of elemental properties from composition.
+  Fingerprint of elemental properties from composition.
 
   Based on the data source chosen, returns properties and statistics
   (min, max, range, mean, standard deviation, mode) for a compound
@@ -23,16 +23,17 @@ class ChemicalFingerprint(Featurizer):
   matminer. It may be useful when only crystal compositions are available
   (and not 3D coordinates).
 
-  References are given for each data source:
-    MagPie data: Ward, L. et al. npj Comput Mater 2, 16028 (2016).
+  References
+  ----------
+  MagPie data: Ward, L. et al. npj Comput Mater 2, 16028 (2016).
     https://doi.org/10.1038/npjcompumats.2016.28
 
-    Deml data: Deml, A. et al. Physical Review B 93, 085142 (2016).
+  Deml data: Deml, A. et al. Physical Review B 93, 085142 (2016).
     10.1103/PhysRevB.93.085142
 
-    Matminer: Ward, L. et al. Comput. Mater. Sci. 152, 60-69 (2018).
+  Matminer: Ward, L. et al. Comput. Mater. Sci. 152, 60-69 (2018).
 
-    Pymatgen: Ong, S.P. et al. Comput. Mater. Sci. 68, 314-319 (2013). 
+  Pymatgen: Ong, S.P. et al. Comput. Mater. Sci. 68, 314-319 (2013). 
 
   """
 
@@ -84,8 +85,7 @@ class SineCoulombMatrix(Featurizer):
   """
   Calculate sine Coulomb matrix for crystals.
 
-  A variant of Coulomb matrix for periodic crystals, based on 
-  Faber et al. Inter. J. Quantum Chem. 115, 16, (2015).
+  A variant of Coulomb matrix for periodic crystals.
 
   The sine Coulomb matrix is identical to the Coulomb matrix, except
   that the inverse distance function is replaced by the inverse of
@@ -97,25 +97,30 @@ class SineCoulombMatrix(Featurizer):
   length, the maximum number of atoms (eigenvalues) in the input
   dataset must be specified.
 
-  This featurizer requires the optional dependency pymatgen. It may be
-  useful when crystal structures with 3D coordinates are available.
+  This featurizer requires the optional dependencies pymatgen and
+  matminer. It may be useful when crystal structures with 3D coordinates 
+  are available.
+
+  References
+  ----------
+  Faber et al. Inter. J. Quantum Chem. 115, 16, 2015.
 
   """
 
-  def __init__(self, max_atoms, eig=True):
+  def __init__(self, max_atoms, flatten=True):
     """
     Parameters
     ----------
     max_atoms : int
       Maximum number of atoms for any crystal in the dataset. Used to
       pad the Coulomb matrix.
-    eig : bool (default True)
+    flatten : bool (default True)
       Return flattened vector of matrix eigenvalues.
 
     """
 
     self.max_atoms = int(max_atoms)
-    self.eig = eig
+    self.flatten = flatten
 
   def _featurize(self, struct):
     """
@@ -135,105 +140,68 @@ class SineCoulombMatrix(Featurizer):
     """
 
     from pymatgen import Structure
+    from matminer.featurizers.structure import SineCoulombMatrix as SCM
 
     s = Structure.from_dict(struct)
-    features = self.sine_coulomb_matrix(s)
+
+    # Get full N x N SCM
+    scm = SCM(flatten=False)
+    sine_mat = scm.featurize(s)
+
+    if self.flatten:
+      eigs, _ = np.linalg.eig(sine_mat)
+      zeros = np.zeros((self.max_atoms,))
+      zeros[:len(eigs)] = eigs
+      features = zeros
+    else:
+      features = pad_array(sine_mat, self.max_atoms)
+
     features = np.asarray(features)
 
     return features
 
-  def sine_coulomb_matrix(self, s):
-    """
-    Generate sine Coulomb matrices for each crystal.
-
-    Parameters
-    ----------
-    s : pymatgen.core.structure
-      A periodic crystal composed of a lattice and a sequence of atomic
-      sites with 3D coordinates and elements.
-
-    Returns
-    -------
-    eigs: np.ndarray
-      1D matrix eigenvalues. 
-    sine_mat: np.ndarray
-      2D sine Coulomb matrix.
-
-    """
-
-    sites = s.sites
-    atomic_numbers = np.array([site.specie.Z for site in sites])
-    sine_mat = np.zeros((len(sites), len(sites)))
-    coords = np.array([site.frac_coords for site in sites])
-    lattice = s.lattice.matrix
-
-    # Conversion factor
-    ang_to_bohr = 1.8897543760313331
-
-    for i in range(len(sine_mat)):
-      for j in range(len(sine_mat)):
-        if i == j:
-          sine_mat[i][i] = 0.5 * atomic_numbers[i]**2.4
-        elif i < j:
-          vec = coords[i] - coords[j]
-          coord_vec = np.sin(np.pi * vec)**2
-          trig_dist = np.linalg.norm(
-              (np.matrix(coord_vec) * lattice).A1) * ang_to_bohr
-          sine_mat[i][j] = atomic_numbers[i] * atomic_numbers[j] / \
-                          trig_dist
-        else:
-          sine_mat[i][j] = sine_mat[j][i]
-
-    if self.eig:  # flatten array to eigenvalues
-      eigs, _ = np.linalg.eig(sine_mat)
-      zeros = np.zeros((self.max_atoms,))
-      zeros[:len(eigs)] = eigs
-      eigs = zeros
-      return eigs
-    else:
-      sine_mat = pad_array(sine_mat, self.max_atoms)
-      return sine_mat
-
 
 class StructureGraphFeaturizer(Featurizer):
   """
-  Calculate structure graph for crystals.
+  Calculate structure graph features for crystals.
 
-  Create a graph representation of a crystal structure where atoms
-  are nodes and connections between atoms (bonds) are edges. Bonds
-  are determined by choosing a strategy for finding nearest neighbors
-  from pymatgen.analysis.local_env. For periodic
-  graphs, each edge belongs to a lattice image.
-
-  The NetworkX package is used for graph representations.
-  Hagberg, A. et al. SciPy2008, 11-15 (2008).
+  Based on the implementation in Crystal Graph Convolutional
+  Neural Networks (CGCNN). The method constructs a crystal graph
+  representation including atom features (atomic numbers) and bond
+  features (neighbor distances). Neighbors are determined by searching
+  in a sphere around atoms in the unit cell. A Gaussian filter is
+  applied to neighbor distances. All units are in angstrom.  
 
   This featurizer requires the optional dependency pymatgen. It may
-  be useful when using graph network models and crystal graph
-  convolutional networks.
+  be useful when 3D coordinates are available and when using graph 
+  network models and crystal graph convolutional networks.
 
-  #TODO (@ncfrey) process graph features for models
+  References
+  ----------
+  T. Xie and J. C. Grossman, Phys. Rev. Lett. 120, 2018.
 
   """
 
-  def __init__(self, strategy=None):
+  def __init__(self, radius=8.0, max_neighbors=12, step=0.2):
     """
     Parameters
     ----------
-    strategy : pymatgen.analysis.local_env.NearNeighbors
-      An instance of NearNeighbors that determines how graph is constructed.
+    radius : float (default 8.0)
+      Radius of sphere for finding neighbors of atoms in unit cell.
+    max_neighbors : int (default 12)
+      Maximum number of neighbors to consider when constructing graph.
+    step : float (default 0.2)
+      Step size for Gaussian filter.
 
     """
 
-    if not strategy:
-      from pymatgen.analysis.local_env import MinimumDistanceNN
-      strategy = MinimumDistanceNN()
-
-    self.strategy = strategy
+    self.radius = radius
+    self.max_neighbors = int(max_neighbors)
+    self.step = step
 
   def _featurize(self, struct):
     """
-    Calculate structure graph from pymatgen structure.
+    Calculate crystal graph features from pymatgen structure.
 
     Parameters
     ----------
@@ -243,8 +211,9 @@ class StructureGraphFeaturizer(Featurizer):
 
     Returns
     -------
-    feats: tuple
-      atomic numbers, nodes, and edges in networkx.classes.multidigraph.MultiDiGraph format.
+    feats: np.array
+      Atomic and bond features. Atomic features are atomic numbers 
+      and bond features are Gaussian filtered interatomic distances.
 
     """
 
@@ -254,6 +223,7 @@ class StructureGraphFeaturizer(Featurizer):
     s = Structure.from_dict(struct)
 
     features = self._get_structure_graph_features(s)
+    features = np.array(features)
 
     return features
 
@@ -269,8 +239,8 @@ class StructureGraphFeaturizer(Featurizer):
 
     Returns
     -------
-    feats: tuple
-      atomic numbers, nodes, and edges in networkx.classes.multidigraph.MultiDiGraph format.
+    feats: tuple[np.array]
+      atomic numbers, filtered interatomic distance tensor, and neighbor ids
     
     """
 
@@ -278,8 +248,53 @@ class StructureGraphFeaturizer(Featurizer):
 
     atom_features = np.array([site.specie.Z for site in struct], dtype='int32')
 
-    sg = StructureGraph.with_local_env_strategy(struct, self.strategy)
-    nodes = np.array(list(sg.graph.nodes))
-    edges = np.array(list(sg.graph.edges))
+    neighbors = struct.get_all_neighbors(self.radius, include_index=True)
+    neighbors = [sorted(n, key=lambda x: x[1]) for n in neighbors]
 
-    return (atom_features, nodes, edges)
+    # Get list of lists of neighbor distances
+    neighbor_features, neighbor_idx = [], []
+    for neighbor in neighbors:
+      if len(neighbor) < self.max_neighbors:
+        neighbor_idx.append(
+            list(map(lambda x: x[2], neighbor)) +
+            [0] * (self.max_neighbors - len(neighbor)))
+        neighbor_features.append(
+            list(map(lambda x: x[1], neighbor)) +
+            [self.radius + 1.] * (self.max_neighbors - len(neighbor)))
+      else:
+        neighbor_idx.append(
+            list(map(lambda x: x[2], neighbor[:self.max_neighbors])))
+        neighbor_features.append(
+            list(map(lambda x: x[1], neighbor[:self.max_neighbors])))
+
+    neighbor_features = np.array(neighbor_features)
+    neighbor_idx = np.array(neighbor_idx)
+    neighbor_features = self._gaussian_filter(neighbor_features)
+    neighbor_features = np.vstack(neighbor_features)
+
+    return (atom_features, neighbor_features, neighbor_idx)
+
+  def _gaussian_filter(self, distances):
+    """
+    Apply Gaussian filter to an array of interatomic distances.
+
+    Parameters
+    ----------
+    distances : np.array
+      Matrix of distances of dimension (num atoms) x (max neighbors). 
+
+    Returns
+    -------
+    expanded_distances: np.array 
+      Expanded distance tensor after Gaussian filtering. Dimensionality
+      is (num atoms) x (max neighbors) x (len(filt))
+    
+    """
+
+    filt = np.arange(0, self.radius + self.step, self.step)
+
+    # Increase dimension of distance tensor and apply filter
+    expanded_distances = np.exp(
+        -(distances[..., np.newaxis] - filt)**2 / self.step**2)
+
+    return expanded_distances

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -7,24 +7,44 @@ import numpy as np
 from deepchem.feat import Featurizer
 from deepchem.utils import pad_array
 
-from matminer.featurizers.composition import ElementProperty
-
-from pymatgen import Composition, Structure
-from pymatgen.analysis.graphs import StructureGraph
-from pymatgen.analysis.local_env import MinimumDistanceNN
-
 
 class ChemicalFingerprint(Featurizer):
   """
   Chemical fingerprint of elemental properties from composition.
 
-  Parameters
-  ----------
-  data_source : str, optional (default "matminer")
-      Source for element property data ("matminer", "magpie", "deml")
+  Based on the data source chosen, returns properties and statistics
+  (min, max, range, mean, standard deviation, mode) for a compound
+  based on elemental stoichiometry. E.g., the average electronegativity
+  of atoms in a crystal structure. The chemical fingerprint is a 
+  vector of these statistics. For a full list of properties and statistics,
+  see ElementProperty(data_source).feature_labels().
+
+  This featurizer requires the optional dependencies pymatgen and
+  matminer. It may be useful when only crystal compositions are available
+  (and not 3D coordinates).
+
+  References are given for each data source:
+    MagPie data: Ward, L. et al. npj Comput Mater 2, 16028 (2016).
+    https://doi.org/10.1038/npjcompumats.2016.28
+
+    Deml data: Deml, A. et al. Physical Review B 93, 085142 (2016).
+    10.1103/PhysRevB.93.085142
+
+    Matminer: Ward, L. et al. Comput. Mater. Sci. 152, 60-69 (2018).
+
+    Pymatgen: Ong, S.P. et al. Comput. Mater. Sci. 68, 314-319 (2013). 
+
   """
 
   def __init__(self, data_source='matminer'):
+    """
+    Parameters
+    ----------
+    data_source : {"matminer", "magpie", "deml"}
+      Source for element property data.
+
+    """
+
     self.data_source = data_source
 
   def _featurize(self, comp):
@@ -33,8 +53,13 @@ class ChemicalFingerprint(Featurizer):
 
     Parameters
     ----------
-    comp : Reduced formula of crystal.
+    comp : str
+      Reduced formula of crystal.
+
     """
+
+    from pymatgen import Composition
+    from matminer.featurizers.composition import ElementProperty
 
     # Get pymatgen Composition object
     c = Composition(comp)
@@ -53,21 +78,36 @@ class SineCoulombMatrix(Featurizer):
   """
   Calculate sine Coulomb matrix for crystals.
 
-  Variant of Coulomb matrix for periodic crystals
-  Faber et al. (Inter. J. Quantum Chem.
-  115, 16, 2015).
+  A variant of Coulomb matrix for periodic crystals, based on 
+  Faber et al. Inter. J. Quantum Chem. 115, 16, (2015).
 
-  Parameters
-  ----------
-  max_atoms : int
-      Maximum number of atoms for any crystal in the dataset. Used to
-      pad the Coulomb matrix.
-  eig : bool (default True)
-      Return flattened vector of matrix eigenvalues
+  The sine Coulomb matrix is identical to the Coulomb matrix, except
+  that the inverse distance function is replaced by the inverse of
+  sin**2 of the vector between sites which are periodic in the 
+  dimensions of the crystal lattice.
+
+  Features are flattened into a vector of matrix eigenvalues by default
+  for ML-readiness. To ensure that all feature vectors are equal
+  length, the maximum number of atoms (eigenvalues) in the input
+  dataset must be specified.
+
+  This featurizer requires the optional dependency pymatgen. It may be
+  useful when crystal structures with 3D coordinates are available.
 
   """
 
   def __init__(self, max_atoms, eig=True):
+    """
+    Parameters
+    ----------
+    max_atoms : int
+      Maximum number of atoms for any crystal in the dataset. Used to
+      pad the Coulomb matrix.
+    eig : bool (default True)
+      Return flattened vector of matrix eigenvalues.
+
+    """
+
     self.max_atoms = int(max_atoms)
     self.eig = eig
 
@@ -77,8 +117,12 @@ class SineCoulombMatrix(Featurizer):
 
     Parameters
     ----------
-    struct : pymatgen structure dictionary
+    struct : dict
+      pymatgen structure dictionary
+
     """
+
+    from pymatgen import Structure
 
     s = Structure.from_dict(struct)
     features = self.sine_coulomb_matrix(s)
@@ -93,6 +137,7 @@ class SineCoulombMatrix(Featurizer):
     Parameters
     ----------
     s : pymatgen structure
+
     """
 
     sites = s.sites
@@ -132,15 +177,36 @@ class StructureGraphFeaturizer(Featurizer):
   """
   Calculate structure graph for crystals.
 
-  Parameters
-  ----------
-  strategy : pymatgen.analysis.local_env.NearNeighbors
-      An instance of NearNeighbors that determines how graph is constructed.
+  Create a graph representation of a crystal structure where atoms
+  are nodes and connections between atoms (bonds) are edges. Bonds
+  are determined by choosing a strategy for finding nearest neighbors
+  from pymatgen.analysis.local_env. For periodic
+  graphs, each edge belongs to a lattice image.
+
+  The NetworkX package is used for graph representations.
+  Hagberg, A. et al. SciPy2008, 11-15 (2008).
+
+  This featurizer requires the optional dependency pymatgen. It may
+  be useful when using graph network models and crystal graph
+  convolutional networks.
 
   #TODO (@ncfrey) process graph features for models
+
   """
 
-  def __init__(self, strategy=MinimumDistanceNN()):
+  def __init__(self, strategy=None):
+    """
+    Parameters
+    ----------
+    strategy : pymatgen.analysis.local_env.NearNeighbors
+      An instance of NearNeighbors that determines how graph is constructed.
+
+    """
+
+    if not strategy:
+      from pymatgen.analysis.local_env import MinimumDistanceNN
+      strategy = MinimumDistanceNN()
+
     self.strategy = strategy
 
   def _featurize(self, struct):
@@ -149,8 +215,12 @@ class StructureGraphFeaturizer(Featurizer):
 
     Parameters
     ----------
-    struct : pymatgen structure dictionary.
+    struct : dict
+      pymatgen structure dictionary.
+
     """
+
+    from pymatgen import Structure
 
     # Get pymatgen structure object
     s = Structure.from_dict(struct)
@@ -166,10 +236,12 @@ class StructureGraphFeaturizer(Featurizer):
     Parameters
     ----------
     struct : pymatgen structure
+    
     """
 
-    atom_features = np.array([site.specie.Z for site in struct],
-                        dtype='int32')
+    from pymatgen.analysis.graphs import StructureGraph
+
+    atom_features = np.array([site.specie.Z for site in struct], dtype='int32')
 
     sg = StructureGraph.with_local_env_strategy(struct, self.strategy)
     nodes = np.asarray(sg.graph.nodes)

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -1,0 +1,178 @@
+"""
+Featurizers for inorganic crystals.
+"""
+
+import numpy as np
+
+from deepchem.feat import Featurizer
+from deepchem.utils import pad_array
+
+from matminer.featurizers.composition import ElementProperty
+
+from pymatgen import Composition, Structure
+from pymatgen.analysis.graphs import StructureGraph
+from pymatgen.analysis.local_env import MinimumDistanceNN
+
+
+class ChemicalFingerprint(Featurizer):
+  """
+  Chemical fingerprint of elemental properties from composition.
+
+  Parameters
+  ----------
+  data_source : str, optional (default "matminer")
+      Source for element property data ("matminer", "magpie", "deml")
+  """
+
+  def __init__(self, data_source='matminer'):
+    self.data_source = data_source
+
+  def _featurize(self, comp):
+    """
+    Calculate chemical fingerprint from crystal composition.
+
+    Parameters
+    ----------
+    comp : Reduced formula of crystal.
+    """
+
+    # Get pymatgen Composition object
+    c = Composition(comp)
+
+    ep = ElementProperty.from_preset(self.data_source)
+
+    try:
+      feats = ep.featurize(c)
+    except:
+      feats = []
+
+    return feats
+
+
+class SineCoulombMatrix(Featurizer):
+  """
+  Calculate sine Coulomb matrix for crystals.
+
+  Variant of Coulomb matrix for periodic crystals
+  Faber et al. (Inter. J. Quantum Chem.
+  115, 16, 2015).
+
+  Parameters
+  ----------
+  max_atoms : int
+      Maximum number of atoms for any crystal in the dataset. Used to
+      pad the Coulomb matrix.
+  eig : bool (default True)
+      Return flattened vector of matrix eigenvalues
+
+  """
+
+  def __init__(self, max_atoms, eig=True):
+    self.max_atoms = int(max_atoms)
+    self.eig = eig
+
+  def _featurize(self, struct):
+    """
+    Calculate sine Coulomb matrix from pymatgen structure.
+
+    Parameters
+    ----------
+    struct : pymatgen structure dictionary
+    """
+
+    s = Structure.from_dict(struct)
+    features = self.sine_coulomb_matrix(s)
+    features = np.asarray(features)
+
+    return features
+
+  def sine_coulomb_matrix(self, s):
+    """
+    Generate sine Coulomb matrices for each crystal.
+
+    Parameters
+    ----------
+    s : pymatgen structure
+    """
+
+    sites = s.sites
+    atomic_numbers = np.array([site.specie.Z for site in sites])
+    sine_mat = np.zeros((len(sites), len(sites)))
+    coords = np.array([site.frac_coords for site in sites])
+    lattice = s.lattice.matrix
+
+    # Conversion factor
+    ang_to_bohr = 1.8897543760313331
+
+    for i in range(len(sine_mat)):
+      for j in range(len(sine_mat)):
+        if i == j:
+          sine_mat[i][i] = 0.5 * atomic_numbers[i]**2.4
+        elif i < j:
+          vec = coords[i] - coords[j]
+          coord_vec = np.sin(np.pi * vec)**2
+          trig_dist = np.linalg.norm(
+              (np.matrix(coord_vec) * lattice).A1) * ang_to_bohr
+          sine_mat[i][j] = atomic_numbers[i] * atomic_numbers[j] / \
+                          trig_dist
+        else:
+          sine_mat[i][j] = sine_mat[j][i]
+
+    if self.eig:  # flatten array to eigenvalues
+      eigs, _ = np.linalg.eig(sine_mat)
+      zeros = np.zeros((self.max_atoms,))
+      zeros[:len(eigs)] = eigs
+      return zeros
+    else:
+      sine_mat = pad_array(sine_mat, self.max_atoms)
+      return sine_mat
+
+
+class StructureGraphFeaturizer(Featurizer):
+  """
+  Calculate structure graph for crystals.
+
+  Parameters
+  ----------
+  strategy : pymatgen.analysis.local_env.NearNeighbors
+      An instance of NearNeighbors that determines how graph is constructed.
+
+  #TODO (@ncfrey) process graph features for models
+  """
+
+  def __init__(self, strategy=MinimumDistanceNN()):
+    self.strategy = strategy
+
+  def _featurize(self, struct):
+    """
+    Calculate structure graph from pymatgen structure.
+
+    Parameters
+    ----------
+    struct : pymatgen structure dictionary.
+    """
+
+    # Get pymatgen structure object
+    s = Structure.from_dict(struct)
+
+    features = self._get_structure_graph_features(s)
+
+    return features
+
+  def _get_structure_graph_features(self, struct):
+    """
+    Calculate structure graph features from pymatgen structure.
+
+    Parameters
+    ----------
+    struct : pymatgen structure
+    """
+
+    atom_features = np.array([site.specie.Z for site in struct],
+                        dtype='int32')
+
+    sg = StructureGraph.with_local_env_strategy(struct, self.strategy)
+    nodes = np.asarray(sg.graph.nodes)
+    edges = np.asarray(sg.graph.edges)
+
+    return (atom_features, nodes, edges)

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -60,7 +60,7 @@ class ChemicalFingerprint(Featurizer):
     -------
     feats: np.ndarray
       Vector of properties and statistics derived from chemical
-      stoichiometry.
+      stoichiometry. Some values may be NaN.
 
     """
 
@@ -77,7 +77,7 @@ class ChemicalFingerprint(Featurizer):
     except:
       feats = []
 
-    return feats
+    return np.array(feats)
 
 
 class SineCoulombMatrix(Featurizer):

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -1,0 +1,66 @@
+"""
+Test featurizers for inorganic crystals.
+"""
+import numpy as np
+import unittest
+
+from deepchem.feat.materials_featurizers import ChemicalFingerprint, SineCoulombMatrix, StructureGraphFeaturizer
+
+
+class TestMaterialFeaturizers(unittest.TestCase):
+  """
+  Test material featurizers.
+  """
+
+  def setUp(self):
+    """
+    Set up tests.
+    """
+    self.formula = 'MoS2'
+    self.struct_dict = {
+        '@module':
+        'pymatgen.core.structure',
+        '@class':
+        'Structure',
+        'charge':
+        None,
+        'lattice': {
+            'matrix': [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+            'a': 1.0,
+            'b': 1.0,
+            'c': 1.0,
+            'alpha': 90.0,
+            'beta': 90.0,
+            'gamma': 90.0,
+            'volume': 1.0
+        },
+        'sites': [{
+            'species': [{
+                'element': 'Fe',
+                'occu': 1
+            }],
+            'abc': [0.0, 0.0, 0.0],
+            'xyz': [0.0, 0.0, 0.0],
+            'label': 'Fe',
+            'properties': {}
+        }]
+    }
+
+  def testCF(self):
+    """
+    Test CF featurizer.
+    """
+
+    featurizer = ChemicalFingerprint(data_source='matminer')
+
+    assert isinstance(featurizer, ChemicalFingerprint)
+
+  def testSCM(self):
+    """
+    Test SCM featurizer.
+    """
+
+    featurizer = SineCoulombMatrix(1)
+    features = featurizer.featurize([self.struct_dict])
+
+    assert np.isclose(features[0], 1244, atol=.5)

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -52,8 +52,11 @@ class TestMaterialFeaturizers(unittest.TestCase):
     """
 
     featurizer = ChemicalFingerprint(data_source='matminer')
+    features = featurizer.featurize([self.formula])
 
-    assert isinstance(featurizer, ChemicalFingerprint)
+    assert len(features[0]) == 65
+    assert np.allclose(
+        features[0][:5], [2.16, 2.58, 0.42, 2.44, 0.29698485], atol=0.1)
 
   def testSCM(self):
     """
@@ -63,4 +66,5 @@ class TestMaterialFeaturizers(unittest.TestCase):
     featurizer = SineCoulombMatrix(1)
     features = featurizer.featurize([self.struct_dict])
 
+    assert len(features) == 1
     assert np.isclose(features[0], 1244, atol=.5)

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -46,7 +46,7 @@ class TestMaterialFeaturizers(unittest.TestCase):
         }]
     }
 
-  def testEPF(self):
+  def test_element_property_fingerprint(self):
     """
     Test Element Property featurizer.
     """
@@ -58,18 +58,18 @@ class TestMaterialFeaturizers(unittest.TestCase):
     assert np.allclose(
         features[0][:5], [2.16, 2.58, 0.42, 2.44, 0.29698485], atol=0.1)
 
-  def testSCM(self):
+  def test_sine_coulomb_matrix(self):
     """
     Test SCM featurizer.
     """
 
-    featurizer = SineCoulombMatrix(1)
+    featurizer = SineCoulombMatrix(max_atoms=1)
     features = featurizer.featurize([self.struct_dict])
 
     assert len(features) == 1
     assert np.isclose(features[0], 1244, atol=.5)
 
-  def testSGF(self):
+  def test_structure_graph_featurizer(self):
     """
     Test StructureGraphFeaturizer.
     """
@@ -79,4 +79,4 @@ class TestMaterialFeaturizers(unittest.TestCase):
 
     assert len(features[0]) == 3
     assert features[0][0] == 26
-    assert features[0][1].shape == (6,16)
+    assert features[0][1].shape == (6, 16)

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -4,7 +4,7 @@ Test featurizers for inorganic crystals.
 import numpy as np
 import unittest
 
-from deepchem.feat.materials_featurizers import ChemicalFingerprint, SineCoulombMatrix, StructureGraphFeaturizer
+from deepchem.feat.materials_featurizers import ElementPropertyFingerprint, SineCoulombMatrix, StructureGraphFeaturizer
 
 
 class TestMaterialFeaturizers(unittest.TestCase):
@@ -46,12 +46,12 @@ class TestMaterialFeaturizers(unittest.TestCase):
         }]
     }
 
-  def testCF(self):
+  def testEPF(self):
     """
-    Test CF featurizer.
+    Test Element Property featurizer.
     """
 
-    featurizer = ChemicalFingerprint(data_source='matminer')
+    featurizer = ElementPropertyFingerprint(data_source='matminer')
     features = featurizer.featurize([self.formula])
 
     assert len(features[0]) == 65
@@ -74,9 +74,9 @@ class TestMaterialFeaturizers(unittest.TestCase):
     Test StructureGraphFeaturizer.
     """
 
-    featurizer = StructureGraphFeaturizer()
+    featurizer = StructureGraphFeaturizer(radius=3.0, max_neighbors=6)
     features = featurizer.featurize([self.struct_dict])
 
     assert len(features[0]) == 3
     assert features[0][0] == 26
-    assert len(features[0][2]) == 6
+    assert features[0][1].shape == (6,16)

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -68,3 +68,15 @@ class TestMaterialFeaturizers(unittest.TestCase):
 
     assert len(features) == 1
     assert np.isclose(features[0], 1244, atol=.5)
+
+  def testSGF(self):
+    """
+    Test StructureGraphFeaturizer.
+    """
+
+    featurizer = StructureGraphFeaturizer()
+    features = featurizer.featurize([self.struct_dict])
+
+    assert len(features[0]) == 3
+    assert features[0][0] == 26
+    assert len(features[0][2]) == 6

--- a/docs/featurizers.rst
+++ b/docs/featurizers.rst
@@ -125,10 +125,10 @@ lattice and 3D coordinates that specify a periodic crystal structure. They
 should be applied on systems that have periodic boundary conditions. Materials
 featurizers are not designed to work with molecules. 
 
-ChemicalFingerprint
+ElementPropertyFingerprint
 ^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: deepchem.feat.ChemicalFingerprint
+.. autoclass:: deepchem.feat.ElementPropertyFingerprint
   :members:
 
 SineCoulombMatrix

--- a/docs/featurizers.rst
+++ b/docs/featurizers.rst
@@ -116,6 +116,15 @@ AtomConvFeaturizer
 .. autoclass:: deepchem.feat.NeighborListComplexAtomicCoordinates
   :members:
 
+MaterialsFeaturizers
+-------------------
+
+Materials Featurizers are those that work with datasets of inorganic crystals.
+These featurizers operate on chemical compositions (e.g. "MoS2"), or on a
+lattice and 3D coordinates that specify a periodic crystal structure. They
+should be applied on systems that have periodic boundary conditions. Materials
+featurizers are not designed to work with molecules. 
+
 ChemicalFingerprint
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/featurizers.rst
+++ b/docs/featurizers.rst
@@ -116,6 +116,23 @@ AtomConvFeaturizer
 .. autoclass:: deepchem.feat.NeighborListComplexAtomicCoordinates
   :members:
 
+ChemicalFingerprint
+^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: deepchem.feat.ChemicalFingerprint
+  :members:
+
+SineCoulombMatrix
+^^^^^^^^^^^^^^^^^
+
+.. autoclass:: deepchem.feat.SineCoulombMatrix
+  :members:
+
+StructureGraphFeaturizer
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: deepchem.feat.StructureGraphFeaturizer
+  :members:
 
 BindingPocketFeaturizer
 -----------------------

--- a/scripts/install_deepchem_conda.ps1
+++ b/scripts/install_deepchem_conda.ps1
@@ -29,8 +29,9 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia `
     py-xgboost `
     rdkit `
     simdna `
+    pymatgen `
     pytest `
     pytest-cov `
     flaky
 
-pip install -U tensorflow tensorflow-probability
+pip install -U matminer tensorflow tensorflow-probability

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -33,7 +33,8 @@ conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     py-xgboost \
     rdkit \
     simdna \
+    pymatgen \
     pytest \
     pytest-cov \
     flaky
-yes | pip install -U tensorflow tensorflow-probability
+yes | pip install -U matminer tensorflow tensorflow-probability


### PR DESCRIPTION
### Summary
This WIP PR adds featurizers for inorganic crystal structures.
- Chemical fingerprint, Sine Coulomb Matrix, and Structure Graph featurizers

### To do
- Add methods for further featurizing structure graphs

### Additional dependencies
`deepchem.feat.materials_featurizers.py` introduces dependencies on `pymatgen` and `matminer`.