### PR TITLE
Remove fit function in graphconv

### DIFF
--- a/deepchem/models/graph_models.py
+++ b/deepchem/models/graph_models.py
@@ -745,9 +745,6 @@ class GraphConvModel(KerasModel):
     super(GraphConvModel, self).__init__(
         model, loss, output_types=output_types, batch_size=batch_size, **kwargs)
 
-  def fit(self, *args, **kwargs):
-    super(GraphConvModel, self).fit(*args, **kwargs)
-
   def default_generator(self,
                         dataset,
                         epochs=1,


### PR DESCRIPTION
This removes the fit function from GraphConv. It directly calls the KerasModel fit, and does not return the loss, causing a None value when running `GraphConvModel.fit()`