### PR TITLE
Rename tensorboard_log_frequency to log_frequency

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -131,8 +131,12 @@ class KerasModel(Model):
     tensorboard: bool
       whether to log progress to TensorBoard during training
     log_frequency: int
-      The frequency at which to log data. Data is logged using `logging` by
-      default. If `tensorboard` is set, data is also logged to TensorBoard.
+      The frequency at which to log data. Data is logged using
+      `logging` by default. If `tensorboard` is set, data is also
+      logged to TensorBoard. Logging happens at global steps. Roughly,
+      a global step corresponds to one batch of training. If you'd
+      like a printout every 10 batch steps, you'd set
+      `log_frequency=10` for example.
     """
     super(KerasModel, self).__init__(
         model_instance=model, model_dir=model_dir, **kwargs)

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -104,7 +104,7 @@ class KerasModel(Model):
                learning_rate=0.001,
                optimizer=None,
                tensorboard=False,
-               tensorboard_log_frequency=100,
+               log_frequency=100,
                **kwargs):
     """Create a new KerasModel.
 
@@ -130,8 +130,9 @@ class KerasModel(Model):
       ignored.
     tensorboard: bool
       whether to log progress to TensorBoard during training
-    tensorboard_log_frequency: int
-      the frequency at which to log data to TensorBoard, measured in batches
+    log_frequency: int
+      The frequency at which to log data. Data is logged using `logging` by
+      default. If `tensorboard` is set, data is also logged to TensorBoard.
     """
     super(KerasModel, self).__init__(
         model_instance=model, model_dir=model_dir, **kwargs)
@@ -146,7 +147,7 @@ class KerasModel(Model):
     else:
       self.optimizer = optimizer
     self.tensorboard = tensorboard
-    self.tensorboard_log_frequency = tensorboard_log_frequency
+    self.log_frequency = log_frequency
     if self.tensorboard:
       self._summary_writer = tf.summary.create_file_writer(self.model_dir)
     if output_types is None:
@@ -348,7 +349,7 @@ class KerasModel(Model):
 
       # Report progress and write checkpoints.
       averaged_batches += 1
-      should_log = (current_step % self.tensorboard_log_frequency == 0)
+      should_log = (current_step % self.log_frequency == 0)
       if should_log:
         avg_loss = float(avg_loss) / averaged_batches
         logger.info(

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -151,7 +151,14 @@ class KerasModel(Model):
     else:
       self.optimizer = optimizer
     self.tensorboard = tensorboard
-    self.log_frequency = log_frequency
+    # Backwards compatibility
+    if "tensorboard_log_frequency" in kwargs:
+      logger.warn(
+          "tensorboard_log_frequency is deprecated. Please use log_frequency instead. This argument will be removed in a future release of DeepChem."
+      )
+      self.log_frequency = kwargs["tensorboard_log_frequency"]
+    else:
+      self.log_frequency = log_frequency
     if self.tensorboard:
       self._summary_writer = tf.summary.create_file_writer(self.model_dir)
     if output_types is None:

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -153,7 +153,7 @@ class KerasModel(Model):
     self.tensorboard = tensorboard
     # Backwards compatibility
     if "tensorboard_log_frequency" in kwargs:
-      logger.warn(
+      logger.warning(
           "tensorboard_log_frequency is deprecated. Please use log_frequency instead. This argument will be removed in a future release of DeepChem."
       )
       self.log_frequency = kwargs["tensorboard_log_frequency"]

--- a/deepchem/models/tests/test_kerasmodel.py
+++ b/deepchem/models/tests/test_kerasmodel.py
@@ -235,7 +235,7 @@ class TestKerasModel(unittest.TestCase):
         keras_model,
         dc.models.losses.CategoricalCrossEntropy(),
         tensorboard=True,
-        tensorboard_log_frequency=1)
+        log_frequency=1)
     model.fit(dataset, nb_epoch=10)
     files_in_dir = os.listdir(model.model_dir)
     event_file = list(filter(lambda x: x.startswith("events"), files_in_dir))


### PR DESCRIPTION
The `KerasModel` variable `tensorboard_log_frequency` is misnamed since it also controls general logging frequency. This PR renames this variable to `log_frequency`.

@peastman Could you take a quick look?