### PR TITLE
Fix cloudpickle version for tfp

### DIFF
--- a/scripts/install_deepchem_conda.ps1
+++ b/scripts/install_deepchem_conda.ps1
@@ -21,6 +21,7 @@ else
 
 conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia `
     biopython `
+    cloudpickle=1.4.1 `
     mdtraj `
     networkx `
     openmm `

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -25,6 +25,7 @@ fi
 yes | pip install --upgrade pip
 conda install -y -q -c deepchem -c rdkit -c conda-forge -c omnia \
     biopython \
+    cloudpickle=1.4.1 \
     mdtraj \
     networkx \
     openmm \


### PR DESCRIPTION
This PR fixes the `cloudpickle v1.5.0` update that broke TensorFlowProbability, causing all of DeepChem's tests to fail. This is a temporary fix by pinning the `cloudpickle` version until `tfp v0.11.0` is released.

This is discussed in more detail here:
https://github.com/scikit-hep/pyhf/pull/915
https://github.com/tensorflow/probability/pull/993