### PR TITLE
Add Model Cheatsheet

### DIFF
--- a/deepchem/trans/__init__.py
+++ b/deepchem/trans/__init__.py
@@ -14,3 +14,6 @@ from deepchem.trans.transformers import IRVTransformer
 from deepchem.trans.transformers import DAGTransformer
 from deepchem.trans.transformers import ANITransformer
 from deepchem.trans.transformers import MinMaxTransformer
+from deepchem.trans.transformers import FeaturizationTransformer
+from deepchem.trans.transformers import ImageTransformer
+from deepchem.trans.transformers import DataTransforms

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,6 +62,12 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+    ],
+}
+
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 html_logo = '_static/logo.png'

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -7,101 +7,124 @@ Model Cheatsheet
 ----------------
 If you're just getting started with DeepChem, you're probably interested in the
 basics. The place to get started is this "model cheatsheet" that lists various
-types of custom DeepChem models. Note that some wrappers like `SklearnModel`
-and `XGBoostModel` which wrap external machine learning libraries are excluded,
+types of custom DeepChem models. Note that some wrappers like :code:`SklearnModel`
+and :code:`XGBoostModel` which wrap external machine learning libraries are excluded,
 but this table is otherwise complete.
 
 As a note about how to read this table, each row describes what's needed to
-invoke a given model. Some models must be applied with given `Transformer` or
-`Featurizer` objects. Some models also have custom training methods. You can
+invoke a given model. Some models must be applied with given :code:`Transformer` or
+:code:`Featurizer` objects. Some models also have custom training methods. You can
 read off what's needed to train the model from the table below.
 
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| Model                            | Type       | Input Type     | Transformations | Acceptable Featurizers                                         | Fit Method    |
-+==================================+============+================+=================+================================================================+===============+
-| `AtomicConvModel`                | Classifier/| Tuple          |                 | `ComplexNeighborListFragmentAtomicCoordinates`                 | `fit`         |
-|                                  | Regressor  |                |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `ChemCeption`                    | Classifier/| Tensor of shape|                 | `SmilesToImage`                                                | `fit`         |
-|                                  | Regressor  | `(N, M, c)`    |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `CNN`                            | Classifier/| Tensor of shape|                 |                                                                | `fit`         |
-|                                  | Regressor  | `(N, c)` or    |                 |                                                                |               |
-|                                  |            | `(N, M, c)` or |                 |                                                                |               |
-|                                  |            | `(N, M, L, c)` |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `DTNNModel`                      | Classifier/| Matrix of      |                 | `CoulombMatrix`                                                | `fit`         |
-|                                  | Regressor  | shape `(N, N)` |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `DAGModel`                       | Classifier/| `ConvMol`      | `DAGTransformer`| `ConvMolFeaturizer`                                            | `fit`         |
-|                                  | Regressor  |                |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `GraphConvModel`                 | Classifier/| `ConvMol`      |                 | `ConvMolFeaturizer`                                            | `fit`         |
-|                                  | Regressor  |                |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `MPNNModel`                      | Classifier/| `WeaveMol`     |                 | `WeaveFeaturizer`                                              | `fit`         |
-|                                  | Regressor  |                |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `MultitaskClassifier`            | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         | 
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `MultitaskRegressor`             | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `MultitaskRegressor`             | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `MultitaskFitTransformRegressor` | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `MultitaskRVClassifier`          | Classifier | Vector of      | `IRVTransformer`| `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `ProgressiveMultitaskClassifier` | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `ProgressiveMultitaskRegressor`  | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `RobustMultitaskClassifier`      | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `RobustMultitaskRegressor`       | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `ScScoreModel`                   | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
-|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
-|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
-|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `SeqToSeq`                       | Sequence   | Sequence       |                 |                                                                |`fit_sequences`|
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `Smiles2Vec`                     | Classifier/| Sequence       |                 | `SmilesToSeq`                                                  | `fit`         |
-|                                  | Regressor  |                |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `TextCNNModel`                   | Classifier/| String         |                 |                                                                | `fit`         |
-|                                  | Regressor  |                |                 |                                                                |               |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
-| `WGAN`                           | Adversarial| Pair           |                 |                                                                |`fit_gan`      |
-+----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| Model                                  | Type       | Input Type           | Transformations        | Acceptable Featurizers                                         | Fit Method           |
++========================================+============+======================+========================+================================================================+======================+
+| :code:`AtomicConvModel`                | Classifier/| Tuple                |                        | :code:`ComplexNeighborListFragmentAtomicCoordinates`           | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`ChemCeption`                    | Classifier/| Tensor of shape      |                        | :code:`SmilesToImage`                                          | :code:`fit`          |
+|                                        | Regressor  | :code:`(N, M, c)`    |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`CNN`                            | Classifier/| Tensor of shape      |                        |                                                                | :code:`fit`          |
+|                                        | Regressor  | :code:`(N, c)` or    |                        |                                                                |                      |
+|                                        |            | :code:`(N, M, c)` or |                        |                                                                |                      |
+|                                        |            | :code:`(N, M, L, c)` |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`DTNNModel`                      | Classifier/| Matrix of            |                        | :code:`CoulombMatrix`                                          | :code:`fit`          |
+|                                        | Regressor  | shape :code:`(N, N)` |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`DAGModel`                       | Classifier/| :code:`ConvMol`      | :code:`DAGTransformer` | :code:`ConvMolFeaturizer`                                      | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`GraphConvModel`                 | Classifier/| :code:`ConvMol`      |                        | :code:`ConvMolFeaturizer`                                      | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`MPNNModel`                      | Classifier/| :code:`WeaveMol`     |                        | :code:`WeaveFeaturizer`                                        | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`MultitaskClassifier`            | Classifier | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`MultitaskRegressor`             | Regressor  | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`MultitaskFitTransformRegressor` | Regressor  | Vector of            | Any                    | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`MultitaskIRVClassifier`         | Classifier | Vector of            | :code:`IRVTransformer` | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`ProgressiveMultitaskClassifier` | Classifier | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`ProgressiveMultitaskRegressor`  | Regressor  | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`RobustMultitaskClassifier`      | Classifier | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`RobustMultitaskRegressor`       | Regressor  | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`ScScoreModel`                   | Classifier | Vector of            |                        | :code:`CircularFingerprint`,                                   | :code:`fit`          | 
+|                                        |            | shape :code:`(N,)`   |                        | :code:`RDKitDescriptors`,                                      |                      |
+|                                        |            |                      |                        | :code:`CoulombMatrixEig`,                                      |                      |
+|                                        |            |                      |                        | :code:`RdkitGridFeaturizer`,                                   |                      |
+|                                        |            |                      |                        | :code:`BindingPocketFeaturizer`,                               |                      |
+|                                        |            |                      |                        | :code:`AdjacencyFingerprint`,                                  |                      |
+|                                        |            |                      |                        | :code:`ElementPropertyFingerprint`,                            |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`SeqToSeq`                       | Sequence   | Sequence             |                        |                                                                | :code:`fit_sequences`|
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`Smiles2Vec`                     | Classifier/| Sequence             |                        | :code:`SmilesToSeq`                                            | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`TextCNNModel`                   | Classifier/| String               |                        |                                                                | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`WGAN`                           | Adversarial| Pair                 |                        |                                                                | :code:`fit_gan`      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
 
 Model
 -----

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -1,6 +1,108 @@
 Model Classes
 =============
 
+DeepChem maintains an extensive collection of models for scientific applications.
+
+Model Cheatsheet
+----------------
+If you're just getting started with DeepChem, you're probably interested in the
+basics. The place to get started is this "model cheatsheet" that lists various
+types of custom DeepChem models. Note that some wrappers like `SklearnModel`
+and `XGBoostModel` which wrap external machine learning libraries are excluded,
+but this table is otherwise complete.
+
+As a note about how to read this table, each row describes what's needed to
+invoke a given model. Some models must be applied with given `Transformer` or
+`Featurizer` objects. Some models also have custom training methods. You can
+read off what's needed to train the model from the table below.
+
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| Model                            | Type       | Input Type     | Transformations | Acceptable Featurizers                                         | Fit Method    |
++==================================+============+================+=================+================================================================+===============+
+| `AtomicConvModel`                | Classifier/| Tuple          |                 | `ComplexNeighborListFragmentAtomicCoordinates`                 | `fit`         |
+|                                  | Regressor  |                |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `ChemCeption`                    | Classifier/| Tensor of shape|                 | `SmilesToImage`                                                | `fit`         |
+|                                  | Regressor  | `(N, M, c)`    |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `CNN`                            | Classifier/| Tensor of shape|                 |                                                                | `fit`         |
+|                                  | Regressor  | `(N, c)` or    |                 |                                                                |               |
+|                                  |            | `(N, M, c)` or |                 |                                                                |               |
+|                                  |            | `(N, M, L, c)` |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `DTNNModel`                      | Classifier/| Matrix of      |                 | `CoulombMatrix`                                                | `fit`         |
+|                                  | Regressor  | shape `(N, N)` |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `DAGModel`                       | Classifier/| `ConvMol`      | `DAGTransformer`| `ConvMolFeaturizer`                                            | `fit`         |
+|                                  | Regressor  |                |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `GraphConvModel`                 | Classifier/| `ConvMol`      |                 | `ConvMolFeaturizer`                                            | `fit`         |
+|                                  | Regressor  |                |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `MPNNModel`                      | Classifier/| `WeaveMol`     |                 | `WeaveFeaturizer`                                              | `fit`         |
+|                                  | Regressor  |                |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `MultitaskClassifier`            | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         | 
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `MultitaskRegressor`             | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `MultitaskRegressor`             | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `MultitaskFitTransformRegressor` | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `MultitaskRVClassifier`          | Classifier | Vector of      | `IRVTransformer`| `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `ProgressiveMultitaskClassifier` | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `ProgressiveMultitaskRegressor`  | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `RobustMultitaskClassifier`      | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `RobustMultitaskRegressor`       | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `ScScoreModel`                   | Classifier | Vector of      |                 | `CircularFingerprint`,                                         | `fit`         |
+|                                  |            | shape `(N,)`   |                 | `RDKitDescriptors`, `CoulombMatrixEig`, `RdkitGridFeaturizer`, |               |
+|                                  |            |                |                 | `BindingPocketFeaturizer`,                                     |               |
+|                                  |            |                |                 | `AdjacencyFingerprint`, `ElementPropertyFingerprint`,          |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `SeqToSeq`                       | Sequence   | Sequence       |                 |                                                                |`fit_sequences`|
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `Smiles2Vec`                     | Classifier/| Sequence       |                 | `SmilesToSeq`                                                  | `fit`         |
+|                                  | Regressor  |                |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `TextCNNModel`                   | Classifier/| String         |                 |                                                                | `fit`         |
+|                                  | Regressor  |                |                 |                                                                |               |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+| `WGAN`                           | Adversarial| Pair           |                 |                                                                |`fit_gan`      |
++----------------------------------+------------+----------------+-----------------+----------------------------------------------------------------+---------------+
+
 Model
 -----
 


### PR DESCRIPTION
At present, it's hard to navigate the large collection of DeepChem models. This PR adds a model cheatsheet that lists for each model the type of model, the type of input, required transformations, and compatible featurizers. The aim for this table is that a beginner to DeepChem should be able to read off how to use a model that they're looking at.

As one minor issue, this table is large so it stretches to the edge of the screen in a not pretty way. Does anyone have ideas on how to format this more nicely?