### PR TITLE
Rename TensorflowMultitaskIRVClassifier to MultitaskIRVClassifier

### DIFF
--- a/deepchem/models/IRV.py
+++ b/deepchem/models/IRV.py
@@ -124,3 +124,14 @@ class TensorflowMultitaskIRVClassifier(KerasModel):
         SigmoidCrossEntropy(),
         output_types=['prediction', 'loss'],
         **kwargs)
+
+
+class TensorflowMultitaskIRVClassifier(MultitaskIRVClassifier):
+
+  def __init__(self, *args, **kwargs):
+
+    warnings.warn(
+        "TensorflowMultitaskIRVClassifier is deprecated and has been renamed to MultitaskIRVClassifier",
+        FutureWarning)
+
+    super(TensorflowMultitaskIRVClassifier, self).__init__(*args, **kwargs)

--- a/deepchem/models/IRV.py
+++ b/deepchem/models/IRV.py
@@ -79,7 +79,7 @@ class Slice(Layer):
     return tf.slice(inputs, [0] * axis + [slice_num], [-1] * axis + [1])
 
 
-class TensorflowMultitaskIRVClassifier(KerasModel):
+class MultitaskIRVClassifier(KerasModel):
 
   def __init__(self,
                n_tasks,

--- a/deepchem/models/IRV.py
+++ b/deepchem/models/IRV.py
@@ -87,7 +87,7 @@ class MultitaskIRVClassifier(KerasModel):
                penalty=0.0,
                mode="classification",
                **kwargs):
-    """Initialize TensorflowMultitaskIRVClassifier
+    """Initialize MultitaskIRVClassifier
 
     Parameters
     ----------
@@ -119,7 +119,7 @@ class MultitaskIRVClassifier(KerasModel):
         if len(logits) == 1 else Concatenate(axis=1)(logits)
     ]
     model = tf.keras.Model(inputs=[mol_features], outputs=outputs)
-    super(TensorflowMultitaskIRVClassifier, self).__init__(
+    super(MultitaskIRVClassifier, self).__init__(
         model,
         SigmoidCrossEntropy(),
         output_types=['prediction', 'loss'],

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -11,7 +11,7 @@ from deepchem.models.callbacks import ValidationCallback
 from deepchem.models.fcnet import MultitaskRegressor
 from deepchem.models.fcnet import MultitaskClassifier
 from deepchem.models.fcnet import MultitaskFitTransformRegressor
-from deepchem.models.IRV import TensorflowMultitaskIRVClassifier
+from deepchem.models.IRV import MultitaskIRVClassifier
 from deepchem.models.robust_multitask import RobustMultitaskClassifier
 from deepchem.models.robust_multitask import RobustMultitaskRegressor
 from deepchem.models.progressive_multitask import ProgressiveMultitaskRegressor, ProgressiveMultitaskClassifier
@@ -29,3 +29,4 @@ from deepchem.models.chemnet_models import Smiles2Vec, ChemCeption
 
 from deepchem.models.text_cnn import TextCNNTensorGraph
 from deepchem.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvTensorGraph, MPNNTensorGraph
+from deepchem.models.IRV import TensorflowMultitaskIRVClassifier

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -429,7 +429,7 @@ class TestOverfit(test_util.TensorFlowTestCase):
     dataset_trans = IRV_transformer.transform(dataset)
     classification_metric = dc.metrics.Metric(
         dc.metrics.accuracy_score, task_averager=np.mean)
-    model = dc.models.TensorflowMultitaskIRVClassifier(
+    model = dc.models.MultitaskIRVClassifier(
         n_tasks, K=5, learning_rate=0.01, batch_size=n_samples)
 
     # Fit trained model


### PR DESCRIPTION
`TensorflowMultitaskIRVClassifier` is the only one of our models which still has a `Tensorflow` label at front. This PR changes the name to `MultitaskIRVClassifier` and deprecates `TensorflowMultitaskIRVClassifier` as a name.