### PR TITLE
First Cut at Nightly PyPi via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,49 +1,46 @@
 jobs:
   include:
-    - name: "Python 3.6"
-      language: python
-      python: "3.6"
-      sudo: required
-      dist: xenial
-
-    - name: "Python 3.7"
-      language: python
-      python: "3.7"
-      sudo: required
-      dist: xenial
-
-    - name: "Windows"
-      language: c # Not really, but travis doesn't support python on Windows
-      python: "3.7"
-      os: windows
-
+  - name: Python 3.6
+    language: python
+    python: '3.6'
+    sudo: required
+    dist: xenial
+  - name: Python 3.7
+    language: python
+    python: '3.7'
+    sudo: required
+    dist: xenial
+  - name: Windows
+    language: c
+    python: '3.7'
+    os: windows
 install:
-  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then
-    wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
-    export python_version=$TRAVIS_PYTHON_VERSION;
-    bash miniconda.sh -b -p $HOME/miniconda;
-    source "$HOME/miniconda/etc/profile.d/conda.sh";
-    fi
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    choco install miniconda3 --params="'/JustMe /AddToPath:1'";
-    export PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:/c/tools/miniconda3/Library/bin:$PATH";
-    source /c/tools/miniconda3/etc/profile.d/conda.sh;
-    fi
-  - hash -r
-  - conda config --set always_yes yes --set changeps1 no
-  - conda update -q conda
-  - conda config --add channels http://conda.binstar.org/omnia
-  - bash scripts/install_deepchem_conda.sh deepchem
-  - conda activate deepchem
-  - pip install yapf==0.22.0
-  - pip install coveralls
-  - python setup.py install
+- if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
+  -O miniconda.sh; export python_version=$TRAVIS_PYTHON_VERSION; bash miniconda.sh
+  -b -p $HOME/miniconda; source "$HOME/miniconda/etc/profile.d/conda.sh"; fi
+- if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install miniconda3 --params="'/JustMe
+  /AddToPath:1'"; export PATH="/c/tools/miniconda3/:/c/tools/miniconda3/Scripts:/c/tools/miniconda3/Library/bin:$PATH";
+  source /c/tools/miniconda3/etc/profile.d/conda.sh; fi
+- hash -r
+- conda config --set always_yes yes --set changeps1 no
+- conda update -q conda
+- conda config --add channels http://conda.binstar.org/omnia
+- bash scripts/install_deepchem_conda.sh deepchem
+- conda activate deepchem
+- pip install yapf==0.22.0
+- pip install coveralls
+- python setup.py install
 script:
-  - pytest -m "not slow" --cov=deepchem deepchem
-  - if [ $TRAVIS_PYTHON_VERSION == '3.7' ]; then
-    find ./deepchem | grep .py$ |xargs python -m doctest -v;
-    fi
-  - bash devtools/travis-ci/test_format_code.sh
+- pytest -m "not slow" --cov=deepchem deepchem
+- if [ $TRAVIS_PYTHON_VERSION == '3.7' ]; then find ./deepchem | grep .py$ |xargs
+  python -m doctest -v; fi
+- bash devtools/travis-ci/test_format_code.sh
 after_success:
-  - echo $TRAVIS_SECURE_ENV_VARS
-  - coveralls
+- echo $TRAVIS_SECURE_ENV_VARS
+- coveralls
+deploy:
+  provider: pypi
+  username: __token__
+  password:
+    secure: b67LO8VZcoKEWo7gDlFdjS1yKUavCt578uAuXPyW6f+e+Tk/sEQRdkx1VYoZlQdfZQo8u4q+E3W184T+/j6ht65/cdy/HYH57LCQySjF/MY2M9+/lcP45aY7Z0F2QHeY9QgpRc8gKthGzgM/bHj2glxlEvT1diItEEoGqE2x/fw1K25cNOni08E4hqz0HPY1SXVwd8/9Z/t1YasrBcOjtJ8kcbyjnmeyhjfkaV/aTaAzuqh2MlqZTSz3dhwsBrZfZp86+8T2TgcoDSuIxCwb777QKW1QlvNyLEKlnfateKMYqrrP65oHrxXEEcHd/N3IH28Bz9wVnENjHLkGJ0vXyXyEWcJFe+V6T0k/8NkZamU4SZE5BM4v6mOdThs4l54vuFajctHDeGgIDjL55MfkDmkKd5lAvlWPwrdw8DERsmqetUfZ/TG7FE6/MT1puu2ffu3A9Ivcch5T46pojIggDWHHn9hUsc6iD3Ov7rVqd024Lzm9V8wXiDYU9EMqAu5lJQRIOO/hnr8Gn6zYRCE1n29MKuNJwauSHfdV/mBTRyOjZyWHSGNaiPw2hqE3tZrrIN4koEYaZiERRVnmVt8wMUTj40YglosTHYpL91SkDH/ResX1rtHKs4Am+R+MmcWULTUQ7UwEtqlsa3nVxTK9gfmJ0nX8Jhjtl2iRhVg5PP8=
+  edge: true

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,17 @@
+import sys
 from setuptools import setup, find_packages
+
+if '--release' in sys.argv:
+  release = True
+  sys.argv.remove('--release')
+else:
+  # Build a nightly package by default.
+  release = False
+
+if release:
+  project_name = 'deepchem'
+else:
+  project_name = 'deepchem-nightly'
 
 
 # get the version from deepchem/__init__.py
@@ -13,7 +26,7 @@ def _get_version():
 
 
 setup(
-    name='deepchem',
+    name=project_name,
     version=_get_version(),
     url='https://github.com/deepchem/deepchem',
     maintainer='DeepChem contributors',
@@ -33,6 +46,9 @@ setup(
         quantum chemistry, and the life sciences.',
     keywords=[
         'deepchem',
+        'chemistry',
+        'biology',
+        'materials-science',
         'life-science',
         'drug-discovery',
     ],


### PR DESCRIPTION
This is my first cut at #1955.

I've followed docs from https://docs.travis-ci.com/user/deployment-v2/providers/pypi/. I've added my (rbharath) PyPi API token (encrypted) to .travis.yml following the directions. I've also modified `setup.py` to generate a package `deepchem-nightly` unless a `--release` argument is provided. 

I need to think a bit more about how this can be shifted to do releases for tagged builds as well but I figure it's worth trying the first step out.