### PR TITLE
Fix classifier for pypi upload

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'Environment :: Console',
         'Intended Audience :: Developers',
         'Intended Audience :: Information Technology',
-        'License :: OSI Approved :: MIT',
+        'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',


### PR DESCRIPTION
Fixes issue left over from #1960 (documented in https://github.com/deepchem/deepchem/issues/1955#issuecomment-653679192) where a classifier is misconfigured and twine complains.