### PR TITLE
Continuing fix to deepchem-nightly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import sys
+import time
 from setuptools import setup, find_packages
 
 if '--release' in sys.argv:
@@ -21,7 +22,14 @@ def _get_version():
       if line.startswith('__version__'):
         g = {}
         exec(line, g)
-        return g['__version__']
+        if project_name == "deepchem":
+          return g['__version__']
+        else:
+          # nightly version string .devYearMonthDayHourMinute
+          base = g['__version__']
+          dev_version = ".dev" + time.strftime("%Y%m%d%H%M")
+          return base + dev_version
+
     raise ValueError('`__version__` not defined in `deepchem/__init__.py`')
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def _get_version():
         else:
           # nightly version string .devYearMonthDayHourMinute
           base = g['__version__']
-          dev_version = ".dev" + time.strftime("%Y%m%d%H%M")
+          dev_version = ".dev" + time.strftime("%Y%m%d%H%M%S")
           return base + dev_version
 
     raise ValueError('`__version__` not defined in `deepchem/__init__.py`')


### PR DESCRIPTION
Continuing work on #1960. DeepChem nightly now uploads, but fails the second time since there aren't dev versions. This adds timestamps to nightly versions so the pip version will update. 