### PR TITLE
First cut at making TF optional dependency in dc.rl

### DIFF
--- a/deepchem/rl/__init__.py
+++ b/deepchem/rl/__init__.py
@@ -1,7 +1,19 @@
 """Interface for reinforcement learning."""
 
-from deepchem.rl.a2c import A2C
-from deepchem.rl.ppo import PPO
+from deepchem.utils import TensorFlowStub
+
+try:
+  import tensorflow as tf
+  import tensorflow_probability as tfp
+  from deepchem.rl.a2c import A2C
+  from deepchem.rl.ppo import PPO
+except ModuleNotFoundError:
+
+  class A2C(TensorFlowStub):
+    pass
+
+  class PPO(TensorFlowStub):
+    pass
 
 
 class Environment(object):

--- a/deepchem/rl/a2c.py
+++ b/deepchem/rl/a2c.py
@@ -1,10 +1,6 @@
 """Advantage Actor-Critic (A2C) algorithm for reinforcement learning."""
 
-from deepchem.models import KerasModel
-from deepchem.models.optimizers import Adam
 import numpy as np
-import tensorflow as tf
-import tensorflow_probability as tfp
 import collections
 import copy
 import multiprocessing
@@ -12,19 +8,30 @@ import os
 import re
 import threading
 import time
+import tensorflow as tf
+import tensorflow_probability as tfp
+from deepchem.models import KerasModel
+from deepchem.models.optimizers import Adam
 
 
 class A2CLossDiscrete(object):
-  """This class computes the loss function for A2C with discrete action spaces."""
+  """This class computes the loss function for A2C with discrete action spaces.
+
+  Note
+  ----
+  This class requires tensorflow to be installed.
+  """
 
   def __init__(self, value_weight, entropy_weight, action_prob_index,
                value_index):
+
     self.value_weight = value_weight
     self.entropy_weight = entropy_weight
     self.action_prob_index = action_prob_index
     self.value_index = value_index
 
   def __call__(self, outputs, labels, weights):
+    import tensorflow as tf
     prob = outputs[self.action_prob_index]
     value = outputs[self.value_index]
     reward, advantage = weights
@@ -40,7 +47,12 @@ class A2CLossDiscrete(object):
 
 
 class A2CLossContinuous(object):
-  """This class computes the loss function for A2C with continuous action spaces."""
+  """This class computes the loss function for A2C with continuous action spaces.
+
+  Note
+  ----
+  This class requires tensorflow to be installed.
+  """
 
   def __init__(self, value_weight, entropy_weight, mean_index, std_index,
                value_index):
@@ -151,6 +163,10 @@ class A2C(object):
       the directory in which the model will be saved.  If None, a temporary directory will be created.
     use_hindsight: bool
       if True, use Hindsight Experience Replay
+
+    Note
+    ----
+    This class requires tensorflow to be installed.
     """
     self._env = env
     self._policy = policy

--- a/deepchem/rl/ppo.py
+++ b/deepchem/rl/ppo.py
@@ -14,7 +14,12 @@ import time
 
 
 class PPOLoss(object):
-  """This class computes the loss function for PPO."""
+  """This class computes the loss function for PPO.
+
+  Note
+  ----
+  This class requires tensorflow to be installed.
+  """
 
   def __init__(self, value_weight, entropy_weight, clipping_width,
                action_prob_index, value_index):
@@ -138,6 +143,10 @@ class PPO(object):
       the directory in which the model will be saved.  If None, a temporary directory will be created.
     use_hindsight: bool
       if True, use Hindsight Experience Replay
+
+    Note
+    ----
+    This class requires tensorflow to be installed.
     """
     self._env = env
     self._policy = policy
@@ -405,7 +414,12 @@ class PPO(object):
 
 
 class _Worker(object):
-  """A Worker object is created for each training thread."""
+  """A Worker object is created for each training thread.
+
+  Note
+  ----
+  This class requires tensorflow to be installed.
+  """
 
   def __init__(self, ppo, index):
     self.ppo = ppo

--- a/deepchem/utils/__init__.py
+++ b/deepchem/utils/__init__.py
@@ -21,6 +21,15 @@ except:
   from urllib import urlretrieve  # Python 2
 
 
+class TensorFlowStub(object):
+  """This class provides a stub to handle TensorFlow import failures."""
+
+  def __init__(self, *args, **kwargs):
+    raise ModuleNotFoundError(
+        "The class '%s' cannot be used because TensorFlow is not installed" %
+        type(self).__name__)
+
+
 def pad_array(x, shape, fill=0, both=False):
   """
   Pad an array with a fill value.


### PR DESCRIPTION
This PR takes a first step towards making TF an optional dependency by converting `dc.rl` to have TensorFlow import guards.

@peastman @vsomnath Could you folks take a look at this design and give me your feedback?