### PR TITLE
Overhauling Balancing Transformer

### DIFF
--- a/deepchem/data/tests/test_property.py
+++ b/deepchem/data/tests/test_property.py
@@ -1,0 +1,30 @@
+import numpy as np
+import deepchem as dc
+
+
+def test_y_property():
+  """Test that dataset.y works."""
+  num_datapoints = 10
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+  y_out = dataset.y
+  np.testing.assert_array_equal(y, y_out)
+
+
+def test_w_property():
+  """Test that dataset.y works."""
+  num_datapoints = 10
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+  w_out = dataset.w
+  np.testing.assert_array_equal(w, w_out)

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -581,7 +581,7 @@ class TestSplitter(unittest.TestCase):
       w = dataset.w
       # verify that there are no rows (samples) in weights matrix w
       # that have no hits.
-      assert len(np.where(~w.any(axis=1))[0]) == 0
+      assert len(np.where(w.any(axis=1) == 0)[0]) == 0
 
   def test_indice_split(self):
 

--- a/deepchem/trans/tests/test_balancing.py
+++ b/deepchem/trans/tests/test_balancing.py
@@ -1,0 +1,148 @@
+import numpy as np
+import unittest
+import deepchem as dc
+import itertools
+import os
+
+
+class TestBalancingTransformer(unittest.TestCase):
+  """
+  Test top-level API for transformer objects.
+  """
+
+  def test_binary_1d(self):
+    """Test balancing transformer on single-task dataset without explicit task dimension."""
+    n_samples = 20
+    n_features = 3
+    n_classes = 2
+    np.random.seed(123)
+    ids = np.arange(n_samples)
+    X = np.random.rand(n_samples, n_features)
+    y = np.random.randint(n_classes, size=(n_samples,))
+    w = np.ones((n_samples,))
+    dataset = dc.data.NumpyDataset(X, y, w)
+
+    balancing_transformer = dc.trans.BalancingTransformer(
+        transform_w=True, dataset=dataset)
+    dataset = balancing_transformer.transform(dataset)
+    X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
+    # Check ids are unchanged.
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+    # Check X is unchanged since this is a w transformer
+    np.testing.assert_allclose(X, X_t)
+    # Check y is unchanged since this is a w transformer
+    np.testing.assert_allclose(y, y_t)
+    y_task = y_t
+    w_task = w_t
+    w_orig_task = w
+    # Assert that entries with zero weight retain zero weight
+    np.testing.assert_allclose(w_task[w_orig_task == 0],
+                               np.zeros_like(w_task[w_orig_task == 0]))
+    # Check that sum of 0s equals sum of 1s in transformed for each task
+    assert np.isclose(np.sum(w_task[y_task == 0]), np.sum(w_task[y_task == 1]))
+
+  def test_binary_singletask(self):
+    """Test balancing transformer on single-task dataset."""
+    n_samples = 20
+    n_features = 3
+    n_tasks = 1
+    n_classes = 2
+    np.random.seed(123)
+    ids = np.arange(n_samples)
+    X = np.random.rand(n_samples, n_features)
+    y = np.random.randint(n_classes, size=(n_samples, n_tasks))
+    w = np.ones((n_samples, n_tasks))
+    dataset = dc.data.NumpyDataset(X, y, w)
+
+    balancing_transformer = dc.trans.BalancingTransformer(
+        transform_w=True, dataset=dataset)
+    dataset = balancing_transformer.transform(dataset)
+    X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
+    # Check ids are unchanged.
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+    # Check X is unchanged since this is a w transformer
+    np.testing.assert_allclose(X, X_t)
+    # Check y is unchanged since this is a w transformer
+    np.testing.assert_allclose(y, y_t)
+    for ind, task in enumerate(dataset.get_task_names()):
+      y_task = y_t[:, ind]
+      w_task = w_t[:, ind]
+      w_orig_task = w[:, ind]
+      # Assert that entries with zero weight retain zero weight
+      np.testing.assert_allclose(w_task[w_orig_task == 0],
+                                 np.zeros_like(w_task[w_orig_task == 0]))
+      # Check that sum of 0s equals sum of 1s in transformed for each task
+      assert np.isclose(
+          np.sum(w_task[y_task == 0]), np.sum(w_task[y_task == 1]))
+
+  def test_binary_multitask(self):
+    """Test balancing transformer on multitask dataset."""
+    n_samples = 10
+    n_features = 3
+    n_tasks = 5
+    n_classes = 2
+    ids = np.arange(n_samples)
+    X = np.random.rand(n_samples, n_features)
+    y = np.random.randint(n_classes, size=(n_samples, n_tasks))
+    w = np.ones((n_samples, n_tasks))
+    multitask_dataset = dc.data.NumpyDataset(X, y, w)
+    balancing_transformer = dc.trans.BalancingTransformer(
+        transform_w=True, dataset=multitask_dataset)
+    #X, y, w, ids = (multitask_dataset.X, multitask_dataset.y,
+    #                multitask_dataset.w, multitask_dataset.ids)
+    multitask_dataset = balancing_transformer.transform(multitask_dataset)
+    X_t, y_t, w_t, ids_t = (multitask_dataset.X, multitask_dataset.y,
+                            multitask_dataset.w, multitask_dataset.ids)
+    # Check ids are unchanged.
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+    # Check X is unchanged since this is a w transformer
+    np.testing.assert_allclose(X, X_t)
+    # Check y is unchanged since this is a w transformer
+    np.testing.assert_allclose(y, y_t)
+    for ind, task in enumerate(multitask_dataset.get_task_names()):
+      y_task = y_t[:, ind]
+      w_task = w_t[:, ind]
+      w_orig_task = w[:, ind]
+      # Assert that entries with zero weight retain zero weight
+      np.testing.assert_allclose(w_task[w_orig_task == 0],
+                                 np.zeros_like(w_task[w_orig_task == 0]))
+      # Check that sum of 0s equals sum of 1s in transformed for each task
+      assert np.isclose(
+          np.sum(w_task[y_task == 0]), np.sum(w_task[y_task == 1]))
+
+  def test_multiclass_singletask(self):
+    """Test balancing transformer on single-task dataset."""
+    n_samples = 50
+    n_features = 3
+    n_tasks = 1
+    n_classes = 5
+    ids = np.arange(n_samples)
+    X = np.random.rand(n_samples, n_features)
+    y = np.random.randint(n_classes, size=(n_samples, n_tasks))
+    w = np.ones((n_samples, n_tasks))
+    dataset = dc.data.NumpyDataset(X, y, w)
+
+    balancing_transformer = dc.trans.BalancingTransformer(
+        transform_w=True, dataset=dataset)
+    dataset = balancing_transformer.transform(dataset)
+    X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
+    # Check ids are unchanged.
+    for id_elt, id_t_elt in zip(ids, ids_t):
+      assert id_elt == id_t_elt
+    # Check X is unchanged since this is a w transformer
+    np.testing.assert_allclose(X, X_t)
+    # Check y is unchanged since this is a w transformer
+    np.testing.assert_allclose(y, y_t)
+    for ind, task in enumerate(dataset.get_task_names()):
+      y_task = y_t[:, ind]
+      w_task = w_t[:, ind]
+      w_orig_task = w[:, ind]
+      # Check that sum of 0s equals sum of 1s in transformed for each task
+      for i, j in itertools.product(range(n_classes), range(n_classes)):
+        if i == j:
+          continue
+        assert np.isclose(
+            np.sum(w_task[y_task == i]), np.sum(w_task[y_task == j]))

--- a/deepchem/trans/tests/test_balancing.py
+++ b/deepchem/trans/tests/test_balancing.py
@@ -7,7 +7,7 @@ import os
 
 class TestBalancingTransformer(unittest.TestCase):
   """
-  Test top-level API for transformer objects.
+  Test BalancingTransformer functionality. 
   """
 
   def test_binary_1d(self):

--- a/deepchem/trans/tests/test_minmax.py
+++ b/deepchem/trans/tests/test_minmax.py
@@ -1,0 +1,108 @@
+import os
+import numpy as np
+import deepchem as dc
+
+
+def load_solubility_data():
+  """Loads solubility dataset"""
+  current_dir = os.path.dirname(os.path.abspath(__file__))
+  featurizer = dc.feat.CircularFingerprint(size=1024)
+  tasks = ["log-solubility"]
+  task_type = "regression"
+  input_file = os.path.join(current_dir, "../../models/tests/example.csv")
+  loader = dc.data.CSVLoader(
+      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
+
+  return loader.create_dataset(input_file)
+
+
+def test_y_minmax_transformer():
+  """Tests MinMax transformer."""
+  solubility_dataset = load_solubility_data()
+  minmax_transformer = dc.trans.MinMaxTransformer(
+      transform_y=True, dataset=solubility_dataset)
+  X, y, w, ids = (solubility_dataset.X, solubility_dataset.y,
+                  solubility_dataset.w, solubility_dataset.ids)
+  solubility_dataset = minmax_transformer.transform(solubility_dataset)
+  X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y,
+                          solubility_dataset.w, solubility_dataset.ids)
+
+  # Check ids are unchanged before and after transformation
+  for id_elt, id_t_elt in zip(ids, ids_t):
+    assert id_elt == id_t_elt
+
+  # Check X is unchanged since transform_y is true
+  np.testing.assert_allclose(X, X_t)
+  # Check w is unchanged since transform_y is true
+  np.testing.assert_allclose(w, w_t)
+
+  # Check minimum and maximum values of transformed y are 0 and 1
+  np.testing.assert_allclose(y_t.min(), 0.)
+  np.testing.assert_allclose(y_t.max(), 1.)
+
+  # Check untransform works correctly
+  y_restored = minmax_transformer.untransform(y_t)
+  assert np.max(y_restored - y) < 1e-5
+
+
+def test_y_minmax_random():
+  """Test on random example"""
+  n_samples = 100
+  n_features = 10
+  n_tasks = 10
+
+  X = np.random.randn(n_samples, n_features)
+  y = np.random.randn(n_samples, n_tasks)
+  dataset = dc.data.NumpyDataset(X, y)
+
+  minmax_transformer = dc.trans.MinMaxTransformer(
+      transform_y=True, dataset=dataset)
+  w, ids = dataset.w, dataset.ids
+
+  dataset = minmax_transformer.transform(dataset)
+  X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
+  # Check ids are unchanged before and after transformation
+  for id_elt, id_t_elt in zip(ids, ids_t):
+    assert id_elt == id_t_elt
+
+  # Check X is unchanged since transform_y is true
+  np.testing.assert_allclose(X, X_t)
+  # Check w is unchanged since transform_y is true
+  np.testing.assert_allclose(w, w_t)
+
+  # Check minimum and maximum values of transformed y are 0 and 1
+  np.testing.assert_allclose(y_t.min(), 0.)
+  np.testing.assert_allclose(y_t.max(), 1.)
+
+  # Test if dimensionality expansion is handled correctly by untransform
+  y_t = np.expand_dims(y_t, axis=-1)
+  y_restored = minmax_transformer.untransform(y_t)
+  assert y_restored.shape == y.shape + (1,)
+  np.testing.assert_allclose(np.squeeze(y_restored, axis=-1), y)
+
+
+def test_X_minmax_transformer():
+  solubility_dataset = load_solubility_data()
+  minmax_transformer = dc.trans.MinMaxTransformer(
+      transform_X=True, dataset=solubility_dataset)
+  X, y, w, ids = (solubility_dataset.X, solubility_dataset.y,
+                  solubility_dataset.w, solubility_dataset.ids)
+  solubility_dataset = minmax_transformer.transform(solubility_dataset)
+  X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y,
+                          solubility_dataset.w, solubility_dataset.ids)
+
+  # Check ids are unchanged before and after transformation
+  for id_elt, id_t_elt in zip(ids, ids_t):
+    assert id_elt == id_t_elt
+
+  # Check X is unchanged since transform_y is true
+  np.testing.assert_allclose(y, y_t)
+  # Check w is unchanged since transform_y is true
+  np.testing.assert_allclose(w, w_t)
+
+  # Check minimum and maximum values of transformed y are 0 and 1
+  np.testing.assert_allclose(X_t.min(), 0.)
+  np.testing.assert_allclose(X_t.max(), 1.)
+
+  # Check untransform works correctly
+  np.testing.assert_allclose(minmax_transformer.untransform(X_t), X)

--- a/deepchem/trans/tests/test_transformers.py
+++ b/deepchem/trans/tests/test_transformers.py
@@ -218,93 +218,6 @@ class TestTransformers(unittest.TestCase):
     # Check that untransform does the right thing.
     np.testing.assert_allclose(log_transformer.untransform(X_t), X)
 
-  def test_y_minmax_transformer(self):
-    """Tests MinMax transformer. """
-    solubility_dataset = load_solubility_data()
-    minmax_transformer = dc.trans.MinMaxTransformer(
-        transform_y=True, dataset=solubility_dataset)
-    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y,
-                    solubility_dataset.w, solubility_dataset.ids)
-    solubility_dataset = minmax_transformer.transform(solubility_dataset)
-    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y,
-                            solubility_dataset.w, solubility_dataset.ids)
-
-    # Check ids are unchanged before and after transformation
-    for id_elt, id_t_elt in zip(ids, ids_t):
-      assert id_elt == id_t_elt
-
-    # Check X is unchanged since transform_y is true
-    np.testing.assert_allclose(X, X_t)
-    # Check w is unchanged since transform_y is true
-    np.testing.assert_allclose(w, w_t)
-
-    # Check minimum and maximum values of transformed y are 0 and 1
-    np.testing.assert_allclose(y_t.min(), 0.)
-    np.testing.assert_allclose(y_t.max(), 1.)
-
-    # Check untransform works correctly
-    np.testing.assert_allclose(minmax_transformer.untransform(y_t), y)
-
-    # Test on random example
-    n_samples = 100
-    n_features = 10
-    n_tasks = 10
-
-    X = np.random.randn(n_samples, n_features)
-    y = np.random.randn(n_samples, n_tasks)
-    dataset = dc.data.NumpyDataset(X, y)
-
-    minmax_transformer = dc.trans.MinMaxTransformer(
-        transform_y=True, dataset=dataset)
-    w, ids = dataset.w, dataset.ids
-
-    dataset = minmax_transformer.transform(dataset)
-    X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
-    # Check ids are unchanged before and after transformation
-    for id_elt, id_t_elt in zip(ids, ids_t):
-      assert id_elt == id_t_elt
-
-    # Check X is unchanged since transform_y is true
-    np.testing.assert_allclose(X, X_t)
-    # Check w is unchanged since transform_y is true
-    np.testing.assert_allclose(w, w_t)
-
-    # Check minimum and maximum values of transformed y are 0 and 1
-    np.testing.assert_allclose(y_t.min(), 0.)
-    np.testing.assert_allclose(y_t.max(), 1.)
-
-    # Test if dimensionality expansion is handled correctly by untransform
-    y_t = np.expand_dims(y_t, axis=-1)
-    y_restored = minmax_transformer.untransform(y_t)
-    assert y_restored.shape == y.shape + (1,)
-    np.testing.assert_allclose(np.squeeze(y_restored, axis=-1), y)
-
-  def test_X_minmax_transformer(self):
-    solubility_dataset = load_solubility_data()
-    minmax_transformer = dc.trans.MinMaxTransformer(
-        transform_X=True, dataset=solubility_dataset)
-    X, y, w, ids = (solubility_dataset.X, solubility_dataset.y,
-                    solubility_dataset.w, solubility_dataset.ids)
-    solubility_dataset = minmax_transformer.transform(solubility_dataset)
-    X_t, y_t, w_t, ids_t = (solubility_dataset.X, solubility_dataset.y,
-                            solubility_dataset.w, solubility_dataset.ids)
-
-    # Check ids are unchanged before and after transformation
-    for id_elt, id_t_elt in zip(ids, ids_t):
-      assert id_elt == id_t_elt
-
-    # Check X is unchanged since transform_y is true
-    np.testing.assert_allclose(y, y_t)
-    # Check w is unchanged since transform_y is true
-    np.testing.assert_allclose(w, w_t)
-
-    # Check minimum and maximum values of transformed y are 0 and 1
-    np.testing.assert_allclose(X_t.min(), 0.)
-    np.testing.assert_allclose(X_t.max(), 1.)
-
-    # Check untransform works correctly
-    np.testing.assert_allclose(minmax_transformer.untransform(X_t), X)
-
   def test_y_normalization_transformer(self):
     """Tests normalization transformer."""
     solubility_dataset = load_solubility_data()
@@ -413,7 +326,9 @@ class TestTransformers(unittest.TestCase):
     np.testing.assert_allclose(sorted, target)
 
     # Check that untransform does the right thing.
-    np.testing.assert_allclose(cdf_transformer.untransform(y_t), y)
+    y_restored = cdf_transformer.untransform(y_t)
+    assert np.max(y_restored - y) < 1e-5
+    #np.testing.assert_allclose(y_restored, y)
 
   def test_clipping_X_transformer(self):
     """Test clipping transformer on X of singletask dataset."""

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -849,7 +849,6 @@ class BalancingTransformer(Transformer):
       raise ValueError("w must be of shape (N,) or (N, n_tasks)")
     # Ensure dataset is binary
     self.classes = sorted(np.unique(y))
-    #np.testing.assert_allclose(sorted(np.unique(y)), np.array([0., 1.]))
     weights = []
     for ind, task in enumerate(dataset.get_task_names()):
       task_w = w[:, ind]


### PR DESCRIPTION
This PR overhauls `BalancingTransformer`. It makes it capable of handling multiclass data, and datasets without explicit task dimensions.

`BalancingTransformer` was previously very slow on large datasets due to its use of `dataset.y` and `dataset.w` which would load the entire dataset using `itershards`. Like we did for `dataset.ids`, I've added `DiskDataset.get_shard_y` and `DiskDataset.get_shard_w` functions that prevent unnecessary data loading.

I've also improved the documentation and added clean examples.