### PR TITLE
Introduce datasetify utility

### DIFF
--- a/deepchem/utils/data.py
+++ b/deepchem/utils/data.py
@@ -13,23 +13,31 @@ def datasetify(data_like):
 
   - `dc.data.Dataset`: If the input is already a
   `dc.data.Dataset`, just return unmodified.
-  - List of strings: The strings are assumed to be unique identifiers. They are packaged into `dc.data.NumpyDataset`, as follows.
-
-  >>> import deepchem as dc
-  >>> import numpy as np
-  >>> l = ["C", "CC"]
-  >>> dc.data.NumpyDataset(X=np.array(l), ids=np.array(l))
-
-  The double packaging as `X` and `ids` is awkward, but it's
-  currently not feasible to create a `dc.data.NumpyDataset`
-  without `X` specified.
-
-  - Numpy array: This array is assumed to be the `X` feature array. This is packaged as follows
 
   >>> import deepchem as dc
   >>> import numpy as np
   >>> X = np.random.rand(5, 5)
-  >>> dc.data.NumpyDataset(X)
+  >>> y = np.random.rand(5,)
+  >>> w = np.random.rand(5,)
+  >>> ids = np.arange(5)
+  >>> dataset = dc.data.NumpyDataset(X, y, w, ids)
+  >>> d = datasetify(dataset)
+
+  - List of strings: The strings are assumed to be unique identifiers. They are packaged into `dc.data.NumpyDataset`, as follows.
+
+  >>> l = ["C", "CC"]
+  >>> d = datasetify(l)
+
+  - Numpy array: This array is assumed to be the `X` feature array. This is packaged as follows
+
+  >>> d = datasetify(X)
+
+  - Tuple: This is assumed to be a tuple of arrays of form `(X,)` or `(X, y)` or `(X, y, w)` or `(X, y, w, ids)`. This is packaged as follows
+
+  >>> d1 = datasetify((X,))
+  >>> d2 = datasetify((X, y))
+  >>> d3 = datasetify((X, y, w))
+  >>> d4 = datasetify((X, y, w, ids))
 
   Parameters
   ----------
@@ -48,6 +56,22 @@ def datasetify(data_like):
     if len(data_like) > 0 and isinstance(data_like[0], str):
       return dc.data.NumpyDataset(
           X=np.array(data_like), ids=np.array(data_like))
+  elif isinstance(data_like, tuple):
+    # Assume (X,)
+    if len(data_like) == 1:
+      return dc.data.NumpyDataset(data_like[0])
+    # Assume (X, y)
+    elif len(data_like) == 2:
+      return dc.data.NumpyDataset(data_like[0], data_like[1])
+    # Assume (X, y, z)
+    elif len(data_like) == 3:
+      return dc.data.NumpyDataset(data_like[0], data_like[1], data_like[2])
+    # Assume (X, y, z, ids)
+    elif len(data_like) == 4:
+      return dc.data.NumpyDataset(data_like[0], data_like[1], data_like[2],
+                                  data_like[3])
+    else:
+      raise ValueError("Cannot convert into Dataset object.")
   elif isinstance(data_like, np.ndarray):
     return dc.data.NumpyDataset(data_like)
   else:

--- a/deepchem/utils/data.py
+++ b/deepchem/utils/data.py
@@ -1,0 +1,54 @@
+"""Utilities for handling datasets."""
+
+import numpy as np
+import deepchem as dc
+
+
+def datasetify(data_like):
+  """Convert input into a dataset if possible.
+
+  This utility function attempts to intelligently convert it's
+  input into a DeepChem dataset object. Here are the classes of
+  common sense transformations it attempts to apply:
+
+  - `dc.data.Dataset`: If the input is already a
+  `dc.data.Dataset`, just return unmodified.
+  - List of strings: The strings are assumed to be unique identifiers. They are packaged into `dc.data.NumpyDataset`, as follows.
+
+  >>> import deepchem as dc
+  >>> import numpy as np
+  >>> l = ["C", "CC"]
+  >>> dc.data.NumpyDataset(X=np.array(l), ids=np.array(l))
+
+  The double packaging as `X` and `ids` is awkward, but it's
+  currently not feasible to create a `dc.data.NumpyDataset`
+  without `X` specified.
+
+  - Numpy array: This array is assumed to be the `X` feature array. This is packaged as follows
+
+  >>> import deepchem as dc
+  >>> import numpy as np
+  >>> X = np.random.rand(5, 5)
+  >>> dc.data.NumpyDataset(X)
+
+  Parameters
+  ----------
+  data_like: object
+    Some object which will attempt to be converted to a
+    `dc.data.Dataset` object.
+
+  Returns
+  -------
+  If successful in conversion, returns `dc.data.NumpyDataset`
+  object. Else raises `ValueError`.
+  """
+  if isinstance(data_like, dc.data.Dataset):
+    return data_like
+  elif isinstance(data_like, list):
+    if len(data_like) > 0 and isinstance(data_like[0], str):
+      return dc.data.NumpyDataset(
+          X=np.array(data_like), ids=np.array(data_like))
+  elif isinstance(data_like, np.ndarray):
+    return dc.data.NumpyDataset(data_like)
+  else:
+    raise ValueError("Cannot convert into Dataset object.")

--- a/deepchem/utils/test/test_data_utils.py
+++ b/deepchem/utils/test/test_data_utils.py
@@ -16,3 +16,28 @@ def test_datasetify():
   dataset = dc.data.NumpyDataset(np.random.rand(5, 5))
   d = datasetify(dataset)
   assert (d.X == dataset.X).all()
+
+
+def test_from_numpy_tuples():
+  X = np.random.rand(5, 5)
+  y = np.random.rand(5,)
+  w = np.random.rand(5,)
+  ids = np.arange(5)
+
+  d = datasetify((X,))
+  assert (d.X == X).all()
+
+  d = datasetify((X, y))
+  assert (d.X == X).all()
+  assert (d.y == y).all()
+
+  d = datasetify((X, y, w))
+  assert (d.X == X).all()
+  assert (d.y == y).all()
+  assert (d.w == w).all()
+
+  d = datasetify((X, y, w, ids))
+  assert (d.X == X).all()
+  assert (d.y == y).all()
+  assert (d.w == w).all()
+  assert (d.ids == ids).all()

--- a/deepchem/utils/test/test_data_utils.py
+++ b/deepchem/utils/test/test_data_utils.py
@@ -1,0 +1,18 @@
+import numpy as np
+import deepchem as dc
+from deepchem.utils.data import datasetify
+
+
+def test_datasetify():
+  l = ["C", "CC"]
+  d = datasetify(l)
+  assert isinstance(d, dc.data.Dataset)
+  assert (d.ids == np.array(l)).all()
+
+  X = np.random.rand(5, 5)
+  d = datasetify(X)
+  assert (d.X == X).all()
+
+  dataset = dc.data.NumpyDataset(np.random.rand(5, 5))
+  d = datasetify(dataset)
+  assert (d.X == dataset.X).all()

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -145,11 +145,19 @@ Hash Function Utilities
 
 .. autofunction:: deepchem.utils.hash_utils.vectorize
 
-Voxel Utils
------------
+Voxel Utilities
+---------------
 
 .. autofunction:: deepchem.utils.voxel_utils.convert_atom_to_voxel
 
 .. autofunction:: deepchem.utils.voxel_utils.convert_atom_pair_to_voxel
 
 .. autofunction:: deepchem.utils.voxel_utils.voxelize
+
+Dataset Utilities
+-----------------
+
+The :code:`datasetify` function provides some useful utilities for converting
+:code:`Dataset`-like inputs into :code:`Dataset` objects.
+
+.. autofunction:: deepchem.utils.data.datasetify


### PR DESCRIPTION
This is a utility that attempts to convert its input into a dataset. With `datasetify`, it becomes possible for classes such as Splitters and Transformers which operate on datasets to attempt to operate on more general input.

@peastman I've found this really convenient when coding, but downside might be that the type gets gnarly