### PR TITLE
Crystal featurizer base classes

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -3,6 +3,7 @@ Making it easy to import in classes.
 """
 from deepchem.feat.base_classes import Featurizer
 from deepchem.feat.base_classes import MolecularFeaturizer
+from deepchem.feat.base_classes import CrystalFeaturizer
 from deepchem.feat.base_classes import ComplexFeaturizer
 from deepchem.feat.base_classes import UserDefinedFeaturizer
 from deepchem.feat.graph_features import ConvMolFeaturizer

--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -3,7 +3,8 @@ Making it easy to import in classes.
 """
 from deepchem.feat.base_classes import Featurizer
 from deepchem.feat.base_classes import MolecularFeaturizer
-from deepchem.feat.base_classes import CrystalFeaturizer
+from deepchem.feat.base_classes import StructureFeaturizer
+from deepchem.feat.base_classes import CompositionFeaturizer
 from deepchem.feat.base_classes import ComplexFeaturizer
 from deepchem.feat.base_classes import UserDefinedFeaturizer
 from deepchem.feat.graph_features import ConvMolFeaturizer

--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -208,17 +208,17 @@ class MolecularFeaturizer(Featurizer):
     return self.featurize(molecules)
 
 
-class CrystalFeaturizer(Featurizer):
+class StructureFeaturizer(Featurizer):
   """
-  Abstract class for calculating a set of features for a
-  crystal structure.
+  Abstract class for calculating a set of features for an
+  inorganic crystal structure.
 
-  The defining feature of a `CrystalFeaturizer` is that it
-  operates on 3D crystals with periodic boundary conditions. Inorganic
-  crystal structures are represented by Pymatgen composition and structure
+  The defining feature of a `StructureFeaturizer` is that it
+  operates on 3D crystal structures with periodic boundary conditions. 
+  Inorganic crystal structures are represented by Pymatgen structure
   objects. Featurizers for inorganic crystal structures that are subclasses of
-  this class should plan to process input which comes as composition
-  strings or pymatgen structure dictionaries. 
+  this class should plan to process input which comes as pymatgen
+  structure objects. 
 
   Child classes need to implement the _featurize method for
   calculating features for a single crystal.
@@ -230,14 +230,16 @@ class CrystalFeaturizer(Featurizer):
 
   """
 
-  def featurize(self, crystals: Iterable, log_every_n: int = 1000) -> np.ndarray:
-    """Calculate features for crystals.
+  def featurize(self, structures: Iterable[dict],
+                log_every_n: int = 1000) -> np.ndarray:
+    """Calculate features for crystal structures.
 
     Parameters
     ----------
-    crystals: Iterable
-      Iterable sequence of composition strings, pymatgen structure
-      dictionaries, or another crystal representation.
+    structures: Iterable[dict]
+      Iterable sequence of pymatgen structure dictionaries.
+      Json-serializable dictionary representation of pymatgen.core.structure
+      https://pymatgen.org/pymatgen.core.structure.html
     log_every_n: int, default 1000
       Logging messages reported every `log_every_n` samples.
 
@@ -245,23 +247,29 @@ class CrystalFeaturizer(Featurizer):
     -------
     features: np.ndarray
       A numpy array containing a featurized representation of
-      `crystals`.
+      `structures`.
 
     """
 
-    # Special case handling of single crystal
-    if not isinstance(crystals, Iterable):
-      crystals = [crystals]
+    # Special case handling of single crystal structure
+    if not isinstance(structures, Iterable):
+      structures = [structures]
     else:
       # Convert iterables to list
-      crystals = list(crystals)
+      structures = list(structures)
+
+    try:
+      from pymatgen import Structure
+    except ModuleNotFoundError:
+      raise ValueError("This class requires pymatgen to be installed.")
 
     features = []
-    for idx, crystal in enumerate(crystals):
+    for idx, structure in enumerate(structures):
       if idx % log_every_n == 0:
         logger.info("Featurizing datapoint %i" % idx)
       try:
-        features.append(self._featurize(crystal))
+        s = Structure.from_dict(structure)
+        features.append(self._featurize(s))
       except:
         logger.warning(
             "Failed to featurize datapoint %i. Appending empty array" % idx)
@@ -270,29 +278,122 @@ class CrystalFeaturizer(Featurizer):
     features = np.asarray(features)
     return features
 
-  def _featurize(self, crystal):
-    """Calculate features for a single crystal.
+  def _featurize(self, structure: "pymatgen.Structure"):
+    """Calculate features for a single crystal structure.
 
     Parameters
     ----------
-    crystal: crystal representation
-        Crystal.
+    structure: pymatgen.Structure object
+      Structure object with 3D coordinates and periodic lattice.
 
     """
 
     raise NotImplementedError('Featurizer is not defined.')
 
-  def __call__(self, crystals: Iterable):
-    """Calculate features for crystals.
+  def __call__(self, structures: Iterable[dict]):
+    """Calculate features for crystal structures.
 
     Parameters
     ----------
-    crystals: Iterable
-        An iterable of crystal representations.
+    structures: Iterable[dict]
+      An iterable of crystal structure dictionaries.
 
     """
 
-    return self.featurize(crystals)
+    return self.featurize(structures)
+
+
+class CompositionFeaturizer(Featurizer):
+  """
+  Abstract class for calculating a set of features for an
+  inorganic crystal composition.
+
+  The defining feature of a `CompositionFeaturizer` is that it
+  operates on 3D crystal chemical compositions. 
+  Inorganic crystal compositions are represented by Pymatgen composition
+  objects. Featurizers for inorganic crystal compositions that are 
+  subclasses of this class should plan to process input which comes as
+  Pymatgen composition objects. 
+
+  Child classes need to implement the _featurize method for
+  calculating features for a single composition.
+
+  Notes
+  -----
+  Some subclasses of this class will require pymatgen and matminer to be
+  installed.
+
+  """
+
+  def featurize(self, compositions: Iterable[str],
+                log_every_n: int = 1000) -> np.ndarray:
+    """Calculate features for crystal compositions.
+
+    Parameters
+    ----------
+    compositions: Iterable[str]
+      Iterable sequence of composition strings, e.g. "MoS2".
+    log_every_n: int, default 1000
+      Logging messages reported every `log_every_n` samples.
+
+    Returns
+    -------
+    features: np.ndarray
+      A numpy array containing a featurized representation of
+      `compositions`.
+
+    """
+
+    # Special case handling of single crystal composition
+    if not isinstance(compositions, Iterable):
+      compositions = [compositions]
+    else:
+      # Convert iterables to list
+      compositions = list(compositions)
+
+    try:
+      from pymatgen import Composition
+    except ModuleNotFoundError:
+      raise ValueError("This class requires pymatgen to be installed.")
+
+    features = []
+    for idx, composition in enumerate(compositions):
+      if idx % log_every_n == 0:
+        logger.info("Featurizing datapoint %i" % idx)
+      try:
+        c = Composition(composition)
+        features.append(self._featurize(c))
+      except:
+        logger.warning(
+            "Failed to featurize datapoint %i. Appending empty array" % idx)
+        features.append(np.array([]))
+
+    features = np.asarray(features)
+    return features
+
+  def _featurize(self, composition: "pymatgen.Composition"):
+    """Calculate features for a single crystal composition.
+
+    Parameters
+    ----------
+    composition: pymatgen.Composition object
+      Composition object for 3D inorganic crystal.
+
+    """
+
+    raise NotImplementedError('Featurizer is not defined.')
+
+  def __call__(self, compositions: Iterable[str]):
+    """Calculate features for crystal compositions.
+
+    Parameters
+    ----------
+    compositions: Iterable[str]
+      An iterable of crystal compositions.
+
+    """
+
+    return self.featurize(compositions)
 
 
 class UserDefinedFeaturizer(Featurizer):

--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -220,8 +220,10 @@ class StructureFeaturizer(Featurizer):
   this class should plan to process input which comes as pymatgen
   structure objects. 
 
-  Child classes need to implement the _featurize method for
-  calculating features for a single crystal.
+  This class is abstract and cannot be invoked directly. You'll
+  likely only interact with this class if you're a developer. Child 
+  classes need to implement the _featurize method for calculating 
+  features for a single crystal structure.
 
   Notes
   -----
@@ -315,8 +317,10 @@ class CompositionFeaturizer(Featurizer):
   subclasses of this class should plan to process input which comes as
   Pymatgen composition objects. 
 
-  Child classes need to implement the _featurize method for
-  calculating features for a single composition.
+  This class is abstract and cannot be invoked directly. You'll
+  likely only interact with this class if you're a developer. Child 
+  classes need to implement the _featurize method for calculating 
+  features for a single crystal composition.
 
   Notes
   -----

--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -5,9 +5,11 @@ import logging
 import types
 import numpy as np
 import multiprocessing
-from typing import Iterable, Union
+from typing import Iterable, Union, Dict, Any
 
 logger = logging.getLogger(__name__)
+
+JSON = Dict[str, Any]
 
 
 def _featurize_complex(featurizer, mol_pdb_file, protein_pdb_file, log_message):
@@ -232,13 +234,13 @@ class StructureFeaturizer(Featurizer):
 
   """
 
-  def featurize(self, structures: Iterable[dict],
+  def featurize(self, structures: Iterable[JSON],
                 log_every_n: int = 1000) -> np.ndarray:
     """Calculate features for crystal structures.
 
     Parameters
     ----------
-    structures: Iterable[dict]
+    structures: Iterable[JSON]
       Iterable sequence of pymatgen structure dictionaries.
       Json-serializable dictionary representation of pymatgen.core.structure
       https://pymatgen.org/pymatgen.core.structure.html

--- a/deepchem/feat/materials_featurizers.py
+++ b/deepchem/feat/materials_featurizers.py
@@ -4,11 +4,11 @@ Featurizers for inorganic crystals.
 
 import numpy as np
 
-from deepchem.feat import Featurizer
+from deepchem.feat import CrystalFeaturizer
 from deepchem.utils import pad_array
 
 
-class ElementPropertyFingerprint(Featurizer):
+class ElementPropertyFingerprint(CrystalFeaturizer):
   """
   Fingerprint of elemental properties from composition.
 
@@ -67,8 +67,11 @@ class ElementPropertyFingerprint(Featurizer):
 
     """
 
-    from pymatgen import Composition
-    from matminer.featurizers.composition import ElementProperty
+    try:
+      from pymatgen import Composition
+      from matminer.featurizers.composition import ElementProperty
+    except ModuleNotFoundError:
+      raise ValueError("This class requires pymatgen and matminer to be installed.")
 
     # Get pymatgen Composition object
     c = Composition(comp)
@@ -83,7 +86,7 @@ class ElementPropertyFingerprint(Featurizer):
     return np.array(feats)
 
 
-class SineCoulombMatrix(Featurizer):
+class SineCoulombMatrix(CrystalFeaturizer):
   """
   Calculate sine Coulomb matrix for crystals.
 
@@ -144,8 +147,11 @@ class SineCoulombMatrix(Featurizer):
 
     """
 
-    from pymatgen import Structure
-    from matminer.featurizers.structure import SineCoulombMatrix as SCM
+    try:
+      from pymatgen import Structure
+      from matminer.featurizers.structure import SineCoulombMatrix as SCM
+    except ModuleNotFoundError:
+      raise ValueError("This class requires pymatgen and matminer to be installed.")
 
     s = Structure.from_dict(struct)
 
@@ -166,7 +172,7 @@ class SineCoulombMatrix(Featurizer):
     return features
 
 
-class StructureGraphFeaturizer(Featurizer):
+class StructureGraphFeaturizer(CrystalFeaturizer):
   """
   Calculate structure graph features for crystals.
 
@@ -224,7 +230,10 @@ class StructureGraphFeaturizer(Featurizer):
 
     """
 
-    from pymatgen import Structure
+    try:
+      from pymatgen import Structure
+    except ModuleNotFoundError:
+      raise ValueError("This class requires pymatgen to be installed.")
 
     # Get pymatgen structure object
     s = Structure.from_dict(struct)

--- a/docs/featurizers.rst
+++ b/docs/featurizers.rst
@@ -161,14 +161,18 @@ AtomConvFeaturizer
 .. autoclass:: deepchem.feat.NeighborListComplexAtomicCoordinates
   :members:
 
-MaterialsFeaturizers
---------------------
+CrystalFeaturizer
+-----------------
 
-Materials Featurizers are those that work with datasets of inorganic crystals.
-These featurizers operate on chemical compositions (e.g. "MoS2"), or on a
-lattice and 3D coordinates that specify a periodic crystal structure. They
-should be applied on systems that have periodic boundary conditions. Materials
-featurizers are not designed to work with molecules. 
+Crystal Featurizers are those that work with datasets of crystals with
+periodic boundary conditions. For inorganic crystal structures, these
+featurizers operate on chemical compositions (e.g. "MoS2"), or on a 
+lattice and 3D coordinates that specify a periodic crystal structure. 
+They should be applied on systems that have periodic boundary conditions.
+Crystal featurizers are not designed to work with molecules. 
+
+.. autoclass:: deepchem.feat.CrystalFeaturizer
+  :members:
 
 ElementPropertyFingerprint
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/featurizers.rst
+++ b/docs/featurizers.rst
@@ -161,23 +161,17 @@ AtomConvFeaturizer
 .. autoclass:: deepchem.feat.NeighborListComplexAtomicCoordinates
   :members:
 
-CrystalFeaturizer
------------------
+StructureFeaturizer
+-------------------
 
-Crystal Featurizers are those that work with datasets of crystals with
+Structure Featurizers are those that work with datasets of crystals with
 periodic boundary conditions. For inorganic crystal structures, these
-featurizers operate on chemical compositions (e.g. "MoS2"), or on a 
+featurizers operate on pymatgen.Structure objects, which include a
 lattice and 3D coordinates that specify a periodic crystal structure. 
 They should be applied on systems that have periodic boundary conditions.
-Crystal featurizers are not designed to work with molecules. 
+Structure featurizers are not designed to work with molecules. 
 
-.. autoclass:: deepchem.feat.CrystalFeaturizer
-  :members:
-
-ElementPropertyFingerprint
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autoclass:: deepchem.feat.ElementPropertyFingerprint
+.. autoclass:: deepchem.feat.StructureFeaturizer
   :members:
 
 SineCoulombMatrix
@@ -190,6 +184,25 @@ StructureGraphFeaturizer
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: deepchem.feat.StructureGraphFeaturizer
+  :members:
+
+CompositionFeaturizer
+---------------------
+
+Composition Featurizers are those that work with datasets of crystal
+compositions with periodic boundary conditions. 
+For inorganic crystal structures, these featurizers operate on chemical
+compositions (e.g. "MoS2"). They should be applied on systems that have
+periodic boundary conditions. Composition featurizers are not designed 
+to work with molecules. 
+
+.. autoclass:: deepchem.feat.CompositionFeaturizer
+  :members:
+
+ElementPropertyFingerprint
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: deepchem.feat.ElementPropertyFingerprint
   :members:
 
 BindingPocketFeaturizer


### PR DESCRIPTION
This PR adds base classes `StructureFeaturizer` and `CompositionFeaturizer` to `dc.feat.base_classes.py`. These abstract base classes handle `pymatgen.Structure` and `pymatgen.Composition` inputs for featurizing inorganic crystal structures. I'm happy to rework things or make changes as needed. This is ready for review.

More discussion at #2005 