### PR TITLE
Use multiple processes to transform datasets

### DIFF
--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -53,6 +53,12 @@ def load_multitask_data():
   return loader.featurize(input_file)
 
 
+class TestTransformer(dc.trans.Transformer):
+
+  def transform_array(self, X, y, w):
+    return (2 * X, 1.5 * y, w)
+
+
 class TestDatasets(test_util.TensorFlowTestCase):
   """
   Test basic top-level API for dataset objects.
@@ -386,10 +392,8 @@ class TestDatasets(test_util.TensorFlowTestCase):
 
     # Transform it
 
-    def fn(x, y, w):
-      return (2 * x, 1.5 * y, w)
-
-    transformed = dataset.transform(fn)
+    transformer = TestTransformer(transform_X=True, transform_y=True)
+    transformed = dataset.transform(transformer)
     np.testing.assert_array_equal(X, dataset.X)
     np.testing.assert_array_equal(y, dataset.y)
     np.testing.assert_array_equal(w, dataset.w)
@@ -408,18 +412,18 @@ class TestDatasets(test_util.TensorFlowTestCase):
     ids = dataset.ids
 
     # Transform it
-    def fn(x, y, w):
-      return (2 * x, 1.5 * y, w)
 
-    transformed = dataset.transform(fn)
-    np.testing.assert_array_equal(X, dataset.X)
-    np.testing.assert_array_equal(y, dataset.y)
-    np.testing.assert_array_equal(w, dataset.w)
-    np.testing.assert_array_equal(ids, dataset.ids)
-    np.testing.assert_array_equal(2 * X, transformed.X)
-    np.testing.assert_array_equal(1.5 * y, transformed.y)
-    np.testing.assert_array_equal(w, transformed.w)
-    np.testing.assert_array_equal(ids, transformed.ids)
+    transformer = TestTransformer(transform_X=True, transform_y=True)
+    for parallel in (True, False):
+      transformed = dataset.transform(transformer, parallel=parallel)
+      np.testing.assert_array_equal(X, dataset.X)
+      np.testing.assert_array_equal(y, dataset.y)
+      np.testing.assert_array_equal(w, dataset.w)
+      np.testing.assert_array_equal(ids, dataset.ids)
+      np.testing.assert_array_equal(2 * X, transformed.X)
+      np.testing.assert_array_equal(1.5 * y, transformed.y)
+      np.testing.assert_array_equal(w, transformed.w)
+      np.testing.assert_array_equal(ids, transformed.ids)
 
   def test_to_numpy(self):
     """Test that transformation to numpy arrays is sensible."""

--- a/deepchem/data/tests/test_reload.py
+++ b/deepchem/data/tests/test_reload.py
@@ -56,9 +56,7 @@ class TestReload(unittest.TestCase):
     # TODO(rbharath): Transformers don't play nice with reload! Namely,
     # reloading will cause the transform to be reapplied. This is undesirable in
     # almost all cases. Need to understand a method to fix this.
-    transformers = [
-        dc.trans.BalancingTransformer(transform_w=True, dataset=train_dataset)
-    ]
+    transformers = [dc.trans.BalancingTransformer(dataset=train_dataset)]
     logger.info("Transforming datasets")
     for dataset in [train_dataset, valid_dataset, test_dataset]:
       for transformer in transformers:

--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -175,9 +175,7 @@ def load_bace_classification(featurizer='ECFP',
 
   if split is None:
     # Initialize transformers
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("Split is None, about to transform data")
     for transformer in transformers:
@@ -204,9 +202,7 @@ def load_bace_classification(featurizer='ECFP',
       frac_valid=frac_valid,
       frac_test=frac_test)
 
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
   logger.info("About to transform data.")
   for transformer in transformers:

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -63,9 +63,7 @@ def load_bbbp(featurizer='ECFP',
 
   if split is None:
     # Initialize transformers
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("Split is None, about to transform data")
     for transformer in transformers:
@@ -91,9 +89,7 @@ def load_bbbp(featurizer='ECFP',
       frac_test=frac_test)
 
   # Initialize transformers
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
   for transformer in transformers:
     train = transformer.transform(train)

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -37,15 +37,15 @@ def load_clintox(featurizer='ECFP',
 
   References
   ----------
-  .. [1] Gayvert, Kaitlyn M., Neel S. Madhukar, and Olivier Elemento. 
-     "A data-driven approach to predicting successes and failures of clinical trials." 
+  .. [1] Gayvert, Kaitlyn M., Neel S. Madhukar, and Olivier Elemento.
+     "A data-driven approach to predicting successes and failures of clinical trials."
      Cell chemical biology 23.10 (2016): 1294-1301.
-  .. [2] Artemov, Artem V., et al. "Integrated deep learned transcriptomic and 
+  .. [2] Artemov, Artem V., et al. "Integrated deep learned transcriptomic and
      structure-based predictor of clinical trials outcomes." bioRxiv (2016): 095653.
-  .. [3] Novick, Paul A., et al. "SWEETLEAD: an in silico database of approved drugs, 
-     regulated chemicals, and herbal isolates for computer-aided drug discovery." 
+  .. [3] Novick, Paul A., et al. "SWEETLEAD: an in silico database of approved drugs,
+     regulated chemicals, and herbal isolates for computer-aided drug discovery."
      PloS one 8.11 (2013): e79568.
-  .. [4] Aggregate Analysis of ClincalTrials.gov (AACT) Database. 
+  .. [4] Aggregate Analysis of ClincalTrials.gov (AACT) Database.
      https://www.ctti-clinicaltrials.org/aact-database
   """
   if data_dir is None:
@@ -97,9 +97,7 @@ def load_clintox(featurizer='ECFP',
 
   # Transform clintox dataset
   if split is None:
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("Split is None, about to transform data.")
     for transformer in transformers:
@@ -117,9 +115,7 @@ def load_clintox(featurizer='ECFP',
   logger.info("About to split data with {} splitter.".format(split))
   train, valid, test = splitter.train_valid_test_split(dataset)
 
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
   logger.info("About to transform data.")
   for transformer in transformers:

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -82,9 +82,7 @@ def load_hiv(featurizer='ECFP',
   dataset = loader.featurize(dataset_file, shard_size=8192)
 
   if split is None:
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("Split is None, about to transform data")
     for transformer in transformers:
@@ -112,9 +110,7 @@ def load_hiv(featurizer='ECFP',
       frac_test=frac_test)
   train, valid, test = splitter.train_valid_test_split(dataset)
 
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
   logger.info("About to transform data.")
   for transformer in transformers:

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -71,9 +71,7 @@ def load_muv(featurizer='ECFP',
   dataset = loader.featurize(dataset_file)
 
   if split == None:
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("Split is None, about to transform data")
     for transformer in transformers:

--- a/deepchem/molnet/load_function/pcba_datasets.py
+++ b/deepchem/molnet/load_function/pcba_datasets.py
@@ -124,9 +124,7 @@ def load_pcba_dataset(featurizer='ECFP',
   dataset = loader.featurize(dataset_file)
 
   if split == None:
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("Split is None, about to transform data")
     for transformer in transformers:
@@ -152,9 +150,7 @@ def load_pcba_dataset(featurizer='ECFP',
       frac_valid=frac_valid,
       frac_test=frac_test)
 
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
   logger.info("About to transform dataset.")
   for transformer in transformers:

--- a/deepchem/molnet/load_function/sider_datasets.py
+++ b/deepchem/molnet/load_function/sider_datasets.py
@@ -94,9 +94,7 @@ def load_sider(featurizer='ECFP',
   logger.info("%d datapoints in SIDER dataset" % len(dataset))
 
   # Initialize transformers
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
   logger.info("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)

--- a/deepchem/molnet/load_function/sweetlead_datasets.py
+++ b/deepchem/molnet/load_function/sweetlead_datasets.py
@@ -21,7 +21,7 @@ def load_sweet(featurizer='ECFP',
                save_dir=None,
                **kwargs):
   """Load sweet datasets.
-  
+
   Sweetlead is a dataset of chemical structures for approved drugs, chemical isolates from traditional medicinal herbs, and regulated chemicals. Resulting structures are filtered for the active pharmaceutical ingredient, standardized, and differing formulations of the same drug were combined in the final database.
 
   Novick, Paul A., et al. "SWEETLEAD: an in silico database of approved drugs, regulated chemicals, and herbal isolates for computer-aided drug discovery." PLoS One 8.11 (2013).
@@ -67,9 +67,7 @@ def load_sweet(featurizer='ECFP',
   dataset = loader.featurize(dataset_file)
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-  ]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   logger.info("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -70,9 +70,7 @@ def load_tox21(featurizer='ECFP',
 
   if split == None:
     # Initialize transformers
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
 
     logger.info("About to transform data")
     for transformer in transformers:
@@ -104,9 +102,7 @@ def load_tox21(featurizer='ECFP',
         frac_test=frac_test)
     all_dataset = (train, valid, test)
 
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
     logger.info("About to transform data")
     for transformer in transformers:

--- a/deepchem/molnet/load_function/toxcast_datasets.py
+++ b/deepchem/molnet/load_function/toxcast_datasets.py
@@ -83,9 +83,7 @@ def load_toxcast(featurizer='ECFP',
   dataset = loader.featurize(dataset_file)
 
   if split == None:
-    transformers = [
-        deepchem.trans.BalancingTransformer(transform_w=True, dataset=dataset)
-    ]
+    transformers = [deepchem.trans.BalancingTransformer(dataset=dataset)]
     logger.info("Split is None, about to transform data.")
     for transformer in transformers:
       dataset = transformer.transform(dataset)
@@ -109,9 +107,7 @@ def load_toxcast(featurizer='ECFP',
       frac_valid=frac_valid,
       frac_test=frac_test)
 
-  transformers = [
-      deepchem.trans.BalancingTransformer(transform_w=True, dataset=train)
-  ]
+  transformers = [deepchem.trans.BalancingTransformer(dataset=train)]
 
   logger.info("About to transform dataset.")
   for transformer in transformers:

--- a/deepchem/trans/tests/test_balancing.py
+++ b/deepchem/trans/tests/test_balancing.py
@@ -18,8 +18,7 @@ def test_binary_1d():
   w = np.ones((n_samples,))
   dataset = dc.data.NumpyDataset(X, y, w)
 
-  balancing_transformer = dc.trans.BalancingTransformer(
-      transform_w=True, dataset=dataset)
+  balancing_transformer = dc.trans.BalancingTransformer(dataset=dataset)
   dataset = balancing_transformer.transform(dataset)
   X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
   # Check ids are unchanged.
@@ -52,8 +51,7 @@ def test_binary_singletask():
   w = np.ones((n_samples, n_tasks))
   dataset = dc.data.NumpyDataset(X, y, w)
 
-  balancing_transformer = dc.trans.BalancingTransformer(
-      transform_w=True, dataset=dataset)
+  balancing_transformer = dc.trans.BalancingTransformer(dataset=dataset)
   dataset = balancing_transformer.transform(dataset)
   X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
   # Check ids are unchanged.
@@ -86,7 +84,7 @@ def test_binary_multitask():
   w = np.ones((n_samples, n_tasks))
   multitask_dataset = dc.data.NumpyDataset(X, y, w)
   balancing_transformer = dc.trans.BalancingTransformer(
-      transform_w=True, dataset=multitask_dataset)
+      dataset=multitask_dataset)
   #X, y, w, ids = (multitask_dataset.X, multitask_dataset.y,
   #                multitask_dataset.w, multitask_dataset.ids)
   multitask_dataset = balancing_transformer.transform(multitask_dataset)
@@ -122,8 +120,7 @@ def test_multiclass_singletask():
   w = np.ones((n_samples, n_tasks))
   dataset = dc.data.NumpyDataset(X, y, w)
 
-  balancing_transformer = dc.trans.BalancingTransformer(
-      transform_w=True, dataset=dataset)
+  balancing_transformer = dc.trans.BalancingTransformer(dataset=dataset)
   dataset = balancing_transformer.transform(dataset)
   X_t, y_t, w_t, ids_t = (dataset.X, dataset.y, dataset.w, dataset.ids)
   # Check ids are unchanged.
@@ -157,8 +154,7 @@ def test_transform_to_directory():
   w = np.ones((n_samples,))
   dataset = dc.data.NumpyDataset(X, y, w)
 
-  balancing_transformer = dc.trans.BalancingTransformer(
-      transform_w=True, dataset=dataset)
+  balancing_transformer = dc.trans.BalancingTransformer(dataset=dataset)
   with tempfile.TemporaryDirectory() as tmpdirname:
     dataset = balancing_transformer.transform(dataset, out_dir=tmpdirname)
     balanced_dataset = dc.data.DiskDataset(tmpdirname)

--- a/examples/low_data/datasets.py
+++ b/examples/low_data/datasets.py
@@ -12,130 +12,129 @@ import tempfile
 import numpy as np
 import deepchem as dc
 
+
 def to_numpy_dataset(dataset):
   """Converts dataset to numpy dataset."""
   return dc.data.NumpyDataset(dataset.X, dataset.y, dataset.w, dataset.ids)
+
 
 def load_tox21_ecfp(num_train=7200):
   """Load Tox21 datasets. Does not do train/test split"""
   # Set some global variables up top
   current_dir = os.path.dirname(os.path.realpath(__file__))
-  dataset_file = os.path.join(
-      current_dir, "../../datasets/tox21.csv.gz")
+  dataset_file = os.path.join(current_dir, "../../datasets/tox21.csv.gz")
   # Featurize Tox21 dataset
   print("About to featurize Tox21 dataset.")
   featurizer = dc.feat.CircularFingerprint(size=1024)
-  tox21_tasks = ['NR-AR', 'NR-AR-LBD', 'NR-AhR', 'NR-Aromatase', 'NR-ER',
-                 'NR-ER-LBD', 'NR-PPAR-gamma', 'SR-ARE', 'SR-ATAD5',
-                 'SR-HSE', 'SR-MMP', 'SR-p53']
+  tox21_tasks = [
+      'NR-AR', 'NR-AR-LBD', 'NR-AhR', 'NR-Aromatase', 'NR-ER', 'NR-ER-LBD',
+      'NR-PPAR-gamma', 'SR-ARE', 'SR-ATAD5', 'SR-HSE', 'SR-MMP', 'SR-p53'
+  ]
 
   loader = dc.data.CSVLoader(
       tasks=tox21_tasks, smiles_field="smiles", featurizer=featurizer)
-  dataset = loader.featurize(
-      dataset_file, shard_size=8192)
+  dataset = loader.featurize(dataset_file, shard_size=8192)
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
 
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
 
   return tox21_tasks, dataset, transformers
+
 
 def load_tox21_convmol(base_dir=None, num_train=7200):
   """Load Tox21 datasets. Does not do train/test split"""
   # Set some global variables up top
   current_dir = os.path.dirname(os.path.realpath(__file__))
-  dataset_file = os.path.join(
-      current_dir, "../../datasets/tox21.csv.gz")
+  dataset_file = os.path.join(current_dir, "../../datasets/tox21.csv.gz")
 
   # Featurize Tox21 dataset
   print("About to featurize Tox21 dataset.")
   featurizer = dc.feat.ConvMolFeaturizer()
-  tox21_tasks = ['NR-AR', 'NR-AR-LBD', 'NR-AhR', 'NR-Aromatase', 'NR-ER',
-                 'NR-ER-LBD', 'NR-PPAR-gamma', 'SR-ARE', 'SR-ATAD5',
-                 'SR-HSE', 'SR-MMP', 'SR-p53']
+  tox21_tasks = [
+      'NR-AR', 'NR-AR-LBD', 'NR-AhR', 'NR-Aromatase', 'NR-ER', 'NR-ER-LBD',
+      'NR-PPAR-gamma', 'SR-ARE', 'SR-ATAD5', 'SR-HSE', 'SR-MMP', 'SR-p53'
+  ]
 
   loader = dc.data.CSVLoader(
       tasks=tox21_tasks, smiles_field="smiles", featurizer=featurizer)
-  dataset = loader.featurize(
-      dataset_file, shard_size=8192)
+  dataset = loader.featurize(dataset_file, shard_size=8192)
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
 
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
 
   return tox21_tasks, dataset, transformers
+
 
 def load_muv_ecfp():
   """Load MUV datasets. Does not do train/test split"""
   # Load MUV dataset
   print("About to load MUV dataset.")
   current_dir = os.path.dirname(os.path.realpath(__file__))
-  dataset_file = os.path.join(
-      current_dir, "../../datasets/muv.csv.gz")
+  dataset_file = os.path.join(current_dir, "../../datasets/muv.csv.gz")
   # Featurize MUV dataset
   print("About to featurize MUV dataset.")
   featurizer = dc.feat.CircularFingerprint(size=1024)
-  MUV_tasks = sorted(['MUV-692', 'MUV-689', 'MUV-846', 'MUV-859', 'MUV-644',
-                      'MUV-548', 'MUV-852', 'MUV-600', 'MUV-810', 'MUV-712',
-                      'MUV-737', 'MUV-858', 'MUV-713', 'MUV-733', 'MUV-652',
-                      'MUV-466', 'MUV-832'])
+  MUV_tasks = sorted([
+      'MUV-692', 'MUV-689', 'MUV-846', 'MUV-859', 'MUV-644', 'MUV-548',
+      'MUV-852', 'MUV-600', 'MUV-810', 'MUV-712', 'MUV-737', 'MUV-858',
+      'MUV-713', 'MUV-733', 'MUV-652', 'MUV-466', 'MUV-832'
+  ])
 
   loader = dc.data.CSVLoader(
       tasks=MUV_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
-      dataset = transformer.transform(dataset)
+    dataset = transformer.transform(dataset)
 
   return MUV_tasks, dataset, transformers
+
 
 def load_muv_convmol():
   """Load MUV datasets. Does not do train/test split"""
   # Load MUV dataset
   print("About to load MUV dataset.")
   current_dir = os.path.dirname(os.path.realpath(__file__))
-  dataset_file = os.path.join(
-      current_dir, "../../datasets/muv.csv.gz")
+  dataset_file = os.path.join(current_dir, "../../datasets/muv.csv.gz")
   # Featurize MUV dataset
   print("About to featurize MUV dataset.")
   featurizer = dc.feat.ConvMolFeaturizer()
-  MUV_tasks = sorted(['MUV-692', 'MUV-689', 'MUV-846', 'MUV-859', 'MUV-644',
-                      'MUV-548', 'MUV-852', 'MUV-600', 'MUV-810', 'MUV-712',
-                      'MUV-737', 'MUV-858', 'MUV-713', 'MUV-733', 'MUV-652',
-                      'MUV-466', 'MUV-832'])
+  MUV_tasks = sorted([
+      'MUV-692', 'MUV-689', 'MUV-846', 'MUV-859', 'MUV-644', 'MUV-548',
+      'MUV-852', 'MUV-600', 'MUV-810', 'MUV-712', 'MUV-737', 'MUV-858',
+      'MUV-713', 'MUV-733', 'MUV-652', 'MUV-466', 'MUV-832'
+  ])
 
   loader = dc.data.CSVLoader(
       tasks=MUV_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
-      dataset = transformer.transform(dataset)
+    dataset = transformer.transform(dataset)
 
   return MUV_tasks, dataset, transformers
+
 
 def load_sider_ecfp():
   """Load SIDER datasets. Does not do train/test split"""
   # Featurize SIDER dataset
   print("About to featurize SIDER dataset.")
   current_dir = os.path.dirname(os.path.realpath(__file__))
-  dataset_file = os.path.join(
-      current_dir, "../sider/sider.csv.gz")
+  dataset_file = os.path.join(current_dir, "../sider/sider.csv.gz")
   featurizer = dc.feat.CircularFingerprint(size=1024)
 
   dataset = dc.utils.save.load_from_disk(dataset_file)
@@ -143,28 +142,26 @@ def load_sider_ecfp():
   print("SIDER tasks: %s" % str(SIDER_tasks))
   print("%d tasks in total" % len(SIDER_tasks))
 
-
   loader = dc.data.CSVLoader(
       tasks=SIDER_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
   print("%d datapoints in SIDER dataset" % len(dataset))
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
 
   return SIDER_tasks, dataset, transformers
 
+
 def load_sider_convmol():
   """Load SIDER datasets. Does not do train/test split"""
   # Featurize SIDER dataset
   print("About to featurize SIDER dataset.")
   current_dir = os.path.dirname(os.path.realpath(__file__))
-  dataset_file = os.path.join(
-      current_dir, "../sider/sider.csv.gz")
+  dataset_file = os.path.join(current_dir, "../sider/sider.csv.gz")
   featurizer = dc.feat.ConvMolFeaturizer()
 
   dataset = dc.utils.save.load_from_disk(dataset_file)
@@ -172,15 +169,13 @@ def load_sider_convmol():
   print("SIDER tasks: %s" % str(SIDER_tasks))
   print("%d tasks in total" % len(SIDER_tasks))
 
-
   loader = dc.data.CSVLoader(
       tasks=SIDER_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
   print("%d datapoints in SIDER dataset" % len(dataset))
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)

--- a/examples/low_data/datasets.py
+++ b/examples/low_data/datasets.py
@@ -34,9 +34,9 @@ def load_tox21_ecfp(num_train=7200):
   dataset = loader.featurize(
       dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
 
   print("About to transform data")
   for transformer in transformers:
@@ -63,9 +63,9 @@ def load_tox21_convmol(base_dir=None, num_train=7200):
   dataset = loader.featurize(
       dataset_file, shard_size=8192)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
 
   print("About to transform data")
   for transformer in transformers:
@@ -92,9 +92,9 @@ def load_muv_ecfp():
       tasks=MUV_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
       dataset = transformer.transform(dataset)
@@ -120,9 +120,9 @@ def load_muv_convmol():
       tasks=MUV_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
       dataset = transformer.transform(dataset)
@@ -151,7 +151,7 @@ def load_sider_ecfp():
 
   # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
@@ -180,7 +180,7 @@ def load_sider_convmol():
 
   # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)

--- a/examples/pcba/pcba_datasets.py
+++ b/examples/pcba/pcba_datasets.py
@@ -57,9 +57,7 @@ def load_pcba(featurizer='ECFP', split='random'):
 
   dataset = loader.featurize(dataset_file)
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)
-  ]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
 
   print("About to transform data")
   for transformer in transformers:

--- a/examples/pcba/pcba_datasets.py
+++ b/examples/pcba/pcba_datasets.py
@@ -58,7 +58,7 @@ def load_pcba(featurizer='ECFP', split='random'):
   dataset = loader.featurize(dataset_file)
   # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)
+      dc.trans.BalancingTransformer(dataset=dataset)
   ]
 
   print("About to transform data")

--- a/examples/sider/sider_datasets.py
+++ b/examples/sider/sider_datasets.py
@@ -39,7 +39,7 @@ def load_sider(featurizer='ECFP', split='index'):
 
   # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)

--- a/examples/sider/sider_datasets.py
+++ b/examples/sider/sider_datasets.py
@@ -10,13 +10,13 @@ import numpy as np
 import shutil
 import deepchem as dc
 
+
 def load_sider(featurizer='ECFP', split='index'):
   current_dir = os.path.dirname(os.path.realpath(__file__))
 
-	  # Load SIDER dataset
+  # Load SIDER dataset
   print("About to load SIDER dataset.")
-  dataset_file = os.path.join(
-      current_dir, "./sider.csv.gz")
+  dataset_file = os.path.join(current_dir, "./sider.csv.gz")
   dataset = dc.utils.save.load_from_disk(dataset_file)
   print("Columns of dataset: %s" % str(dataset.columns.values))
   print("Number of examples in dataset: %s" % str(dataset.shape[0]))
@@ -38,15 +38,16 @@ def load_sider(featurizer='ECFP', split='index'):
   print("%d datapoints in SIDER dataset" % len(dataset))
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
 
-  splitters = {'index': dc.splits.IndexSplitter(),
-               'random': dc.splits.RandomSplitter(),
-               'scaffold': dc.splits.ScaffoldSplitter()}
+  splitters = {
+      'index': dc.splits.IndexSplitter(),
+      'random': dc.splits.RandomSplitter(),
+      'scaffold': dc.splits.ScaffoldSplitter()
+  }
   splitter = splitters[split]
   train, valid, test = splitter.train_valid_test_split(dataset)
 

--- a/examples/toxcast/toxcast_datasets.py
+++ b/examples/toxcast/toxcast_datasets.py
@@ -10,14 +10,14 @@ import numpy as np
 import shutil
 import deepchem as dc
 
+
 def load_toxcast(featurizer='ECFP', split='index'):
 
   current_dir = os.path.dirname(os.path.realpath(__file__))
 
   # Load TOXCAST dataset
   print("About to load TOXCAST dataset.")
-  dataset_file = os.path.join(
-      current_dir, "./processing/toxcast_data.csv.gz")
+  dataset_file = os.path.join(current_dir, "./processing/toxcast_data.csv.gz")
   dataset = dc.utils.save.load_from_disk(dataset_file)
   print("Columns of dataset: %s" % str(dataset.columns.values))
   print("Number of examples in dataset: %s" % str(dataset.shape[0]))
@@ -26,9 +26,9 @@ def load_toxcast(featurizer='ECFP', split='index'):
   print("About to featurize TOXCAST dataset.")
 
   if featurizer == 'ECFP':
-      featurizer = dc.feat.CircularFingerprint(size=1024)
+    featurizer = dc.feat.CircularFingerprint(size=1024)
   elif featurizer == 'GraphConv':
-      featurizer = dc.feat.ConvMolFeaturizer()
+    featurizer = dc.feat.ConvMolFeaturizer()
 
   TOXCAST_tasks = dataset.columns.values[1:].tolist()
 
@@ -37,15 +37,16 @@ def load_toxcast(featurizer='ECFP', split='index'):
   dataset = loader.featurize(dataset_file)
 
   # Initialize transformers
-  transformers = [
-      dc.trans.BalancingTransformer(dataset=dataset)]
+  transformers = [dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
 
-  splitters = {'index': dc.splits.IndexSplitter(),
-               'random': dc.splits.RandomSplitter(),
-               'scaffold': dc.splits.ScaffoldSplitter()}
+  splitters = {
+      'index': dc.splits.IndexSplitter(),
+      'random': dc.splits.RandomSplitter(),
+      'scaffold': dc.splits.ScaffoldSplitter()
+  }
   splitter = splitters[split]
 
   train, valid, test = splitter.train_valid_test_split(dataset)

--- a/examples/toxcast/toxcast_datasets.py
+++ b/examples/toxcast/toxcast_datasets.py
@@ -36,9 +36,9 @@ def load_toxcast(featurizer='ECFP', split='index'):
       tasks=TOXCAST_tasks, smiles_field="smiles", featurizer=featurizer)
   dataset = loader.featurize(dataset_file)
 
-  # Initialize transformers 
+  # Initialize transformers
   transformers = [
-      dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)]
+      dc.trans.BalancingTransformer(dataset=dataset)]
   print("About to transform data")
   for transformer in transformers:
     dataset = transformer.transform(dataset)
@@ -49,5 +49,5 @@ def load_toxcast(featurizer='ECFP', split='index'):
   splitter = splitters[split]
 
   train, valid, test = splitter.train_valid_test_split(dataset)
-  
+
   return TOXCAST_tasks, (train, valid, test), transformers

--- a/examples/tutorials/09_Creating_a_high_fidelity_model_from_experimental_data.ipynb
+++ b/examples/tutorials/09_Creating_a_high_fidelity_model_from_experimental_data.ipynb
@@ -2033,7 +2033,7 @@
         }
       },
       "source": [
-        "transformer = dc.trans.BalancingTransformer(transform_w=True, dataset=dataset)\n",
+        "transformer = dc.trans.BalancingTransformer(dataset=dataset)\n",
         "dataset = transformer.transform(dataset)"
       ],
       "execution_count": 46,


### PR DESCRIPTION
Fixes #1990.

This started out as just adding support for parallelizing transformations.  Due to the limitations of Python (we have to use processes instead of threads, all data passed between processes is pickled), I ended up having to make some deeper changes.  In particular, `Dataset.transform()` now takes a Transformer instead of a function.  Then while I was at it, I did some cleanup to the Transformer classes, like removing inappropriate constructor arguments.

Curiously, `Transformer.transform()` already had a `parallel` argument.  It just wasn't used.  Now it is.