### PR TITLE
Updating MoleculeNet URLs

### DIFF
--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -9,7 +9,7 @@ from deepchem.molnet.load_function.bace_features import bace_user_specified_feat
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-BACE_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/bace.csv'
+BACE_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/bace.csv"
 
 
 def load_bace_regression(featurizer='ECFP',

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-BBBP_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/BBBP.csv'
+BBBP_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/BBBP.csv"
 
 
 def load_bbbp(featurizer='ECFP',

--- a/deepchem/molnet/load_function/chembl25_datasets.py
+++ b/deepchem/molnet/load_function/chembl25_datasets.py
@@ -12,7 +12,7 @@ import pickle
 from deepchem.feat import SmilesToSeq, SmilesToImage
 from deepchem.feat.smiles_featurizers import create_char_to_idx
 
-CHEMBL_URL = "https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/chembl_25.csv.gz"
+CHEMBL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_25.csv.gz"
 DEFAULT_DIR = dc.utils.get_data_dir()
 
 logger = logging.getLogger(__name__)

--- a/deepchem/molnet/load_function/chembl_datasets.py
+++ b/deepchem/molnet/load_function/chembl_datasets.py
@@ -43,35 +43,35 @@ def load_chembl(shard_size=2000,
   if not os.path.exists(dataset_path):
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_5thresh.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_5thresh.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_sparse.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_sparse.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_test.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_test.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_train.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_train.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_valid.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_5thresh_ts_valid.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_test.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_test.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_train.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_train.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
         url=
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_valid.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_year_sets/chembl_sparse_ts_valid.csv.gz",
         dest_dir=data_dir)
 
   if split == "year":

--- a/deepchem/molnet/load_function/clearance_datasets.py
+++ b/deepchem/molnet/load_function/clearance_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-CLEARANCE_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/clearance.csv'
+CLEARANCE_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/clearance.csv"
 
 
 def load_clearance(featurizer='ECFP',

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -9,7 +9,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-CLINTOX_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/clintox.csv.gz'
+CLINTOX_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/clintox.csv.gz"
 
 
 def load_clintox(featurizer='ECFP',

--- a/deepchem/molnet/load_function/delaney_datasets.py
+++ b/deepchem/molnet/load_function/delaney_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-DELANEY_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/delaney-processed.csv'
+DELANEY_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/delaney-processed.csv"
 
 
 def load_delaney(featurizer='ECFP',

--- a/deepchem/molnet/load_function/factors_datasets.py
+++ b/deepchem/molnet/load_function/factors_datasets.py
@@ -11,9 +11,9 @@ from deepchem.molnet.load_function.kaggle_features import merck_descriptors
 
 logger = logging.getLogger(__name__)
 
-TRAIN_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/FACTORS_training_disguised_combined_full.csv.gz'
-VALID_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/FACTORS_test1_disguised_combined_full.csv.gz'
-TEST_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/FACTORS_test2_disguised_combined_full.csv.gz'
+TRAIN_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/FACTORS_training_disguised_combined_full.csv.gz"
+VALID_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/FACTORS_test1_disguised_combined_full.csv.gz"
+TEST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/FACTORS_test2_disguised_combined_full.csv.gz"
 
 TRAIN_FILENAME = "FACTORS_training_disguised_combined_full.csv.gz"
 VALID_FILENAME = "FACTORS_test1_disguised_combined_full.csv.gz"

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -7,7 +7,7 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
-HIV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/HIV.csv'
+HIV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/HIV.csv"
 DEFAULT_DIR = deepchem.utils.get_data_dir()
 
 

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -7,7 +7,7 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
-HOPV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/hopv.tar.gz'
+HOPV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/hopv.tar.gz"
 DEFAULT_DIR = deepchem.utils.get_data_dir()
 
 

--- a/deepchem/molnet/load_function/hppb_datasets.py
+++ b/deepchem/molnet/load_function/hppb_datasets.py
@@ -8,7 +8,7 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-HPPB_URL = "http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/hppb.csv"
+HPPB_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/hppb.csv"
 DEFAULT_DATA_DIR = deepchem.utils.get_data_dir()
 
 

--- a/deepchem/molnet/load_function/kaggle_datasets.py
+++ b/deepchem/molnet/load_function/kaggle_datasets.py
@@ -59,13 +59,13 @@ def gen_kaggle(KAGGLE_tasks,
                             "KAGGLE_test2_disguised_combined_full.csv.gz")
   if not os.path.exists(train_files):
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz",
         dest_dir=data_dir)
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz',
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz",
         dest_dir=data_dir)
 
   # Featurize KAGGLE dataset

--- a/deepchem/molnet/load_function/kinase_datasets.py
+++ b/deepchem/molnet/load_function/kinase_datasets.py
@@ -9,9 +9,9 @@ import numpy as np
 import deepchem
 from deepchem.molnet.load_function.kaggle_features import merck_descriptors
 
-TRAIN_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/KINASE_training_disguised_combined_full.csv.gz'
-VALID_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/KINASE_test1_disguised_combined_full.csv.gz'
-TEST_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/KINASE_test2_disguised_combined_full.csv.gz'
+TRAIN_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KINASE_training_disguised_combined_full.csv.gz"
+VALID_UR = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KINASE_test1_disguised_combined_full.csv.gz"
+TEST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KINASE_test2_disguised_combined_full.csv.gz"
 
 TRAIN_FILENAME = "KINASE_training_disguised_combined_full.csv.gz"
 VALID_FILENAME = "KINASE_test1_disguised_combined_full.csv.gz"

--- a/deepchem/molnet/load_function/lipo_datasets.py
+++ b/deepchem/molnet/load_function/lipo_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-LIPO_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/Lipophilicity.csv'
+LIPO_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/Lipophilicity.csv"
 
 
 def load_lipo(featurizer='ECFP',

--- a/deepchem/molnet/load_function/load_dataset_template.py
+++ b/deepchem/molnet/load_function/load_dataset_template.py
@@ -14,8 +14,8 @@ from typing import List, Tuple, Dict, Optional
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-MYDATASET_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/mydataset.tar.gz'
-MYDATASET_CSV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/mydataset.csv'
+MYDATASET_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/mydataset.tar.gz"
+MYDATASET_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/mydataset.csv"
 
 # dict of accepted featurizers for this dataset
 # modify the returned dicts for your dataset

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-MUV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/muv.csv.gz'
+MUV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/muv.csv.gz"
 
 
 def load_muv(featurizer='ECFP',

--- a/deepchem/molnet/load_function/nci_datasets.py
+++ b/deepchem/molnet/load_function/nci_datasets.py
@@ -10,7 +10,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-NCI_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/nci_unique.csv'
+NCI_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/nci_unique.csv"
 
 
 def load_nci(featurizer='ECFP',

--- a/deepchem/molnet/load_function/pcba_datasets.py
+++ b/deepchem/molnet/load_function/pcba_datasets.py
@@ -107,7 +107,7 @@ def load_pcba_dataset(featurizer='ECFP',
 
   if not os.path.exists(dataset_file):
     deepchem.utils.download_url(
-        url="http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/{0}".
+        url="https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/{0}".
         format(assay_file_name),
         dest_dir=data_dir)
 

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -28,13 +28,13 @@ def featurize_pdbbind(data_dir=None, feat="grid", subset="core"):
 
   if not os.path.exists(dataset_dir):
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/core_grid.tar.gz'
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/featurized_datasets/core_grid.tar.gz"
     )
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/full_grid.tar.gz'
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/featurized_datasets/full_grid.tar.gz"
     )
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/featurized_datasets/refined_grid.tar.gz'
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/featurized_datasets/refined_grid.tar.gz"
     )
     if not os.path.exists(pdbbind_dir):
       os.system('mkdir ' + pdbbind_dir)
@@ -85,8 +85,8 @@ def load_pdbbind_grid(split="random",
 
     if not os.path.exists(dataset_file):
       deepchem.utils.download_url(
-          'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/' +
-          subset + "_smiles_labels.csv")
+          "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/" + subset +
+          "_smiles_labels.csv")
 
     tasks = ["-logKd/Ki"]
     if reload:
@@ -221,8 +221,7 @@ def load_pdbbind(reload=True,
   if not os.path.exists(dataset_file):
     logger.warning("About to download PDBBind full dataset. Large file, 2GB")
     deepchem.utils.download_url(
-        'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/' +
-        "pdbbind_v2015.tar.gz",
+        "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/pdbbind_v2015.tar.gz",
         dest_dir=data_dir)
   if os.path.exists(data_folder):
     logger.info("PDBBind full dataset already exists.")

--- a/deepchem/molnet/load_function/ppb_datasets.py
+++ b/deepchem/molnet/load_function/ppb_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-PPB_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/PPB.csv'
+PPB_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/PPB.csv"
 
 
 def load_ppb(featurizer='ECFP',

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -10,10 +10,10 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-QM7_MAT_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.mat'
-QM7_CSV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7.csv'
-QM7B_MAT_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm7b.mat'
-GDB7_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb7.tar.gz'
+QM7_MAT_UTL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm7.mat"
+QM7_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm7.csv"
+QM7B_MAT_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm7b.mat"
+GDB7_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb7.tar.gz"
 
 
 def load_qm7_from_mat(featurizer='CoulombMatrix',

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -8,8 +8,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-GDB8_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb8.tar.gz'
-QM8_CSV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm8.csv'
+GDB8_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb8.tar.gz"
+QM8_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm8.csv"
 
 
 def load_qm8(featurizer='CoulombMatrix',

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -8,8 +8,8 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-GDB9_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/gdb9.tar.gz'
-QM9_CSV_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/qm9.csv'
+GDB9_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb9.tar.gz"
+QM9_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm9.csv"
 
 
 def load_qm9(featurizer='CoulombMatrix',

--- a/deepchem/molnet/load_function/sampl_datasets.py
+++ b/deepchem/molnet/load_function/sampl_datasets.py
@@ -7,7 +7,7 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
-SAMPL_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/SAMPL.csv'
+SAMPL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/SAMPL.csv"
 DEFAULT_DIR = deepchem.utils.get_data_dir()
 
 

--- a/deepchem/molnet/load_function/sider_datasets.py
+++ b/deepchem/molnet/load_function/sider_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-SIDER_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/sider.csv.gz'
+SIDER_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/sider.csv.gz"
 
 
 def load_sider(featurizer='ECFP',

--- a/deepchem/molnet/load_function/sweetlead_datasets.py
+++ b/deepchem/molnet/load_function/sweetlead_datasets.py
@@ -10,7 +10,7 @@ import deepchem as dc
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = dc.utils.get_data_dir()
-SWEETLEAD_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/sweet.csv.gz'
+SWEETLEAD_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/sweet.csv.gz"
 
 
 def load_sweet(featurizer='ECFP',

--- a/deepchem/molnet/load_function/thermosol_datasets.py
+++ b/deepchem/molnet/load_function/thermosol_datasets.py
@@ -8,7 +8,7 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
-THERMOSOL_URL = "http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/thermosol.csv"
+THERMOSOL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/thermosol.csv"
 DEFAULT_DATA_DIR = deepchem.utils.get_data_dir()
 
 

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -7,7 +7,7 @@ import deepchem
 
 logger = logging.getLogger(__name__)
 
-TOX21_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/tox21.csv.gz'
+TOX21_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/tox21.csv.gz"
 DEFAULT_DIR = deepchem.utils.get_data_dir()
 
 

--- a/deepchem/molnet/load_function/toxcast_datasets.py
+++ b/deepchem/molnet/load_function/toxcast_datasets.py
@@ -8,7 +8,7 @@ import deepchem
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-TOXCAST_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/toxcast_data.csv.gz'
+TOXCAST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/toxcast_data.csv.gz"
 
 
 def load_toxcast(featurizer='ECFP',

--- a/deepchem/molnet/load_function/uv_datasets.py
+++ b/deepchem/molnet/load_function/uv_datasets.py
@@ -12,9 +12,9 @@ from deepchem.molnet.load_function.uv_tasks import UV_tasks
 
 logger = logging.getLogger(__name__)
 
-TRAIN_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/UV_training_disguised_combined_full.csv.gz'
-VALID_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/UV_test1_disguised_combined_full.csv.gz'
-TEST_URL = 'https://s3-us-west-1.amazonaws.com/deepchem.io/datasets/UV_test2_disguised_combined_full.csv.gz'
+TRAIN_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/UV_training_disguised_combined_full.csv.gz"
+VALID_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/UV_test1_disguised_combined_full.csv.gz"
+TEST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/UV_test2_disguised_combined_full.csv.gz"
 
 TRAIN_FILENAME = "UV_training_disguised_combined_full.csv.gz"
 VALID_FILENAME = "UV_test1_disguised_combined_full.csv.gz"


### PR DESCRIPTION
This PR updates all MoleculeNet URLs to point towards the new DeepChem S3 bucket. This addresses one of the critical blockers for https://github.com/deepchem/deepchem/issues/1883