### PR TITLE
Allow for reporting of loss curve from KerasModel.fit

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -303,7 +303,7 @@ class KerasModel(Model):
     callbacks: function or list of functions
       one or more functions of the form f(model, step) that will be invoked after
       every step.  This can be used to perform validation, logging, etc.
-    all_losses: Optional[List[float]], optional (default False)
+    all_losses: Optional[List[float]], optional (default None)
       If specified, all logged losses are appended into this list. Note that
       you can call `fit()` repeatedly with the same list and losses will
       continue to be appended.
@@ -352,7 +352,7 @@ class KerasModel(Model):
     callbacks: function or list of functions
       one or more functions of the form f(model, step) that will be invoked after
       every step.  This can be used to perform validation, logging, etc.
-    all_losses: Optional[List[float]], optional (default False)
+    all_losses: Optional[List[float]], optional (default None)
       If specified, all logged losses are appended into this list. Note that
       you can call `fit()` repeatedly with the same list and losses will
       continue to be appended.

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -21,7 +21,7 @@ from deepchem.utils.save import load_from_disk
 from deepchem.utils.save import save_to_disk
 from deepchem.utils.evaluate import Evaluator
 
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Dict, List, Optional, Sequence
 from deepchem.utils.typing import OneOrMany
 
 logger = logging.getLogger(__name__)
@@ -127,8 +127,7 @@ class Model(BaseEstimator):
     """
     raise NotImplementedError
 
-  def fit(self, dataset: Dataset,
-          nb_epoch: int = 10) -> Union[float, List[float]]:
+  def fit(self, dataset: Dataset, nb_epoch: int = 10) -> float:
     """
     Fits a model on data in a Dataset object.
 

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -127,7 +127,7 @@ class Model(BaseEstimator):
     """
     raise NotImplementedError
 
-  def fit(self, dataset: Dataset, nb_epoch: int = 10) -> float:
+  def fit(self, dataset: Dataset, nb_epoch: int = 10) -> List[float]:
     """
     Fits a model on data in a Dataset object.
 
@@ -140,7 +140,7 @@ class Model(BaseEstimator):
 
     Returns
     -------
-    the average loss over the most recent epoch
+    The average losses over course of training. 
     """
     for epoch in range(nb_epoch):
       logger.info("Starting epoch %s" % str(epoch + 1))

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -21,7 +21,7 @@ from deepchem.utils.save import load_from_disk
 from deepchem.utils.save import save_to_disk
 from deepchem.utils.evaluate import Evaluator
 
-from typing import Any, Dict, List, Optional, Sequence
+from typing import Any, Dict, List, Optional, Sequence, Union
 from deepchem.utils.typing import OneOrMany
 
 logger = logging.getLogger(__name__)
@@ -127,7 +127,8 @@ class Model(BaseEstimator):
     """
     raise NotImplementedError
 
-  def fit(self, dataset: Dataset, nb_epoch: int = 10) -> List[float]:
+  def fit(self, dataset: Dataset,
+          nb_epoch: int = 10) -> Union[float, List[float]]:
     """
     Fits a model on data in a Dataset object.
 

--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -140,7 +140,7 @@ class Model(BaseEstimator):
 
     Returns
     -------
-    The average losses over course of training. 
+    The average loss over the most recent checkpoint interval. 
     """
     for epoch in range(nb_epoch):
       logger.info("Starting epoch %s" % str(epoch + 1))

--- a/deepchem/models/tests/test_kerasmodel.py
+++ b/deepchem/models/tests/test_kerasmodel.py
@@ -58,7 +58,7 @@ def test_overfit_sequential_model():
   assert scores[metric.name] > 0.9
 
 
-def test_fit_return_loss_curve():
+def test_fit_use_all_losses():
   """Test fitting a KerasModel and getting a loss curve back."""
   n_data_points = 10
   n_features = 2
@@ -74,7 +74,8 @@ def test_fit_return_loss_curve():
       dc.models.losses.BinaryCrossEntropy(),
       learning_rate=0.005,
       log_frequency=10)
-  losses = model.fit(dataset, nb_epoch=1000, return_loss_curve=True)
+  losses = []
+  model.fit(dataset, nb_epoch=1000, all_losses=losses)
   # Each epoch is a single step for this model
   assert len(losses) == 100
 

--- a/deepchem/models/tests/test_kerasmodel.py
+++ b/deepchem/models/tests/test_kerasmodel.py
@@ -78,6 +78,7 @@ def test_fit_use_all_losses():
   model.fit(dataset, nb_epoch=1000, all_losses=losses)
   # Each epoch is a single step for this model
   assert len(losses) == 100
+  assert np.count_nonzero(np.array(losses)) == 100
 
 
 def test_fit_on_batch():

--- a/deepchem/models/tests/test_kerasmodel.py
+++ b/deepchem/models/tests/test_kerasmodel.py
@@ -58,6 +58,27 @@ def test_overfit_sequential_model():
   assert scores[metric.name] > 0.9
 
 
+def test_fit_return_loss_curve():
+  """Test fitting a KerasModel and getting a loss curve back."""
+  n_data_points = 10
+  n_features = 2
+  X = np.random.rand(n_data_points, n_features)
+  y = (X[:, 0] > X[:, 1]).astype(np.float32)
+  dataset = dc.data.NumpyDataset(X, y)
+  keras_model = tf.keras.Sequential([
+      tf.keras.layers.Dense(10, activation='relu'),
+      tf.keras.layers.Dense(1, activation='sigmoid')
+  ])
+  model = dc.models.KerasModel(
+      keras_model,
+      dc.models.losses.BinaryCrossEntropy(),
+      learning_rate=0.005,
+      log_frequency=10)
+  losses = model.fit(dataset, nb_epoch=1000, return_loss_curve=True)
+  # Each epoch is a single step for this model
+  assert len(losses) == 100
+
+
 def test_fit_on_batch():
   """Test fitting a KerasModel to individual batches."""
   n_data_points = 10


### PR DESCRIPTION
This PR allows for the return of the full loss curve from `KerasModel.fit` by adding a new argument `return_loss_curve` as discussed in https://github.com/deepchem/deepchem/issues/2058 and adds a unit test.

This PR also fixes the logging issues from https://github.com/deepchem/deepchem/issues/1944.