### PR TITLE
Fix DiskDataset.shuffle_each_shard

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1722,7 +1722,6 @@ class DiskDataset(Dataset):
       shard_basenames = ["shard-%d" % shard_num for shard_num in range(n_rows)]
     for i, basename in zip(range(n_rows), shard_basenames):
       logger.info("Shuffling shard %d/%d" % (i, n_rows))
-      row = self.metadata_df.iloc[i]
       X, y, w, ids = self.get_shard(i)
       n = X.shape[0]
       permutation = np.random.permutation(n)

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1713,7 +1713,6 @@ class DiskDataset(Dataset):
     tasks = self.get_task_names()
     # Shuffle the arrays corresponding to each row in metadata_df
     n_rows = len(self.metadata_df.index)
-    n_rows = len(self.metadata_df.index)
     if shard_basenames is not None:
       if len(shard_basenames) != n_rows:
         raise ValueError(

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1629,6 +1629,7 @@ class DiskDataset(Dataset):
     ids: List[np.ndarray] = []
     num_features = -1
     for i in range(num_shards):
+      logger.info("Sparsifying shard %d/%d" % (i, num_shards))
       (X_s, y_s, w_s, ids_s) = self.get_shard(i)
       if num_features == -1:
         num_features = X_s.shape[1]
@@ -1645,7 +1646,7 @@ class DiskDataset(Dataset):
                            w[permutation], ids[permutation])
     # Write shuffled shards out to disk
     for i in range(num_shards):
-      logger.info("Sparse shuffling shard %d" % i)
+      logger.info("Sparse shuffling shard %d/%d" % (i, num_shards))
       start, stop = i * shard_size, (i + 1) * shard_size
       (X_sparse_s, y_s, w_s, ids_s) = (X_sparse[start:stop], y[start:stop],
                                        w[start:stop], ids[start:stop])
@@ -1706,7 +1707,7 @@ class DiskDataset(Dataset):
     ----------
     shard_basenames: Optional[List[str]], optional (default None)
       The basenames for each shard. If this isn't specified, will assume the
-      default basenames of form "shard-i" used by `create_dataset` and
+       basenames of form "shard-i" used by `create_dataset` and
       `reshard`.
     """
     tasks = self.get_task_names()

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -13,12 +13,7 @@ import deepchem as dc
 import numpy as np
 
 
-class TestShuffle(unittest.TestCase):
-  """
-  Test singletask/multitask dataset shuffling.
-  """
-
-  #def test_shuffle(self):
+  #def test_shuffle():
   #  """Test that datasets can be merged."""
   #  current_dir = os.path.dirname(os.path.realpath(__file__))
 
@@ -49,89 +44,98 @@ class TestShuffle(unittest.TestCase):
   #  assert y_orig.shape == y_new.shape
   #  assert w_orig.shape == w_new.shape
 
-  def test_sparse_shuffle(self):
-    """Test that sparse datasets can be shuffled quickly."""
-    current_dir = os.path.dirname(os.path.realpath(__file__))
+def test_sparse_shuffle():
+  """Test that sparse datasets can be shuffled quickly."""
+  current_dir = os.path.dirname(os.path.realpath(__file__))
 
-    dataset_file = os.path.join(current_dir, "../../models/tests/example.csv")
+  dataset_file = os.path.join(current_dir, "../../models/tests/example.csv")
 
-    featurizer = dc.feat.CircularFingerprint(size=1024)
-    tasks = ["log-solubility"]
-    loader = dc.data.CSVLoader(
-        tasks=tasks, smiles_field="smiles", featurizer=featurizer)
-    dataset = loader.featurize(dataset_file, shard_size=2)
+  featurizer = dc.feat.CircularFingerprint(size=1024)
+  tasks = ["log-solubility"]
+  loader = dc.data.CSVLoader(
+      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
+  dataset = loader.featurize(dataset_file, shard_size=2)
 
-    X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
-                                        dataset.ids)
-    orig_len = len(dataset)
+  X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
+                                      dataset.ids)
+  orig_len = len(dataset)
 
-    dataset.sparse_shuffle()
-    X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w,
-                                    dataset.ids)
+  dataset.sparse_shuffle()
+  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w,
+                                  dataset.ids)
 
-    assert len(dataset) == orig_len
-    # The shuffling should have switched up the ordering
-    assert not np.array_equal(orig_ids, new_ids)
-    # But all the same entries should still be present
-    assert sorted(orig_ids) == sorted(new_ids)
-    # All the data should have same shape
-    assert X_orig.shape == X_new.shape
-    assert y_orig.shape == y_new.shape
-    assert w_orig.shape == w_new.shape
+  assert len(dataset) == orig_len
+  # The shuffling should have switched up the ordering
+  assert not np.array_equal(orig_ids, new_ids)
+  # But all the same entries should still be present
+  assert sorted(orig_ids) == sorted(new_ids)
+  # All the data should have same shape
+  assert X_orig.shape == X_new.shape
+  assert y_orig.shape == y_new.shape
+  assert w_orig.shape == w_new.shape
 
-  def test_shuffle_each_shard(self):
-    """Test that shuffle_each_shard works."""
-    n_samples = 100
-    n_tasks = 10
-    n_features = 10
+def test_shuffle_each_shard():
+  """Test that shuffle_each_shard works."""
+  n_samples = 100
+  n_tasks = 10
+  n_features = 10
 
-    X = np.random.rand(n_samples, n_features)
-    y = np.random.randint(2, size=(n_samples, n_tasks))
-    w = np.random.randint(2, size=(n_samples, n_tasks))
-    ids = np.arange(n_samples)
-    dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
-    dataset.reshard(shard_size=10)
+  X = np.random.rand(n_samples, n_features)
+  y = np.random.randint(2, size=(n_samples, n_tasks))
+  w = np.random.randint(2, size=(n_samples, n_tasks))
+  ids = np.arange(n_samples)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+  dataset.reshard(shard_size=10)
 
-    dataset.shuffle_each_shard()
-    X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
-    assert X_s.shape == X.shape
-    assert y_s.shape == y.shape
-    assert ids_s.shape == ids.shape
-    assert w_s.shape == w.shape
+  dataset.shuffle_each_shard()
+  X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
+  ##############
+  print("ids_s")
+  print(ids_s)
+  ##############
+  assert X_s.shape == X.shape
+  assert y_s.shape == y.shape
+  assert ids_s.shape == ids.shape
+  assert w_s.shape == w.shape
+  ##############
+  print("ids")
+  print(ids)
+  ##############
+  assert not (ids_s == ids).all()
 
-    # The ids should now store the performed permutation. Check that the
-    # original dataset is recoverable.
-    for i in range(n_samples):
-      np.testing.assert_array_equal(X_s[i], X[ids_s[i]])
-      np.testing.assert_array_equal(y_s[i], y[ids_s[i]])
-      np.testing.assert_array_equal(w_s[i], w[ids_s[i]])
-      np.testing.assert_array_equal(ids_s[i], ids[ids_s[i]])
+  # The ids should now store the performed permutation. Check that the
+  # original dataset is recoverable.
+  for i in range(n_samples):
+    np.testing.assert_array_equal(X_s[i], X[ids_s[i]])
+    np.testing.assert_array_equal(y_s[i], y[ids_s[i]])
+    np.testing.assert_array_equal(w_s[i], w[ids_s[i]])
+    np.testing.assert_array_equal(ids_s[i], ids[ids_s[i]])
 
-  def test_shuffle_shards(self):
-    """Test that shuffle_shards works."""
-    n_samples = 100
-    n_tasks = 10
-    n_features = 10
+def test_shuffle_shards():
+  """Test that shuffle_shards works."""
+  n_samples = 100
+  n_tasks = 10
+  n_features = 10
 
-    X = np.random.rand(n_samples, n_features)
-    y = np.random.randint(2, size=(n_samples, n_tasks))
-    w = np.random.randint(2, size=(n_samples, n_tasks))
-    ids = np.arange(n_samples)
-    dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
-    dataset.reshard(shard_size=10)
-    dataset.shuffle_shards()
+  X = np.random.rand(n_samples, n_features)
+  y = np.random.randint(2, size=(n_samples, n_tasks))
+  w = np.random.randint(2, size=(n_samples, n_tasks))
+  ids = np.arange(n_samples)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+  dataset.reshard(shard_size=10)
+  dataset.shuffle_shards()
 
-    X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
+  X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
 
-    assert X_s.shape == X.shape
-    assert y_s.shape == y.shape
-    assert ids_s.shape == ids.shape
-    assert w_s.shape == w.shape
+  assert X_s.shape == X.shape
+  assert y_s.shape == y.shape
+  assert ids_s.shape == ids.shape
+  assert w_s.shape == w.shape
 
-    # The ids should now store the performed permutation. Check that the
-    # original dataset is recoverable.
-    for i in range(n_samples):
-      np.testing.assert_array_equal(X_s[i], X[ids_s[i]])
-      np.testing.assert_array_equal(y_s[i], y[ids_s[i]])
-      np.testing.assert_array_equal(w_s[i], w[ids_s[i]])
-      np.testing.assert_array_equal(ids_s[i], ids[ids_s[i]])
+  # The ids should now store the performed permutation. Check that the
+  # original dataset is recoverable.
+  for i in range(n_samples):
+    np.testing.assert_array_equal(X_s[i], X[ids_s[i]])
+    np.testing.assert_array_equal(y_s[i], y[ids_s[i]])
+    np.testing.assert_array_equal(w_s[i], w[ids_s[i]])
+    np.testing.assert_array_equal(ids_s[i], ids[ids_s[i]])

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -12,37 +12,37 @@ import unittest
 import deepchem as dc
 import numpy as np
 
+#def test_shuffle():
+#  """Test that datasets can be merged."""
+#  current_dir = os.path.dirname(os.path.realpath(__file__))
 
-  #def test_shuffle():
-  #  """Test that datasets can be merged."""
-  #  current_dir = os.path.dirname(os.path.realpath(__file__))
+#  dataset_file = os.path.join(
+#      current_dir, "../../models/tests/example.csv")
 
-  #  dataset_file = os.path.join(
-  #      current_dir, "../../models/tests/example.csv")
+#  featurizer = dc.feat.CircularFingerprint(size=1024)
+#  tasks = ["log-solubility"]
+#  loader = dc.data.CSVLoader(
+#      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
+#  dataset = loader.featurize(dataset_file, shard_size=2)
 
-  #  featurizer = dc.feat.CircularFingerprint(size=1024)
-  #  tasks = ["log-solubility"]
-  #  loader = dc.data.CSVLoader(
-  #      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
-  #  dataset = loader.featurize(dataset_file, shard_size=2)
+#  X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
+#                                      dataset.ids)
+#  orig_len = len(dataset)
 
-  #  X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
-  #                                      dataset.ids)
-  #  orig_len = len(dataset)
+#  dataset.shuffle(iterations=5)
+#  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w,
+#                                  dataset.ids)
+#
+#  assert len(dataset) == orig_len
+#  # The shuffling should have switched up the ordering
+#  assert not np.array_equal(orig_ids, new_ids)
+#  # But all the same entries should still be present
+#  assert sorted(orig_ids) == sorted(new_ids)
+#  # All the data should have same shape
+#  assert X_orig.shape == X_new.shape
+#  assert y_orig.shape == y_new.shape
+#  assert w_orig.shape == w_new.shape
 
-  #  dataset.shuffle(iterations=5)
-  #  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w,
-  #                                  dataset.ids)
-  #
-  #  assert len(dataset) == orig_len
-  #  # The shuffling should have switched up the ordering
-  #  assert not np.array_equal(orig_ids, new_ids)
-  #  # But all the same entries should still be present
-  #  assert sorted(orig_ids) == sorted(new_ids)
-  #  # All the data should have same shape
-  #  assert X_orig.shape == X_new.shape
-  #  assert y_orig.shape == y_new.shape
-  #  assert w_orig.shape == w_new.shape
 
 def test_sparse_shuffle():
   """Test that sparse datasets can be shuffled quickly."""
@@ -61,8 +61,7 @@ def test_sparse_shuffle():
   orig_len = len(dataset)
 
   dataset.sparse_shuffle()
-  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w,
-                                  dataset.ids)
+  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
 
   assert len(dataset) == orig_len
   # The shuffling should have switched up the ordering
@@ -73,6 +72,7 @@ def test_sparse_shuffle():
   assert X_orig.shape == X_new.shape
   assert y_orig.shape == y_new.shape
   assert w_orig.shape == w_new.shape
+
 
 def test_shuffle_each_shard():
   """Test that shuffle_each_shard works."""
@@ -89,18 +89,10 @@ def test_shuffle_each_shard():
 
   dataset.shuffle_each_shard()
   X_s, y_s, w_s, ids_s = (dataset.X, dataset.y, dataset.w, dataset.ids)
-  ##############
-  print("ids_s")
-  print(ids_s)
-  ##############
   assert X_s.shape == X.shape
   assert y_s.shape == y.shape
   assert ids_s.shape == ids.shape
   assert w_s.shape == w.shape
-  ##############
-  print("ids")
-  print(ids)
-  ##############
   assert not (ids_s == ids).all()
 
   # The ids should now store the performed permutation. Check that the
@@ -110,6 +102,7 @@ def test_shuffle_each_shard():
     np.testing.assert_array_equal(y_s[i], y[ids_s[i]])
     np.testing.assert_array_equal(w_s[i], w[ids_s[i]])
     np.testing.assert_array_equal(ids_s[i], ids[ids_s[i]])
+
 
 def test_shuffle_shards():
   """Test that shuffle_shards works."""

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -12,36 +12,35 @@ import unittest
 import deepchem as dc
 import numpy as np
 
-#def test_shuffle():
-#  """Test that datasets can be merged."""
-#  current_dir = os.path.dirname(os.path.realpath(__file__))
 
-#  dataset_file = os.path.join(
-#      current_dir, "../../models/tests/example.csv")
+def test_complete_shuffle():
+  """Test that complete shuffle."""
+  current_dir = os.path.dirname(os.path.realpath(__file__))
 
-#  featurizer = dc.feat.CircularFingerprint(size=1024)
-#  tasks = ["log-solubility"]
-#  loader = dc.data.CSVLoader(
-#      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
-#  dataset = loader.featurize(dataset_file, shard_size=2)
+  dataset_file = os.path.join(current_dir, "../../models/tests/example.csv")
 
-#  X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
-#                                      dataset.ids)
-#  orig_len = len(dataset)
+  featurizer = dc.feat.CircularFingerprint(size=1024)
+  tasks = ["log-solubility"]
+  loader = dc.data.CSVLoader(
+      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
+  dataset = loader.featurize(dataset_file, shard_size=2)
 
-#  dataset.shuffle(iterations=5)
-#  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w,
-#                                  dataset.ids)
-#
-#  assert len(dataset) == orig_len
-#  # The shuffling should have switched up the ordering
-#  assert not np.array_equal(orig_ids, new_ids)
-#  # But all the same entries should still be present
-#  assert sorted(orig_ids) == sorted(new_ids)
-#  # All the data should have same shape
-#  assert X_orig.shape == X_new.shape
-#  assert y_orig.shape == y_new.shape
-#  assert w_orig.shape == w_new.shape
+  X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
+                                      dataset.ids)
+  orig_len = len(dataset)
+
+  dataset = dataset.complete_shuffle()
+  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
+
+  assert len(dataset) == orig_len
+  # The shuffling should have switched up the ordering
+  assert not np.array_equal(orig_ids, new_ids)
+  # But all the same entries should still be present
+  assert sorted(orig_ids) == sorted(new_ids)
+  # All the data should have same shape
+  assert X_orig.shape == X_new.shape
+  assert y_orig.shape == y_new.shape
+  assert w_orig.shape == w_new.shape
 
 
 def test_sparse_shuffle():


### PR DESCRIPTION
This PR fixes `DiskDataset.shuffle_each_shard` (bug noted in https://github.com/deepchem/deepchem/issues/2056). The reason we weren't catching this earlier was that our unit test didn't check that a permutation had actually been applied. This PR adds a check to the unittest and fixes `shuffle_each_shard`

CC @peastman 