### PR TITLE
Fix load material dataset function

### DIFF
--- a/deepchem/data/tests/test_json_loader.py
+++ b/deepchem/data/tests/test_json_loader.py
@@ -23,11 +23,11 @@ def test_json_loader():
 
   a = [4625.32086965, 6585.20209678, 61.00680193, 48.72230922, 48.72230922]
 
-  assert dataset.X.shape == (5, 1, 5)
-  assert np.allclose(dataset.X[0][0], a, atol=.5)
+  assert dataset.X.shape == (5, 5)
+  assert np.allclose(dataset.X[0], a, atol=.5)
 
   dataset = loader.create_dataset(input_file, shard_size=None)
-  assert dataset.X.shape == (5, 1, 5)
+  assert dataset.X.shape == (5, 5)
 
   dataset = loader.create_dataset([input_file, input_file], shard_size=5)
-  assert dataset.X.shape == (10, 1, 5)
+  assert dataset.X.shape == (10, 5)

--- a/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
+++ b/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
@@ -44,11 +44,11 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
   This class requires matminer and Pymatgen to be installed.
   """
 
-  def __init__(self, max_atoms: int, flatten: bool = True):
+  def __init__(self, max_atoms: int = 100, flatten: bool = True):
     """
     Parameters
     ----------
-    max_atoms: int
+    max_atoms: int (deafult 100)
       Maximum number of atoms for any crystal in the dataset. Used to
       pad the Coulomb matrix.
     flatten: bool (default True)
@@ -86,8 +86,8 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
 
     if self.flatten:
       eigs, _ = np.linalg.eig(sine_mat)
-      zeros = np.zeros((1, self.max_atoms))
-      zeros[:len(eigs)] = eigs
+      zeros = np.zeros(self.max_atoms)
+      zeros[:len(eigs[0])] = eigs[0]
       features = zeros
     else:
       features = pad_array(sine_mat, self.max_atoms)

--- a/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
+++ b/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
@@ -48,7 +48,7 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
     """
     Parameters
     ----------
-    max_atoms: int (deafult 100)
+    max_atoms: int (default 100)
       Maximum number of atoms for any crystal in the dataset. Used to
       pad the Coulomb matrix.
     flatten: bool (default True)

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -63,10 +63,11 @@ class TestMaterialFeaturizers(unittest.TestCase):
     Test SCM featurizer.
     """
 
-    featurizer = SineCoulombMatrix(max_atoms=1)
+    featurizer = SineCoulombMatrix(max_atoms=3)
     features = featurizer.featurize([self.struct_dict])
 
     assert len(features) == 1
+    assert features.shape == (1, 3)
     assert np.isclose(features[0], 1244, atol=.5)
 
   def test_cgcnn_featurizer(self):

--- a/deepchem/feat/tests/test_materials_featurizers.py
+++ b/deepchem/feat/tests/test_materials_featurizers.py
@@ -68,7 +68,7 @@ class TestMaterialFeaturizers(unittest.TestCase):
 
     assert len(features) == 1
     assert features.shape == (1, 3)
-    assert np.isclose(features[0], 1244, atol=.5)
+    assert np.isclose(features[0][0], 1244, atol=.5)
 
   def test_cgcnn_featurizer(self):
     """

--- a/deepchem/molnet/load_function/material_datasets/load_bandgap.py
+++ b/deepchem/molnet/load_function/material_datasets/load_bandgap.py
@@ -3,19 +3,18 @@ Experimental bandgaps for inorganic crystals.
 """
 import os
 import logging
+
 import deepchem
-from deepchem.feat import Featurizer, MaterialStructureFeaturizer, MaterialCompositionFeaturizer
-from deepchem.trans import Transformer
+from deepchem.feat import MaterialCompositionFeaturizer
 from deepchem.splits.splitters import Splitter
 from deepchem.molnet.defaults import get_defaults
 
-from typing import List, Tuple, Dict, Optional, Union, Any, Type
+from typing import List, Tuple, Dict, Optional, Any
 
 logger = logging.getLogger(__name__)
 
-# TODO: Change URLs
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-BANDGAP_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/expt_gap.tar.gz'
+BANDGAP_URL = 'https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/expt_gap.tar.gz'
 
 # dict of accepted featurizers for this dataset
 # modify the returned dicts for your dataset
@@ -60,16 +59,16 @@ def load_bandgap(
   """Load band gap dataset.
 
   Contains 4604 experimentally measured band gaps for inorganic
-  crystal structure compositions. In benchmark studies, random forest 
-  models achieved a mean average error of 0.45 eV during five-fold 
-  nested cross validation on this dataset. 
+  crystal structure compositions. In benchmark studies, random forest
+  models achieved a mean average error of 0.45 eV during five-fold
+  nested cross validation on this dataset.
 
   For more details on the dataset see [1]_. For more details
   on previous benchmarks for this dataset, see [2]_.
-  
+
   Parameters
   ----------
-  featurizer : MaterialCompositionFeaturizer 
+  featurizer : MaterialCompositionFeaturizer
     (default ElementPropertyFingerprint)
     A featurizer that inherits from deepchem.feat.Featurizer.
   transformers : List[Transformer]
@@ -106,9 +105,10 @@ def load_bandgap(
 
   References
   ----------
-  .. [1] Zhuo, Y. et al. "Predicting the Band Gaps of Inorganic Solids by Machine Learning." J. Phys. Chem. Lett. (2018) DOI: 10.1021/acs.jpclett.8b00124.
-
-  .. [2] Dunn, A. et al. "Benchmarking Materials Property Prediction Methods: The Matbench Test Set and Automatminer Reference Algorithm." https://arxiv.org/abs/2005.00707 (2020)
+  .. [1] Zhuo, Y. et al. "Predicting the Band Gaps of Inorganic Solids by Machine Learning."
+     J. Phys. Chem. Lett. (2018) DOI: 10.1021/acs.jpclett.8b00124.
+  .. [2] Dunn, A. et al. "Benchmarking Materials Property Prediction Methods: The Matbench Test Set
+     and Automatminer Reference Algorithm." https://arxiv.org/abs/2005.00707 (2020)
 
   Examples
   --------
@@ -159,12 +159,13 @@ def load_bandgap(
 
   # Load .tar.gz file
   if featurizer.__class__.__name__ in supported_featurizers:
-    dataset_file = os.path.join(data_dir, 'expt_gap.tar.gz')
-    deepchem.utils.untargz_file(dataset_file, dest_dir=data_dir)
     dataset_file = os.path.join(data_dir, 'expt_gap.json')
 
     if not os.path.exists(dataset_file):
-      deepchem.utils.download_url(url=BANDGAP_URL, dest_dir=data_dir)
+      targz_file = os.path.join(data_dir, 'expt_gap.tar.gz')
+      if not os.path.exists(targz_file):
+        deepchem.utils.download_url(url=BANDGAP_URL, dest_dir=data_dir)
+
       deepchem.utils.untargz_file(
           os.path.join(data_dir, 'expt_gap.tar.gz'), data_dir)
 

--- a/deepchem/molnet/load_function/material_datasets/load_bandgap.py
+++ b/deepchem/molnet/load_function/material_datasets/load_bandgap.py
@@ -44,7 +44,7 @@ def load_bandgap(
     reload: bool = True,
     data_dir: Optional[str] = None,
     save_dir: Optional[str] = None,
-    featurizer_kwargs: Dict[str, Any] = {'data_source': 'matminer'},
+    featurizer_kwargs: Dict[str, Any] = {},
     splitter_kwargs: Dict[str, Any] = {
         'frac_train': 0.8,
         'frac_valid': 0.1,

--- a/deepchem/molnet/load_function/material_datasets/load_perovskite.py
+++ b/deepchem/molnet/load_function/material_datasets/load_perovskite.py
@@ -4,18 +4,16 @@ Perovskite crystal structures and formation energies.
 import os
 import logging
 import deepchem
-from deepchem.feat import Featurizer, MaterialStructureFeaturizer, MaterialCompositionFeaturizer
-from deepchem.trans import Transformer
+from deepchem.feat import MaterialStructureFeaturizer
 from deepchem.splits.splitters import Splitter
 from deepchem.molnet.defaults import get_defaults
 
-from typing import List, Tuple, Dict, Optional, Union, Any, Type, Callable
+from typing import List, Tuple, Dict, Optional, Any
 
 logger = logging.getLogger(__name__)
 
-# TODO: Change URLs
 DEFAULT_DIR = deepchem.utils.get_data_dir()
-PEROVSKITE_URL = 'http://deepchem.io.s3-website-us-west-1.amazonaws.com/datasets/perovskite.tar.gz'
+PEROVSKITE_URL = 'https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/perovskite.tar.gz'
 
 # dict of accepted featurizers for this dataset
 # modify the returned dicts for your dataset
@@ -61,11 +59,11 @@ def load_perovskite(
   In benchmark studies, random forest models and crystal graph
   neural networks achieved mean average error of 0.23 and 0.05 eV/atom,
   respectively, during five-fold nested cross validation on this
-  dataset. 
+  dataset.
 
   For more details on the dataset see [1]_. For more details
   on previous benchmarks for this dataset, see [2]_.
-  
+
   Parameters
   ----------
   featurizer : MaterialStructureFeaturizer
@@ -104,9 +102,11 @@ def load_perovskite(
 
   References
   ----------
-  .. [1] Castelli, I. et al. "New cubic perovskites for one- and two-photon water splitting using the computational materials repository." Energy Environ. Sci., (2012), 5, 9034-9043 DOI: 10.1039/C2EE22341D.
-
-  .. [2] Dunn, A. et al. "Benchmarking Materials Property Prediction Methods: The Matbench Test Set and Automatminer Reference Algorithm." https://arxiv.org/abs/2005.00707 (2020)
+  .. [1] Castelli, I. et al. "New cubic perovskites for one- and two-photon water splitting
+     using the computational materials repository." Energy Environ. Sci., (2012), 5,
+     9034-9043 DOI: 10.1039/C2EE22341D.
+  .. [2] Dunn, A. et al. "Benchmarking Materials Property Prediction Methods:
+     The Matbench Test Set and Automatminer Reference Algorithm." https://arxiv.org/abs/2005.00707 (2020)
 
   Examples
   --------
@@ -157,12 +157,13 @@ def load_perovskite(
 
   # Load .tar.gz file
   if featurizer.__class__.__name__ in supported_featurizers:
-    dataset_file = os.path.join(data_dir, 'perovskite.tar.gz')
-    deepchem.utils.untargz_file(dataset_file, dest_dir=data_dir)
     dataset_file = os.path.join(data_dir, 'perovskite.json')
 
     if not os.path.exists(dataset_file):
-      deepchem.utils.download_url(url=PEROVSKITE_URL, dest_dir=data_dir)
+      targz_file = os.path.join(data_dir, 'perovskite.tar.gz')
+      if not os.path.exists(targz_file):
+        deepchem.utils.download_url(url=PEROVSKITE_URL, dest_dir=data_dir)
+
       deepchem.utils.untargz_file(
           os.path.join(data_dir, 'perovskite.tar.gz'), data_dir)
 

--- a/deepchem/molnet/load_function/material_datasets/tests/test_load_bandgap.py
+++ b/deepchem/molnet/load_function/material_datasets/tests/test_load_bandgap.py
@@ -3,10 +3,7 @@ Tests for bandgap loader.
 """
 
 import os
-import tempfile
-import shutil
 import numpy as np
-import deepchem as dc
 from deepchem.molnet import load_bandgap
 
 

--- a/deepchem/molnet/load_function/material_datasets/tests/test_load_perovskite.py
+++ b/deepchem/molnet/load_function/material_datasets/tests/test_load_perovskite.py
@@ -3,10 +3,7 @@ Tests for perovskite loader.
 """
 
 import os
-import tempfile
-import shutil
 import numpy as np
-import deepchem as dc
 from deepchem.molnet import load_perovskite
 
 
@@ -25,11 +22,11 @@ def test_perovskite_loader():
       })
 
   assert tasks[0] == 'formation_energy'
-  assert datasets[0].X.shape == (3, 1, 5)
-  assert datasets[1].X.shape == (1, 1, 5)
-  assert datasets[2].X.shape == (1, 1, 5)
+  assert datasets[0].X.shape == (3, 5)
+  assert datasets[1].X.shape == (1, 5)
+  assert datasets[2].X.shape == (1, 5)
   assert np.allclose(
-      datasets[0].X[0][0],
+      datasets[0].X[0],
       [0.02444208, -0.4804022, -0.51238194, -0.20286038, 0.53483076],
       atol=0.01)
 


### PR DESCRIPTION
I try to use new material dataset, but I couldn't. So, I fixed the some bugs.

## What I did

- Fix dataset URL
- Reupload the dataset file
  - The previous `expt_gap.tar.gz` was zipped molnet_datasets directory (`molnet_datasets/expt_gap.json`).
  - The new `expt_gap.tar.gz` is zipped only `expt_gap.json`
- Fix the logic for loading .tar.gz file
- Fix the flatten feature dimension of SineCoulombMatrix


CC. @ncfrey 
If you have time, I want you to review 🙇‍♂️ 

