### PR TITLE
Convert graph_feature -> node_pos_features in GraphData

### DIFF
--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -162,8 +162,28 @@ class BatchGraphData(GraphData):
 
   Attributes
   ----------
+  node_features: np.ndarray
+    Concatenated node feature matrix with shape [num_nodes, num_node_features].
+    `num_nodes` is total number of nodes in the batch graph.
+  edge_index: np.ndarray, dtype int
+    Concatenated graph connectivity in COO format with shape [2, num_edges].
+    `num_edges` is total number of edges in the batch graph.
+  edge_features: np.ndarray, optional (default None)
+    Concatenated edge feature matrix with shape [num_edges, num_edge_features].
+    `num_edges` is total number of edges in the batch graph.
+  node_pos_features: np.ndarray, optional (default None)
+    Concatenated node position matrix with shape [num_nodes, num_dimensions].
+    `num_nodes` is total number of edges in the batch graph.
+  num_nodes: int
+    The number of nodes in the batch graph.
+  num_node_features: int
+    The number of features per node in the graph.
+  num_edges: int
+    The number of edges in the batch graph.
+  num_edges_features: int, optional (default None)
+    The number of features per edge in the graph.
   graph_index: np.ndarray, dtype int
-    This vector indicates which graph the node belongs with shape [num_nodes,]
+    This vector indicates which graph the node belongs with shape [num_nodes,].
 
   Examples
   --------

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -76,9 +76,10 @@ class GraphData:
 
     if node_pos_features is not None:
       if isinstance(node_pos_features, np.ndarray) is False:
-        raise ValueError('pos must be np.ndarray or None.')
+        raise ValueError('node_pos_features must be np.ndarray or None.')
       elif node_pos_features.shape[0] != node_features.shape[0]:
-        raise ValueError('The length of pos must be the same as the \
+        raise ValueError(
+            'The length of node_pos_features must be the same as the \
                           length of node_features.')
 
     self.node_features = node_features

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -15,13 +15,13 @@ class TestGraph(unittest.TestCase):
         [0, 1, 2, 2, 3, 4],
         [1, 2, 0, 3, 4, 0],
     ])
-    graph_features = None
+    node_pos_features = None
 
     graph = GraphData(
         node_features=node_features,
         edge_index=edge_index,
         edge_features=edge_features,
-        graph_features=graph_features)
+        node_pos_features=node_pos_features)
 
     assert graph.num_nodes == num_nodes
     assert graph.num_node_features == num_node_features
@@ -92,7 +92,7 @@ class TestGraph(unittest.TestCase):
             edge_index=edge_index_list[i],
             edge_features=np.random.random_sample((num_edge_list[i],
                                                    num_edge_features)),
-            graph_features=None) for i in range(len(num_edge_list))
+            node_pos_features=None) for i in range(len(num_edge_list))
     ]
     batch = BatchGraphData(graph_list)
 


### PR DESCRIPTION
I noticed that DGL doesn't support using graph wise feature with DGLGraph, so I removed it. (PyG supports, but we use kwargs...)
And then, I add new attribute for node position matrix. This attribute is useful for implementing SchNet. 

See : 
https://github.com/rusty1s/pytorch_geometric/blob/fcfd27c1ea8f5cd5d3fb11d1f63845e004c4fb56/examples/qm9_pretrained_schnet.py#L25
https://github.com/rusty1s/pytorch_geometric/blob/fcfd27c1ea8f5cd5d3fb11d1f63845e004c4fb56/torch_geometric/datasets/qm9.py#L212-L214