### PR TITLE
Implement a complete shuffle for large datasets

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2098,10 +2098,8 @@ class DiskDataset(Dataset):
     DiskDataset.write_data_to_disk(self.data_dir, basename, tasks, X, y, w, ids)
     self._cached_shards = None
 
-  def select(self,
-             indices: Sequence[int],
-             select_dir: Optional[str] = None,
-             sort_indices: Optional[bool] = True) -> "DiskDataset":
+  def select(self, indices: Sequence[int],
+             select_dir: Optional[str] = None) -> "DiskDataset":
     """Creates a new dataset from a selection of indices from self.
 
     Note
@@ -2117,8 +2115,6 @@ class DiskDataset(Dataset):
     select_dir: Optional[str], (default None)
       Path to new directory that the selected indices will be copied
       to.
-    sort_indices: Optional[bool], (default True)
-      If True, sort indices before returning them.
 
     Returns
     -------

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -36,6 +36,20 @@ def test_complete_shuffle_multiple_shard():
   assert shuffled.w.shape == dataset.w.shape
 
 
+def test_complete_shuffle_multiple_shard_uneven():
+  """Test that complete shuffle works with multiple shards and some shards not full size."""
+  X = np.random.rand(57, 10)
+  dataset = dc.data.DiskDataset.from_numpy(X)
+  dataset.reshard(shard_size=10)
+  shuffled = dataset.complete_shuffle()
+  assert len(shuffled) == len(dataset)
+  assert not np.array_equal(shuffled.ids, dataset.ids)
+  assert sorted(shuffled.ids) == sorted(dataset.ids)
+  assert shuffled.X.shape == dataset.X.shape
+  assert shuffled.y.shape == dataset.y.shape
+  assert shuffled.w.shape == dataset.w.shape
+
+
 def test_complete_shuffle():
   """Test that complete shuffle."""
   current_dir = os.path.dirname(os.path.realpath(__file__))

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -1,16 +1,39 @@
 """
 Testing singletask/multitask dataset shuffling 
 """
-__author__ = "Bharath Ramsundar"
-__copyright__ = "Copyright 2016, Stanford University"
-__license__ = "MIT"
-
 import os
 import shutil
 import tempfile
 import unittest
 import deepchem as dc
 import numpy as np
+
+
+def test_complete_shuffle_one_shard():
+  """Test that complete shuffle works with only one shard."""
+  X = np.random.rand(10, 10)
+  dataset = dc.data.DiskDataset.from_numpy(X)
+  shuffled = dataset.complete_shuffle()
+  assert len(shuffled) == len(dataset)
+  assert not np.array_equal(shuffled.ids, dataset.ids)
+  assert sorted(shuffled.ids) == sorted(dataset.ids)
+  assert shuffled.X.shape == dataset.X.shape
+  assert shuffled.y.shape == dataset.y.shape
+  assert shuffled.w.shape == dataset.w.shape
+
+
+def test_complete_shuffle_multiple_shard():
+  """Test that complete shuffle works with multiple shards."""
+  X = np.random.rand(100, 10)
+  dataset = dc.data.DiskDataset.from_numpy(X)
+  dataset.reshard(shard_size=10)
+  shuffled = dataset.complete_shuffle()
+  assert len(shuffled) == len(dataset)
+  assert not np.array_equal(shuffled.ids, dataset.ids)
+  assert sorted(shuffled.ids) == sorted(dataset.ids)
+  assert shuffled.X.shape == dataset.X.shape
+  assert shuffled.y.shape == dataset.y.shape
+  assert shuffled.w.shape == dataset.w.shape
 
 
 def test_complete_shuffle():
@@ -22,8 +45,8 @@ def test_complete_shuffle():
   featurizer = dc.feat.CircularFingerprint(size=1024)
   tasks = ["log-solubility"]
   loader = dc.data.CSVLoader(
-      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
-  dataset = loader.featurize(dataset_file, shard_size=2)
+      tasks=tasks, feature_field="smiles", featurizer=featurizer)
+  dataset = loader.create_dataset(dataset_file, shard_size=2)
 
   X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
                                       dataset.ids)
@@ -52,8 +75,8 @@ def test_sparse_shuffle():
   featurizer = dc.feat.CircularFingerprint(size=1024)
   tasks = ["log-solubility"]
   loader = dc.data.CSVLoader(
-      tasks=tasks, smiles_field="smiles", featurizer=featurizer)
-  dataset = loader.featurize(dataset_file, shard_size=2)
+      tasks=tasks, feature_field="smiles", featurizer=featurizer)
+  dataset = loader.create_dataset(dataset_file, shard_size=2)
 
   X_orig, y_orig, w_orig, orig_ids = (dataset.X, dataset.y, dataset.w,
                                       dataset.ids)


### PR DESCRIPTION
At present, `DiskDataset.complete_shuffle()` operates in memory, which means that we currently lack an algorithm to shuffle a dataset too large to fit in memory. (We do support `DiskDataset.shuffle_shards()` which shuffles the order of shards for the dataset but doesn't shuffle across shards). For training models on large datasets, it's often necessary to be able to shuffle the full dataset to get smooth training.

This PR updates the implementation of `DiskDataset.complete_shuffle()` to allow for shuffling of large datasets. It does so with a simple O(N^2) algorithm (where N is the number of shards) that uses `DiskDataset.select()` to select the elements of each shuffled shard from the source shards. Although this is O(N^2), in practice the number of shards N shouldn't be too large (several hundred is a common number of shards for large datasets), so this method can still be efficient in practice.

I've also added some unit tests for this new method.