### PR TITLE
Make Order Respecting Select for DiskDataset

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2136,7 +2136,8 @@ class DiskDataset(Dataset):
               "Selecting from input shard %d/%d for selection output shard %d" %
               (shard_num + 1, n_shards, select_shard_num + 1))
           if self.legacy_metadata:
-            shard_len = len(X)
+            ids = self.get_shard_ids(shard_num)
+            shard_len = len(ids)
           else:
             shard_X_shape, _, _, _ = self._get_shard_shape(shard_num)
             if len(shard_X_shape) > 0:

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2327,27 +2327,6 @@ class DiskDataset(Dataset):
     # metadata
     if not self.legacy_metadata:
       for shard_num in range(n_rows):
-        #row = self.metadata_df.iloc[shard_num]
-        #if row['X_shape'] is not None:
-        #  shard_X_shape = make_tuple(str(row['X_shape']))
-        #else:
-        #  shard_X_shape = tuple()
-        #if n_tasks > 0:
-        #  if row['y_shape'] is not None:
-        #    shard_y_shape = make_tuple(str(row['y_shape']))
-        #  else:
-        #    shard_y_shape = tuple()
-        #  if row['w_shape'] is not None:
-        #    shard_w_shape = make_tuple(str(row['w_shape']))
-        #  else:
-        #    shard_w_shape = tuple()
-        #else:
-        #  shard_y_shape = tuple()
-        #  shard_w_shape = tuple()
-        #if row['ids_shape'] is not None:
-        #  shard_ids_shape = make_tuple(str(row['ids_shape']))
-        #else:
-        #  shard_ids_shape = tuple()
         shard_X_shape, shard_y_shape, shard_w_shape, shard_ids_shape = self._get_shard_shape(
             shard_num)
         if shard_num == 0:

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -272,27 +272,6 @@ def test_reshard():
   np.testing.assert_array_equal(ids, ids_rr)
 
 
-def test_select():
-  """Test that dataset select works."""
-  num_datapoints = 10
-  num_features = 10
-  num_tasks = 1
-  X = np.random.rand(num_datapoints, num_features)
-  y = np.random.randint(2, size=(num_datapoints, num_tasks))
-  w = np.ones((num_datapoints, num_tasks))
-  ids = np.array(["id"] * num_datapoints)
-  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
-
-  indices = [0, 4, 5, 8]
-  select_dataset = dataset.select(indices)
-  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
-                                  select_dataset.w, select_dataset.ids)
-  np.testing.assert_array_equal(X[indices], X_sel)
-  np.testing.assert_array_equal(y[indices], y_sel)
-  np.testing.assert_array_equal(w[indices], w_sel)
-  np.testing.assert_array_equal(ids[indices], ids_sel)
-
-
 def test_complete_shuffle():
   shard_sizes = [1, 2, 3, 4, 5]
 

--- a/deepchem/data/tests/test_image_dataset.py
+++ b/deepchem/data/tests/test_image_dataset.py
@@ -1,10 +1,6 @@
 """
 Tests for ImageDataset class
 """
-__author__ = "Bharath Ramsundar"
-__copyright__ = "Copyright 2016, Stanford University"
-__license__ = "MIT"
-
 import unittest
 import numpy as np
 import deepchem as dc

--- a/deepchem/data/tests/test_select.py
+++ b/deepchem/data/tests/test_select.py
@@ -1,0 +1,130 @@
+import deepchem as dc
+import numpy as np
+import os
+
+
+def test_select():
+  """Test that dataset select works."""
+  num_datapoints = 10
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+
+  indices = [0, 4, 5, 8]
+  select_dataset = dataset.select(indices)
+  assert isinstance(select_dataset, dc.data.DiskDataset)
+  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                  select_dataset.w, select_dataset.ids)
+  np.testing.assert_array_equal(X[indices], X_sel)
+  np.testing.assert_array_equal(y[indices], y_sel)
+  np.testing.assert_array_equal(w[indices], w_sel)
+  np.testing.assert_array_equal(ids[indices], ids_sel)
+
+
+def test_image_dataset_select():
+  """Test that select works on image datasets."""
+  path = os.path.join(os.path.dirname(__file__), 'images')
+  files = [os.path.join(path, f) for f in os.listdir(path)]
+  dataset = dc.data.ImageDataset(files, np.random.random(10))
+  indices = [0, 4, 5, 8, 2]
+  select_dataset = dataset.select(indices)
+  assert isinstance(select_dataset, dc.data.ImageDataset)
+  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                  select_dataset.w, select_dataset.ids)
+  np.testing.assert_array_equal(dataset.X[indices], X_sel)
+  np.testing.assert_array_equal(dataset.y[indices], y_sel)
+  np.testing.assert_array_equal(dataset.w[indices], w_sel)
+  np.testing.assert_array_equal(dataset.ids[indices], ids_sel)
+
+
+def test_numpy_dataset_select():
+  """Test that dataset select works with numpy dataset."""
+  num_datapoints = 10
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.NumpyDataset(X, y, w, ids)
+
+  indices = [0, 4, 5, 8, 2]
+  select_dataset = dataset.select(indices)
+  assert isinstance(select_dataset, dc.data.NumpyDataset)
+  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                  select_dataset.w, select_dataset.ids)
+  np.testing.assert_array_equal(X[indices], X_sel)
+  np.testing.assert_array_equal(y[indices], y_sel)
+  np.testing.assert_array_equal(w[indices], w_sel)
+  np.testing.assert_array_equal(ids[indices], ids_sel)
+
+
+def test_select_multishard():
+  """Test that dataset select works with multiple shards."""
+  num_datapoints = 100
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+  dataset.reshard(shard_size=10)
+
+  indices = [10, 42, 51, 82, 2, 4, 6]
+  select_dataset = dataset.select(indices)
+  assert isinstance(select_dataset, dc.data.DiskDataset)
+  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                  select_dataset.w, select_dataset.ids)
+  np.testing.assert_array_equal(X[indices], X_sel)
+  np.testing.assert_array_equal(y[indices], y_sel)
+  np.testing.assert_array_equal(w[indices], w_sel)
+  np.testing.assert_array_equal(ids[indices], ids_sel)
+
+
+def test_select_not_sorted():
+  """Test that dataset select with ids not in sorted order."""
+  num_datapoints = 10
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+
+  indices = [4, 2, 8, 5, 0]
+  select_dataset = dataset.select(indices)
+  assert isinstance(select_dataset, dc.data.DiskDataset)
+  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                  select_dataset.w, select_dataset.ids)
+  np.testing.assert_array_equal(X[indices], X_sel)
+  np.testing.assert_array_equal(y[indices], y_sel)
+  np.testing.assert_array_equal(w[indices], w_sel)
+  np.testing.assert_array_equal(ids[indices], ids_sel)
+
+
+def test_select_to_numpy():
+  """Test that dataset select works."""
+  num_datapoints = 10
+  num_features = 10
+  num_tasks = 1
+  X = np.random.rand(num_datapoints, num_features)
+  y = np.random.randint(2, size=(num_datapoints, num_tasks))
+  w = np.ones((num_datapoints, num_tasks))
+  ids = np.array(["id"] * num_datapoints)
+  dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+
+  indices = [0, 4, 5, 8]
+  select_dataset = dataset.select(indices, output_numpy_dataset=True)
+  assert isinstance(select_dataset, dc.data.NumpyDataset)
+  X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                  select_dataset.w, select_dataset.ids)
+  np.testing.assert_array_equal(X[indices], X_sel)
+  np.testing.assert_array_equal(y[indices], y_sel)
+  np.testing.assert_array_equal(w[indices], w_sel)
+  np.testing.assert_array_equal(ids[indices], ids_sel)

--- a/deepchem/data/tests/test_shuffle.py
+++ b/deepchem/data/tests/test_shuffle.py
@@ -20,6 +20,14 @@ def test_complete_shuffle_one_shard():
   assert shuffled.X.shape == dataset.X.shape
   assert shuffled.y.shape == dataset.y.shape
   assert shuffled.w.shape == dataset.w.shape
+  original_indices = dict((id, i) for i, id in enumerate(dataset.ids))
+  shuffled_indices = dict((id, i) for i, id in enumerate(shuffled.ids))
+  for id in dataset.ids:
+    i = original_indices[id]
+    j = shuffled_indices[id]
+    assert np.array_equal(dataset.X[i], shuffled.X[j])
+    assert np.array_equal(dataset.y[i], shuffled.y[j])
+    assert np.array_equal(dataset.w[i], shuffled.w[j])
 
 
 def test_complete_shuffle_multiple_shard():
@@ -34,6 +42,14 @@ def test_complete_shuffle_multiple_shard():
   assert shuffled.X.shape == dataset.X.shape
   assert shuffled.y.shape == dataset.y.shape
   assert shuffled.w.shape == dataset.w.shape
+  original_indices = dict((id, i) for i, id in enumerate(dataset.ids))
+  shuffled_indices = dict((id, i) for i, id in enumerate(shuffled.ids))
+  for id in dataset.ids:
+    i = original_indices[id]
+    j = shuffled_indices[id]
+    assert np.array_equal(dataset.X[i], shuffled.X[j])
+    assert np.array_equal(dataset.y[i], shuffled.y[j])
+    assert np.array_equal(dataset.w[i], shuffled.w[j])
 
 
 def test_complete_shuffle_multiple_shard_uneven():
@@ -48,6 +64,14 @@ def test_complete_shuffle_multiple_shard_uneven():
   assert shuffled.X.shape == dataset.X.shape
   assert shuffled.y.shape == dataset.y.shape
   assert shuffled.w.shape == dataset.w.shape
+  original_indices = dict((id, i) for i, id in enumerate(dataset.ids))
+  shuffled_indices = dict((id, i) for i, id in enumerate(shuffled.ids))
+  for id in dataset.ids:
+    i = original_indices[id]
+    j = shuffled_indices[id]
+    assert np.array_equal(dataset.X[i], shuffled.X[j])
+    assert np.array_equal(dataset.y[i], shuffled.y[j])
+    assert np.array_equal(dataset.w[i], shuffled.w[j])
 
 
 def test_complete_shuffle():
@@ -66,10 +90,11 @@ def test_complete_shuffle():
                                       dataset.ids)
   orig_len = len(dataset)
 
-  dataset = dataset.complete_shuffle()
-  X_new, y_new, w_new, new_ids = (dataset.X, dataset.y, dataset.w, dataset.ids)
+  shuffled = dataset.complete_shuffle()
+  X_new, y_new, w_new, new_ids = (shuffled.X, shuffled.y, shuffled.w,
+                                  shuffled.ids)
 
-  assert len(dataset) == orig_len
+  assert len(shuffled) == orig_len
   # The shuffling should have switched up the ordering
   assert not np.array_equal(orig_ids, new_ids)
   # But all the same entries should still be present
@@ -78,6 +103,14 @@ def test_complete_shuffle():
   assert X_orig.shape == X_new.shape
   assert y_orig.shape == y_new.shape
   assert w_orig.shape == w_new.shape
+  original_indices = dict((id, i) for i, id in enumerate(dataset.ids))
+  shuffled_indices = dict((id, i) for i, id in enumerate(shuffled.ids))
+  for id in dataset.ids:
+    i = original_indices[id]
+    j = shuffled_indices[id]
+    assert np.array_equal(dataset.X[i], shuffled.X[j])
+    assert np.array_equal(dataset.y[i], shuffled.y[j])
+    assert np.array_equal(dataset.w[i], shuffled.w[j])
 
 
 def test_sparse_shuffle():


### PR DESCRIPTION
This PR grew out of @peastman's excellent comment on #2101 that the fact that `DiskDataset.select()` doesn't respect ordering is a bug. I started fixing this and realized that this makes implementing `DiskDataset.complete_shuffle()` very simple since a shuffle is just a select operation on a specified permutation. I've addressed the other comments from #2101 on here by adding more tests and moving more operations into memory to avoid unnecessary disk writing.