### PR TITLE
Remove unnecessary warnings for Evaluator and Metrics

### DIFF
--- a/deepchem/metrics/metric.py
+++ b/deepchem/metrics/metric.py
@@ -660,7 +660,6 @@ class Metric(object):
           y_task,
           y_pred_task,
           w_task,
-          n_samples=n_samples,
           use_sample_weights=use_sample_weights,
           **kwargs)
       computed_metrics.append(metric_value)


### PR DESCRIPTION
When reviewing #2115, I found many unnecessary warnings happened when using Evaluator and Metric. 


```
n_samples is a deprecated argument which is ignored.
```

So, I fixed the `compute_singletask_metric`  argument to suppress warnings.