### PR TITLE
Add Transformers as soft requirement + to list of requirements for ReadTheDocs

### DIFF
--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -98,6 +98,10 @@ DeepChem has a number of "soft" requirements.
 |                                |               | :code:`dc.models.callbacks`                       |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
+| `HuggingFace Transformers`_    | Not Testing   | :code:`dc.feat.smiles_tokenizer`                  |
+|                                |               |                                                   |
+|                                |               |                                                   |
++--------------------------------+---------------+---------------------------------------------------+
           
 .. _`joblib`: https://pypi.python.org/pypi/joblib
 .. _`NumPy`: https://numpy.org/
@@ -123,3 +127,5 @@ DeepChem has a number of "soft" requirements.
 .. _`Tensorflow Probability`: https://www.tensorflow.org/probability
 .. _`XGBoost`: https://xgboost.readthedocs.io/en/latest/
 .. _`Weights & Biases`: https://docs.wandb.com/
+.. _`HuggingFace Transformers`: https://huggingface.co/transformers/
+

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ pandas
 scikit-learn
 sphinx_rtd_theme
 tensorflow==2.2.0
+transformers


### PR DESCRIPTION
This PR adds HuggingFace's transformers library as a soft requirement for SmilesTokenizer and adds `transformers` to the list of requirements in `dc.docs`.

@rbharath 