### PR TITLE
Fix position for throwing ModuleNotFoundError

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -19,12 +19,13 @@ from deepchem.feat.atomic_coordinates import AtomicCoordinates
 from deepchem.feat.atomic_coordinates import NeighborListComplexAtomicCoordinates
 
 # molecule featurizers
-from deepchem.feat.molecule_featurizers import MolGraphConvFeaturizer
+from deepchem.feat.molecule_featurizers import BPSymmetryFunctionInput
 from deepchem.feat.molecule_featurizers import CircularFingerprint
 from deepchem.feat.molecule_featurizers import CoulombMatrix
 from deepchem.feat.molecule_featurizers import CoulombMatrixEig
 from deepchem.feat.molecule_featurizers import MordredDescriptors
 from deepchem.feat.molecule_featurizers import Mol2VecFingerprint
+from deepchem.feat.molecule_featurizers import MolGraphConvFeaturizer
 from deepchem.feat.molecule_featurizers import OneHotFeaturizer
 from deepchem.feat.molecule_featurizers import RawFeaturizer
 from deepchem.feat.molecule_featurizers import RDKitDescriptors

--- a/deepchem/feat/material_featurizers/element_property_fingerprint.py
+++ b/deepchem/feat/material_featurizers/element_property_fingerprint.py
@@ -50,8 +50,13 @@ class ElementPropertyFingerprint(MaterialCompositionFeaturizer):
     data_source: str of "matminer", "magpie" or "deml" (default "matminer")
       Source for element property data.
     """
+    try:
+      from matminer.featurizers.composition import ElementProperty
+    except ModuleNotFoundError:
+      raise ValueError("This class requires matminer to be installed.")
 
     self.data_source = data_source
+    self.ep_featurizer = ElementProperty.from_preset(self.data_source)
 
   def _featurize(self, composition: PymatgenComposition) -> np.ndarray:
     """
@@ -69,14 +74,7 @@ class ElementPropertyFingerprint(MaterialCompositionFeaturizer):
       stoichiometry. Some values may be NaN.
     """
     try:
-      from matminer.featurizers.composition import ElementProperty
-    except ModuleNotFoundError:
-      raise ValueError("This class requires matminer to be installed.")
-
-    ep = ElementProperty.from_preset(self.data_source)
-
-    try:
-      feats = ep.featurize(composition)
+      feats = self.ep_featurizer.featurize(composition)
     except:
       feats = []
 

--- a/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
+++ b/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
@@ -54,9 +54,14 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
     flatten: bool (default True)
       Return flattened vector of matrix eigenvalues.
     """
+    try:
+      from matminer.featurizers.structure import SineCoulombMatrix as SCM
+    except ModuleNotFoundError:
+      raise ValueError("This class requires matminer to be installed.")
 
     self.max_atoms = max_atoms
     self.flatten = flatten
+    self.scm = SCM(flatten=False)
 
   def _featurize(self, struct: PymatgenStructure) -> np.ndarray:
     """
@@ -74,15 +79,8 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
       2D sine Coulomb matrix with shape (max_atoms, max_atoms),
       or 1D matrix eigenvalues with shape (max_atoms,).
     """
-
-    try:
-      from matminer.featurizers.structure import SineCoulombMatrix as SCM
-    except ModuleNotFoundError:
-      raise ValueError("This class requires matminer to be installed.")
-
     # Get full N x N SCM
-    scm = SCM(flatten=False)
-    sine_mat = scm.featurize(struct)
+    sine_mat = self.scm.featurize(struct)
 
     if self.flatten:
       eigs, _ = np.linalg.eig(sine_mat)

--- a/deepchem/feat/molecule_featurizers/circular_fingerprint.py
+++ b/deepchem/feat/molecule_featurizers/circular_fingerprint.py
@@ -76,8 +76,8 @@ class CircularFingerprint(MolecularFeaturizer):
       when calculating sparse fingerprints).
     """
     try:
-      from rdkit import Chem # noqa
-      from rdkit.Chem import rdMolDescriptors # noqa
+      from rdkit import Chem  # noqa
+      from rdkit.Chem import rdMolDescriptors  # noqa
     except ModuleNotFoundError:
       raise ValueError("This class requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/circular_fingerprint.py
+++ b/deepchem/feat/molecule_featurizers/circular_fingerprint.py
@@ -54,6 +54,33 @@ class CircularFingerprint(MolecularFeaturizer):
                features: bool = False,
                sparse: bool = False,
                smiles: bool = False):
+    """
+    Parameters
+    ----------
+    radius: int, optional (default 2)
+      Fingerprint radius.
+    size: int, optional (default 2048)
+      Length of generated bit vector.
+    chiral: bool, optional (default False)
+      Whether to consider chirality in fingerprint generation.
+    bonds: bool, optional (default True)
+      Whether to consider bond order in fingerprint generation.
+    features: bool, optional (default False)
+      Whether to use feature information instead of atom information; see
+      RDKit docs for more info.
+    sparse: bool, optional (default False)
+      Whether to return a dict for each molecule containing the sparse
+      fingerprint.
+    smiles: bool, optional (default False)
+      Whether to calculate SMILES strings for fragment IDs (only applicable
+      when calculating sparse fingerprints).
+    """
+    try:
+      from rdkit import Chem # noqa
+      from rdkit.Chem import rdMolDescriptors # noqa
+    except ModuleNotFoundError:
+      raise ValueError("This class requires RDKit to be installed.")
+
     self.radius = radius
     self.size = size
     self.chiral = chiral
@@ -75,11 +102,8 @@ class CircularFingerprint(MolecularFeaturizer):
     np.ndarray
       A numpy array of circular fingerprint.
     """
-    try:
-      from rdkit import Chem
-      from rdkit.Chem import rdMolDescriptors
-    except ModuleNotFoundError:
-      raise ValueError("This class requires RDKit to be installed.")
+    from rdkit import Chem
+    from rdkit.Chem import rdMolDescriptors
 
     if self.sparse:
       info: Dict = {}

--- a/deepchem/feat/molecule_featurizers/coulomb_matrices.py
+++ b/deepchem/feat/molecule_featurizers/coulomb_matrices.py
@@ -63,6 +63,12 @@ class CoulombMatrix(MolecularFeaturizer):
     seed: int, optional (default None)
       Random seed to use.
     """
+    try:
+      from rdkit import Chem # noqa
+      from rdkit.Chem import AllChem # noqa
+    except ModuleNotFoundError:
+      raise ValueError("This class requires RDKit to be installed.")
+
     self.max_atoms = int(max_atoms)
     self.remove_hydrogens = remove_hydrogens
     self.randomize = randomize
@@ -116,11 +122,8 @@ class CoulombMatrix(MolecularFeaturizer):
     np.ndarray
       The coulomb matrices of the given molecule
     """
-    try:
-      from rdkit import Chem
-      from rdkit.Chem import AllChem
-    except ModuleNotFoundError:
-      raise ValueError("This class requires RDKit to be installed.")
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
 
     # Check whether num_confs >=1 or not
     num_confs = len(mol.GetConformers())

--- a/deepchem/feat/molecule_featurizers/coulomb_matrices.py
+++ b/deepchem/feat/molecule_featurizers/coulomb_matrices.py
@@ -64,8 +64,8 @@ class CoulombMatrix(MolecularFeaturizer):
       Random seed to use.
     """
     try:
-      from rdkit import Chem # noqa
-      from rdkit.Chem import AllChem # noqa
+      from rdkit import Chem  # noqa
+      from rdkit.Chem import AllChem  # noqa
     except ModuleNotFoundError:
       raise ValueError("This class requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/mol_graph_conv_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/mol_graph_conv_featurizer.py
@@ -124,6 +124,7 @@ class MolGraphConvFeaturizer(MolecularFeaturizer):
   -----
   This class requires RDKit to be installed.
   """
+
   def __init__(self, add_self_edges: bool = False):
     """
     Parameters
@@ -133,8 +134,8 @@ class MolGraphConvFeaturizer(MolecularFeaturizer):
       you sometimes need to add explicit self-connected edges.
     """
     try:
-      from rdkit import Chem # noqa
-      from rdkit.Chem import AllChem # noqa
+      from rdkit import Chem  # noqa
+      from rdkit.Chem import AllChem  # noqa
     except ModuleNotFoundError:
       raise ValueError("This method requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/mol_graph_conv_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/mol_graph_conv_featurizer.py
@@ -124,7 +124,6 @@ class MolGraphConvFeaturizer(MolecularFeaturizer):
   -----
   This class requires RDKit to be installed.
   """
-
   def __init__(self, add_self_edges: bool = False):
     """
     Parameters
@@ -133,6 +132,12 @@ class MolGraphConvFeaturizer(MolecularFeaturizer):
       Whether to add self-connected edges or not. If you want to use DGL,
       you sometimes need to add explicit self-connected edges.
     """
+    try:
+      from rdkit import Chem # noqa
+      from rdkit.Chem import AllChem # noqa
+    except ModuleNotFoundError:
+      raise ValueError("This method requires RDKit to be installed.")
+
     self.add_self_edges = add_self_edges
 
   def _featurize(self, mol: RDKitMol) -> GraphData:
@@ -148,11 +153,8 @@ class MolGraphConvFeaturizer(MolecularFeaturizer):
     graph: GraphData
       A molecule graph with some features.
     """
-    try:
-      from rdkit import Chem
-      from rdkit.Chem import AllChem
-    except ModuleNotFoundError:
-      raise ValueError("This method requires RDKit to be installed.")
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
 
     # construct atom and bond features
     try:

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -37,6 +37,11 @@ class OneHotFeaturizer(MolecularFeaturizer):
       The max length for SMILES string. If the length of SMILES string is
       shorter than max_length, the SMILES is padded using space.
     """
+    try:
+      from rdkit import Chem # noqa
+    except ModuleNotFoundError:
+      raise ValueError("This class requires RDKit to be installed.")
+
     if len(charset) != len(set(charset)):
       raise ValueError("All values in charset must be unique.")
     self.charset = charset
@@ -57,10 +62,7 @@ class OneHotFeaturizer(MolecularFeaturizer):
       The shape is `(max_length, len(charset) + 1)`.
       The index of unknown character is `len(charset)`.
     """
-    try:
-      from rdkit import Chem
-    except ModuleNotFoundError:
-      raise ValueError("This class requires RDKit to be installed.")
+    from rdkit import Chem
 
     smiles = Chem.MolToSmiles(mol)
     # validation

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -38,7 +38,7 @@ class OneHotFeaturizer(MolecularFeaturizer):
       shorter than max_length, the SMILES is padded using space.
     """
     try:
-      from rdkit import Chem # noqa
+      from rdkit import Chem  # noqa
     except ModuleNotFoundError:
       raise ValueError("This class requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/raw_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/raw_featurizer.py
@@ -25,7 +25,7 @@ class RawFeaturizer(MolecularFeaturizer):
       If True, encode this molecule as a SMILES string. Else as a RDKit mol.
     """
     try:
-      from rdkit import Chem # noqa
+      from rdkit import Chem  # noqa
     except ModuleNotFoundError:
       raise ValueError("This class requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/raw_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/raw_featurizer.py
@@ -24,6 +24,11 @@ class RawFeaturizer(MolecularFeaturizer):
     smiles: bool, optional (default False)
       If True, encode this molecule as a SMILES string. Else as a RDKit mol.
     """
+    try:
+      from rdkit import Chem # noqa
+    except ModuleNotFoundError:
+      raise ValueError("This class requires RDKit to be installed.")
+
     self.smiles = smiles
 
   def _featurize(self, mol: RDKitMol) -> Union[str, RDKitMol]:
@@ -39,10 +44,7 @@ class RawFeaturizer(MolecularFeaturizer):
     str or rdkit.Chem.rdchem.Mol
       SMILES string or RDKit Mol object.
     """
-    try:
-      from rdkit import Chem
-    except ModuleNotFoundError:
-      raise ValueError("This class requires RDKit to be installed.")
+    from rdkit import Chem
 
     if self.smiles:
       return Chem.MolToSmiles(mol)

--- a/deepchem/feat/molecule_featurizers/smiles_to_image.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_image.py
@@ -55,8 +55,8 @@ class SmilesToImage(MolecularFeaturizer):
       Indicates the channel organization of the image tensor
     """
     try:
-      from rdkit import Chem # noqa
-      from rdkit.Chem import AllChem # noqa
+      from rdkit import Chem  # noqa
+      from rdkit.Chem import AllChem  # noqa
     except ModuleNotFoundError:
       raise ValueError("This class requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/smiles_to_image.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_image.py
@@ -54,10 +54,17 @@ class SmilesToImage(MolecularFeaturizer):
     img_spec: str, default std
       Indicates the channel organization of the image tensor
     """
+    try:
+      from rdkit import Chem # noqa
+      from rdkit.Chem import AllChem # noqa
+    except ModuleNotFoundError:
+      raise ValueError("This class requires RDKit to be installed.")
+
     if img_spec not in ["std", "engd"]:
       raise ValueError(
           "Image mode must be one of std or engd. {} is not supported".format(
               img_spec))
+
     self.img_size = img_size
     self.max_len = max_len
     self.res = res
@@ -78,11 +85,8 @@ class SmilesToImage(MolecularFeaturizer):
       A 3D array of image, the shape is `(img_size, img_size, 1)`.
       If the length of SMILES is longer than `max_len`, this value is an empty array.
     """
-    try:
-      from rdkit import Chem
-      from rdkit.Chem import AllChem
-    except ModuleNotFoundError:
-      raise ValueError("This class requires RDKit to be installed.")
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
 
     smile = Chem.MolToSmiles(mol)
     if len(smile) > self.max_len:

--- a/deepchem/feat/molecule_featurizers/smiles_to_seq.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_seq.py
@@ -84,7 +84,7 @@ class SmilesToSeq(MolecularFeaturizer):
       Amount of padding to add on either side of the SMILES seq
     """
     try:
-      from rdkit import Chem #noqa
+      from rdkit import Chem  # noqa
     except ModuleNotFoundError:
       raise ValueError("This class requires RDKit to be installed.")
 

--- a/deepchem/feat/molecule_featurizers/smiles_to_seq.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_seq.py
@@ -83,6 +83,11 @@ class SmilesToSeq(MolecularFeaturizer):
     pad_len: int, default 10
       Amount of padding to add on either side of the SMILES seq
     """
+    try:
+      from rdkit import Chem #noqa
+    except ModuleNotFoundError:
+      raise ValueError("This class requires RDKit to be installed.")
+
     self.max_len = max_len
     self.char_to_idx = char_to_idx
     self.idx_to_char = {idx: letter for letter, idx in self.char_to_idx.items()}
@@ -129,10 +134,7 @@ class SmilesToSeq(MolecularFeaturizer):
       A 1D array of a SMILES sequence.
       If the length of SMILES is longer than `max_len`, this value is an empty array.
     """
-    try:
-      from rdkit import Chem
-    except ModuleNotFoundError:
-      raise ValueError("This class requires RDKit to be installed.")
+    from rdkit import Chem
 
     smile = Chem.MolToSmiles(mol)
     if len(smile) > self.max_len:


### PR DESCRIPTION
This PR is related to #2162 

Currently, the error `raise ValueError("This class requires XXXX to be installed.")` which was thrown by `_featurize` method is not shown because base featurizers catches it and convert these lines.

```
logger.warning("Failed to featurize datapoint %d. Appending empty array")
features.append(np.array([]))
```

So, I moved the import checking codes from `_featurize` to  `__init__`.
