### PR TITLE
Add SDFLoader docs

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -685,7 +685,9 @@ class JsonLoader(DataLoader):
 class SDFLoader(DataLoader):
   """Creates a `Dataset` object from SDF input files.
 
-  This class provides conveniences to load and featurize data from SDF files.
+  This class provides conveniences to load and featurize data from
+  Structure Data Files (SDFs). SDF is a standard format for structural
+  information (3D coordinates of atoms and bonds) of molecular compounds.
 
   Examples
   --------

--- a/docs/dataloaders.rst
+++ b/docs/dataloaders.rst
@@ -48,6 +48,12 @@ ImageLoader
 .. autoclass:: deepchem.data.ImageLoader
   :members:
 
+SDFLoader
+^^^^^^^^^
+
+.. autoclass:: deepchem.data.SDFLoader
+  :members:
+
 InMemoryLoader
 ^^^^^^^^^^^^^^
 The :code:`dc.data.InMemoryLoader` is designed to facilitate the processing of large datasets where you already hold the raw data in-memory (say in a pandas dataframe).


### PR DESCRIPTION
While looking at the docs for [Data Loaders](https://deepchem.readthedocs.io/en/latest/dataloaders.html), I noticed that `SDFLoader` was not documented. I also expanded the docstring a bit.