### PR TITLE
Changes to ButinaSplitter

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1015,14 +1015,26 @@ class ButinaSplitter(Splitter):
   This class requires RDKit to be installed.
   """
 
-  def split(self,
-            dataset: Dataset,
-            frac_train: float = 0.8,
-            frac_valid: float = 0.1,
-            frac_test: float = 0.1,
-            seed: Optional[int] = None,
-            log_every_n: Optional[int] = None,
-            cutoff: float = 0.18) -> Tuple[List[int], List[int], List]:
+  def __init__(self, cutoff: float = 0.6):
+    """Create a ButinaSplitter.
+
+    Parameters
+    ----------
+    cutoff: float (default 0.6)
+      The cutoff value for tanimoto similarity.  Molecules that are more similar
+      than this will tend to be put in the same dataset.
+    """
+    super(ButinaSplitter, self).__init__()
+    self.cutoff = cutoff
+
+  def split(
+      self,
+      dataset: Dataset,
+      frac_train: float = 0.8,
+      frac_valid: float = 0.1,
+      frac_test: float = 0.1,
+      seed: Optional[int] = None,
+      log_every_n: Optional[int] = None) -> Tuple[List[int], List[int], List]:
     """
     Splits internal compounds into train and validation based on the butina
     clustering algorithm. This splitting algorithm has an O(N^2) run time, where N
@@ -1047,19 +1059,12 @@ class ButinaSplitter(Splitter):
       Random seed to use.
     log_every_n: int, optional (default None)
       Log every n examples (not currently used).
-    cutoff: float, optional (default 0.18)
-      The cutoff value for similarity.
 
     Returns
     -------
     Tuple[List[int], List[int], List[int]]
       A tuple of train indices, valid indices, and test indices.
       Each indices is a list of integers and test indices is always an empty list.
-
-    Notes
-    -----
-    This function entirely disregards the ratios for frac_train, frac_valid,
-    and frac_test. Furthermore, it does not generate a test set, only a train and valid set.
     """
     try:
       from rdkit import Chem, DataStructs
@@ -1068,7 +1073,7 @@ class ButinaSplitter(Splitter):
     except ModuleNotFoundError:
       raise ValueError("This function requires RDKit to be installed.")
 
-    logger.info("Performing butina clustering with cutoff of", cutoff)
+    logger.info("Performing butina clustering with cutoff of", self.cutoff)
     mols = []
     for ind, smiles in enumerate(dataset.ids):
       mols.append(Chem.MolFromSmiles(smiles))
@@ -1081,26 +1086,26 @@ class ButinaSplitter(Splitter):
     for i in range(1, nfps):
       sims = DataStructs.BulkTanimotoSimilarity(fps[i], fps[:i])
       dists.extend([1 - x for x in sims])
-    scaffold_sets = Butina.ClusterData(dists, nfps, cutoff, isDistData=True)
+    scaffold_sets = Butina.ClusterData(
+        dists, nfps, self.cutoff, isDistData=True)
     scaffold_sets = sorted(scaffold_sets, key=lambda x: -len(x))
 
-    ys = dataset.y
-    valid_inds = []
-    for c_idx, cluster in enumerate(scaffold_sets):
-      # for m_idx in cluster:
-      valid_inds.extend(cluster)
-      # continue until we find an active in all the tasks, otherwise we can't
-      # compute a meaningful AUC
-      # TODO (ytz): really, we want at least one active and inactive in both scenarios.
-      # TODO (Ytz): for regression tasks we'd stop after only one cluster.
-      active_populations = np.sum(ys[valid_inds], axis=0)
-      if np.all(active_populations):
-        logger.info("# of actives per task in valid:", active_populations)
-        logger.info("Total # of validation points:", len(valid_inds))
-        break
+    train_cutoff = frac_train * len(dataset)
+    valid_cutoff = (frac_train + frac_valid) * len(dataset)
+    train_inds: List[int] = []
+    valid_inds: List[int] = []
+    test_inds: List[int] = []
 
-    train_inds = list(itertools.chain.from_iterable(scaffold_sets[c_idx + 1:]))
-    return train_inds, valid_inds, []
+    logger.info("About to sort in scaffold sets")
+    for scaffold_set in scaffold_sets:
+      if len(train_inds) + len(scaffold_set) > train_cutoff:
+        if len(train_inds) + len(valid_inds) + len(scaffold_set) > valid_cutoff:
+          test_inds += scaffold_set
+        else:
+          valid_inds += scaffold_set
+      else:
+        train_inds += scaffold_set
+    return train_inds, valid_inds, test_inds
 
 
 def _generate_scaffold(smiles: str, include_chirality: bool = False) -> str:

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -204,9 +204,9 @@ class TestSplitter(unittest.TestCase):
     train_data, valid_data, test_data = \
       butina_splitter.train_valid_test_split(
         solubility_dataset)
-    assert len(train_data) == 7
-    assert len(valid_data) == 3
-    assert len(test_data) == 0
+    assert len(train_data) == 8
+    assert len(valid_data) == 1
+    assert len(test_data) == 1
 
   def test_k_fold_splitter(self):
     """

--- a/examples/tutorials/08_Working_With_Splitters.ipynb
+++ b/examples/tutorials/08_Working_With_Splitters.ipynb
@@ -94,6 +94,10 @@
     "\n",
     "This splitter tries to address the problem discussed above where many molecules are very similar to each other.  It identifies the scaffold that forms the core of each molecule, and ensures that all molecules with the same scaffold are put into the same dataset.  This is still not a perfect solution, since two molecules may have different scaffolds but be very similar in other ways, but it usually is a large improvement over random splitting.\n",
     "\n",
+    "### ButinaSplitter\n",
+    "\n",
+    "This is another splitter that tries to address the problem of similar molecules.  It clusters them based on their molecular fingerprints, so that ones with similar fingerprints will tend to be in the same dataset.  The time required by this splitting algorithm scales as the square of the number of molecules, so it is mainly useful for small to medium sized datasets.\n",
+    "\n",
     "### SpecifiedSplitter\n",
     "\n",
     "This splitter leaves everything up to the user.  You tell it exactly which samples to put in each dataset.  This is useful when you know in advance that a particular splitting is appropriate for your data.\n",
@@ -102,7 +106,7 @@
     "\n",
     "## Effect of Using Different Splitters\n",
     "\n",
-    "Let's look at an example.  We will load the Tox21 toxicity dataset using both random and scaffold splitting.  For each one we train a model and evaluate it on the training and test sets."
+    "Let's look at an example.  We will load the Tox21 toxicity dataset using random, scaffold, and Butina splitting.  For each one we train a model and evaluate it on the training and test sets."
    ]
   },
   {
@@ -119,12 +123,16 @@
      "output_type": "stream",
      "text": [
       "splitter: random\n",
-      "training set score: {'roc_auc_score': 0.955262277942416}\n",
-      "test set score: {'roc_auc_score': 0.7822195797170739}\n",
+      "training set score: {'roc_auc_score': 0.9560766203173238}\n",
+      "test set score: {'roc_auc_score': 0.8088861019955839}\n",
       "\n",
       "splitter: scaffold\n",
-      "training set score: {'roc_auc_score': 0.9589920031585532}\n",
-      "test set score: {'roc_auc_score': 0.6864850510346351}\n",
+      "training set score: {'roc_auc_score': 0.9582835670901536}\n",
+      "test set score: {'roc_auc_score': 0.6803307954037949}\n",
+      "\n",
+      "splitter: butina\n",
+      "training set score: {'roc_auc_score': 0.9578120869103354}\n",
+      "test set score: {'roc_auc_score': 0.6057007877463954}\n",
       "\n"
      ]
     }
@@ -132,7 +140,7 @@
    "source": [
     "import deepchem as dc\n",
     "\n",
-    "splitters = ['random', 'scaffold']\n",
+    "splitters = ['random', 'scaffold', 'butina']\n",
     "metric = dc.metrics.Metric(dc.metrics.roc_auc_score)\n",
     "for splitter in splitters:\n",
     "    tasks, datasets, transformers = dc.molnet.load_tox21(featurizer='ECFP', split=splitter)\n",
@@ -149,7 +157,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Both of them produce very similar performance on the training set, but the random splitter has much higher performance on the test set.  Does that mean random splitting is better?  No!  It means random splitting doesn't give you an accurate measure of how well your model works.  Because the test set contains lots of molecules that are very similar to ones in the training set, it isn't truly independent.  It makes the model appear to work better than it really does.  Scaffold splitting gives a better indication of what you can expect on independent data in the future."
+    "All of them produce very similar performance on the training set, but the random splitter has much higher performance on the test set.  Scaffold splitting has a lower test set score, and Butina splitting is even lower.  Does that mean random splitting is better?  No!  It means random splitting doesn't give you an accurate measure of how well your model works.  Because the test set contains lots of molecules that are very similar to ones in the training set, it isn't truly independent.  It makes the model appear to work better than it really does.  Scaffold splitting and Butina splitting give a better indication of what you can expect on independent data in the future."
    ]
   },
   {


### PR DESCRIPTION
Fixes #2198.  I made the following changes.

1. It now performs the splitting using identical code to ScaffoldSplitter, just based on clusters instead of scaffolds.
2. I increased the default cutoff to 0.6.
3. The cutoff is now a constructor argument.  This allows `split()` to have an identical signature to other splitters.  It also will allow you to control the cutoff for molnet loader function with, for example, `splitter=dc.split.ButinaSplitter(0.7)`.
4. I updated the splitters tutorial to discuss it as well.