### PR TITLE
Adding in some more tests for save/reload

### DIFF
--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -2686,7 +2686,15 @@ class DTNNEmbedding(tf.keras.layers.Layer):
     return config
 
   def build(self, input_shape):
-    init = initializers.get(self.init)
+
+    def init(input_shape):
+      return self.add_weight(
+          name='kernel',
+          shape=(input_shape[0], input_shape[1]),
+          initializer=self.init,
+          trainable=True)
+
+    #init = initializers.get(self.init)
     self.embedding_list = init([self.periodic_table_length, self.n_embedding])
     self.built = True
 
@@ -2739,7 +2747,15 @@ class DTNNStep(tf.keras.layers.Layer):
     return config
 
   def build(self, input_shape):
-    init = initializers.get(self.init)
+
+    def init(input_shape):
+      return self.add_weight(
+          name='kernel',
+          shape=(input_shape[0], input_shape[1]),
+          initializer=self.init,
+          trainable=True)
+
+    #init = initializers.get(self.init)
     self.W_cf = init([self.n_embedding, self.n_hidden])
     self.W_df = init([self.n_distance, self.n_hidden])
     self.W_fc = init([self.n_hidden, self.n_embedding])
@@ -2824,7 +2840,15 @@ class DTNNGather(tf.keras.layers.Layer):
   def build(self, input_shape):
     self.W_list = []
     self.b_list = []
-    init = initializers.get(self.init)
+
+    def init(input_shape):
+      return self.add_weight(
+          name='kernel',
+          shape=(input_shape[0], input_shape[1]),
+          initializer=self.init,
+          trainable=True)
+
+    #init = initializers.get(self.init)
     prev_layer_size = self.n_embedding
     for i, layer_size in enumerate(self.layer_sizes):
       self.W_list.append(init([prev_layer_size, layer_size]))
@@ -3230,9 +3254,17 @@ class EdgeNetwork(tf.keras.layers.Layer):
     return config
 
   def build(self, input_shape):
+
+    def init(input_shape):
+      return self.add_weight(
+          name='kernel',
+          shape=(input_shape[0], input_shape[1]),
+          initializer=self.init,
+          trainable=True)
+
     n_pair_features = self.n_pair_features
     n_hidden = self.n_hidden
-    init = initializers.get(self.init)
+    #init = initializers.get(self.init)
     self.W = init([n_pair_features, n_hidden * n_hidden])
     self.b = backend.zeros(shape=(n_hidden * n_hidden,))
     self.built = True
@@ -3262,7 +3294,15 @@ class GatedRecurrentUnit(tf.keras.layers.Layer):
 
   def build(self, input_shape):
     n_hidden = self.n_hidden
-    init = initializers.get(self.init)
+
+    def init(input_shape):
+      return self.add_weight(
+          name='kernel',
+          shape=(input_shape[0], input_shape[1]),
+          initializer=self.init,
+          trainable=True)
+
+    #init = initializers.get(self.init)
     self.Wz = init([n_hidden, n_hidden])
     self.Wr = init([n_hidden, n_hidden])
     self.Wh = init([n_hidden, n_hidden])
@@ -3317,7 +3357,15 @@ class SetGather(tf.keras.layers.Layer):
     return config
 
   def build(self, input_shape):
-    init = initializers.get(self.init)
+
+    def init(input_shape):
+      return self.add_weight(
+          name='kernel',
+          shape=(input_shape[0], input_shape[1]),
+          initializer=self.init,
+          trainable=True)
+
+    #init = initializers.get(self.init)
     self.U = init((2 * self.n_hidden, 4 * self.n_hidden))
     self.b = tf.Variable(
         np.concatenate((np.zeros(self.n_hidden), np.ones(self.n_hidden),

--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -2694,7 +2694,6 @@ class DTNNEmbedding(tf.keras.layers.Layer):
           initializer=self.init,
           trainable=True)
 
-    #init = initializers.get(self.init)
     self.embedding_list = init([self.periodic_table_length, self.n_embedding])
     self.built = True
 
@@ -2755,7 +2754,6 @@ class DTNNStep(tf.keras.layers.Layer):
           initializer=self.init,
           trainable=True)
 
-    #init = initializers.get(self.init)
     self.W_cf = init([self.n_embedding, self.n_hidden])
     self.W_df = init([self.n_distance, self.n_hidden])
     self.W_fc = init([self.n_hidden, self.n_embedding])
@@ -2848,7 +2846,6 @@ class DTNNGather(tf.keras.layers.Layer):
           initializer=self.init,
           trainable=True)
 
-    #init = initializers.get(self.init)
     prev_layer_size = self.n_embedding
     for i, layer_size in enumerate(self.layer_sizes):
       self.W_list.append(init([prev_layer_size, layer_size]))
@@ -3264,7 +3261,6 @@ class EdgeNetwork(tf.keras.layers.Layer):
 
     n_pair_features = self.n_pair_features
     n_hidden = self.n_hidden
-    #init = initializers.get(self.init)
     self.W = init([n_pair_features, n_hidden * n_hidden])
     self.b = backend.zeros(shape=(n_hidden * n_hidden,))
     self.built = True
@@ -3302,7 +3298,6 @@ class GatedRecurrentUnit(tf.keras.layers.Layer):
           initializer=self.init,
           trainable=True)
 
-    #init = initializers.get(self.init)
     self.Wz = init([n_hidden, n_hidden])
     self.Wr = init([n_hidden, n_hidden])
     self.Wh = init([n_hidden, n_hidden])
@@ -3365,7 +3360,6 @@ class SetGather(tf.keras.layers.Layer):
           initializer=self.init,
           trainable=True)
 
-    #init = initializers.get(self.init)
     self.U = init((2 * self.n_hidden, 4 * self.n_hidden))
     self.b = tf.Variable(
         np.concatenate((np.zeros(self.n_hidden), np.ones(self.n_hidden),

--- a/deepchem/models/tests/test_reload.py
+++ b/deepchem/models/tests/test_reload.py
@@ -773,6 +773,10 @@ def test_textCNN_classification_reload():
       model_dir=model_dir)
   reloaded_model.restore()
 
+  # Eval model on train
+  scores = reloaded_model.evaluate(dataset, [classification_metric])
+  assert scores[classification_metric.name] > .8
+
   assert len(reloaded_model.model.get_weights()) == len(
       model.model.get_weights())
   for (reloaded, orig) in zip(reloaded_model.model.get_weights(),
@@ -785,18 +789,9 @@ def test_textCNN_classification_reload():
   predset = dc.data.NumpyDataset(Xpred, ids=predmols)
   origpred = model.predict(predset)
   reloadpred = reloaded_model.predict(predset)
-
-  Xproc = reloaded_model.smiles_to_seq_batch(np.array(predmols))
-  reloadout = reloaded_model.model(Xproc)
-  origout = model.model(Xproc)
-
-  assert len(model.model.layers) == len(reloaded_model.model.layers)
-
   assert np.all(origpred == reloadpred)
 
-  # Eval model on train
-  scores = reloaded_model.evaluate(dataset, [classification_metric])
-  assert scores[classification_metric.name] > .8
+  assert len(model.model.layers) == len(reloaded_model.model.layers)
 
 
 def test_1d_cnn_regression_reload():

--- a/deepchem/models/text_cnn.py
+++ b/deepchem/models/text_cnn.py
@@ -54,24 +54,36 @@ default_dict = {
 
 class TextCNNModel(KerasModel):
   """ A Convolutional neural network on smiles strings
-  Reimplementation of the discriminator module in ORGAN: https://arxiv.org/abs/1705.10843
-  Originated from: http://emnlp2014.org/papers/pdf/EMNLP2014181.pdf
 
-  This model applies multiple 1D convolutional filters to the padded strings,
-  then max-over-time pooling is applied on all filters, extracting one feature per filter.
-  All features are concatenated and transformed through several hidden layers to form predictions.
+  Reimplementation of the discriminator module in ORGAN [1]_ .
+  Originated from [2]_. 
 
-  This model is initially developed for sentence-level classification tasks, with
-  words represented as vectors. In this implementation, SMILES strings are dissected
-  into characters and transformed to one-hot vectors in a similar way. The model can
-  be used for general molecular-level classification or regression tasks. It is also
-  used in the ORGAN model as discriminator.
+  This model applies multiple 1D convolutional filters to
+  the padded strings, then max-over-time pooling is applied on
+  all filters, extracting one feature per filter.  All
+  features are concatenated and transformed through several
+  hidden layers to form predictions.
 
-  Training of the model only requires SMILES strings input, all featurized datasets
-  that include SMILES in the `ids` attribute are accepted. PDBbind, QM7 and QM7b
-  are not supported. To use the model, `build_char_dict` should be called first
-  before defining the model to build character dict of input dataset, example can
-  be found in examples/delaney/delaney_textcnn.py
+  This model is initially developed for sentence-level
+  classification tasks, with words represented as vectors. In
+  this implementation, SMILES strings are dissected into
+  characters and transformed to one-hot vectors in a similar
+  way. The model can be used for general molecular-level
+  classification or regression tasks. It is also used in the
+  ORGAN model as discriminator.
+
+  Training of the model only requires SMILES strings input,
+  all featurized datasets that include SMILES in the `ids`
+  attribute are accepted. PDBbind, QM7 and QM7b are not
+  supported. To use the model, `build_char_dict` should be
+  called first before defining the model to build character
+  dict of input dataset, example can be found in
+  examples/delaney/delaney_textcnn.py
+
+  References
+  ----------
+  .. [1]  Guimaraes, Gabriel Lima, et al. "Objective-reinforced generative adversarial networks (ORGAN) for sequence generation models." arXiv preprint arXiv:1705.10843 (2017).
+  .. [2] Kim, Yoon. "Convolutional neural networks for sentence classification." arXiv preprint arXiv:1408.5882 (2014).
 
   """
 


### PR DESCRIPTION
This PR continues work for #2217 and adds save/reload tests for a few more models following the fix @hsjang001205 introduced to make sure weights are initialized correctly.

As a notable omission, `GraphConvModel` is still broken. I'm seeing the same errors @nesanders reports in https://github.com/deepchem/deepchem/issues/2217#issuecomment-710234044. 