### PR TITLE
Model Wrapper for GCNPredictor from DGL-LifeSci

### DIFF
--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -123,7 +123,7 @@ class GraphData:
         edge_attr=edge_features,
         pos=node_pos_features)
 
-  def to_dgl_graph(self, self_loop=False):
+  def to_dgl_graph(self, self_loop: bool=False):
     """Convert to DGL graph data instance
 
     Returns

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -150,9 +150,9 @@ class GraphData:
       src = np.concatenate([src, np.arange(self.num_nodes)])
       dst = np.concatenate([dst, np.arange(self.num_nodes)])
 
-    g = dgl.graph((torch.from_numpy(src).long(),
-                   torch.from_numpy(dst).long()),
-                  num_nodes=self.num_nodes)
+    g = dgl.graph(
+        (torch.from_numpy(src).long(), torch.from_numpy(dst).long()),
+        num_nodes=self.num_nodes)
     g.ndata['x'] = torch.from_numpy(self.node_features).float()
 
     if self.node_pos_features is not None:

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -123,7 +123,7 @@ class GraphData:
         edge_attr=edge_features,
         pos=node_pos_features)
 
-  def to_dgl_graph(self, self_loop: bool=False):
+  def to_dgl_graph(self, self_loop: bool = False):
     """Convert to DGL graph data instance
 
     Returns

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -136,16 +136,14 @@ class GraphData:
     This method requires DGL to be installed.
     """
     try:
+      import dgl
       import torch
-      from dgl import DGLGraph
     except ModuleNotFoundError:
       raise ValueError("This function requires DGL to be installed.")
 
-    g = DGLGraph()
-    g.add_nodes(self.num_nodes)
-    g.add_edges(
-        torch.from_numpy(self.edge_index[0]).long(),
-        torch.from_numpy(self.edge_index[1]).long())
+    g = dgl.graph((torch.from_numpy(self.edge_index[0]).long(),
+                   torch.from_numpy(self.edge_index[1]).long()),
+                  num_nodes=self.num_nodes)
     g.ndata['x'] = torch.from_numpy(self.node_features).float()
 
     if self.node_pos_features is not None:

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -123,13 +123,16 @@ class GraphData:
         edge_attr=edge_features,
         pos=node_pos_features)
 
-  def to_dgl_graph(self):
+  def to_dgl_graph(self, self_loop=False):
     """Convert to DGL graph data instance
 
     Returns
     -------
     dgl.DGLGraph
       Graph data for DGL
+    self_loop: bool
+      Whether to add self loops for the nodes, i.e. edges from nodes
+      to themselves. Default to False.
 
     Notes
     -----
@@ -141,8 +144,14 @@ class GraphData:
     except ModuleNotFoundError:
       raise ValueError("This function requires DGL to be installed.")
 
-    g = dgl.graph((torch.from_numpy(self.edge_index[0]).long(),
-                   torch.from_numpy(self.edge_index[1]).long()),
+    src = self.edge_index[0]
+    dst = self.edge_index[1]
+    if self_loop:
+      src = np.concatenate([src, np.arange(self.num_nodes)])
+      dst = np.concatenate([dst, np.arange(self.num_nodes)])
+
+    g = dgl.graph((torch.from_numpy(src).long(),
+                   torch.from_numpy(dst).long()),
                   num_nodes=self.num_nodes)
     g.ndata['x'] = torch.from_numpy(self.node_features).float()
 

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -123,7 +123,7 @@ class GraphData:
         edge_attr=edge_features,
         pos=node_pos_features)
 
-  def to_dgl_graph(self, self_loop=False):
+  def to_dgl_graph(self, self_loop=True):
     """Convert to DGL graph data instance
 
     Returns
@@ -132,7 +132,7 @@ class GraphData:
       Graph data for DGL
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes
-      to themselves. Default to False.
+      to themselves. Default to True.
 
     Notes
     -----

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -123,7 +123,7 @@ class GraphData:
         edge_attr=edge_features,
         pos=node_pos_features)
 
-  def to_dgl_graph(self, self_loop=True):
+  def to_dgl_graph(self, self_loop=False):
     """Convert to DGL graph data instance
 
     Returns
@@ -132,7 +132,7 @@ class GraphData:
       Graph data for DGL
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes
-      to themselves. Default to True.
+      to themselves. Default to False.
 
     Notes
     -----

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -33,6 +33,7 @@ try:
   from deepchem.models.torch_models import TorchModel
   from deepchem.models.torch_models import CGCNN, CGCNNModel
   from deepchem.models.torch_models import GAT, GATModel
+  from deepchem.models.torch_models import GCN, GCNModel
 except ModuleNotFoundError:
   pass
 

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -29,7 +29,7 @@ def test_gcn_regression():
     model = GCNModel(mode='regression', n_tasks=n_tasks, number_atom_features=30, batch_size=10)
 
     # overfit test
-    model.fit(dataset, nb_epoch=60)
+    model.fit(dataset, nb_epoch=100)
     scores = model.evaluate(dataset, [metric], transformers)
     assert scores['mean_absolute_error'] < 0.5
 

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -29,7 +29,7 @@ def test_gcn_regression():
     model = GCNModel(mode='regression', n_tasks=n_tasks, number_atom_features=30, batch_size=10)
 
     # overfit test
-    model.fit(dataset, nb_epoch=300)
+    model.fit(dataset, nb_epoch=50)
     scores = model.evaluate(dataset, [metric], transformers)
     assert scores['mean_absolute_error'] < 0.5
 
@@ -51,7 +51,7 @@ def test_gcn_classification():
         learning_rate=0.001)
 
     # overfit test
-    model.fit(dataset, nb_epoch=150)
+    model.fit(dataset, nb_epoch=50)
     scores = model.evaluate(dataset, [metric], transformers)
     assert scores['mean-roc_auc_score'] >= 0.85
 
@@ -74,7 +74,7 @@ def test_gcn_reload():
         batch_size=10,
         learning_rate=0.001)
 
-    model.fit(dataset, nb_epoch=150)
+    model.fit(dataset, nb_epoch=50)
     scores = model.evaluate(dataset, [metric], transformers)
     assert scores['mean-roc_auc_score'] >= 0.85
 

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -1,0 +1,95 @@
+import unittest
+import tempfile
+
+import numpy as np
+
+import deepchem as dc
+from deepchem.feat import MolGraphConvFeaturizer
+from deepchem.models import GCNModel
+from deepchem.models.tests.test_graph_models import get_dataset
+
+try:
+    import dgl
+    import dgllife
+    import torch
+    has_torch_and_dgl = True
+except:
+    has_torch_and_dgl = False
+
+@unittest.skipIf(not has_torch_and_dgl,
+                 'PyTorch, DGL, or DGL-LifeSci are not installed')
+def test_gcn_regression():
+    # load datasets
+    featurizer = MolGraphConvFeaturizer()
+    tasks, dataset, transformers, metric = get_dataset(
+        'regression', featurizer=featurizer)
+
+    # initialize models
+    n_tasks = len(tasks)
+    model = GCNModel(mode='regression', n_tasks=n_tasks, number_atom_features=30, batch_size=10)
+
+    # overfit test
+    model.fit(dataset, nb_epoch=300)
+    scores = model.evaluate(dataset, [metric], transformers)
+    assert scores['mean_absolute_error'] < 0.5
+
+@unittest.skipIf(not has_torch_and_dgl,
+                 'PyTorch, DGL, or DGL-LifeSci are not installed')
+def test_gcn_classification():
+    # load datasets
+    featurizer = MolGraphConvFeaturizer()
+    tasks, dataset, transformers, metric = get_dataset(
+    'classification', featurizer=featurizer)
+
+    # initialize models
+    n_tasks = len(tasks)
+    model = GCNModel(
+        mode='classification',
+        n_tasks=n_tasks,
+        number_atom_features=30,
+        batch_size=10,
+        learning_rate=0.001)
+
+    # overfit test
+    model.fit(dataset, nb_epoch=150)
+    scores = model.evaluate(dataset, [metric], transformers)
+    assert scores['mean-roc_auc_score'] >= 0.85
+
+@unittest.skipIf(not has_torch_and_dgl,
+                 'PyTorch, DGL, or DGL-LifeSci are not installed')
+def test_gcn_reload():
+    # load datasets
+    featurizer = MolGraphConvFeaturizer()
+    tasks, dataset, transformers, metric = get_dataset(
+        'classification', featurizer=featurizer)
+
+    # initialize models
+    n_tasks = len(tasks)
+    model_dir = tempfile.mkdtemp()
+    model = GCNModel(
+        mode='classification',
+        n_tasks=n_tasks,
+        number_atom_features=30,
+        model_dir=model_dir,
+        batch_size=10,
+        learning_rate=0.001)
+
+    model.fit(dataset, nb_epoch=150)
+    scores = model.evaluate(dataset, [metric], transformers)
+    assert scores['mean-roc_auc_score'] >= 0.85
+
+    reloaded_model = GCNModel(
+        mode='classification',
+        n_tasks=n_tasks,
+        number_atom_features=30,
+        model_dir=model_dir,
+        batch_size=10,
+        learning_rate=0.001)
+    reloaded_model.restore()
+
+    pred_mols = ["CCCC", "CCCCCO", "CCCCC"]
+    X_pred = featurizer(pred_mols)
+    random_dataset = dc.data.NumpyDataset(X_pred)
+    original_pred = model.predict(random_dataset)
+    reload_pred = reloaded_model.predict(random_dataset)
+    assert np.all(original_pred == reload_pred)

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -29,7 +29,7 @@ def test_gcn_regression():
     model = GCNModel(mode='regression', n_tasks=n_tasks, number_atom_features=30, batch_size=10)
 
     # overfit test
-    model.fit(dataset, nb_epoch=50)
+    model.fit(dataset, nb_epoch=60)
     scores = model.evaluate(dataset, [metric], transformers)
     assert scores['mean_absolute_error'] < 0.5
 

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -9,87 +9,94 @@ from deepchem.models import GCNModel
 from deepchem.models.tests.test_graph_models import get_dataset
 
 try:
-    import dgl
-    import dgllife
-    import torch
-    has_torch_and_dgl = True
+  import dgl
+  import dgllife
+  import torch
+  has_torch_and_dgl = True
 except:
-    has_torch_and_dgl = False
+  has_torch_and_dgl = False
+
 
 @unittest.skipIf(not has_torch_and_dgl,
                  'PyTorch, DGL, or DGL-LifeSci are not installed')
 def test_gcn_regression():
-    # load datasets
-    featurizer = MolGraphConvFeaturizer()
-    tasks, dataset, transformers, metric = get_dataset(
-        'regression', featurizer=featurizer)
+  # load datasets
+  featurizer = MolGraphConvFeaturizer()
+  tasks, dataset, transformers, metric = get_dataset(
+      'regression', featurizer=featurizer)
 
-    # initialize models
-    n_tasks = len(tasks)
-    model = GCNModel(mode='regression', n_tasks=n_tasks, number_atom_features=30, batch_size=10)
+  # initialize models
+  n_tasks = len(tasks)
+  model = GCNModel(
+      mode='regression',
+      n_tasks=n_tasks,
+      number_atom_features=30,
+      batch_size=10)
 
-    # overfit test
-    model.fit(dataset, nb_epoch=100)
-    scores = model.evaluate(dataset, [metric], transformers)
-    assert scores['mean_absolute_error'] < 0.5
+  # overfit test
+  model.fit(dataset, nb_epoch=100)
+  scores = model.evaluate(dataset, [metric], transformers)
+  assert scores['mean_absolute_error'] < 0.5
+
 
 @unittest.skipIf(not has_torch_and_dgl,
                  'PyTorch, DGL, or DGL-LifeSci are not installed')
 def test_gcn_classification():
-    # load datasets
-    featurizer = MolGraphConvFeaturizer()
-    tasks, dataset, transformers, metric = get_dataset(
-    'classification', featurizer=featurizer)
+  # load datasets
+  featurizer = MolGraphConvFeaturizer()
+  tasks, dataset, transformers, metric = get_dataset(
+      'classification', featurizer=featurizer)
 
-    # initialize models
-    n_tasks = len(tasks)
-    model = GCNModel(
-        mode='classification',
-        n_tasks=n_tasks,
-        number_atom_features=30,
-        batch_size=10,
-        learning_rate=0.001)
+  # initialize models
+  n_tasks = len(tasks)
+  model = GCNModel(
+      mode='classification',
+      n_tasks=n_tasks,
+      number_atom_features=30,
+      batch_size=10,
+      learning_rate=0.001)
 
-    # overfit test
-    model.fit(dataset, nb_epoch=50)
-    scores = model.evaluate(dataset, [metric], transformers)
-    assert scores['mean-roc_auc_score'] >= 0.85
+  # overfit test
+  model.fit(dataset, nb_epoch=50)
+  scores = model.evaluate(dataset, [metric], transformers)
+  assert scores['mean-roc_auc_score'] >= 0.85
+
 
 @unittest.skipIf(not has_torch_and_dgl,
                  'PyTorch, DGL, or DGL-LifeSci are not installed')
 def test_gcn_reload():
-    # load datasets
-    featurizer = MolGraphConvFeaturizer()
-    tasks, dataset, transformers, metric = get_dataset(
-        'classification', featurizer=featurizer)
+  # load datasets
+  featurizer = MolGraphConvFeaturizer()
+  tasks, dataset, transformers, metric = get_dataset(
+      'classification', featurizer=featurizer)
 
-    # initialize models
-    n_tasks = len(tasks)
-    model_dir = tempfile.mkdtemp()
-    model = GCNModel(
-        mode='classification',
-        n_tasks=n_tasks,
-        number_atom_features=30,
-        model_dir=model_dir,
-        batch_size=10,
-        learning_rate=0.001)
+  # initialize models
+  n_tasks = len(tasks)
+  model_dir = tempfile.mkdtemp()
+  model = GCNModel(
+      mode='classification',
+      n_tasks=n_tasks,
+      number_atom_features=30,
+      model_dir=model_dir,
+      batch_size=10,
+      learning_rate=0.001)
 
-    model.fit(dataset, nb_epoch=50)
-    scores = model.evaluate(dataset, [metric], transformers)
-    assert scores['mean-roc_auc_score'] >= 0.85
+  model.fit(dataset, nb_epoch=50)
+  scores = model.evaluate(dataset, [metric], transformers)
+  assert scores['mean-roc_auc_score'] >= 0.85
 
-    reloaded_model = GCNModel(
-        mode='classification',
-        n_tasks=n_tasks,
-        number_atom_features=30,
-        model_dir=model_dir,
-        batch_size=10,
-        learning_rate=0.001)
-    reloaded_model.restore()
+  reloaded_model = GCNModel(
+      mode='classification',
+      n_tasks=n_tasks,
+      number_atom_features=30,
+      model_dir=model_dir,
+      batch_size=10,
+      learning_rate=0.001)
+  reloaded_model.restore()
 
-    pred_mols = ["CCCC", "CCCCCO", "CCCCC"]
-    X_pred = featurizer(pred_mols)
-    random_dataset = dc.data.NumpyDataset(X_pred)
-    original_pred = model.predict(random_dataset)
-    reload_pred = reloaded_model.predict(random_dataset)
-    assert np.all(original_pred == reload_pred)
+  pred_mols = ["CCCC", "CCCCCO", "CCCCC"]
+  X_pred = featurizer(pred_mols)
+  random_dataset = dc.data.NumpyDataset(X_pred)
+  original_pred = model.predict(random_dataset)
+  reload_pred = reloaded_model.predict(random_dataset)
+  assert np.all(original_pred == reload_pred)

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -2,3 +2,4 @@
 from deepchem.models.torch_models.torch_model import TorchModel
 from deepchem.models.torch_models.cgcnn import CGCNN, CGCNNModel
 from deepchem.models.torch_models.gat import GAT, GATModel
+from deepchem.models.torch_models.gcn import GCN, GCNModel

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -207,15 +207,16 @@ class GCNModel(TorchModel):
     Examples
     --------
 
-    >>> import deepchem as dc
-    >>> from deepchem.models import GCNModel
-    >>> featurizer = dc.feat.MolGraphConvFeaturizer()
-    >>> tasks, datasets, transformers = dc.molnet.load_tox21(
-    ...     reload=False, featurizer=featurizer, transformers=[])
-    >>> train, valid, test = datasets
-    >>> model = dc.models.GCNModel(mode='classification', n_tasks=len(tasks),
-    ...                            number_atom_features=30, batch_size=32, learning_rate=0.001)
-    >>> model.fit(train, nb_epoch=50)
+    >>>
+    >> import deepchem as dc
+    >> from deepchem.models import GCNModel
+    >> featurizer = dc.feat.MolGraphConvFeaturizer()
+    >> tasks, datasets, transformers = dc.molnet.load_tox21(
+    ..     reload=False, featurizer=featurizer, transformers=[])
+    >> train, valid, test = datasets
+    >> model = dc.models.GCNModel(mode='classification', n_tasks=len(tasks),
+    ..                            number_atom_features=30, batch_size=32, learning_rate=0.001)
+    >> model.fit(train, nb_epoch=50)
 
     References
     ----------

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -4,7 +4,7 @@ DGL-based GCN for graph property prediction.
 import torch.nn as nn
 import torch.nn.functional as F
 
-from deepchem.models.losses import L2Loss, SparseSoftmaxCrossEntropy
+from deepchem.models.losses import Loss, L2Loss, SparseSoftmaxCrossEntropy
 from deepchem.models.torch_models.torch_model import TorchModel
 
 class GCN(nn.Module):
@@ -308,7 +308,7 @@ class GCNModel(TorchModel):
                     n_classes=n_classes,
                     nfeat_name=nfeat_name)
         if mode == 'regression':
-            loss = L2Loss()
+            loss: Loss = L2Loss()
             output_types = ['prediction']
         else:
             loss = SparseSoftmaxCrossEntropy()

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -1,0 +1,280 @@
+"""
+DGL-based GCN for graph property prediction.
+"""
+import torch.nn as nn
+import torch.nn.functional as F
+
+from deepchem.models.losses import L2Loss, SparseSoftmaxCrossEntropy
+from deepchem.models.torch_models.torch_model import TorchModel
+
+class GCN(nn.Module):
+    """Model for Graph Property Prediction Based on Graph Convolution Networks (GCN).
+
+    This model proceeds as follows:
+
+    * Update node representations in graphs with a variant of GCN
+    * For each graph, compute its representation by 1) a weighted sum of the node
+      representations in the graph, where the weights are computed by applying a
+      gating function to the node representations 2) a max pooling of the node
+      representations 3) concatenating the output of 1) and 2)
+    * Perform the final prediction using an MLP
+
+    Examples
+    --------
+    # Todo
+
+    References
+    ----------
+    .. [1] Thomas N. Kipf and Max Welling. "Semi-Supervised Classification with Graph
+       Convolutional Networks." ICLR 2017.
+
+    Notes
+    -----
+    This class requires DGL (https://github.com/dmlc/dgl) and DGL-LifeSci
+    (https://github.com/awslabs/dgl-lifesci) to be installed.
+    """
+    def __init__(self,
+                 in_node_dim: int,
+                 hidden_node_dim: int,
+                 num_gnn_layers: int,
+                 activation = None,
+                 residual: bool = True,
+                 batchnorm: bool = True,
+                 dropout: float = 0.,
+                 predictor_hidden_feats: int = 128,
+                 predictor_dropout: float = 0.,
+                 n_tasks: int = 1,
+                 mode: str = 'regression',
+                 n_classes: int = 2,
+                 nfeat_name: str = 'x'):
+        """
+        Parameters
+        ----------
+        in_node_dim: int
+            The length of the initial node feature vectors.
+        hidden_node_dim: int
+            The length of the hidden node feature vectors.
+        num_gnn_layers: int
+            The number of GCN layers.
+        activation: callable
+            The activation function to apply to the output of each GCN layer.
+            By default, no activation function will be applied.
+        residual: bool
+            Whether to add a residual connection within each GCN layer. Default to True.
+        batchnorm: bool
+            Whether to apply batch normalization to the output of each GCN layer. Default to True.
+        dropout: float
+            The dropout probability for the output of each GCN layer. Default to 0.
+        predictor_hidden_feats: int
+            The size for hidden representations in the output MLP predictor. Default to 128.
+        predictor_dropout: float
+            The dropout probability in the output MLP predictor. Default to 0.
+        n_tasks: int
+            The output size.
+        mode: str
+            The model type, 'classification' or 'regression'.
+        n_classes: int
+            The number of classes to predict per task
+            (only used when ``mode`` is 'classification').
+        nfeat_name: str
+            For an input graph ``g``, the model assumes that it stores node features in
+            ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
+        """
+        try:
+            import dgl
+        except:
+            raise ImportError('This class requires dgl.')
+        try:
+            import dgllife
+        except:
+            raise ImportError('This class requires dgllife.')
+
+        if mode not in ['classification', 'regression']:
+            raise ValueError("mode must be either 'classification' or 'regression'")
+
+        super(GCN, self).__init__()
+
+        self.n_tasks = n_tasks
+        self.mode = mode
+        self.n_classes = n_classes
+        self.nfeat_name = nfeat_name
+        if mode == 'classification':
+            out_size = n_tasks * n_classes
+        else:
+            out_size = n_tasks
+
+        from dgllife.model import GCNPredictor as DGLGCNPredictor
+        self.model = DGLGCNPredictor(in_feats=in_node_dim,
+                                     hidden_feats=[hidden_node_dim] * num_gnn_layers,
+                                     activation=[activation] * num_gnn_layers,
+                                     residual=[residual] * num_gnn_layers,
+                                     batchnorm=[batchnorm] * num_gnn_layers,
+                                     dropout=[dropout] * num_gnn_layers,
+                                     n_tasks=out_size,
+                                     predictor_hidden_feats=predictor_hidden_feats,
+                                     predictor_dropout=predictor_dropout)
+
+    def forward(self, g):
+        """Predict graph labels
+
+        Parameters
+        ----------
+        g: DGLGraph
+            A DGLGraph for a batch of graphs. It stores the node features in
+            ``dgl_graph.ndata[self.nfeat_name]``.
+
+        Returns
+        -------
+        torch.Tensor
+            The model output.
+
+            * When self.mode = 'regression',
+              its shape will be ``(dgl_graph.batch_size, self.n_tasks)``.
+            * When self.mode = 'classification', the output consists of probabilities
+              for classes. Its shape will be
+              ``(dgl_graph.batch_size, self.n_tasks, self.n_classes)`` if self.n_tasks > 1;
+              its shape will be ``(dgl_graph.batch_size, self.n_classes)`` if self.n_tasks is 1.
+        torch.Tensor, optional
+            This is only returned when self.mode = 'classification', the output consists of the
+            logits for classes before softmax.
+        """
+        node_feats = g.ndata.pop(self.nfeat_name)
+        out = self.model(g, node_feats)
+
+        if self.mode == 'classification':
+            if self.n_tasks == 1:
+                logits = out.view(-1, self.n_classes)
+                softmax_dim = 1
+            else:
+                logits = out.view(-1, self.n_tasks, self.n_classes)
+                softmax_dim = 2
+            proba = F.softmax(logits, dim=softmax_dim)
+            return proba, logits
+        else:
+            return out
+
+class GCNModel(TorchModel):
+    """Model for Graph Property Prediction Based on Graph Convolution Networks (GCN).
+
+    This model proceeds as follows:
+
+    * Update node representations in graphs with a variant of GCN
+    * For each graph, compute its representation by 1) a weighted sum of the node
+      representations in the graph, where the weights are computed by applying a
+      gating function to the node representations 2) a max pooling of the node
+      representations 3) concatenating the output of 1) and 2)
+    * Perform the final prediction using an MLP
+
+    Examples
+    --------
+    # Todo
+
+    References
+    ----------
+    .. [1] Thomas N. Kipf and Max Welling. "Semi-Supervised Classification with Graph
+       Convolutional Networks." ICLR 2017.
+
+    Notes
+    -----
+    This class requires DGL (https://github.com/dmlc/dgl) and DGL-LifeSci
+    (https://github.com/awslabs/dgl-lifesci) to be installed.
+    """
+    def __init__(self,
+                 in_node_dim: int,
+                 hidden_node_dim: int,
+                 num_gnn_layers: int,
+                 activation = None,
+                 residual: bool = True,
+                 batchnorm: bool = True,
+                 dropout: float = 0.,
+                 predictor_hidden_feats: int = 128,
+                 predictor_dropout: float = 0.,
+                 n_tasks: int = 1,
+                 mode: str = 'regression',
+                 n_classes: int = 2,
+                 nfeat_name: str = 'x',
+                 **kwargs):
+        """
+        Parameters
+        ----------
+        in_node_dim: int
+            The length of the initial node feature vectors.
+        hidden_node_dim: int
+            The length of the hidden node feature vectors.
+        num_gnn_layers: int
+            The number of GCN layers.
+        activation: callable
+            The activation function to apply to the output of each GCN layer.
+            By default, no activation function will be applied.
+        residual: bool
+            Whether to add a residual connection within each GCN layer. Default to True.
+        batchnorm: bool
+            Whether to apply batch normalization to the output of each GCN layer. Default to True.
+        dropout: float
+            The dropout probability for the output of each GCN layer. Default to 0.
+        predictor_hidden_feats: int
+            The size for hidden representations in the output MLP predictor. Default to 128.
+        predictor_dropout: float
+            The dropout probability in the output MLP predictor. Default to 0.
+        n_tasks: int
+            The output size.
+        mode: str
+            The model type, 'classification' or 'regression'.
+        n_classes: int
+            The number of classes to predict per task
+            (only used when ``mode`` is 'classification').
+        nfeat_name: str
+            For an input graph ``g``, the model assumes that it stores node features in
+            ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
+        kwargs
+            This can include any keyword argument of TorchModel.
+        """
+        model = GCN(in_node_dim=in_node_dim,
+                    hidden_node_dim=hidden_node_dim,
+                    num_gnn_layers=num_gnn_layers,
+                    activation=activation,
+                    residual=residual,
+                    batchnorm=batchnorm,
+                    dropout=dropout,
+                    predictor_hidden_feats=predictor_hidden_feats,
+                    predictor_dropout=predictor_dropout,
+                    n_tasks=n_tasks,
+                    mode=mode,
+                    n_classes=n_classes,
+                    nfeat_name=nfeat_name)
+        if mode == 'regression':
+            loss = L2Loss()
+            output_types = ['prediction']
+        else:
+            loss = SparseSoftmaxCrossEntropy()
+            output_types = ['prediction', 'loss']
+        super(GCNModel, self).__init__(
+            model, loss=loss, output_types=output_types, **kwargs)
+
+    def _prepare_batch(self, batch):
+        """Create batch data for GCN.
+
+        Parameters
+        ----------
+        batch: tuple
+            The tuple is ``(inputs, labels, weights)``.
+
+        Returns
+        -------
+        inputs: DGLGraph
+            DGLGraph for a batch of graphs.
+        labels: list of torch.Tensor or None
+            The graph labels.
+        weights: list of torch.Tensor or None
+            The weights for each sample or sample/task pair converted to torch.Tensor.
+        """
+        try:
+            import dgl
+        except:
+            raise ImportError('This class requires dgl.')
+
+        inputs, labels, weights = batch
+        dgl_graphs = [graph.to_dgl_graph() for graph in inputs[0]]
+        inputs = dgl.batch(dgl_graphs).to(self.device)
+        _, labels, weights = super(GCNModel, self)._prepare_batch(([], labels, weights))
+        return inputs, labels, weights

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -21,7 +21,19 @@ class GCN(nn.Module):
 
     Examples
     --------
-    # Todo
+
+    >>> import deepchem as dc
+    >>> import pymatgen as mg
+    >>> from deepchem.models import GCN
+    >>> lattice = mg.Lattice.cubic(4.2)
+    >>> structure = mg.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+    >>> featurizer = dc.feat.CGCNNFeaturizer()
+    >>> cgcnn_graph = featurizer.featurize([structure])[0]
+    >>> cgcnn_graph.num_node_features
+    92
+    >>> cgcnn_dgl_graph = cgcnn_graph.to_dgl_graph()
+    >>> model = GCN(in_node_dim=92, hidden_node_dim=92, num_gnn_layers=2)
+    >>> model(cgcnn_dgl_graph)
 
     References
     ----------
@@ -39,7 +51,7 @@ class GCN(nn.Module):
                  num_gnn_layers: int,
                  activation = None,
                  residual: bool = True,
-                 batchnorm: bool = True,
+                 batchnorm: bool = False,
                  dropout: float = 0.,
                  predictor_hidden_feats: int = 128,
                  predictor_dropout: float = 0.,
@@ -62,7 +74,8 @@ class GCN(nn.Module):
         residual: bool
             Whether to add a residual connection within each GCN layer. Default to True.
         batchnorm: bool
-            Whether to apply batch normalization to the output of each GCN layer. Default to True.
+            Whether to apply batch normalization to the output of each GCN layer.
+            Default to False.
         dropout: float
             The dropout probability for the output of each GCN layer. Default to 0.
         predictor_hidden_feats: int
@@ -104,9 +117,13 @@ class GCN(nn.Module):
             out_size = n_tasks
 
         from dgllife.model import GCNPredictor as DGLGCNPredictor
+
+        if activation is not None:
+            activation = [activation] * num_gnn_layers
+
         self.model = DGLGCNPredictor(in_feats=in_node_dim,
                                      hidden_feats=[hidden_node_dim] * num_gnn_layers,
-                                     activation=[activation] * num_gnn_layers,
+                                     activation=activation,
                                      residual=[residual] * num_gnn_layers,
                                      batchnorm=[batchnorm] * num_gnn_layers,
                                      dropout=[dropout] * num_gnn_layers,
@@ -185,7 +202,7 @@ class GCNModel(TorchModel):
                  num_gnn_layers: int,
                  activation = None,
                  residual: bool = True,
-                 batchnorm: bool = True,
+                 batchnorm: bool = False,
                  dropout: float = 0.,
                  predictor_hidden_feats: int = 128,
                  predictor_dropout: float = 0.,
@@ -209,7 +226,8 @@ class GCNModel(TorchModel):
         residual: bool
             Whether to add a residual connection within each GCN layer. Default to True.
         batchnorm: bool
-            Whether to apply batch normalization to the output of each GCN layer. Default to True.
+            Whether to apply batch normalization to the output of each GCN layer.
+            Default to False.
         dropout: float
             The dropout probability for the output of each GCN layer. Default to 0.
         predictor_hidden_feats: int

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -33,6 +33,8 @@ class GCN(nn.Module):
     92
     >>> cgcnn_dgl_graph = cgcnn_graph.to_dgl_graph()
     >>> model = GCN(in_node_dim=92, hidden_node_dim=92, num_gnn_layers=2)
+    >>> # Call model.eval as batch norm is implemented
+    >>> model.eval()
     >>> model(cgcnn_dgl_graph)
 
     References
@@ -184,7 +186,14 @@ class GCNModel(TorchModel):
 
     Examples
     --------
-    # Todo
+
+    >>> import deepchem as dc
+    >>> from deepchem.models import GCNModel
+    >>> dataset_config = {"reload": False, "featurizer": dc.feat.CGCNNFeaturizer, "transformers": []}
+    >>> tasks, datasets, transformers = dc.molnet.load_perovskite(**dataset_config)
+    >>> train, valid, test = datasets
+    >>> model = dc.models.CGCNNModel(mode='regression', batch_size=32, learning_rate=0.001)
+    >>> model.fit(train, nb_epoch=50)
 
     References
     ----------

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -312,7 +312,7 @@ class GCNModel(TorchModel):
         super(GCNModel, self).__init__(
             model, loss=loss, output_types=output_types, **kwargs)
 
-    def _prepare_batch(self, batch, self_loop=True):
+    def _prepare_batch(self, batch):
         """Create batch data for GCN.
 
         Parameters
@@ -338,7 +338,7 @@ class GCNModel(TorchModel):
             raise ImportError('This class requires dgl.')
 
         inputs, labels, weights = batch
-        dgl_graphs = [graph.to_dgl_graph(self_loop=self_loop) for graph in inputs[0]]
+        dgl_graphs = [graph.to_dgl_graph(self_loop=True) for graph in inputs[0]]
         inputs = dgl.batch(dgl_graphs).to(self.device)
         _, labels, weights = super(GCNModel, self)._prepare_batch(([], labels, weights))
         return inputs, labels, weights

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -7,8 +7,9 @@ import torch.nn.functional as F
 from deepchem.models.losses import Loss, L2Loss, SparseSoftmaxCrossEntropy
 from deepchem.models.torch_models.torch_model import TorchModel
 
+
 class GCN(nn.Module):
-    """Model for Graph Property Prediction Based on Graph Convolution Networks (GCN).
+  """Model for Graph Property Prediction Based on Graph Convolution Networks (GCN).
 
     This model proceeds as follows:
 
@@ -65,20 +66,21 @@ class GCN(nn.Module):
     * There are various minor differences in using dropout, skip connection and batch
       normalization.
     """
-    def __init__(self,
-                 n_tasks: int,
-                 graph_conv_layers: list = None,
-                 activation = None,
-                 residual: bool = True,
-                 batchnorm: bool = False,
-                 dropout: float = 0.,
-                 predictor_hidden_feats: int = 128,
-                 predictor_dropout: float = 0.,
-                 mode: str = 'regression',
-                 number_atom_features: int = 75,
-                 n_classes: int = 2,
-                 nfeat_name: str = 'x'):
-        """
+
+  def __init__(self,
+               n_tasks: int,
+               graph_conv_layers: list = None,
+               activation=None,
+               residual: bool = True,
+               batchnorm: bool = False,
+               dropout: float = 0.,
+               predictor_hidden_feats: int = 128,
+               predictor_dropout: float = 0.,
+               mode: str = 'regression',
+               number_atom_features: int = 75,
+               n_classes: int = 2,
+               nfeat_name: str = 'x'):
+    """
         Parameters
         ----------
         n_tasks: int
@@ -111,50 +113,51 @@ class GCN(nn.Module):
             For an input graph ``g``, the model assumes that it stores node features in
             ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
         """
-        try:
-            import dgl
-        except:
-            raise ImportError('This class requires dgl.')
-        try:
-            import dgllife
-        except:
-            raise ImportError('This class requires dgllife.')
+    try:
+      import dgl
+    except:
+      raise ImportError('This class requires dgl.')
+    try:
+      import dgllife
+    except:
+      raise ImportError('This class requires dgllife.')
 
-        if mode not in ['classification', 'regression']:
-            raise ValueError("mode must be either 'classification' or 'regression'")
+    if mode not in ['classification', 'regression']:
+      raise ValueError("mode must be either 'classification' or 'regression'")
 
-        super(GCN, self).__init__()
+    super(GCN, self).__init__()
 
-        self.n_tasks = n_tasks
-        self.mode = mode
-        self.n_classes = n_classes
-        self.nfeat_name = nfeat_name
-        if mode == 'classification':
-            out_size = n_tasks * n_classes
-        else:
-            out_size = n_tasks
+    self.n_tasks = n_tasks
+    self.mode = mode
+    self.n_classes = n_classes
+    self.nfeat_name = nfeat_name
+    if mode == 'classification':
+      out_size = n_tasks * n_classes
+    else:
+      out_size = n_tasks
 
-        from dgllife.model import GCNPredictor as DGLGCNPredictor
+    from dgllife.model import GCNPredictor as DGLGCNPredictor
 
-        if graph_conv_layers is None:
-            graph_conv_layers = [64, 64]
-        num_gnn_layers = len(graph_conv_layers)
+    if graph_conv_layers is None:
+      graph_conv_layers = [64, 64]
+    num_gnn_layers = len(graph_conv_layers)
 
-        if activation is not None:
-            activation = [activation] * num_gnn_layers
+    if activation is not None:
+      activation = [activation] * num_gnn_layers
 
-        self.model = DGLGCNPredictor(in_feats=number_atom_features,
-                                     hidden_feats=graph_conv_layers,
-                                     activation=activation,
-                                     residual=[residual] * num_gnn_layers,
-                                     batchnorm=[batchnorm] * num_gnn_layers,
-                                     dropout=[dropout] * num_gnn_layers,
-                                     n_tasks=out_size,
-                                     predictor_hidden_feats=predictor_hidden_feats,
-                                     predictor_dropout=predictor_dropout)
+    self.model = DGLGCNPredictor(
+        in_feats=number_atom_features,
+        hidden_feats=graph_conv_layers,
+        activation=activation,
+        residual=[residual] * num_gnn_layers,
+        batchnorm=[batchnorm] * num_gnn_layers,
+        dropout=[dropout] * num_gnn_layers,
+        n_tasks=out_size,
+        predictor_hidden_feats=predictor_hidden_feats,
+        predictor_dropout=predictor_dropout)
 
-    def forward(self, g):
-        """Predict graph labels
+  def forward(self, g):
+    """Predict graph labels
 
         Parameters
         ----------
@@ -177,23 +180,24 @@ class GCN(nn.Module):
             This is only returned when self.mode = 'classification', the output consists of the
             logits for classes before softmax.
         """
-        node_feats = g.ndata[self.nfeat_name]
-        out = self.model(g, node_feats)
+    node_feats = g.ndata[self.nfeat_name]
+    out = self.model(g, node_feats)
 
-        if self.mode == 'classification':
-            if self.n_tasks == 1:
-                logits = out.view(-1, self.n_classes)
-                softmax_dim = 1
-            else:
-                logits = out.view(-1, self.n_tasks, self.n_classes)
-                softmax_dim = 2
-            proba = F.softmax(logits, dim=softmax_dim)
-            return proba, logits
-        else:
-            return out
+    if self.mode == 'classification':
+      if self.n_tasks == 1:
+        logits = out.view(-1, self.n_classes)
+        softmax_dim = 1
+      else:
+        logits = out.view(-1, self.n_tasks, self.n_classes)
+        softmax_dim = 2
+      proba = F.softmax(logits, dim=softmax_dim)
+      return proba, logits
+    else:
+      return out
+
 
 class GCNModel(TorchModel):
-    """Model for Graph Property Prediction Based on Graph Convolution Networks (GCN).
+  """Model for Graph Property Prediction Based on Graph Convolution Networks (GCN).
 
     This model proceeds as follows:
 
@@ -243,22 +247,23 @@ class GCNModel(TorchModel):
     * There are various minor differences in using dropout, skip connection and batch
       normalization.
     """
-    def __init__(self,
-                 n_tasks: int,
-                 graph_conv_layers: list = None,
-                 activation = None,
-                 residual: bool = True,
-                 batchnorm: bool = False,
-                 dropout: float = 0.,
-                 predictor_hidden_feats: int = 128,
-                 predictor_dropout: float = 0.,
-                 mode: str = 'regression',
-                 number_atom_features=75,
-                 n_classes: int = 2,
-                 nfeat_name: str = 'x',
-                 self_loop: bool = True,
-                 **kwargs):
-        """
+
+  def __init__(self,
+               n_tasks: int,
+               graph_conv_layers: list = None,
+               activation=None,
+               residual: bool = True,
+               batchnorm: bool = False,
+               dropout: float = 0.,
+               predictor_hidden_feats: int = 128,
+               predictor_dropout: float = 0.,
+               mode: str = 'regression',
+               number_atom_features=75,
+               n_classes: int = 2,
+               nfeat_name: str = 'x',
+               self_loop: bool = True,
+               **kwargs):
+    """
         Parameters
         ----------
         n_tasks: int
@@ -296,31 +301,32 @@ class GCNModel(TorchModel):
         kwargs
             This can include any keyword argument of TorchModel.
         """
-        model = GCN(graph_conv_layers=graph_conv_layers,
-                    activation=activation,
-                    residual=residual,
-                    batchnorm=batchnorm,
-                    dropout=dropout,
-                    predictor_hidden_feats=predictor_hidden_feats,
-                    predictor_dropout=predictor_dropout,
-                    n_tasks=n_tasks,
-                    mode=mode,
-                    number_atom_features=number_atom_features,
-                    n_classes=n_classes,
-                    nfeat_name=nfeat_name)
-        if mode == 'regression':
-            loss: Loss = L2Loss()
-            output_types = ['prediction']
-        else:
-            loss = SparseSoftmaxCrossEntropy()
-            output_types = ['prediction', 'loss']
-        super(GCNModel, self).__init__(
-            model, loss=loss, output_types=output_types, **kwargs)
+    model = GCN(
+        graph_conv_layers=graph_conv_layers,
+        activation=activation,
+        residual=residual,
+        batchnorm=batchnorm,
+        dropout=dropout,
+        predictor_hidden_feats=predictor_hidden_feats,
+        predictor_dropout=predictor_dropout,
+        n_tasks=n_tasks,
+        mode=mode,
+        number_atom_features=number_atom_features,
+        n_classes=n_classes,
+        nfeat_name=nfeat_name)
+    if mode == 'regression':
+      loss: Loss = L2Loss()
+      output_types = ['prediction']
+    else:
+      loss = SparseSoftmaxCrossEntropy()
+      output_types = ['prediction', 'loss']
+    super(GCNModel, self).__init__(
+        model, loss=loss, output_types=output_types, **kwargs)
 
-        self._self_loop = self_loop
+    self._self_loop = self_loop
 
-    def _prepare_batch(self, batch):
-        """Create batch data for GCN.
+  def _prepare_batch(self, batch):
+    """Create batch data for GCN.
 
         Parameters
         ----------
@@ -339,13 +345,16 @@ class GCNModel(TorchModel):
         weights: list of torch.Tensor or None
             The weights for each sample or sample/task pair converted to torch.Tensor.
         """
-        try:
-            import dgl
-        except:
-            raise ImportError('This class requires dgl.')
+    try:
+      import dgl
+    except:
+      raise ImportError('This class requires dgl.')
 
-        inputs, labels, weights = batch
-        dgl_graphs = [graph.to_dgl_graph(self_loop=self._self_loop) for graph in inputs[0]]
-        inputs = dgl.batch(dgl_graphs).to(self.device)
-        _, labels, weights = super(GCNModel, self)._prepare_batch(([], labels, weights))
-        return inputs, labels, weights
+    inputs, labels, weights = batch
+    dgl_graphs = [
+        graph.to_dgl_graph(self_loop=self._self_loop) for graph in inputs[0]
+    ]
+    inputs = dgl.batch(dgl_graphs).to(self.device)
+    _, labels, weights = super(GCNModel, self)._prepare_batch(([], labels,
+                                                               weights))
+    return inputs, labels, weights

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -126,7 +126,7 @@ read off what's needed to train the model from the table below.
 | :code:`GATModel`                       | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
 |                                        | Regressor  |                      |                        |                                                                |                      |
 +----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
-| :code:`GCNModel`                       | Classifier/| :code:`GraphData`    |                        | :code:`CGCNNFeaturizer`                                        | :code:`fit`          |
+| :code:`GCNModel`                       | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
 |                                        | Regressor  |                      |                        |                                                                |                      |
 +----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -126,6 +126,9 @@ read off what's needed to train the model from the table below.
 | :code:`GATModel`                       | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
 |                                        | Regressor  |                      |                        |                                                                |                      |
 +----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`GCNModel`                       | Classifier/| :code:`GraphData`    |                        | :code:`CGCNNFeaturizer`                                        | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
 
 Model
 -----
@@ -446,4 +449,10 @@ GATModel
 --------
 
 .. autoclass:: deepchem.models.GATModel
+  :members:
+
+GCNModel
+--------
+
+.. autoclass:: deepchem.models.GCNModel
   :members:

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -30,7 +30,11 @@ DeepChem has a number of "soft" requirements.
 |                                |               |                                                   |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
-| `Deep Graph Library`_          | latset        | :code:`dc.feat.graph_data`                        |
+| `Deep Graph Library`_          | latest        | :code:`dc.feat.graph_data`                        |
+|                                |               |                                                   |
+|                                |               |                                                   |
++--------------------------------+---------------+---------------------------------------------------+
+| `DGL-LifeSci`_                 | latest        | :code:`dc.models.torch_models`                    |
 |                                |               |                                                   |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
@@ -127,6 +131,7 @@ DeepChem has a number of "soft" requirements.
 .. _`TensorFlow`: https://www.tensorflow.org/
 .. _`BioPython`: https://biopython.org/wiki/Documentation
 .. _`Deep Graph Library`: https://www.dgl.ai/
+.. _`DGL-LifeSci`: https://github.com/awslabs/dgl-lifesci
 .. _`HuggingFace Transformers`: https://huggingface.co/transformers/
 .. _`LightGBM`: https://lightgbm.readthedocs.io/en/latest/index.html
 .. _`matminer`: https://hackingmaterials.lbl.gov/matminer/

--- a/scripts/install_deepchem_conda.ps1
+++ b/scripts/install_deepchem_conda.ps1
@@ -49,6 +49,7 @@ pip install torch-cluster==latest+$cuda -f https://pytorch-geometric.com/whl/tor
 pip install torch-spline-conv==latest+$cuda -f https://pytorch-geometric.com/whl/torch-$pyg_torch.html
 pip install torch-geometric
 pip install $dgl_pkg
+pip install dgllife
 # install transformers package
 pip install transformers
 

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -58,5 +58,6 @@ pip install torch-cluster==latest+$cuda -f https://pytorch-geometric.com/whl/tor
 pip install torch-spline-conv==latest+$cuda -f https://pytorch-geometric.com/whl/torch-$pyg_torch.html
 pip install torch-geometric
 pip install $dgl_pkg
+pip install dgllife
 # install transformers package
 pip install transformers


### PR DESCRIPTION
@rbharath This PR serves as a proof of concept for wrappers of models from DGL-LifeSci. I basically follow the design by @nd-02110114. The PR assumes the latest version of DGL (0.5.2) and DGL-LifeSci (0.2.5).

Previously the GAT model was implemented in PyG and GCN in this PR is implemented in DGL. What if there are both DGL and PyG implementations for a model? How should we arrange the name space?