### PR TITLE
Fix import failure

### DIFF
--- a/deepchem/molnet/__init__.py
+++ b/deepchem/molnet/__init__.py
@@ -37,7 +37,7 @@ from deepchem.molnet.load_function.material_datasets.load_perovskite import load
 from deepchem.molnet.load_function.material_datasets.load_mp_formation_energy import load_mp_formation_energy
 from deepchem.molnet.load_function.material_datasets.load_mp_metallicity import load_mp_metallicity
 
-from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _MolnetLoader
+from deepchem.molnet.load_function.molnet_loader import featurizers, splitters, transformers, TransformerGenerator, _MolnetLoader
 
 from deepchem.molnet.dnasim import simulate_motif_density_localization
 from deepchem.molnet.dnasim import simulate_motif_counting

--- a/deepchem/molnet/__init__.py
+++ b/deepchem/molnet/__init__.py
@@ -37,7 +37,7 @@ from deepchem.molnet.load_function.material_datasets.load_perovskite import load
 from deepchem.molnet.load_function.material_datasets.load_mp_formation_energy import load_mp_formation_energy
 from deepchem.molnet.load_function.material_datasets.load_mp_metallicity import load_mp_metallicity
 
-from deepchem.molnet.load_function.molnet_loader import featurizers, splitters, transformers, TransformerGenerator, _MolnetLoader
+from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _MolnetLoader
 
 from deepchem.molnet.dnasim import simulate_motif_density_localization
 from deepchem.molnet.dnasim import simulate_motif_counting

--- a/deepchem/molnet/load_function/molnet_loader.py
+++ b/deepchem/molnet/load_function/molnet_loader.py
@@ -57,7 +57,7 @@ try:
   featurizers['raw'] = dc.feat.RawFeaturizer()
   featurizers['smiles2img'] = dc.feat.SmilesToImage(img_size=80, img_spec='std')
   featurizers['onehot'] = dc.feat.OneHotFeaturizer()
-except:
+except ImportError:
   pass
 
 splitters = {

--- a/deepchem/molnet/load_function/molnet_loader.py
+++ b/deepchem/molnet/load_function/molnet_loader.py
@@ -46,37 +46,6 @@ class TransformerGenerator(object):
     return name
 
 
-featurizers = {
-    'ecfp': dc.feat.CircularFingerprint(size=1024),
-    'graphconv': dc.feat.ConvMolFeaturizer(),
-    'weave': dc.feat.WeaveFeaturizer(),
-    'raw': dc.feat.RawFeaturizer(),
-    'smiles2img': dc.feat.SmilesToImage(img_size=80, img_spec='std')
-}
-
-splitters = {
-    'index': dc.splits.IndexSplitter(),
-    'random': dc.splits.RandomSplitter(),
-    'scaffold': dc.splits.ScaffoldSplitter(),
-    'butina': dc.splits.ButinaSplitter(),
-    'task': dc.splits.TaskSplitter(),
-    'stratified': dc.splits.RandomStratifiedSplitter()
-}
-
-transformers = {
-    'balancing':
-    TransformerGenerator(dc.trans.BalancingTransformer),
-    'normalization':
-    TransformerGenerator(dc.trans.NormalizationTransformer, transform_y=True),
-    'minmax':
-    TransformerGenerator(dc.trans.MinMaxTransformer, transform_y=True),
-    'clipping':
-    TransformerGenerator(dc.trans.ClippingTransformer, transform_y=True),
-    'log':
-    TransformerGenerator(dc.trans.LogTransformer, transform_y=True)
-}
-
-
 class _MolnetLoader(object):
   """The class provides common functionality used by many molnet loader functions.
   It is an abstract class.  Subclasses implement loading of particular datasets.
@@ -110,6 +79,36 @@ class _MolnetLoader(object):
     save_dir: str
       a directory to save the dataset in
     """
+    featurizers = {
+        'ecfp': dc.feat.CircularFingerprint(size=1024),
+        'graphconv': dc.feat.ConvMolFeaturizer(),
+        'weave': dc.feat.WeaveFeaturizer(),
+        'raw': dc.feat.RawFeaturizer(),
+        'smiles2img': dc.feat.SmilesToImage(img_size=80, img_spec='std')
+    }
+
+    splitters = {
+        'index': dc.splits.IndexSplitter(),
+        'random': dc.splits.RandomSplitter(),
+        'scaffold': dc.splits.ScaffoldSplitter(),
+        'butina': dc.splits.ButinaSplitter(),
+        'task': dc.splits.TaskSplitter(),
+        'stratified': dc.splits.RandomStratifiedSplitter()
+    }
+
+    transformers = {
+        'balancing':
+        TransformerGenerator(dc.trans.BalancingTransformer),
+        'normalization':
+        TransformerGenerator(dc.trans.NormalizationTransformer, transform_y=True),
+        'minmax':
+        TransformerGenerator(dc.trans.MinMaxTransformer, transform_y=True),
+        'clipping':
+        TransformerGenerator(dc.trans.ClippingTransformer, transform_y=True),
+        'log':
+        TransformerGenerator(dc.trans.LogTransformer, transform_y=True)
+    }
+
     if 'split' in kwargs:
       splitter = kwargs['split']
       logger.warning("'split' is deprecated.  Use 'splitter' instead.")

--- a/deepchem/molnet/load_function/molnet_loader.py
+++ b/deepchem/molnet/load_function/molnet_loader.py
@@ -51,6 +51,7 @@ featurizers = {
     'weave': dc.feat.WeaveFeaturizer(),
 }
 
+# These featurizers depend on RDKit, so we need RDKit when globally instantiating.
 try:
   featurizers['ecfp'] = dc.feat.CircularFingerprint(size=1024)
   featurizers['raw'] = dc.feat.RawFeaturizer()

--- a/deepchem/molnet/load_function/molnet_loader.py
+++ b/deepchem/molnet/load_function/molnet_loader.py
@@ -51,11 +51,23 @@ featurizers = {
     'weave': dc.feat.WeaveFeaturizer(),
 }
 
-# These featurizers depend on RDKit, so we need RDKit when globally instantiating.
+# some featurizers require soft dependencies to instantiate
 try:
   featurizers['ecfp'] = dc.feat.CircularFingerprint(size=1024)
+except ImportError:
+  pass
+
+try:
   featurizers['raw'] = dc.feat.RawFeaturizer()
+except ImportError:
+  pass
+
+try:
   featurizers['smiles2img'] = dc.feat.SmilesToImage(img_size=80, img_spec='std')
+except ImportError:
+  pass
+
+try:
   featurizers['onehot'] = dc.feat.OneHotFeaturizer()
 except ImportError:
   pass

--- a/deepchem/molnet/load_function/molnet_loader.py
+++ b/deepchem/molnet/load_function/molnet_loader.py
@@ -46,6 +46,42 @@ class TransformerGenerator(object):
     return name
 
 
+featurizers = {
+    'graphconv': dc.feat.ConvMolFeaturizer(),
+    'weave': dc.feat.WeaveFeaturizer(),
+}
+
+try:
+  featurizers['ecfp'] = dc.feat.CircularFingerprint(size=1024)
+  featurizers['raw'] = dc.feat.RawFeaturizer()
+  featurizers['smiles2img'] = dc.feat.SmilesToImage(img_size=80, img_spec='std')
+  featurizers['onehot'] = dc.feat.OneHotFeaturizer()
+except:
+  pass
+
+splitters = {
+    'index': dc.splits.IndexSplitter(),
+    'random': dc.splits.RandomSplitter(),
+    'scaffold': dc.splits.ScaffoldSplitter(),
+    'butina': dc.splits.ButinaSplitter(),
+    'task': dc.splits.TaskSplitter(),
+    'stratified': dc.splits.RandomStratifiedSplitter()
+}
+
+transformers = {
+    'balancing':
+    TransformerGenerator(dc.trans.BalancingTransformer),
+    'normalization':
+    TransformerGenerator(dc.trans.NormalizationTransformer, transform_y=True),
+    'minmax':
+    TransformerGenerator(dc.trans.MinMaxTransformer, transform_y=True),
+    'clipping':
+    TransformerGenerator(dc.trans.ClippingTransformer, transform_y=True),
+    'log':
+    TransformerGenerator(dc.trans.LogTransformer, transform_y=True)
+}
+
+
 class _MolnetLoader(object):
   """The class provides common functionality used by many molnet loader functions.
   It is an abstract class.  Subclasses implement loading of particular datasets.
@@ -79,36 +115,6 @@ class _MolnetLoader(object):
     save_dir: str
       a directory to save the dataset in
     """
-    featurizers = {
-        'ecfp': dc.feat.CircularFingerprint(size=1024),
-        'graphconv': dc.feat.ConvMolFeaturizer(),
-        'weave': dc.feat.WeaveFeaturizer(),
-        'raw': dc.feat.RawFeaturizer(),
-        'smiles2img': dc.feat.SmilesToImage(img_size=80, img_spec='std')
-    }
-
-    splitters = {
-        'index': dc.splits.IndexSplitter(),
-        'random': dc.splits.RandomSplitter(),
-        'scaffold': dc.splits.ScaffoldSplitter(),
-        'butina': dc.splits.ButinaSplitter(),
-        'task': dc.splits.TaskSplitter(),
-        'stratified': dc.splits.RandomStratifiedSplitter()
-    }
-
-    transformers = {
-        'balancing':
-        TransformerGenerator(dc.trans.BalancingTransformer),
-        'normalization':
-        TransformerGenerator(dc.trans.NormalizationTransformer, transform_y=True),
-        'minmax':
-        TransformerGenerator(dc.trans.MinMaxTransformer, transform_y=True),
-        'clipping':
-        TransformerGenerator(dc.trans.ClippingTransformer, transform_y=True),
-        'log':
-        TransformerGenerator(dc.trans.LogTransformer, transform_y=True)
-    }
-
     if 'split' in kwargs:
       splitter = kwargs['split']
       logger.warning("'split' is deprecated.  Use 'splitter' instead.")

--- a/deepchem/molnet/load_function/zinc15_datasets.py
+++ b/deepchem/molnet/load_function/zinc15_datasets.py
@@ -54,7 +54,7 @@ class _Zinc15Loader(_MolnetLoader):
 
 
 def load_zinc15(
-    featurizer: Union[dc.feat.Featurizer, str] = dc.feat.OneHotFeaturizer(),
+    featurizer: Union[dc.feat.Featurizer, str] = 'OneHot',
     splitter: Union[dc.splits.Splitter, str, None] = 'random',
     transformers: List[Union[TransformerGenerator, str]] = ['normalization'],
     reload: bool = True,


### PR DESCRIPTION
The HEAD of master branch failed importing and also the readthedocs build has been broken. 

readthedocs build : https://readthedocs.org/projects/deepchem/builds/

Error message

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/deepchem/feat/molecule_featurizers/circular_fingerprint.py", line 59, in __init__
    from rdkit import Chem  # noqa
ModuleNotFoundError: No module named 'rdkit'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/envs/latest/lib/python3.7/site-packages/sphinx/config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/envs/latest/lib/python3.7/site-packages/sphinx/util/pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/docs/conf.py", line 80, in <module>
    import deepchem
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/deepchem/__init__.py", line 18, in <module>
    import deepchem.molnet
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/deepchem/molnet/__init__.py", line 8, in <module>
    from deepchem.molnet.load_function.delaney_datasets import load_delaney
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/deepchem/molnet/load_function/delaney_datasets.py", line 7, in <module>
    from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _MolnetLoader
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/deepchem/molnet/load_function/molnet_loader.py", line 50, in <module>
    'ecfp': dc.feat.CircularFingerprint(size=1024),
  File "/home/docs/checkouts/readthedocs.org/user_builds/deepchem/checkouts/latest/deepchem/feat/molecule_featurizers/circular_fingerprint.py", line 62, in __init__
    raise ValueError("This class requires RDKit to be installed.")
ValueError: This class requires RDKit to be installed.
```

This reason is to instantiate the featurizer which depends on RDKit in `deepchem/molnet/load_function/molnet_loader.py`.  The current DeepChem require RDKit  as a hard requirement.

https://github.com/deepchem/deepchem/blob/7e745b93840d1f646a74c48af5c9320d233a1932/deepchem/molnet/load_function/molnet_loader.py#L49-L55

So, I fixed by moving the these instantiation to class constructor.