### PR TITLE
Fix docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 pandas
 scikit-learn
-sphinx_rtd_theme
+sphinx>=3.2,<4
+sphinx_rtd_theme>=0.5,<1
 tensorflow==2.3.0
 transformers
 torch==1.6.0


### PR DESCRIPTION
This PR may fix #2281 
#2281 can't reproduce in local machine, so I seem the version mismatch of `sphinx` causes the error of readthedocs build. The latest version of `sphinx` is 3.2.1, but the version in readthedocs build is 1.8.5. This is a huge gap..