### PR TITLE
Model Wrapper for MPNNPredictor from DGL-LifeSci 

### DIFF
--- a/deepchem/models/tests/test_gat.py
+++ b/deepchem/models/tests/test_gat.py
@@ -35,7 +35,7 @@ def test_gat_regression():
       learning_rate=0.001)
 
   # overfit test
-  model.fit(dataset, nb_epoch=400)
+  model.fit(dataset, nb_epoch=500)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean_absolute_error'] < 0.5
 

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -35,7 +35,7 @@ def test_gcn_regression():
       learning_rate=0.003)
 
   # overfit test
-  model.fit(dataset, nb_epoch=200)
+  model.fit(dataset, nb_epoch=300)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean_absolute_error'] < 0.5
 

--- a/deepchem/models/tests/test_mpnn.py
+++ b/deepchem/models/tests/test_mpnn.py
@@ -30,7 +30,7 @@ def test_mpnn_regression():
   model = MPNNModel(mode='regression', n_tasks=n_tasks, batch_size=10)
 
   # overfit test
-  model.fit(dataset, nb_epoch=300)
+  model.fit(dataset, nb_epoch=400)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean_absolute_error'] < 0.5
 

--- a/deepchem/models/tests/test_mpnn.py
+++ b/deepchem/models/tests/test_mpnn.py
@@ -75,7 +75,7 @@ def test_mpnn_reload():
       batch_size=10,
       learning_rate=0.001)
 
-  model.fit(dataset, nb_epoch=100)
+  model.fit(dataset, nb_epoch=200)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean-roc_auc_score'] >= 0.85
 

--- a/deepchem/models/tests/test_mpnn.py
+++ b/deepchem/models/tests/test_mpnn.py
@@ -1,0 +1,95 @@
+import unittest
+import tempfile
+
+import numpy as np
+
+import deepchem as dc
+from deepchem.feat import MolGraphConvFeaturizer
+from deepchem.models.torch_models import MPNNModel
+from deepchem.models.tests.test_graph_models import get_dataset
+
+try:
+  import dgl
+  import dgllife
+  import torch
+  has_torch_and_dgl = True
+except:
+  has_torch_and_dgl = False
+
+
+@unittest.skipIf(not has_torch_and_dgl,
+                 'PyTorch, DGL, or DGL-LifeSci are not installed')
+def test_mpnn_regression():
+  # load datasets
+  featurizer = MolGraphConvFeaturizer(use_edges=True)
+  tasks, dataset, transformers, metric = get_dataset(
+      'regression', featurizer=featurizer)
+
+  # initialize models
+  n_tasks = len(tasks)
+  model = MPNNModel(mode='regression', n_tasks=n_tasks, batch_size=10)
+
+  # overfit test
+  model.fit(dataset, nb_epoch=100)
+  scores = model.evaluate(dataset, [metric], transformers)
+  assert scores['mean_absolute_error'] < 0.5
+
+
+@unittest.skipIf(not has_torch_and_dgl,
+                 'PyTorch, DGL, or DGL-LifeSci are not installed')
+def test_mpnn_classification():
+  # load datasets
+  featurizer = MolGraphConvFeaturizer(use_edges=True)
+  tasks, dataset, transformers, metric = get_dataset(
+      'classification', featurizer=featurizer)
+
+  # initialize models
+  n_tasks = len(tasks)
+  model = MPNNModel(
+      mode='classification',
+      n_tasks=n_tasks,
+      batch_size=10,
+      learning_rate=0.001)
+
+  # overfit test
+  model.fit(dataset, nb_epoch=100)
+  scores = model.evaluate(dataset, [metric], transformers)
+  assert scores['mean-roc_auc_score'] >= 0.85
+
+
+@unittest.skipIf(not has_torch_and_dgl,
+                 'PyTorch, DGL, or DGL-LifeSci are not installed')
+def test_mpnn_reload():
+  # load datasets
+  featurizer = MolGraphConvFeaturizer(use_edges=True)
+  tasks, dataset, transformers, metric = get_dataset(
+      'classification', featurizer=featurizer)
+
+  # initialize models
+  n_tasks = len(tasks)
+  model_dir = tempfile.mkdtemp()
+  model = MPNNModel(
+      mode='classification',
+      n_tasks=n_tasks,
+      model_dir=model_dir,
+      batch_size=10,
+      learning_rate=0.001)
+
+  model.fit(dataset, nb_epoch=100)
+  scores = model.evaluate(dataset, [metric], transformers)
+  assert scores['mean-roc_auc_score'] >= 0.85
+
+  reloaded_model = MPNNModel(
+      mode='classification',
+      n_tasks=n_tasks,
+      model_dir=model_dir,
+      batch_size=10,
+      learning_rate=0.001)
+  reloaded_model.restore()
+
+  pred_mols = ["CCCC", "CCCCCO", "CCCCC"]
+  X_pred = featurizer(pred_mols)
+  random_dataset = dc.data.NumpyDataset(X_pred)
+  original_pred = model.predict(random_dataset)
+  reload_pred = reloaded_model.predict(random_dataset)
+  assert np.all(original_pred == reload_pred)

--- a/deepchem/models/tests/test_mpnn.py
+++ b/deepchem/models/tests/test_mpnn.py
@@ -30,7 +30,7 @@ def test_mpnn_regression():
   model = MPNNModel(mode='regression', n_tasks=n_tasks, batch_size=10)
 
   # overfit test
-  model.fit(dataset, nb_epoch=100)
+  model.fit(dataset, nb_epoch=200)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean_absolute_error'] < 0.5
 
@@ -52,7 +52,7 @@ def test_mpnn_classification():
       learning_rate=0.001)
 
   # overfit test
-  model.fit(dataset, nb_epoch=100)
+  model.fit(dataset, nb_epoch=200)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean-roc_auc_score'] >= 0.85
 

--- a/deepchem/models/tests/test_mpnn.py
+++ b/deepchem/models/tests/test_mpnn.py
@@ -30,7 +30,7 @@ def test_mpnn_regression():
   model = MPNNModel(mode='regression', n_tasks=n_tasks, batch_size=10)
 
   # overfit test
-  model.fit(dataset, nb_epoch=200)
+  model.fit(dataset, nb_epoch=300)
   scores = model.evaluate(dataset, [metric], transformers)
   assert scores['mean_absolute_error'] < 0.5
 

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -4,3 +4,4 @@ from deepchem.models.torch_models.attentivefp import AttentiveFP, AttentiveFPMod
 from deepchem.models.torch_models.cgcnn import CGCNN, CGCNNModel
 from deepchem.models.torch_models.gat import GAT, GATModel
 from deepchem.models.torch_models.gcn import GCN, GCNModel
+from deepchem.models.torch_models.mpnn import MPNN, MPNNModel

--- a/deepchem/models/torch_models/attentivefp.py
+++ b/deepchem/models/torch_models/attentivefp.py
@@ -283,9 +283,6 @@ class AttentiveFPModel(TorchModel):
     ----------
     batch: tuple
       The tuple is ``(inputs, labels, weights)``.
-    self_loop: bool
-      Whether to add self loops for the nodes, i.e. edges from nodes
-      to themselves. Default to False.
 
     Returns
     -------

--- a/deepchem/models/torch_models/attentivefp.py
+++ b/deepchem/models/torch_models/attentivefp.py
@@ -251,7 +251,8 @@ class AttentiveFPModel(TorchModel):
       (only used when ``mode`` is 'classification'). Default to 2.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
-      Default to True.
+      When input graphs have isolated nodes, self loops allow preserving the original feature
+      of them in message passing. Default to True.
     kwargs
       This can include any keyword argument of TorchModel.
     """

--- a/deepchem/models/torch_models/attentivefp.py
+++ b/deepchem/models/torch_models/attentivefp.py
@@ -224,8 +224,6 @@ class AttentiveFPModel(TorchModel):
                number_atom_features: int = 30,
                number_bond_features: int = 11,
                n_classes: int = 2,
-               nfeat_name: str = 'x',
-               efeat_name: str = 'edge_attr',
                self_loop: bool = True,
                **kwargs):
     """
@@ -251,14 +249,6 @@ class AttentiveFPModel(TorchModel):
     n_classes: int
       The number of classes to predict per task
       (only used when ``mode`` is 'classification'). Default to 2.
-    nfeat_name: str
-      For an input graph ``g``, the model assumes that it stores node features in
-      ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
-      Default to 'x'.
-    efeat_name: str
-      For an input graph ``g``, the model assumes that it stores edge features in
-      ``g.edata[efeat_name]`` and will retrieve input edge features from that.
-      Default to 'edge_attr'.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
       Default to True.
@@ -274,9 +264,7 @@ class AttentiveFPModel(TorchModel):
         mode=mode,
         number_atom_features=number_atom_features,
         number_bond_features=number_bond_features,
-        n_classes=n_classes,
-        nfeat_name=nfeat_name,
-        efeat_name=efeat_name)
+        n_classes=n_classes)
     if mode == 'regression':
       loss: Loss = L2Loss()
       output_types = ['prediction']

--- a/deepchem/models/torch_models/gat.py
+++ b/deepchem/models/torch_models/gat.py
@@ -308,7 +308,8 @@ class GATModel(TorchModel):
       (only used when ``mode`` is 'classification'). Default to 2.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
-      Default to True.
+      When input graphs have isolated nodes, self loops allow preserving the original feature
+      of them in message passing. Default to True.
     kwargs
       This can include any keyword argument of TorchModel.
     """

--- a/deepchem/models/torch_models/gat.py
+++ b/deepchem/models/torch_models/gat.py
@@ -235,8 +235,8 @@ class GATModel(TorchModel):
   >> tasks, datasets, transformers = dc.molnet.load_tox21(
   ..     reload=False, featurizer=featurizer, transformers=[])
   >> train, valid, test = datasets
-  >> model = dc.models.GATModel(mode='classification', n_tasks=len(tasks),
-  ..                            batch_size=32, learning_rate=0.001)
+  >> model = GATModel(mode='classification', n_tasks=len(tasks),
+  ..                  batch_size=32, learning_rate=0.001)
   >> model.fit(train, nb_epoch=50)
 
   References

--- a/deepchem/models/torch_models/gat.py
+++ b/deepchem/models/torch_models/gat.py
@@ -264,7 +264,6 @@ class GATModel(TorchModel):
                mode: str = 'regression',
                number_atom_features: int = 30,
                n_classes: int = 2,
-               nfeat_name: str = 'x',
                self_loop: bool = True,
                **kwargs):
     """
@@ -307,10 +306,6 @@ class GATModel(TorchModel):
     n_classes: int
       The number of classes to predict per task
       (only used when ``mode`` is 'classification'). Default to 2.
-    nfeat_name: str
-      For an input graph ``g``, the model assumes that it stores node features in
-      ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
-      Default to 'x'.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
       Default to True.
@@ -330,8 +325,7 @@ class GATModel(TorchModel):
         predictor_dropout=predictor_dropout,
         mode=mode,
         number_atom_features=number_atom_features,
-        n_classes=n_classes,
-        nfeat_name=nfeat_name)
+        n_classes=n_classes)
     if mode == 'regression':
       loss: Loss = L2Loss()
       output_types = ['prediction']

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -261,7 +261,6 @@ class GCNModel(TorchModel):
                mode: str = 'regression',
                number_atom_features=30,
                n_classes: int = 2,
-               nfeat_name: str = 'x',
                self_loop: bool = True,
                **kwargs):
     """
@@ -293,10 +292,6 @@ class GCNModel(TorchModel):
     n_classes: int
       The number of classes to predict per task
       (only used when ``mode`` is 'classification'). Default to 2.
-    nfeat_name: str
-      For an input graph ``g``, the model assumes that it stores node features in
-      ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
-      Default to 'x'.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
       Default to True.
@@ -314,8 +309,7 @@ class GCNModel(TorchModel):
         predictor_dropout=predictor_dropout,
         mode=mode,
         number_atom_features=number_atom_features,
-        n_classes=n_classes,
-        nfeat_name=nfeat_name)
+        n_classes=n_classes)
     if mode == 'regression':
       loss: Loss = L2Loss()
       output_types = ['prediction']

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -328,9 +328,6 @@ class GCNModel(TorchModel):
     ----------
     batch: tuple
       The tuple is ``(inputs, labels, weights)``.
-    self_loop: bool
-      Whether to add self loops for the nodes, i.e. edges from nodes
-      to themselves. Default to False.
 
     Returns
     -------

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -294,7 +294,8 @@ class GCNModel(TorchModel):
       (only used when ``mode`` is 'classification'). Default to 2.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
-      Default to True.
+      When input graphs have isolated nodes, self loops allow preserving the original feature
+      of them in message passing. Default to True.
     kwargs
       This can include any keyword argument of TorchModel.
     """

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -219,8 +219,8 @@ class GCNModel(TorchModel):
   >> tasks, datasets, transformers = dc.molnet.load_tox21(
   ..     reload=False, featurizer=featurizer, transformers=[])
   >> train, valid, test = datasets
-  >> model = dc.models.GCNModel(mode='classification', n_tasks=len(tasks),
-  ..                            batch_size=32, learning_rate=0.001)
+  >> model = GCNModel(mode='classification', n_tasks=len(tasks),
+  ..                  batch_size=32, learning_rate=0.001)
   >> model.fit(train, nb_epoch=50)
 
   References

--- a/deepchem/models/torch_models/mpnn.py
+++ b/deepchem/models/torch_models/mpnn.py
@@ -1,5 +1,5 @@
 """
-DGL-based AttentiveFP for graph property prediction.
+DGL-based MPNN for graph property prediction.
 """
 import torch.nn as nn
 import torch.nn.functional as F
@@ -8,24 +8,23 @@ from deepchem.models.losses import Loss, L2Loss, SparseSoftmaxCrossEntropy
 from deepchem.models.torch_models.torch_model import TorchModel
 
 
-class AttentiveFP(nn.Module):
+class MPNN(nn.Module):
   """Model for Graph Property Prediction.
 
   This model proceeds as follows:
 
-  * Combine node features and edge features for initializing node representations,
-    which involves a round of message passing
-  * Update node representations with multiple rounds of message passing
+  * Combine latest node representations and edge features in updating node representations,
+    which involves multiple rounds of message passing
   * For each graph, compute its representation by combining the representations
-    of all nodes in it, which involves a gated recurrent unit (GRU).
-  * Perform the final prediction using a linear layer
+    of all nodes in it, which involves a Set2Set layer.
+  * Perform the final prediction using an MLP
 
   Examples
   --------
 
   >>> import deepchem as dc
   >>> import dgl
-  >>> from deepchem.models import AttentiveFP
+  >>> from deepchem.models.torch_models import MPNN
   >>> smiles = ["C1CCC1", "C1=CC=CN=C1"]
   >>> featurizer = dc.feat.MolGraphConvFeaturizer(use_edges=True)
   >>> graphs = featurizer.featurize(smiles)
@@ -34,7 +33,7 @@ class AttentiveFP(nn.Module):
   >>> dgl_graphs = [graphs[i].to_dgl_graph(self_loop=True) for i in range(len(graphs))]
   >>> # Batch two graphs into a graph of two connected components
   >>> batch_dgl_graph = dgl.batch(dgl_graphs)
-  >>> model = AttentiveFP(n_tasks=1, mode='regression')
+  >>> model = MPNN(n_tasks=1, mode='regression')
   >>> preds = model(batch_dgl_graph)
   >>> print(type(preds))
   <class 'torch.Tensor'>
@@ -43,10 +42,8 @@ class AttentiveFP(nn.Module):
 
   References
   ----------
-  .. [1] Zhaoping Xiong, Dingyan Wang, Xiaohong Liu, Feisheng Zhong, Xiaozhe Wan, Xutong Li,
-         Zhaojun Li, Xiaomin Luo, Kaixian Chen, Hualiang Jiang, and Mingyue Zheng. "Pushing
-         the Boundaries of Molecular Representation for Drug Discovery with the Graph Attention
-         Mechanism." Journal of Medicinal Chemistry. 2020, 63, 16, 8749–8760.
+  .. [1] Justin Gilmer, Samuel S. Schoenholz, Patrick F. Riley, Oriol Vinyals, George E. Dahl.
+         "Neural Message Passing for Quantum Chemistry." ICML 2017.
 
   Notes
   -----
@@ -56,10 +53,11 @@ class AttentiveFP(nn.Module):
 
   def __init__(self,
                n_tasks: int,
-               num_layers: int = 2,
-               num_timesteps: int = 2,
-               graph_feat_size: int = 200,
-               dropout: float = 0.,
+               node_out_feats: int = 64,
+               edge_hidden_feats: int = 128,
+               num_step_message_passing: int = 3,
+               num_step_set2set: int = 6,
+               num_layer_set2set: int = 3,
                mode: str = 'regression',
                number_atom_features: int = 30,
                number_bond_features: int = 11,
@@ -71,15 +69,16 @@ class AttentiveFP(nn.Module):
     ----------
     n_tasks: int
       Number of tasks.
-    num_layers: int
-      Number of graph neural network layers, i.e. number of rounds of message passing.
-      Default to 2.
-    num_timesteps: int
-      Number of time steps for updating graph representations with a GRU. Default to 2.
-    graph_feat_size: int
-      Size for graph representations. Default to 200.
-    dropout: float
-      Dropout probability. Default to 0.
+    node_out_feats: int
+      The length of the final node representation vectors. Default to 64.
+    edge_hidden_feats: int
+      The length of the hidden edge representation vectors. Default to 128.
+    num_step_message_passing: int
+      The number of rounds of message passing. Default to 3.
+    num_step_set2set: int
+      The number of set2set steps. Default to 6.
+    num_layer_set2set: int
+      The number of set2set layers. Default to 3.
     mode: str
       The model type, 'classification' or 'regression'. Default to 'regression'.
     number_atom_features: int
@@ -110,7 +109,7 @@ class AttentiveFP(nn.Module):
     if mode not in ['classification', 'regression']:
       raise ValueError("mode must be either 'classification' or 'regression'")
 
-    super(AttentiveFP, self).__init__()
+    super(MPNN, self).__init__()
 
     self.n_tasks = n_tasks
     self.mode = mode
@@ -122,16 +121,17 @@ class AttentiveFP(nn.Module):
     else:
       out_size = n_tasks
 
-    from dgllife.model import AttentiveFPPredictor as DGLAttentiveFPPredictor
+    from dgllife.model import MPNNPredictor as DGLMPNNPredictor
 
-    self.model = DGLAttentiveFPPredictor(
-        node_feat_size=number_atom_features,
-        edge_feat_size=number_bond_features,
-        num_layers=num_layers,
-        num_timesteps=num_timesteps,
-        graph_feat_size=graph_feat_size,
+    self.model = DGLMPNNPredictor(
+        node_in_feats=number_atom_features,
+        edge_in_feats=number_bond_features,
+        node_out_feats=node_out_feats,
+        edge_hidden_feats=edge_hidden_feats,
         n_tasks=out_size,
-        dropout=dropout)
+        num_step_message_passing=num_step_message_passing,
+        num_step_set2set=num_step_set2set,
+        num_layer_set2set=num_layer_set2set)
 
   def forward(self, g):
     """Predict graph labels
@@ -175,38 +175,35 @@ class AttentiveFP(nn.Module):
       return out
 
 
-class AttentiveFPModel(TorchModel):
-  """Model for Graph Property Prediction.
+class MPNNModel(TorchModel):
+  """Model for graph property prediction
 
   This model proceeds as follows:
 
-  * Combine node features and edge features for initializing node representations,
-    which involves a round of message passing
-  * Update node representations with multiple rounds of message passing
+  * Combine latest node representations and edge features in updating node representations,
+    which involves multiple rounds of message passing
   * For each graph, compute its representation by combining the representations
-    of all nodes in it, which involves a gated recurrent unit (GRU).
-  * Perform the final prediction using a linear layer
+    of all nodes in it, which involves a Set2Set layer.
+  * Perform the final prediction using an MLP
 
   Examples
   --------
 
   >>>
   >> import deepchem as dc
-  >> from deepchem.models import AttentiveFPModel
+  >> from deepchem.models.torch_models import MPNNModel
   >> featurizer = dc.feat.MolGraphConvFeaturizer(use_edges=True)
   >> tasks, datasets, transformers = dc.molnet.load_tox21(
   ..     reload=False, featurizer=featurizer, transformers=[])
   >> train, valid, test = datasets
-  >> model = AttentiveFPModel(mode='classification', n_tasks=len(tasks),
-  ..                          batch_size=32, learning_rate=0.001)
+  >> model = MPNNModel(mode='classification', n_tasks=len(tasks),
+  ..                   batch_size=32, learning_rate=0.001)
   >> model.fit(train, nb_epoch=50)
 
   References
   ----------
-  .. [1] Zhaoping Xiong, Dingyan Wang, Xiaohong Liu, Feisheng Zhong, Xiaozhe Wan, Xutong Li,
-         Zhaojun Li, Xiaomin Luo, Kaixian Chen, Hualiang Jiang, and Mingyue Zheng. "Pushing
-         the Boundaries of Molecular Representation for Drug Discovery with the Graph
-         Attention Mechanism." Journal of Medicinal Chemistry. 2020, 63, 16, 8749–8760.
+  .. [1] Justin Gilmer, Samuel S. Schoenholz, Patrick F. Riley, Oriol Vinyals, George E. Dahl.
+         "Neural Message Passing for Quantum Chemistry." ICML 2017.
 
   Notes
   -----
@@ -216,10 +213,11 @@ class AttentiveFPModel(TorchModel):
 
   def __init__(self,
                n_tasks: int,
-               num_layers: int = 2,
-               num_timesteps: int = 2,
-               graph_feat_size: int = 200,
-               dropout: float = 0.,
+               node_out_feats: int = 64,
+               edge_hidden_feats: int = 128,
+               num_step_message_passing: int = 3,
+               num_step_set2set: int = 6,
+               num_layer_set2set: int = 3,
                mode: str = 'regression',
                number_atom_features: int = 30,
                number_bond_features: int = 11,
@@ -233,15 +231,16 @@ class AttentiveFPModel(TorchModel):
     ----------
     n_tasks: int
       Number of tasks.
-    num_layers: int
-      Number of graph neural network layers, i.e. number of rounds of message passing.
-      Default to 2.
-    num_timesteps: int
-      Number of time steps for updating graph representations with a GRU. Default to 2.
-    graph_feat_size: int
-      Size for graph representations. Default to 200.
-    dropout: float
-      Dropout probability. Default to 0.
+    node_out_feats: int
+      The length of the final node representation vectors. Default to 64.
+    edge_hidden_feats: int
+      The length of the hidden edge representation vectors. Default to 128.
+    num_step_message_passing: int
+      The number of rounds of message passing. Default to 3.
+    num_step_set2set: int
+      The number of set2set steps. Default to 6.
+    num_layer_set2set: int
+      The number of set2set layers. Default to 3.
     mode: str
       The model type, 'classification' or 'regression'. Default to 'regression'.
     number_atom_features: int
@@ -265,12 +264,13 @@ class AttentiveFPModel(TorchModel):
     kwargs
       This can include any keyword argument of TorchModel.
     """
-    model = AttentiveFP(
+    model = MPNN(
         n_tasks=n_tasks,
-        num_layers=num_layers,
-        num_timesteps=num_timesteps,
-        graph_feat_size=graph_feat_size,
-        dropout=dropout,
+        node_out_feats=node_out_feats,
+        edge_hidden_feats=edge_hidden_feats,
+        num_step_message_passing=num_step_message_passing,
+        num_step_set2set=num_step_set2set,
+        num_layer_set2set=num_layer_set2set,
         mode=mode,
         number_atom_features=number_atom_features,
         number_bond_features=number_bond_features,
@@ -283,13 +283,13 @@ class AttentiveFPModel(TorchModel):
     else:
       loss = SparseSoftmaxCrossEntropy()
       output_types = ['prediction', 'loss']
-    super(AttentiveFPModel, self).__init__(
+    super(MPNNModel, self).__init__(
         model, loss=loss, output_types=output_types, **kwargs)
 
     self._self_loop = self_loop
 
   def _prepare_batch(self, batch):
-    """Create batch data for AttentiveFP.
+    """Create batch data for MPNN.
 
     Parameters
     ----------
@@ -318,6 +318,6 @@ class AttentiveFPModel(TorchModel):
         graph.to_dgl_graph(self_loop=self._self_loop) for graph in inputs[0]
     ]
     inputs = dgl.batch(dgl_graphs).to(self.device)
-    _, labels, weights = super(AttentiveFPModel, self)._prepare_batch(
+    _, labels, weights = super(MPNNModel, self)._prepare_batch(
         ([], labels, weights))
     return inputs, labels, weights

--- a/deepchem/models/torch_models/mpnn.py
+++ b/deepchem/models/torch_models/mpnn.py
@@ -222,7 +222,7 @@ class MPNNModel(TorchModel):
                number_atom_features: int = 30,
                number_bond_features: int = 11,
                n_classes: int = 2,
-               self_loop: bool = True,
+               self_loop: bool = False,
                **kwargs):
     """
     Parameters
@@ -250,7 +250,7 @@ class MPNNModel(TorchModel):
       (only used when ``mode`` is 'classification'). Default to 2.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
-      Default to True.
+      Generally, an MPNNModel does not require self loops. Default to False.
     kwargs
       This can include any keyword argument of TorchModel.
     """

--- a/deepchem/models/torch_models/mpnn.py
+++ b/deepchem/models/torch_models/mpnn.py
@@ -306,6 +306,6 @@ class MPNNModel(TorchModel):
         graph.to_dgl_graph(self_loop=self._self_loop) for graph in inputs[0]
     ]
     inputs = dgl.batch(dgl_graphs).to(self.device)
-    _, labels, weights = super(MPNNModel, self)._prepare_batch(
-        ([], labels, weights))
+    _, labels, weights = super(MPNNModel, self)._prepare_batch(([], labels,
+                                                                weights))
     return inputs, labels, weights

--- a/deepchem/models/torch_models/mpnn.py
+++ b/deepchem/models/torch_models/mpnn.py
@@ -222,8 +222,6 @@ class MPNNModel(TorchModel):
                number_atom_features: int = 30,
                number_bond_features: int = 11,
                n_classes: int = 2,
-               nfeat_name: str = 'x',
-               efeat_name: str = 'edge_attr',
                self_loop: bool = True,
                **kwargs):
     """
@@ -250,14 +248,6 @@ class MPNNModel(TorchModel):
     n_classes: int
       The number of classes to predict per task
       (only used when ``mode`` is 'classification'). Default to 2.
-    nfeat_name: str
-      For an input graph ``g``, the model assumes that it stores node features in
-      ``g.ndata[nfeat_name]`` and will retrieve input node features from that.
-      Default to 'x'.
-    efeat_name: str
-      For an input graph ``g``, the model assumes that it stores edge features in
-      ``g.edata[efeat_name]`` and will retrieve input edge features from that.
-      Default to 'edge_attr'.
     self_loop: bool
       Whether to add self loops for the nodes, i.e. edges from nodes to themselves.
       Default to True.
@@ -274,9 +264,7 @@ class MPNNModel(TorchModel):
         mode=mode,
         number_atom_features=number_atom_features,
         number_bond_features=number_bond_features,
-        n_classes=n_classes,
-        nfeat_name=nfeat_name,
-        efeat_name=efeat_name)
+        n_classes=n_classes)
     if mode == 'regression':
       loss: Loss = L2Loss()
       output_types = ['prediction']

--- a/deepchem/models/torch_models/mpnn.py
+++ b/deepchem/models/torch_models/mpnn.py
@@ -283,9 +283,6 @@ class MPNNModel(TorchModel):
     ----------
     batch: tuple
       The tuple is ``(inputs, labels, weights)``.
-    self_loop: bool
-      Whether to add self loops for the nodes, i.e. edges from nodes
-      to themselves. Default to False.
 
     Returns
     -------

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -463,8 +463,8 @@ AttentiveFPModel
 MPNNModel
 ---------
 
-.. autoclass:: deepchem.models.torch_models.MPNNModel
-  :members:
-
 Note that this is an alternative implementation for MPNN and currently you can only import it from
 ``deepchem.models.torch_models``.
+
+.. autoclass:: deepchem.models.torch_models.MPNNModel
+  :members:

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -132,6 +132,9 @@ read off what's needed to train the model from the table below.
 | :code:`AttentiveFPModel`               | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
 |                                        | Regressor  |                      |                        |                                                                |                      |
 +----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
+| :code:`MPNNModel`                      | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
+|                                        | Regressor  |                      |                        |                                                                |                      |
++----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
 
 Model
 -----
@@ -458,4 +461,10 @@ AttentiveFPModel
 ----------------
 
 .. autoclass:: deepchem.models.AttentiveFPModel
+  :members:
+
+MPNNModel
+---------
+
+.. autoclass:: deepchem.models.MPNNModel
   :members:

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -132,9 +132,6 @@ read off what's needed to train the model from the table below.
 | :code:`AttentiveFPModel`               | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
 |                                        | Regressor  |                      |                        |                                                                |                      |
 +----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
-| :code:`MPNNModel`                      | Classifier/| :code:`GraphData`    |                        | :code:`MolGraphConvFeaturizer`                                 | :code:`fit`          |
-|                                        | Regressor  |                      |                        |                                                                |                      |
-+----------------------------------------+------------+----------------------+------------------------+----------------------------------------------------------------+----------------------+
 
 Model
 -----
@@ -466,5 +463,5 @@ AttentiveFPModel
 MPNNModel
 ---------
 
-.. autoclass:: deepchem.models.MPNNModel
+.. autoclass:: deepchem.models.torch_models.MPNNModel
   :members:

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -465,3 +465,6 @@ MPNNModel
 
 .. autoclass:: deepchem.models.torch_models.MPNNModel
   :members:
+
+Note that this is an alternative implementation for MPNN and currently you can only import it from
+``deepchem.models.torch_models``.


### PR DESCRIPTION
As discussed in #2280 , this PR adds a model wrapper for MPNN from DGL-LifeSci. The PR assumes DGL (0.5.0+) and DGL-LifeSci (0.2.5+). 

I've not deprecated the previous MPNN implementation. Currently one needs to import it from `deepchem.models.torch_models`, not `deepchem.models`.

@rbharath @nd-02110114 @peastman This PR is complete and you may start reviewing.