### PR TITLE
Add prepare inputs utility for AutoDock Vina

### DIFF
--- a/deepchem/utils/__init__.py
+++ b/deepchem/utils/__init__.py
@@ -84,6 +84,7 @@ from deepchem.utils.pdbqt_utils import convert_mol_to_pdbqt
 
 from deepchem.utils.vina_utils import write_vina_conf
 from deepchem.utils.vina_utils import load_docked_ligands
+from deepchem.utils.vina_utils import prepare_inputs
 
 from deepchem.utils.voxel_utils import convert_atom_to_voxel
 from deepchem.utils.voxel_utils import convert_atom_pair_to_voxel

--- a/deepchem/utils/test/test_vina_utils.py
+++ b/deepchem/utils/test/test_vina_utils.py
@@ -25,3 +25,24 @@ class TestVinaUtils(unittest.TestCase):
       xyz = rdkit_utils.get_xyz_from_mol(ligand)
       assert score < 0  # This is a binding free energy
       assert np.count_nonzero(xyz) > 0
+
+  def test_prepare_inputs(self):
+    from rdkit import Chem
+    pdbid = '3cyx'
+    ligand_smiles = 'CC(C)(C)NC(O)C1CC2CCCCC2C[NH+]1CC(O)C(CC1CCCCC1)NC(O)C(CC(N)O)NC(O)C1CCC2CCCCC2N1'
+
+    protein, ligand = vina_utils.prepare_inputs(
+        pdbid, ligand_smiles, pdb_name=pdbid)
+
+    assert protein.GetNumAtoms() == 1415
+    assert ligand.GetNumAtoms() == 124
+
+    protein, ligand = vina_utils.prepare_inputs(pdbid + '.pdb',
+                                                'ligand_' + pdbid + '.pdb')
+
+    assert protein.GetNumAtoms() == 1415
+    assert ligand.GetNumAtoms() == 124
+
+    os.remove(pdbid + '.pdb')
+    os.remove('ligand_' + pdbid + '.pdb')
+    os.remove('tmp.pdb')

--- a/deepchem/utils/test/test_vina_utils.py
+++ b/deepchem/utils/test/test_vina_utils.py
@@ -27,21 +27,20 @@ class TestVinaUtils(unittest.TestCase):
       assert np.count_nonzero(xyz) > 0
 
   def test_prepare_inputs(self):
-    from rdkit import Chem
     pdbid = '3cyx'
     ligand_smiles = 'CC(C)(C)NC(O)C1CC2CCCCC2C[NH+]1CC(O)C(CC1CCCCC1)NC(O)C(CC(N)O)NC(O)C1CCC2CCCCC2N1'
 
     protein, ligand = vina_utils.prepare_inputs(
         pdbid, ligand_smiles, pdb_name=pdbid)
 
-    assert protein.GetNumAtoms() == 1415
-    assert ligand.GetNumAtoms() == 124
+    assert np.isclose(protein.GetNumAtoms(), 1415, atol=3)
+    assert np.isclose(ligand.GetNumAtoms(), 124, atol=3)
 
     protein, ligand = vina_utils.prepare_inputs(pdbid + '.pdb',
                                                 'ligand_' + pdbid + '.pdb')
 
-    assert protein.GetNumAtoms() == 1415
-    assert ligand.GetNumAtoms() == 124
+    assert np.isclose(protein.GetNumAtoms(), 1415, atol=3)
+    assert np.isclose(ligand.GetNumAtoms(), 124, atol=3)
 
     os.remove(pdbid + '.pdb')
     os.remove('ligand_' + pdbid + '.pdb')

--- a/deepchem/utils/vina_utils.py
+++ b/deepchem/utils/vina_utils.py
@@ -116,13 +116,23 @@ def load_docked_ligands(
   return molecules, scores
 
 
-def prepare_inputs(protein: str, ligand: str,
+def prepare_inputs(protein: str,
+                   ligand: str,
+                   replace_nonstandard_residues: bool = True,
+                   remove_heterogens: bool = True,
+                   remove_water: bool = True,
+                   add_hydrogens: bool = True,
+                   pH: float = 7.0,
+                   optimize_ligand: bool = True,
                    pdb_name: Optional[str] = None) -> Tuple[RDKitMol, RDKitMol]:
   """This prepares protein-ligand complexes for docking.
 
   Autodock Vina requires PDB files for proteins and ligands with
   sensible inputs. This function uses PDBFixer and RDKit to ensure
-  that inputs are reasonable and ready for docking.
+  that inputs are reasonable and ready for docking. Default values
+  are given for convenience, but fixing PDB files is complicated and
+  human judgement is required to produce protein structures suitable
+  for docking.
 
   Parameters
   ----------
@@ -130,6 +140,18 @@ def prepare_inputs(protein: str, ligand: str,
     Filename for protein PDB file or a PDBID.
   ligand: str
     Either a filename for a ligand PDB file or a SMILES string.
+  replace_nonstandard_residues: bool (default True)
+    Replace nonstandard residues with standard residues.
+  remove_heterogens: bool (default True)
+    Removes residues that are not standard amino acids or nucleotides.
+  remove_water: bool (default True)
+    Remove water molecules.
+  add_hydrogens: bool (default True)
+    Add missing hydrogens at the protonation state given by `pH`.
+  pH: float (default 7.0)
+    Most common form of each residue at given `pH` value is used.
+  optimize_ligand: bool (default True)
+    If True, optimize ligand with RDKit. Required for SMILES inputs.
   pdb_name: Optional[str]
     If given, write sanitized protein and ligand to files called
     "pdb_name.pdb" and "ligand_pdb_name.pdb"
@@ -139,10 +161,22 @@ def prepare_inputs(protein: str, ligand: str,
   Tuple[RDKitMol, RDKitMol]
     Tuple of `protein_molecule, ligand_molecule` with 3D information.
 
-  Notes
-  -----
+  Note
+  ----
   This function requires RDKit and OpenMM to be installed.
   Read more about PDBFixer here: https://github.com/openmm/pdbfixer.
+
+  Examples
+  --------
+  >>> p, m = prepare_inputs('3cyx', 'CCC')
+  >>> p.GetNumAtoms()
+  1415
+  >>> m.GetNumAtoms()
+  11
+
+  >>> p, m = prepare_inputs('3cyx', 'CCC', remove_heterogens=False)
+  >>> p.GetNumAtoms()
+  1720
 
   """
 
@@ -165,18 +199,25 @@ def prepare_inputs(protein: str, ligand: str,
     m = Chem.MolFromSmiles(ligand, sanitize=True)
 
   # Apply common fixes to PDB files
-  fixer.findMissingResidues()
-  fixer.findNonstandardResidues()
-  fixer.replaceNonstandardResidues()
-  fixer.removeHeterogens(False)  # remove water
-  fixer.addMissingHydrogens(7.0)
+  if replace_nonstandard_residues:
+    fixer.findMissingResidues()
+    fixer.findNonstandardResidues()
+    fixer.replaceNonstandardResidues()
+  if remove_heterogens and not remove_water:
+    fixer.removeHeterogens(True)
+  if remove_heterogens and remove_water:
+    fixer.removeHeterogens(False)
+  if add_hydrogens:
+    fixer.addMissingHydrogens(pH)
+
   PDBFile.writeFile(fixer.topology, fixer.positions, open('tmp.pdb', 'w'))
   p = Chem.MolFromPDBFile('tmp.pdb', sanitize=True)
 
   # Optimize ligand
-  m = Chem.AddHs(m)  # need hydrogens for optimization
-  Chem.AllChem.EmbedMolecule(m)
-  Chem.AllChem.MMFFOptimizeMolecule(m)
+  if optimize_ligand:
+    m = Chem.AddHs(m)  # need hydrogens for optimization
+    Chem.AllChem.EmbedMolecule(m)
+    Chem.AllChem.MMFFOptimizeMolecule(m)
 
   if pdb_name:
     Chem.rdmolfiles.MolToPDBFile(p, '%s.pdb' % (pdb_name))

--- a/deepchem/utils/vina_utils.py
+++ b/deepchem/utils/vina_utils.py
@@ -132,7 +132,8 @@ def prepare_inputs(protein: str,
   that inputs are reasonable and ready for docking. Default values
   are given for convenience, but fixing PDB files is complicated and
   human judgement is required to produce protein structures suitable
-  for docking.
+  for docking. Always inspect the results carefully before trying to 
+  perform docking.
 
   Parameters
   ----------

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -191,6 +191,19 @@ Graph Convolution Utilities
 Debug Utilities
 ---------------
 
+Docking Utilities
+-----------------
+
+These utilities assist in file preparation and processing for molecular
+docking.
+
+.. autofunction:: deepchem.utils.vina_utils.write_vina_conf
+
+.. autofunction:: deepchem.utils.vina_utils.load_docked_ligands
+
+.. autofunction:: deepchem.utils.vina_utils.prepare_inputs
+
+
 Print Threshold
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
This PR adds a short utility function for preparing protein-ligand complex inputs to AutoDock Vina. Vina requires sanitized inputs saved as pdb files. Currently, this utility does the following:
* Reads PDB file or a PDBID for a protein and downloads from PDB
* Reads PDB file or a SMILES string for a ligand 
* Uses `PDBFixer` to fix issues in the protein PDB file
* Uses RDKit to optimize the ligand geometry 
* Sanitizes both molecules with RDKit and returns as RDKit Molecules 
* Optionally writes prepared molecules to PDB files for Vina

I know there is a lot of complexity involved in preparing complexes, this is just what worked for me to get `dc.dock` to work. I'm hoping this will also standardize how inputs are prepared for docking and ML workflows in DeepChem. Happy to make any suggested changes.

CCing @peastman and @rbharath 