### PR TITLE
Flake8 fix in vina_utils.py

### DIFF
--- a/deepchem/utils/vina_utils.py
+++ b/deepchem/utils/vina_utils.py
@@ -132,7 +132,7 @@ def prepare_inputs(protein: str,
   that inputs are reasonable and ready for docking. Default values
   are given for convenience, but fixing PDB files is complicated and
   human judgement is required to produce protein structures suitable
-  for docking. Always inspect the results carefully before trying to 
+  for docking. Always inspect the results carefully before trying to
   perform docking.
 
   Parameters


### PR DESCRIPTION
There was a trailing space in `vina_utils.py` introduced in #2298 that was causing travis failures, as mentioned in #2297. Should be fixed now.