### PR TITLE
changing the expected output of get_task_names for DiskDataset to List[str]

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1410,7 +1410,7 @@ class DiskDataset(Dataset):
     shutil.copytree(self.data_dir, new_data_dir)
     return DiskDataset(new_data_dir)
 
-  def get_task_names(self) -> np.ndarray:
+  def get_task_names(self) -> List[str]:
     """Gets learning tasks associated with this dataset."""
     return self.tasks
 


### PR DESCRIPTION
It is a very very minor correction to the `DiskDataset` object. `DiskDataset` object has `get_task_names()` method and I believe the expected output for this method is `List[str]` instead of `np.ndarray`. So, I changed this one line. 