### PR TITLE
Hotfix for release process

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,17 @@ on:
   push: # ci work when pushing master branch
     branches:
       - master
+    paths:
+      - "scripts/install_deepchem_conda.ps1"
+      - "scripts/install_deepchem_conda.sh"
+      - "env.*.yml"
   pull_request: # ci work when creating a PR to master branch
     branches:
       - master
+    paths:
+      - "scripts/install_deepchem_conda.ps1"
+      - "scripts/install_deepchem_conda.sh"
+      - "env.*.yml"
 jobs:
   bash-build:
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/deepchem/badges/version.svg)](https://anaconda.org/conda-forge/deepchem)
 [![PyPI version](https://badge.fury.io/py/deepchem.svg)](https://badge.fury.io/py/deepchem)
-[![Documentation Status](https://readthedocs.org/projects/deepchem/badge/?version=latest)](https://deepchem.readthedocs.io/en/latest/?badge=latest)
-
+[![Documentation Status](https://readthedocs.org/projects/deepchem/badge/?version=latest)](https://deepchem.readthedocs.io/en/latest/?badge=latest)  
 ![Test for DeepChem Core](https://github.com/deepchem/deepchem/workflows/Test%20for%20DeepChem%20Core/badge.svg)
 ![Test for documents](https://github.com/deepchem/deepchem/workflows/Test%20for%20documents/badge.svg)
 ![Test for build scripts](https://github.com/deepchem/deepchem/workflows/Test%20for%20build%20scripts/badge.svg)
@@ -39,15 +38,15 @@ DeepChem currently supports Python 3.6 through 3.7 and requires these packages o
 - [scikit-learn](https://scikit-learn.org/stable/)
 - [SciPy](https://www.scipy.org/)
 - [TensorFlow](https://www.tensorflow.org/)
-  - `deepchem>=2.4.0` requires tensorflow v2
-  - `deepchem<2.4.0` requires tensorflow v1
+  - `deepchem>=2.4.0` depends on TensorFlow v2
+  - `deepchem<2.4.0` depends on TensorFlow v1
 
 ### Soft Requirements
 
-DeepChem has a number of "soft" requirements.  
+DeepChem has a number of "soft" requirements.
 If you face some errors like `ImportError: This class requires XXXX`, you may need to install some packages.
 
-Please check [the document](https://deepchem.readthedocs.io/en/latest/requirements.html##soft-requirements) about soft requirements.
+Please check [the document](https://deepchem.readthedocs.io/en/latest/requirements.html#soft-requirements) about soft requirements.
 
 ## Installation
 
@@ -74,7 +73,7 @@ conda install -y -c conda-forge rdkit deepchem==2.3.0
 You install the nightly build version via pip. The nightly version is built by the HEAD of DeepChem.
 
 ```bash
-pip install tensorflow==2.3.0
+pip install tensorflow==2.3.*
 pip install --pre deepchem
 ```
 
@@ -90,11 +89,11 @@ If you want to install deepchem using a docker, you can pull two kinds of images
 DockerHub : https://hub.docker.com/repository/docker/deepchemio/deepchem
 
 - `deepchemio/deepchem:x.x.x`
-  - Image built by using a conda package manager (x.x.x is a version of deepchem)
+  - Image built by using a conda (x.x.x is a version of deepchem)
   - The x.x.x image is built when we push x.x.x. tag
   - Dockerfile is put in `docker/conda-forge` directory
 - `deepchemio/deepchem:latest`
-  - Image built by the master branch of deepchem source codes
+  - Image built from source codes
   - The latest image is built every time we commit to the master branch
   - Dockerfile is put in `docker/master` directory
 
@@ -110,7 +109,7 @@ If you want to know docker usages with deepchem in more detail, please check [th
 
 If you try install all soft dependencies at once or contribute to deepchem, we recommend you should install deepchem from source.
 
-Please check [this introduction](https://deepchem.readthedocs.io/en/latest/installation.html#from-source).
+Please check [this introduction](https://deepchem.readthedocs.io/en/latest/installation.html#from-source-with-conda).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 ﻿# DeepChem
 
 [![Anaconda-Server Badge](https://anaconda.org/conda-forge/deepchem/badges/version.svg)](https://anaconda.org/conda-forge/deepchem)
-[![PyPI version](https://badge.fury.io/py/deepchem.svg)](https://badge.fury.io/py/deepchem)
+[![PyPI version](https://badge.fury.io/py/deepchem.svg)](https://pypi.org/project/deepchem/)
 [![Documentation Status](https://readthedocs.org/projects/deepchem/badge/?version=latest)](https://deepchem.readthedocs.io/en/latest/?badge=latest)  
-![Test for DeepChem Core](https://github.com/deepchem/deepchem/workflows/Test%20for%20DeepChem%20Core/badge.svg)
-![Test for documents](https://github.com/deepchem/deepchem/workflows/Test%20for%20documents/badge.svg)
-![Test for build scripts](https://github.com/deepchem/deepchem/workflows/Test%20for%20build%20scripts/badge.svg)
-[![codecov](https://codecov.io/gh/deepchem/deepchem/branch/master/graph/badge.svg?token=5rOZB2BY3h)](https://codecov.io/gh/deepchem/deepchem)
+[![Test for DeepChem Core](https://github.com/deepchem/deepchem/workflows/Test%20for%20DeepChem%20Core/badge.svg)](https://github.com/deepchem/deepchem/actions?query=workflow%3A%22Test+for+DeepChem+Core%22)
+[![Test for documents](https://github.com/deepchem/deepchem/workflows/Test%20for%20documents/badge.svg)](https://github.com/deepchem/deepchem/actions?query=workflow%3A%22Test+for+documents%22)
+[![Test for build scripts](https://github.com/deepchem/deepchem/workflows/Test%20for%20build%20scripts/badge.svg)](https://github.com/deepchem/deepchem/actions?query=workflow%3A%22Test+for+build+scripts%22)
+[![codecov](https://codecov.io/gh/deepchem/deepchem/branch/master/graph/badge.svg?token=5rOZB2BY3h)](https://codecov.io/gh/deepchem/deepchem)  
 
 [Website](https://deepchem.io/) | [Documentation](https://deepchem.readthedocs.io/en/latest/) | [Colab Tutorial](https://github.com/deepchem/deepchem/tree/master/examples/tutorials) | [Discussion Forum](https://forum.deepchem.io/) | [Gitter](https://gitter.im/deepchem/Lobby)
 

--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -3,7 +3,7 @@ Imports all submodules
 """
 
 # If you push the tag, please remove `.dev`
-__version__ = '2.4.0.dev'
+__version__ = '2.4.0-rc1.dev'
 
 import deepchem.data
 import deepchem.feat

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -34,7 +34,7 @@ The nightly version is built by the HEAD of DeepChem.
 
 .. code-block:: bash
 
-    pip install tensorflow==2.3.0
+    pip install tensorflow==2.3.*
     pip install --pre deepchem
 
 
@@ -63,13 +63,13 @@ you can pull two kinds of images from `DockerHub`_.
 
 - **deepchemio/deepchem:x.x.x**
 
-  - Image built by using a conda package manager (x.x.x is a version of deepchem)
+  - Image built by using a conda (x.x.x is a version of deepchem)
   - This image is built when we push x.x.x. tag
   - Dockerfile is put in `docker/conda-forge`_ directory
 
 - **deepchemio/deepchem:latest**
 
-  - Image built by the master branch of deepchem source codes
+  - Image built from source codes
   - This image is built every time we commit to the master branch
   - Dockerfile is put in `docker/master`_ directory
 
@@ -123,6 +123,7 @@ From source with conda
 **Installing via these steps will ensure you are installing from the source**.
 
 **Prerequisite**
+
 - Shell: Bash, Zsh, PowerShell
 - Conda: >4.6
 

--- a/docs/source/get_started/requirements.rst
+++ b/docs/source/get_started/requirements.rst
@@ -13,8 +13,8 @@ DeepChem officially supports Python 3.6 through 3.7 and requires these packages 
 - `SciPy`_
 - `TensorFlow`_
 
-  - `deepchem>=2.4.0` requires tensorflow v2 (2.3.x)
-  - `deepchem<2.4.0` requires tensorflow v1 (>=1.14)
+  - `deepchem>=2.4.0` depends on TensorFlow v2 (2.3.x)
+  - `deepchem<2.4.0` depends on  TensorFlow v1 (>=1.14)
 
 
 Soft requirements

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -58,7 +58,7 @@ RDKit is a soft requirement package, but many useful methods depend on it.
 
 .. code-block:: bash
 
-    pip install tensorflow==2.3.0
+    pip install tensorflow==2.3.*
     pip install --pre deepchem
     conda install -y -c conda-forge rdkit
 

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -4,7 +4,7 @@ dependencies:
     - -f https://pytorch-geometric.com/whl/torch-1.6.0+cu101.html
     - dgl-cu101==0.5.*
     - torch==1.6.0+cu101
-    - torchvision==1.6.0+cu101
+    - torchvision==0.7.0+cu101
     - torch-cluster
     - torch-scatter
     - torch-sparse


### PR DESCRIPTION
## Description

This PR is a follow-up for #2331.
#2331 fixed the publish process, but PyPI don't recognize the published package as the latest.
https://pypi.org/project/deepchem/2.4.0.dev20201222014716/#history
https://pypi.org/project/deepchem/2.4.0.dev20201222014716/#files

The published package is `deepchem 2.4.0.dev20201222014716` and PyPI recognize the `2.4.0rc1.devXXXXXXX` as the latest. (`2.4.0rc1.devXXXXXXX` is newer than `2.4.0.devXXXXXXX`) So, I set back the previous version in `deepchem/__init__.py`. 

But, I think the `rc` flag is not needed (`.dev` is enough to indicate the package is a nightly build) and it should be removed in the next version.

In addtion to this, Docker build still failed, so I fixed.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
