### PR TITLE
Handle Warnings for Deprecated DGL APIs

### DIFF
--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -364,7 +364,7 @@ class TorchModel(Model):
 
       # Execute the loss function, accumulating the gradients.
 
-      if len(inputs) == 1:
+      if isinstance(inputs, list) and len(inputs) == 1:
         inputs = inputs[0]
 
       optimizer.zero_grad()
@@ -524,7 +524,7 @@ class TorchModel(Model):
       inputs, _, _ = self._prepare_batch((inputs, None, None))
 
       # Invoke the model.
-      if len(inputs) == 1:
+      if isinstance(inputs, list) and len(inputs) == 1:
         inputs = inputs[0]
       output_values = self.model(inputs)
       if isinstance(output_values, torch.Tensor):


### PR DESCRIPTION
# Pull Request Template
DGL has deprecated the use of `len` for `DGLGraphs`, resulting in deprecation warnings. This PR checks if `inputs` is a list first before checking `len(inputs)` to prevent the warnings. @nd-02110114 Can you take a look?

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
