### PR TITLE
Turning on SDF sanitization for load_qm7/8/9

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -714,7 +714,7 @@ class SDFLoader(DataLoader):
   def __init__(self,
                tasks: List[str],
                featurizer: Featurizer,
-               sanitize: bool = False,
+               sanitize: bool = True,
                log_every_n: int = 1000):
     """Initialize SDF Loader
 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -714,7 +714,7 @@ class SDFLoader(DataLoader):
   def __init__(self,
                tasks: List[str],
                featurizer: Featurizer,
-               sanitize: bool = True,
+               sanitize: bool = False,
                log_every_n: int = 1000):
     """Initialize SDF Loader
 

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -22,7 +22,8 @@ class _QM7Loader(_MolnetLoader):
       dc.utils.data_utils.download_url(url=GDB7_URL, dest_dir=self.data_dir)
       dc.utils.data_utils.untargz_file(
           os.path.join(self.data_dir, "gdb7.tar.gz"), self.data_dir)
-    loader = dc.data.SDFLoader(tasks=self.tasks, featurizer=self.featurizer)
+    loader = dc.data.SDFLoader(
+        tasks=self.tasks, featurizer=self.featurizer, sanitize=True)
     return loader.create_dataset(dataset_file, shard_size=8192)
 
 
@@ -80,6 +81,16 @@ def load_qm7(
     a directory to save the raw data in
   save_dir: str
     a directory to save the dataset in
+
+  Note
+  ----
+  DeepChem 2.4.0 has turned on sanitization for SDF files by default.
+  For the QM7 dataset, this means that calling this function will
+  return 6838 compounds instead of 7160 in the source dataset file.
+  This appears to be due to valence specification mismatches in the
+  dataset that weren't caught in earlier more lax versions of RDKit.
+  Note that this may subtly affect benchmarking results on this
+  dataset.
 
   References
   ----------

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -84,12 +84,13 @@ def load_qm7(
 
   Note
   ----
-  DeepChem 2.4.0 has turned on sanitization for SDF files by default.
-  For the QM7 dataset, this means that calling this function will
-  return 6838 compounds instead of 7160 in the source dataset file.
-  This appears to be due to valence specification mismatches in the
-  dataset that weren't caught in earlier more lax versions of RDKit.
-  Note that this may subtly affect benchmarking results on this
+  DeepChem 2.4.0 has turned on sanitization for this dataset by
+  default.  For the QM7 dataset, this means that calling this
+  function will return 6838 compounds instead of 7160 in the source
+  dataset file.  This appears to be due to valence specification
+  mismatches in the dataset that weren't caught in earlier more lax
+  versions of RDKit.  Note that this may subtly affect benchmarking
+  results on this
   dataset.
 
   References

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -93,13 +93,13 @@ def load_qm8(
 
   Note
   ----
-  DeepChem 2.4.0 has turned on sanitization for SDF files by default.
-  For the QM8 dataset, this means that calling this function will
-  return 21747 compounds instead of 21786 in the source dataset file.
-  This appears to be due to valence specification mismatches in the
-  dataset that weren't caught in earlier more lax versions of RDKit.
-  Note that this may subtly affect benchmarking results on this
-  dataset.
+  DeepChem 2.4.0 has turned on sanitization for this dataset by
+  default.  For the QM8 dataset, this means that calling this
+  function will return 21747 compounds instead of 21786 in the source
+  dataset file.  This appears to be due to valence specification
+  mismatches in the dataset that weren't caught in earlier more lax
+  versions of RDKit.  Note that this may subtly affect benchmarking
+  results on this dataset.
 
   References
   ----------

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -24,7 +24,8 @@ class _QM8Loader(_MolnetLoader):
       dc.utils.data_utils.download_url(url=GDB8_URL, dest_dir=self.data_dir)
       dc.utils.data_utils.untargz_file(
           os.path.join(self.data_dir, "gdb8.tar.gz"), self.data_dir)
-    loader = dc.data.SDFLoader(tasks=self.tasks, featurizer=self.featurizer)
+    loader = dc.data.SDFLoader(
+        tasks=self.tasks, featurizer=self.featurizer, sanitize=True)
     return loader.create_dataset(dataset_file, shard_size=8192)
 
 
@@ -89,6 +90,16 @@ def load_qm8(
     a directory to save the raw data in
   save_dir: str
     a directory to save the dataset in
+
+  Note
+  ----
+  DeepChem 2.4.0 has turned on sanitization for SDF files by default.
+  For the QM8 dataset, this means that calling this function will
+  return 21747 compounds instead of 21786 in the source dataset file.
+  This appears to be due to valence specification mismatches in the
+  dataset that weren't caught in earlier more lax versions of RDKit.
+  Note that this may subtly affect benchmarking results on this
+  dataset.
 
   References
   ----------

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -39,10 +39,10 @@ def load_qm9(
   """Load QM9 dataset
 
   QM9 is a comprehensive dataset that provides geometric, energetic,
-  electronic and thermodynamic properties for a subset of GDB-17 database,
-  comprising 134 thousand stable organic molecules with up to 9 heavy atoms.
-  All molecules are modeled using density functional theory
-  (B3LYP/6-31G(2df,p) based DFT).
+  electronic and thermodynamic properties for a subset of GDB-17
+  database, comprising 134 thousand stable organic molecules with up
+  to 9 heavy atoms.  All molecules are modeled using density
+  functional theory (B3LYP/6-31G(2df,p) based DFT).
 
   Random splitting is recommended for this dataset.
 
@@ -98,6 +98,16 @@ def load_qm9(
     a directory to save the raw data in
   save_dir: str
     a directory to save the dataset in
+
+  Note
+  ----
+  DeepChem 2.4.0 has turned on sanitization for SDF files by default.
+  For the QM9 dataset, this means that calling this function will
+  return a list of 132480 compounds instead of 133885 in the source
+  dataset file. This appears to be due to valence specification
+  mismatches in the dataset that weren't caught in earlier more lax
+  versions of RDKit. Note that this may subtly affect benchmarking
+  results on this dataset.
 
   References
   ----------

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -102,13 +102,13 @@ def load_qm9(
 
   Note
   ----
-  DeepChem 2.4.0 has turned on sanitization for SDF files by default.
-  For the QM9 dataset, this means that calling this function will
-  return 132480 compounds instead of 133885 in the source dataset
-  file. This appears to be due to valence specification mismatches in
-  the dataset that weren't caught in earlier more lax versions of
-  RDKit. Note that this may subtly affect benchmarking results on
-  this dataset.
+  DeepChem 2.4.0 has turned on sanitization for this dataset by
+  default.  For the QM9 dataset, this means that calling this
+  function will return 132480 compounds instead of 133885 in the
+  source dataset file. This appears to be due to valence
+  specification mismatches in the dataset that weren't caught in
+  earlier more lax versions of RDKit. Note that this may subtly
+  affect benchmarking results on this dataset.
 
   References
   ----------

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -23,7 +23,8 @@ class _QM9Loader(_MolnetLoader):
       dc.utils.data_utils.download_url(url=GDB9_URL, dest_dir=self.data_dir)
       dc.utils.data_utils.untargz_file(
           os.path.join(self.data_dir, "gdb9.tar.gz"), self.data_dir)
-    loader = dc.data.SDFLoader(tasks=self.tasks, featurizer=self.featurizer)
+    loader = dc.data.SDFLoader(
+        tasks=self.tasks, featurizer=self.featurizer, sanitize=True)
     return loader.create_dataset(dataset_file, shard_size=8192)
 
 
@@ -103,11 +104,11 @@ def load_qm9(
   ----
   DeepChem 2.4.0 has turned on sanitization for SDF files by default.
   For the QM9 dataset, this means that calling this function will
-  return a list of 132480 compounds instead of 133885 in the source
-  dataset file. This appears to be due to valence specification
-  mismatches in the dataset that weren't caught in earlier more lax
-  versions of RDKit. Note that this may subtly affect benchmarking
-  results on this dataset.
+  return 132480 compounds instead of 133885 in the source dataset
+  file. This appears to be due to valence specification mismatches in
+  the dataset that weren't caught in earlier more lax versions of
+  RDKit. Note that this may subtly affect benchmarking results on
+  this dataset.
 
   References
   ----------


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #2334

This PR turns on sanitization for `load_qm7`, `load_qm8`, `load_qm9`. I've also updated the docstrings on these functions noting the difference. This changes behavior for these loaders subtly but the change is documented and the loaders weren't working previously so I think this is an acceptable fix for now.

## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [X] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
