### PR TITLE
Add training nb_epoch to hyperparameter optimization

### DIFF
--- a/deepchem/hyper/base_classes.py
+++ b/deepchem/hyper/base_classes.py
@@ -111,7 +111,7 @@ class HyperparamOpt(object):
       `train_dataset` and `valid_dataset` may have been transformed
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
-    nb_epoch: int, (default 5)
+    nb_epoch: int, (default 10)
       Specifies the number of training epochs during each iteration of optimization.
     use_max: bool, optional
       If True, return the model with the highest score. Else return

--- a/deepchem/hyper/base_classes.py
+++ b/deepchem/hyper/base_classes.py
@@ -80,7 +80,7 @@ class HyperparamOpt(object):
                         valid_dataset: Dataset,
                         metric: Metric,
                         output_transformers: List[Transformer] = [],
-                        nb_epoch: int = 5,
+                        nb_epoch: int = 10,
                         use_max: bool = True,
                         logdir: Optional[str] = None,
                         **kwargs) -> Tuple[Model, Dict, Dict]:

--- a/deepchem/hyper/base_classes.py
+++ b/deepchem/hyper/base_classes.py
@@ -80,6 +80,7 @@ class HyperparamOpt(object):
                         valid_dataset: Dataset,
                         metric: Metric,
                         output_transformers: List[Transformer] = [],
+                        nb_epoch: int = 5,
                         use_max: bool = True,
                         logdir: Optional[str] = None,
                         **kwargs) -> Tuple[Model, Dict, Dict]:
@@ -110,6 +111,8 @@ class HyperparamOpt(object):
       `train_dataset` and `valid_dataset` may have been transformed
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
+    nb_epoch: int, (default 5)
+      Specifies the number of training epochs during each iteration of optimization.
     use_max: bool, optional
       If True, return the model with the highest score. Else return
       model with the minimum score.

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -315,7 +315,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
         valid set performances
       """
       return _optimize(nb_epoch=nb_epoch, **placeholders)
-    
+
     # execute GPGO
     cov = matern32()
     gp = GaussianProcess(cov)
@@ -344,6 +344,6 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
         f.write("params_dict:")
         f.write(str(params_dict))
         f.write('\n')
-    
+
     # Return default hyperparameters
     return best_model, hyper_parameters, all_results

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -320,7 +320,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
     def optimizing_function(**placeholders):
       """Wrapper function
 
-      Take in hyper parameter values. 
+      Take in hyper parameter values.
       Calls a private optimize function (_optimize) with number of epochs.
       Returns valid set performances.
 

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -163,6 +163,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
       the metric can be evaluated on a model.
     nb_epoch: int, (default 5)
       Specifies the number of training epochs during each iteration of optimization.
+      Not used by all model types.
     use_max: bool, (default True)
       Specifies whether to maximize or minimize `metric`.
       maximization(True) or minimization(False)
@@ -235,6 +236,24 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
 
     # Private opt_func to pass nb_epoch for optimizing_function
     def _optimize(nb_epoch, **placeholders):
+      """Private Optimizing function
+
+      Take in hyper parameter values and number of training epochs.
+      Return valid set performances.
+
+      Parameters
+      ----------
+      nb_epoch: int
+        Number of epochs to train model being optimized during each iteration.
+        Not used by all model types.
+      placeholders: keyword arguments
+        Should be various hyperparameters as specified in `param_keys` above.
+
+      Returns:
+      --------
+      valid_scores: float
+        valid set performances
+      """
       hyper_parameters = {}
       for hp in param_keys:
         if param_range[hp][0] == "int":
@@ -300,9 +319,11 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
 
     # Demarcating internal function for readability
     def optimizing_function(**placeholders):
-      """Private Optimizing function
+      """Wrapper function
 
-      Take in hyper parameter values and return valid set performances
+      Take in hyper parameter values. 
+      Calls a private optimize function (_optimize) with number of epochs.
+      Returns valid set performances.
 
       Parameters
       ----------

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -234,7 +234,6 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
     # Stores all model locations
     model_locations = {}
 
-    # Private opt_func to pass nb_epoch for optimizing_function
     def _optimize(nb_epoch, **placeholders):
       """Private Optimizing function
 

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -132,7 +132,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
                         valid_dataset: Dataset,
                         metric: Metric,
                         output_transformers: List[Transformer] = [],
-                        nb_epoch: int = 5,
+                        nb_epoch: int = 10,
                         use_max: bool = True,
                         logdir: Optional[str] = None,
                         max_iter: int = 20,

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -161,7 +161,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
       `train_dataset` and `valid_dataset` may have been transformed
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
-    nb_epoch: int, (default 5)
+    nb_epoch: int, (default 10)
       Specifies the number of training epochs during each iteration of optimization.
       Not used by all model types.
     use_max: bool, (default True)

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -266,7 +266,11 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
       # Add it on to the information needed for the constructor
       hyper_parameters["model_dir"] = model_dir
       model = self.model_builder(**hyper_parameters)
-      model.fit(train_dataset, nb_epoch=nb_epoch)
+      try:
+        model.fit(train_dataset, nb_epoch=nb_epoch)
+      # Not all models have nb_epoch
+      except TypeError:
+        model.fit(train_dataset)
       try:
         model.save()
       # Some models autosave

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -161,6 +161,8 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
       `train_dataset` and `valid_dataset` may have been transformed
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
+    nb_epoch: int, (default 5)
+      Specifies the number of epochs during each iteration of optimization
     use_max: bool, (default True)
       Specifies whether to maximize or minimize `metric`.
       maximization(True) or minimization(False)

--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -162,7 +162,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
     nb_epoch: int, (default 5)
-      Specifies the number of epochs during each iteration of optimization
+      Specifies the number of training epochs during each iteration of optimization.
     use_max: bool, (default True)
       Specifies whether to maximize or minimize `metric`.
       maximization(True) or minimization(False)

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -94,6 +94,7 @@ class GridHyperparamOpt(HyperparamOpt):
       the metric can be evaluated on a model.
     nb_epoch: int, (default 5)
       Specifies the number of training epochs during each iteration of optimization.
+      Not used by all model types.
     use_max: bool, optional
       If True, return the model with the highest score. Else return
       model with the minimum score.

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -66,6 +66,7 @@ class GridHyperparamOpt(HyperparamOpt):
       valid_dataset: Dataset,
       metric: Metric,
       output_transformers: List[Transformer] = [],
+      nb_epoch: int = 5,
       use_max: bool = True,
       logdir: Optional[str] = None,
       **kwargs,
@@ -91,6 +92,7 @@ class GridHyperparamOpt(HyperparamOpt):
       `train_dataset` and `valid_dataset` may have been transformed
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
+    nb_epoch: int, (default 5)
     use_max: bool, optional
       If True, return the model with the highest score. Else return
       model with the minimum score.
@@ -144,7 +146,7 @@ class GridHyperparamOpt(HyperparamOpt):
         model_dir = tempfile.mkdtemp()
       model_params['model_dir'] = model_dir
       model = self.model_builder(**model_params)
-      model.fit(train_dataset)
+      model.fit(train_dataset, nb_epoch=nb_epoch)
       try:
         model.save()
       # Some models autosave

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -93,6 +93,7 @@ class GridHyperparamOpt(HyperparamOpt):
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
     nb_epoch: int, (default 5)
+      Specifies the number of training epochs during each iteration of optimization.
     use_max: bool, optional
       If True, return the model with the highest score. Else return
       model with the minimum score.

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -150,7 +150,7 @@ class GridHyperparamOpt(HyperparamOpt):
       model = self.model_builder(**model_params)
       # mypy test throws error, so ignoring it in try
       try:
-        model.fit(train_dataset, nb_epoch=nb_epoch) # type: ignore
+        model.fit(train_dataset, nb_epoch=nb_epoch)  # type: ignore
       # Not all models have nb_epoch
       except TypeError:
         model.fit(train_dataset)

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -92,7 +92,7 @@ class GridHyperparamOpt(HyperparamOpt):
       `train_dataset` and `valid_dataset` may have been transformed
       for learning and need the transform to be inverted before
       the metric can be evaluated on a model.
-    nb_epoch: int, (default 5)
+    nb_epoch: int, (default 10)
       Specifies the number of training epochs during each iteration of optimization.
       Not used by all model types.
     use_max: bool, optional

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -147,7 +147,11 @@ class GridHyperparamOpt(HyperparamOpt):
         model_dir = tempfile.mkdtemp()
       model_params['model_dir'] = model_dir
       model = self.model_builder(**model_params)
-      model.fit(train_dataset, nb_epoch=nb_epoch)
+      try:
+        model.fit(train_dataset, nb_epoch=nb_epoch)
+      # Not all models have nb_epoch
+      except TypeError:
+        model.fit(train_dataset)
       try:
         model.save()
       # Some models autosave

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -66,7 +66,7 @@ class GridHyperparamOpt(HyperparamOpt):
       valid_dataset: Dataset,
       metric: Metric,
       output_transformers: List[Transformer] = [],
-      nb_epoch: int = 5,
+      nb_epoch: int = 10,
       use_max: bool = True,
       logdir: Optional[str] = None,
       **kwargs,

--- a/deepchem/hyper/grid_search.py
+++ b/deepchem/hyper/grid_search.py
@@ -148,8 +148,9 @@ class GridHyperparamOpt(HyperparamOpt):
         model_dir = tempfile.mkdtemp()
       model_params['model_dir'] = model_dir
       model = self.model_builder(**model_params)
+      # mypy test throws error, so ignoring it in try
       try:
-        model.fit(train_dataset, nb_epoch=nb_epoch)
+        model.fit(train_dataset, nb_epoch=nb_epoch) # type: ignore
       # Not all models have nb_epoch
       except TypeError:
         model.fit(train_dataset)

--- a/deepchem/hyper/tests/test_gaussian_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_gaussian_hyperparam_opt.py
@@ -175,7 +175,7 @@ class TestGaussianHyperparamOpt(unittest.TestCase):
 
   @flaky
   def test_multitask_example_nb_epoch(self):
-    """Test a simple example of optimizing a multitask model with a gaussian process search."""
+    """Test a simple example of optimizing a multitask model with a gaussian process search with a different number of training epochs."""
     # Generate dummy dataset
     np.random.seed(123)
     train_dataset = dc.data.NumpyDataset(

--- a/deepchem/hyper/tests/test_gaussian_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_gaussian_hyperparam_opt.py
@@ -7,6 +7,7 @@ valuable test suite so leaving it in despite the flakiness.
 """
 import numpy as np
 import sklearn
+import sklearn.ensemble
 import deepchem as dc
 import unittest
 import tempfile
@@ -169,5 +170,41 @@ class TestGaussianHyperparamOpt(unittest.TestCase):
       # Recall that the key is a string of the form _batch_size_39_learning_rate_0.01 for example
       assert "batch_size" in hp_str
       assert "learning_rate" in hp_str
+    assert valid_score["mean-mean_squared_error"] == min(all_results.values())
+    assert valid_score["mean-mean_squared_error"] > 0
+
+  @flaky
+  def test_multitask_example_nb_epoch(self):
+    """Test a simple example of optimizing a multitask model with a gaussian process search."""
+    # Generate dummy dataset
+    np.random.seed(123)
+    train_dataset = dc.data.NumpyDataset(
+        np.random.rand(10, 3), np.zeros((10, 2)), np.ones((10, 2)),
+        np.arange(10))
+    valid_dataset = dc.data.NumpyDataset(
+        np.random.rand(5, 3), np.zeros((5, 2)), np.ones((5, 2)), np.arange(5))
+    transformers = []
+
+    optimizer = dc.hyper.GaussianProcessHyperparamOpt(
+        lambda **params: dc.models.MultitaskRegressor(n_tasks=2,
+                                                      n_features=3, dropouts=[0.],
+                                                      weight_init_stddevs=[np.sqrt(6) / np.sqrt(1000)],
+                                                      learning_rate=0.003, **params))
+
+    params_dict = {"batch_size": 10}
+    metric = dc.metrics.Metric(
+        dc.metrics.mean_squared_error, task_averager=np.mean)
+
+    best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
+        params_dict,
+        train_dataset,
+        valid_dataset,
+        metric,
+        transformers,
+        nb_epoch=3,
+        max_iter=1,
+        use_max=False)
+
+    valid_score = best_model.evaluate(valid_dataset, [metric], transformers)
     assert valid_score["mean-mean_squared_error"] == min(all_results.values())
     assert valid_score["mean-mean_squared_error"] > 0

--- a/deepchem/hyper/tests/test_grid_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_grid_hyperparam_opt.py
@@ -161,7 +161,7 @@ class TestGridHyperparamOpt(unittest.TestCase):
     assert valid_score["mean-mean_squared_error"] > 0
 
   def test_multitask_nb_epoch(self):
-    """Test a simple example of optimizing a multitask model with a grid search."""
+    """Test a simple example of optimizing a multitask model with a grid search with a different number of training epochs."""
     # Generate dummy dataset
     np.random.seed(123)
     train_dataset = dc.data.NumpyDataset(
@@ -181,6 +181,7 @@ class TestGridHyperparamOpt(unittest.TestCase):
     metric = dc.metrics.Metric(
         dc.metrics.mean_squared_error, task_averager=np.mean)
 
+    # Define nb_epoch in hyperparam_search function call
     best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
         params_dict,
         train_dataset,

--- a/deepchem/hyper/tests/test_grid_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_grid_hyperparam_opt.py
@@ -193,4 +193,3 @@ class TestGridHyperparamOpt(unittest.TestCase):
     valid_score = best_model.evaluate(valid_dataset, [metric])
     assert valid_score["mean-mean_squared_error"] == min(all_results.values())
     assert valid_score["mean-mean_squared_error"] > 0
-    

--- a/deepchem/hyper/tests/test_grid_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_grid_hyperparam_opt.py
@@ -193,3 +193,4 @@ class TestGridHyperparamOpt(unittest.TestCase):
     valid_score = best_model.evaluate(valid_dataset, [metric])
     assert valid_score["mean-mean_squared_error"] == min(all_results.values())
     assert valid_score["mean-mean_squared_error"] > 0
+    


### PR DESCRIPTION
# Pull Request Template

## Description
Adds nb_epoch argument to specify number of training epochs for applicable models to hyperparam_search function for Grid Search (grid_search.py) and Gaussian Process Search (gaussian_process.py). 

Fix #2194

For Gaussian Search:
1) Add `nb_epochs` as an argument to the `hyperparam_search` class function in `gaussian_process.py`
2) Defined a new class function called `_optimize`, which takes `nb_epochs` and '**placeholders` as arguments
3) Moved the contents of the `optimizing_function` function to `_optimize`, and rewrote `optimizing_function` to return `_optimize(nb_epochs, **placeholders)`
4) Changed the `model.fit(train_dataset)` call to a `try except` statement that first tries `model.fit(train_dataset, nb_epoch=nb_epoch)`, and on a `TypeError` exception calls `model.fit(train_dataset)`. This change handles model types that do not accept an nb_epoch argument.

For Grid Search:
1) Add `nb_epochs` as an argument to the `hyperparam_search` class function in `grid_process.py`
2) Changed the `model.fit(train_dataset)` call to a `try except` statement that first tries `model.fit(train_dataset, nb_epoch=nb_epoch)`, and on a `TypeError` exception calls `model.fit(train_dataset)`. This change handles model types that do not accept an nb_epoch argument.

For Base Class:
1) Added `nb_epoch` to `hyperparam_search` function in `base_classes`.py for completeness.

Grid Search does not use a private optimizing function, so there was no need to make the same change as in Gaussian Search.

Added unit tests for Gaussian Process search and Grid Search, both of which specify `nb_epoch` as an integer different from the default in the `hyperparam_search` function call. However, these tests are not a direct test of the number of training epochs ran, and instead only test that hyperparam_search function can be called with the nb_epoch argument. I could not find a reasonable way to confirm the number of training epochs. Suggestions are welcome. I did run tests by changing `nb_epoch` and looking at the training results, confirming expected changes in training logging output.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [o] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [o] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [o] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [?] Run `mypy -p deepchem` and check no errors
  - [o] Run `flake8 <modified file> --count` and check no errors
- [o] I have performed a self-review of my own code
- [o] I have commented my code, particularly in hard-to-understand areas
- [o] I have made corresponding changes to the documentation
- [?] I have added tests that prove my fix is effective or that my feature works
- [o] New unit tests pass locally with my changes
- [o] I have checked my code and corrected any misspellings

? `mypy -p deepchem` gives me an error in `grid_search.py` that complains that model.fit() does not take nb_epoch argument, citing the `Model` class. The `fit` method of `Model` does not take the nb_epoch argument. However, some classes that subclass `Model` do take an `nb_epoch` argument. The `try except` clause should handle this situation. This error does not come up in `gaussian_process.py`, so not sure why it does in `grid_search.py`. Open to suggestions on how to proceed.

? See discussion of unit tests in the Discussion