### PR TITLE
Added known issues page

### DIFF
--- a/docs/source/get_started/issues.rst
+++ b/docs/source/get_started/issues.rst
@@ -1,0 +1,57 @@
+Known Issues & Limitations
+--------------------------
+
+Broken features
+^^^^^^^^^^^^^^^
+
+A small number of Deepchem features are known to be broken. The Deepchem team 
+will either fix or deprecate these broken features. It is impossible to 
+know of every possible bug in a large project like Deepchem, but we hope to 
+save you some headache by listing features that we know are partially or completely
+ broken.
+
+*Note: This list is likely to be non-exhaustive. If we missed something,
+ please let us know [here.](https://github.com/deepchem/deepchem/issues/2376)*
+
++--------------------------------+-------------------+---------------------------------------------------+
+| Feature                        | Deepchem response | Tracker and notes                                 |
+|                                |                   |                                                   |
++================================+===================+===================================================+
+| AtomicConvModel                | Severe            | [pull#2374](https://github.com/deepchem/deepchem/pull/2374)                   |
+|                                | Will fix          |                                                   |
+|                                |                   |                                                   |
++--------------------------------+-------------------+---------------------------------------------------+
+| RdkitGridFeaturizer            | Severe            | [issue#2366](https://github.com/deepchem/deepchem/issues/2366)                      |
+|                                | Will fix          |                                                   |
+|                                |                   |                                                   |
++--------------------------------+-------------------+---------------------------------------------------+
+| ANIFeaturizer/ANIModel         | Low Priority      | The Deepchem team recommends using TorchANI       |
+|                                | Likely deprecate  | instead.                                          |
+|                                |                   |                                                   |
++--------------------------------+-------------------+---------------------------------------------------+
+
+Experimental features
+^^^^^^^^^^^^^^^^^^^^^
+
+Deepchem features usually undergo rigorous code review and testing to ensure that 
+they are ready for production environments. The following Deepchem features have not
+been thoroughly tested to the level of other Deepchem modules, and could be
+potentially problematic in production environments.
+
+*Note: This list is likely to be non-exhaustive. If we missed something,
+ please let us know [here.](https://github.com/deepchem/deepchem/issues/2376)*
+
++--------------------------------+---------------------------------------------------+
+| Feature                        | Tracker and notes                                 |
+|                                |                                                   |
++================================+===================================================+
+| Mol2 Loading                   | Needs more testing.                               |
+|                                |                                                   |
+|                                |                                                   |
++--------------------------------+---------------------------------------------------+
+| Interaction Fingerprints       | Needs more testing.                               |
+|                                |                                                   |
+|                                |                                                   |
++--------------------------------+---------------------------------------------------+
+
+If you would like to help us address these known issues, please consider contributing to Deepchem!

--- a/docs/source/get_started/issues.rst
+++ b/docs/source/get_started/issues.rst
@@ -34,8 +34,8 @@ Experimental features
 ^^^^^^^^^^^^^^^^^^^^^
 
 Deepchem features usually undergo rigorous code review and testing to ensure that 
-they are ready for production environments. The following Deepchem features have not
-been thoroughly tested to the level of other Deepchem modules, and could be
+they are ready for production environments. The following Deepchem features have not 
+been thoroughly tested to the level of other Deepchem modules, and could be 
 potentially problematic in production environments.
 
 *Note: This list is likely to be non-exhaustive. If we missed something,

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -96,6 +96,7 @@ To listen in, please email X.Y@gmail.com, where X=bharath and Y=ramsundar to int
    get_started/requirements
    get_started/tutorials
    get_started/examples
+   get_started/issues
 
 .. toctree::
    :glob:


### PR DESCRIPTION
# Adding Known Issues Page

## Description

Fix #2376 (DO NOT CLOSE)

<!-- This creates an additional page in the Deepchem documentation that keeps track modules that are known to be broken or insufficiently tested. This page was proposed on the January 28 Deepchem meeting. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ X ] Documentations (modification for documents)

## Checklist

(Do not apply to documentation changes)
