### PR TITLE
Fixed markdown formatting issues in Known Issues.

### DIFF
--- a/docs/source/get_started/issues.rst
+++ b/docs/source/get_started/issues.rst
@@ -7,11 +7,11 @@ Broken features
 A small number of Deepchem features are known to be broken. The Deepchem team 
 will either fix or deprecate these broken features. It is impossible to 
 know of every possible bug in a large project like Deepchem, but we hope to 
-save you some headache by listing features that we know are partially or completely
- broken.
+save you some headache by listing features that we know are partially or completely 
+broken.
 
-*Note: This list is likely to be non-exhaustive. If we missed something,
- please let us know [here.](https://github.com/deepchem/deepchem/issues/2376)*
+*Note: This list is likely to be non-exhaustive. If we missed something, 
+please let us know [here](https://github.com/deepchem/deepchem/issues/2376).*
 
 +--------------------------------+-------------------+---------------------------------------------------+
 | Feature                        | Deepchem response | Tracker and notes                                 |
@@ -38,8 +38,8 @@ they are ready for production environments. The following Deepchem features have
 been thoroughly tested to the level of other Deepchem modules, and could be 
 potentially problematic in production environments.
 
-*Note: This list is likely to be non-exhaustive. If we missed something,
- please let us know [here.](https://github.com/deepchem/deepchem/issues/2376)*
+*Note: This list is likely to be non-exhaustive. If we missed something, 
+please let us know [here](https://github.com/deepchem/deepchem/issues/2376).*
 
 +--------------------------------+---------------------------------------------------+
 | Feature                        | Tracker and notes                                 |


### PR DESCRIPTION
# Known Issues Page

## The recently added Known Issues page had some markdown issues. This PR should fix them.

Fix #2384 

<!-- Removed some leading spaces on new lines which seemed to have been misinterpreted by the Markdown interpreter. Also, put a period between a Markdown hyperlink and a trailing asterisk. -->


## Type of change

Please check the option that is related to your PR.

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ x ] Documentations (modification for documents)

## Checklist

- [ x ] I have performed a self-review of my own code
- [ x ] I have checked my code and corrected any misspellings
