### PR TITLE
Fixing flaky test

### DIFF
--- a/deepchem/models/tests/test_kerasmodel.py
+++ b/deepchem/models/tests/test_kerasmodel.py
@@ -227,7 +227,7 @@ def test_uncertainty():
   model.fit(dataset, nb_epoch=2500)
   pred, std = model.predict_uncertainty(dataset)
   assert np.mean(np.abs(y - pred)) < 1.0
-  assert noise < np.mean(std) < 1.0
+  assert noise < np.mean(std) < 1.6
 
 
 def test_saliency_mapping():


### PR DESCRIPTION
Hi,

The test `test_uncertainty` sometimes fails non-deterministically. The assertion `assert (np.mean(std) < 1.0)` fails sometimes when np.mean(std) exceeds 1.0.

To find a solution, I collected several samples of `np.mean(std)` from several test executions and computed the tail distribution. I computed the extreme percentiles to check how low can the values be:

```
0.9 :: 0.63
0.99 :: 0.95
0.9999 :: 1.58 ~ 1.6
```
It seems setting this to 1.6 might be good enough to fix this test.  I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.

Thanks!

