### PR TITLE
Attempting version fix for pytorch spline conv

### DIFF
--- a/env.cpu.mac.yml
+++ b/env.cpu.mac.yml
@@ -8,4 +8,4 @@ dependencies:
     - torch-cluster
     - torch-scatter
     - torch-sparse
-    - torch-spline-conv
+    - torch-spline-conv==1.2.0

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -8,4 +8,4 @@ dependencies:
     - torch-cluster
     - torch-scatter
     - torch-sparse
-    - torch-spline-conv
+    - torch-spline-conv==1.2.0

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -8,4 +8,4 @@ dependencies:
     - torch-cluster
     - torch-scatter
     - torch-sparse
-    - torch-spline-conv
+    - torch-spline-conv==1.2.0


### PR DESCRIPTION
## Description

Attempting to fix test errors in #2406 and #2407 by pinning version of pytorch spline conv. I think the [new release](https://github.com/rusty1s/pytorch_spline_conv/releases/tag/1.2.1) from yesterday introduced errors in our test suite.


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
