### PR TITLE
Install dependencies with conda

### DIFF
--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -823,8 +823,8 @@ class TorchModel(Model):
         grad_output.zero_()
         grad_output[i] = 1
         output.backward(grad_output, retain_graph=True)
-        result.append(X_tensor.grad.clone())
-        X_tensor.grad.zero_()
+        result.append(X_tensor.grad.clone()) # type: ignore
+        X_tensor.grad.zero_() # type: ignore
       final_result.append(
           torch.reshape(torch.stack(result),
                         output_shape + input_shape).cpu().numpy())

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -823,8 +823,8 @@ class TorchModel(Model):
         grad_output.zero_()
         grad_output[i] = 1
         output.backward(grad_output, retain_graph=True)
-        result.append(X_tensor.grad.clone()) # type: ignore
-        X_tensor.grad.zero_() # type: ignore
+        result.append(X_tensor.grad.clone())  # type: ignore
+        X_tensor.grad.zero_()  # type: ignore
       final_result.append(
           torch.reshape(torch.stack(result),
                         output_shape + input_shape).cpu().numpy())

--- a/env.common.yml
+++ b/env.common.yml
@@ -11,19 +11,19 @@ dependencies:
   - pip==20.2.*
   - biopython
   - lightgbm
-  - mordred
   - networkx
   - pillow
   - pubchempy
   - pymatgen==2020.12.31
   - simdna
-  - transformers==3.5.*
   - pip:
     - dgllife==0.2.*
     - matminer
+    - mordred
     - pyGPGO
     - tensorflow==2.3.*
     - tensorflow_probability==0.11.*
     - torch-geometric==1.6.*
+    - transformers==3.5.*
     - xgboost==1.*
     - git+https://github.com/samoturk/mol2vec

--- a/env.common.yml
+++ b/env.common.yml
@@ -1,6 +1,5 @@
 name: deepchem
 channels:
-  - omnia
   - conda-forge
   - defaults
 dependencies:
@@ -12,19 +11,19 @@ dependencies:
   - pip==20.2.*
   - biopython
   - lightgbm
-  - matminer
   - mordred
   - networkx
   - pillow
   - pubchempy
   - pymatgen==2020.12.31
   - simdna
-  - tensorflow==2.3.*
-  - tensorflow-probability
   - transformers==3.5.*
-  - xgboost==1.*
   - pip:
     - dgllife==0.2.*
+    - matminer
     - pyGPGO
+    - tensorflow==2.3.*
+    - tensorflow_probability==0.11.*
     - torch-geometric==1.6.*
+    - xgboost==1.*
     - git+https://github.com/samoturk/mol2vec

--- a/env.common.yml
+++ b/env.common.yml
@@ -10,21 +10,21 @@ dependencies:
   - mdtraj
   - numpy==1.19.*
   - pip==20.2.*
+  - biopython
+  - lightgbm
+  - matminer
+  - mordred
+  - networkx
+  - pillow
+  - pubchempy
+  - pymatgen==2020.12.31
+  - simdna
+  - tensorflow==2.3.*
+  - tensorflow-probability
+  - transformers==3.5.*
+  - xgboost==1.*
   - pip:
-    - biopython
     - dgllife==0.2.*
-    - lightgbm==3.*
-    - matminer
-    - mordred
-    - networkx
-    - pillow
-    - pubchempy
     - pyGPGO
-    - pymatgen==2020.12.31
-    - simdna
-    - tensorflow==2.3.*
-    - tensorflow_probability==0.11.*
     - torch-geometric==1.6.*
-    - transformers==3.5.*
-    - xgboost==1.*
     - git+https://github.com/samoturk/mol2vec

--- a/env.cpu.mac.yml
+++ b/env.cpu.mac.yml
@@ -1,9 +1,9 @@
 dependencies:
+  - pytorch
   - pip:
     - -f https://pytorch-geometric.com/whl/torch-1.6.0.html
     - -f https://pytorch-geometric.com/whl/torch-1.6.0+cpu.html
     - dgl==0.5.*
-    - torch==1.6.0
     - torchvision==0.7.0
     - torch-cluster
     - torch-scatter

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -1,9 +1,9 @@
 dependencies:
+  - pytorch
   - pip:
     - -f https://download.pytorch.org/whl/torch_stable.html
     - -f https://pytorch-geometric.com/whl/torch-1.6.0+cpu.html
     - dgl==0.5.*
-    - torch==1.6.0+cpu
     - torchvision==0.7.0+cpu
     - torch-cluster
     - torch-scatter

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -1,9 +1,9 @@
 dependencies:
+  - pytorch-gpu
   - pip:
     - -f https://download.pytorch.org/whl/torch_stable.html
     - -f https://pytorch-geometric.com/whl/torch-1.6.0+cu101.html
     - dgl-cu101==0.5.*
-    - torch==1.6.0+cu101
     - torchvision==0.7.0+cu101
     - torch-cluster
     - torch-scatter

--- a/env.test.yml
+++ b/env.test.yml
@@ -1,8 +1,7 @@
 dependencies:
-  - pip:
-    - flake8
-    - flaky
-    - mypy
-    - pytest
-    - pytest-cov
-    - yapf==0.22.0
+  - flake8
+  - flaky
+  - mypy
+  - pytest
+  - pytest-cov
+  - yapf==0.22.0


### PR DESCRIPTION
Whenever possible, use conda instead of pip to install dependencies.  Fixes #2410.

We should also consider whether we really need as many version pins as we currently have.  I know we need them for numpy and tensorflow, but are the pip, pymatgen, transformers, and xgboost ones really needed?