### PR TITLE
Pin the old version of RDKit for Colab

### DIFF
--- a/scripts/colab_install.py
+++ b/scripts/colab_install.py
@@ -19,7 +19,7 @@ default_channels = [
     "omnia",
 ]
 default_packages = [
-    "rdkit",
+    "rdkit=2020.09.02",
     "openmm",
     "pdbfixer",
 ]


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #2413 
Many users face the import error related to RDKit on Colab , so I pin the old version.

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
