### PR TITLE
Fixing RdkitGridFeaturizer output dimension

### DIFF
--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -174,16 +174,27 @@ class ComplexFeaturizer(Featurizer):
 
     if not isinstance(complexes, Iterable):
       complexes = [cast(Tuple[str, str], complexes)]
-    features = []
-    for i, point in enumerate(complexes):
-      if i % log_every_n == 0:
-        logger.info("Featurizing datapoint %i" % i)
+    features, failures = [], []
+    for idx, point in enumerate(complexes):
+      if idx % log_every_n == 0:
+        logger.info("Featurizing datapoint %i" % idx)
       try:
         features.append(self._featurize(point))
       except:
         logger.warning(
-            "Failed to featurize datapoint %i. Appending empty array." % i)
-        features.append(np.array([]))
+            "Failed to featurize datapoint %i. Appending empty array." % idx)
+        features.append(np.zeros(1))
+        failures.append(idx)
+
+    # Find a successful featurization
+    i = np.argmax([f.shape[0] for f in features])
+    dtype = features[i].dtype
+    shape = features[i].shape
+    dummy_array = np.zeros(shape, dtype=dtype)
+
+    # Replace failed featurizations with appropriate array
+    for idx in failures:
+      features[idx] = dummy_array
 
     return np.asarray(features)
 

--- a/deepchem/feat/complex_featurizers/rdkit_grid_featurizer.py
+++ b/deepchem/feat/complex_featurizers/rdkit_grid_featurizer.py
@@ -449,7 +449,5 @@ class RdkitGridFeaturizer(ComplexFeaturizer):
         else:
           features_dict[system_id] = np.concatenate(feature_arrays, axis=-1)
 
-    features = np.array(list(features_dict.values()))
-    if self.nb_rotations == 0:  # squeeze out axis with dimension 1
-      features = np.squeeze(features, axis=0)
+    features = np.concatenate(list(features_dict.values()))
     return features

--- a/deepchem/feat/complex_featurizers/rdkit_grid_featurizer.py
+++ b/deepchem/feat/complex_featurizers/rdkit_grid_featurizer.py
@@ -449,6 +449,7 @@ class RdkitGridFeaturizer(ComplexFeaturizer):
         else:
           features_dict[system_id] = np.concatenate(feature_arrays, axis=-1)
 
-    # TODO(rbharath): Is this squeeze OK?
-    features = np.squeeze(np.array(list(features_dict.values())))
+    features = np.array(list(features_dict.values()))
+    if self.nb_rotations == 0:  # squeeze out axis with dimension 1
+      features = np.squeeze(features, axis=0)
     return features

--- a/deepchem/feat/tests/test_rdkit_grid_features.py
+++ b/deepchem/feat/tests/test_rdkit_grid_features.py
@@ -134,6 +134,8 @@ class TestRdkitGridFeaturizer(unittest.TestCase):
   def test_rotations(self):
     featurizer = RdkitGridFeaturizer(
         nb_rotations=3,
+        box_width=16.,
+        voxel_width=1.,
         feature_types=['voxel_combined'],
         flatten=False,
         sanitize=True)

--- a/deepchem/utils/voxel_utils.py
+++ b/deepchem/utils/voxel_utils.py
@@ -39,10 +39,6 @@ def convert_atom_to_voxel(coordinates: np.ndarray, atom_index: int,
   indices = np.floor(
       (coordinates[atom_index] + box_width / 2.0) / voxel_width).astype(int)
 
-  if ((indices < 0) | (indices >= box_width / voxel_width)).any():
-    logger.warning('Coordinates are outside of the box (atom id = %s,'
-                   ' coords xyz = %s, coords in box = %s' %
-                   (atom_index, coordinates[atom_index], indices))
   return indices
 
 


### PR DESCRIPTION
## Description

Fix #2425 

`RdkitGridFeaturizer` outputs features with an axis that has dimension equal to the number of rotations performed on the molecule. This and the `np.squeeze()` call were causing an error with one of the book examples, which expected a 2D array of features rather than a 1D array. I think this fix will address the book example error.


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
