### PR TITLE
complex featurizer output fix

### DIFF
--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -174,12 +174,13 @@ class ComplexFeaturizer(Featurizer):
 
     if not isinstance(complexes, Iterable):
       complexes = [cast(Tuple[str, str], complexes)]
-    features, failures = [], []
+    features, failures, successes = [], [], []
     for idx, point in enumerate(complexes):
       if idx % log_every_n == 0:
         logger.info("Featurizing datapoint %i" % idx)
       try:
         features.append(self._featurize(point))
+        successes.append(idx)
       except:
         logger.warning(
             "Failed to featurize datapoint %i. Appending empty array." % idx)
@@ -187,10 +188,13 @@ class ComplexFeaturizer(Featurizer):
         failures.append(idx)
 
     # Find a successful featurization
-    i = np.argmax([f.shape[0] for f in features])
-    dtype = features[i].dtype
-    shape = features[i].shape
-    dummy_array = np.zeros(shape, dtype=dtype)
+    try:
+      i = np.argmax([f.shape[0] for f in features])
+      dtype = features[i].dtype
+      shape = features[i].shape
+      dummy_array = np.zeros(shape, dtype=dtype)
+    except AttributeError:
+      dummy_array = features[successes[0]]
 
     # Replace failed featurizations with appropriate array
     for idx in failures:

--- a/examples/tutorials/14_Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb
+++ b/examples/tutorials/14_Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb
@@ -1,1 +1,445 @@
-{"nbformat":4,"nbformat_minor":0,"metadata":{"kernelspec":{"display_name":"Python 3","language":"python","name":"python3"},"language_info":{"codemirror_mode":{"name":"ipython","version":3},"file_extension":".py","mimetype":"text/x-python","name":"python","nbconvert_exporter":"python","pygments_lexer":"ipython3","version":"3.6.10"},"colab":{"name":"14_Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb","provenance":[{"file_id":"1f9ESZgWtCg0ZH4ljyBszH-ooIT4b0oXs","timestamp":1613682143417}],"collapsed_sections":[],"toc_visible":true},"accelerator":"GPU"},"cells":[{"cell_type":"markdown","metadata":{"id":"f7FPLsj4nB-6"},"source":["# Tutorial Part 14: Modeling Protein-Ligand Interactions with Atomic Convolutions\n","By [Nathan C. Frey](https://ncfrey.github.io/) | [Twitter](https://twitter.com/nc_frey) and [Bharath Ramsundar](https://rbharath.github.io/) | [Twitter](https://twitter.com/rbhar90)\n","\n","This DeepChem tutorial introduces the [Atomic Convolutional Neural Network](https://arxiv.org/pdf/1703.10603.pdf). We'll see the structure of the `AtomicConvModel` and write a simple program to run Atomic Convolutions.\n","\n","### ACNN Architecture\n","ACNN’s directly exploit the local three-dimensional structure of molecules to hierarchically learn more complex chemical features by optimizing both the model and featurization simultaneously in an end-to-end fashion.\n","\n","The atom type convolution makes use of a neighbor-listed distance matrix to extract features encoding local chemical environments from an input representation (Cartesian atomic coordinates) that does not necessarily contain spatial locality. The following methods are used to build the ACNN architecture:\n","\n","- __Distance Matrix__  \n","The distance matrix $R$ is constructed from the Cartesian atomic coordinates $X$. It calculates distances from the distance tensor $D$. The distance matrix construction accepts as input a $(N, 3)$ coordinate matrix $C$. This matrix is “neighbor listed” into a $(N, M)$ matrix $R$.\n","\n","```python\n","    R = tf.reduce_sum(tf.multiply(D, D), 3)     # D: Distance Tensor\n","    R = tf.sqrt(R)                              # R: Distance Matrix\n","    return R\n","```\n","\n","- **Atom type convolution**  \n","The output of the atom type convolution is constructed from the distance matrix $R$ and atomic number matrix $Z$. The matrix $R$ is fed into a (1x1) filter with stride 1 and depth of $N_{at}$ , where $N_{at}$ is the number of unique atomic numbers (atom types) present in the molecular system. The atom type convolution kernel is a step function that operates on the neighbor distance matrix $R$.\n","\n","- **Radial Pooling layer**  \n","Radial Pooling is basically a dimensionality reduction process that down-samples the output of the atom type convolutions. The reduction process prevents overfitting by providing an abstracted form of representation through feature binning, as well as reducing the number of parameters learned.\n","Mathematically, radial pooling layers pool over tensor slices (receptive fields) of size (1x$M$x1) with stride 1 and a depth of $N_r$, where $N_r$ is the number of desired radial filters and $M$ is the maximum number of neighbors.\n","\n","- **Atomistic fully connected network**  \n","Atomic Convolution layers are stacked by feeding the flattened ($N$, $N_{at}$ $\\cdot$ $N_r$) output of the radial pooling layer into the atom type convolution operation. Finally, we feed the tensor row-wise (per-atom) into a fully-connected network. The\n","same fully connected weights and biases are used for each atom in a given molecule.\n","\n","Now that we have seen the structural overview of ACNNs, we'll try to get deeper into the model and see how we can train it and what we expect as the output.\n","\n","For the training, we will use the publicly available PDBbind dataset. In this example, every row reflects a protein-ligand complex and the target is the binding affinity ($K_i$) of the ligand to the protein in the complex.\n","\n","## Colab\n","\n","This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n","\n","[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/14_Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb)\n","\n","## Setup\n","\n","To run DeepChem within Colab, you'll need to run the following cell of installation commands. This will take about 5 minutes to run to completion and install your environment."]},{"cell_type":"code","metadata":{"id":"Y2xCQyOInB_D"},"source":["!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n","import conda_installer\n","conda_installer.install()\n","!/root/miniconda/bin/conda info -e"],"execution_count":null,"outputs":[]},{"cell_type":"code","metadata":{"id":"WKxOGlhhMrC7"},"source":["!/root/miniconda/bin/conda install -c conda-forge mdtraj -y -q  # needed for AtomicConvs"],"execution_count":null,"outputs":[]},{"cell_type":"code","metadata":{"id":"jFQmra_fFE8U"},"source":["!pip install --pre deepchem\n","import deepchem\n","deepchem.__version__"],"execution_count":null,"outputs":[]},{"cell_type":"code","metadata":{"id":"W1cCOOYXnB_L","executionInfo":{"status":"ok","timestamp":1615311388818,"user_tz":300,"elapsed":677,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}}},"source":["import deepchem as dc\n","import os\n","\n","import numpy as np\n","import tensorflow as tf\n","\n","import matplotlib.pyplot as plt\n","\n","from rdkit import Chem\n","\n","from deepchem.molnet import load_pdbbind\n","from deepchem.models import AtomicConvModel\n","from deepchem.feat import AtomicConvFeaturizer"],"execution_count":18,"outputs":[]},{"cell_type":"markdown","metadata":{"id":"fACLMson_-vk"},"source":["### Getting protein-ligand data\r\n","If you worked through [Tutorial 13](https://github.com/deepchem/deepchem/blob/master/examples/tutorials/13_Modeling_Protein_Ligand_Interactions.ipynb) on modeling protein-ligand interactions, you'll already be familiar with how to obtain a set of data from PDBbind for training our model. Since we explored molecular complexes in detail in the [previous tutorial]((https://github.com/deepchem/deepchem/blob/master/examples/tutorials/13_Modeling_Protein_Ligand_Interactions.ipynb)), this time we'll simply initialize an `AtomicConvFeaturizer` and load the PDBbind dataset directly using MolNet."]},{"cell_type":"code","metadata":{"id":"_qu5DlVa3aV3","executionInfo":{"status":"ok","timestamp":1615310394750,"user_tz":300,"elapsed":945,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}}},"source":["f1_num_atoms = 100  # maximum number of atoms to consider in the ligand\r\n","f2_num_atoms = 1000  # maximum number of atoms to consider in the protein\r\n","max_num_neighbors = 12  # maximum number of spatial neighbors for an atom\r\n","\r\n","acf = AtomicConvFeaturizer(frag1_num_atoms=f1_num_atoms,\r\n","                      frag2_num_atoms=f2_num_atoms,\r\n","                      complex_num_atoms=f1_num_atoms+f2_num_atoms,\r\n","                      max_num_neighbors=max_num_neighbors,\r\n","                      neighbor_cutoff=4)"],"execution_count":5,"outputs":[]},{"cell_type":"markdown","metadata":{"id":"pyH9KUkvxlxk"},"source":["`load_pdbbind` allows us to specify if we want to use the entire protein or only the binding pocket (`pocket=True`) for featurization. Using only the pocket saves memory and speeds up the featurization. We can also use the \"core\" dataset of ~200 high-quality complexes for rapidly testing our model, or the larger \"refined\" set of nearly 5000 complexes for more datapoints and more robust training/validation. On Colab, it takes only a minute to featurize the core PDBbind set! This is pretty incredible, and it means you can quickly experiment with different featurizations and model architectures."]},{"cell_type":"code","metadata":{"id":"Z9eyanh35qyj","colab":{"base_uri":"https://localhost:8080/"},"executionInfo":{"status":"ok","timestamp":1615311594396,"user_tz":300,"elapsed":70747,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}},"outputId":"1bdc22d2-bf73-48cc-9f31-ecc0f56cf4bc"},"source":["%%time\r\n","tasks, datasets, transformers = load_pdbbind(featurizer=acf,\r\n","                                             save_dir='.',\r\n","                                             data_dir='.',\r\n","                                             pocket=True,\r\n","                                             reload=False,\r\n","                                             set_name='core'})"],"execution_count":20,"outputs":[{"output_type":"stream","text":["/usr/local/lib/python3.7/dist-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n","  return array(a, dtype, copy=False, order=order)\n"],"name":"stderr"},{"output_type":"stream","text":["CPU times: user 43.2 s, sys: 18.6 s, total: 1min 1s\n","Wall time: 1min 10s\n"],"name":"stdout"}]},{"cell_type":"code","metadata":{"colab":{"base_uri":"https://localhost:8080/"},"id":"EaGn9UbwEdyY","executionInfo":{"status":"ok","timestamp":1615311616629,"user_tz":300,"elapsed":459,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}},"outputId":"6b235d21-88a2-45b0-d6ba-55a4d6a72dd9"},"source":["datasets"],"execution_count":21,"outputs":[{"output_type":"execute_result","data":{"text/plain":["(<DiskDataset X.shape: (154, 9), y.shape: (154,), w.shape: (154,), ids: ['1mq6' '3pe2' '2wtv' ... '3f3c' '4gqq' '2x00'], task_names: [0]>,\n"," <DiskDataset X.shape: (19, 9), y.shape: (19,), w.shape: (19,), ids: ['3ivg' '4de1' '4tmn' ... '2vw5' '1w3l' '2zjw'], task_names: [0]>,\n"," <DiskDataset X.shape: (20, 9), y.shape: (20,), w.shape: (20,), ids: ['1kel' '2w66' '2xnb' ... '2qbp' '3lka' '1qi0'], task_names: [0]>)"]},"metadata":{"tags":[]},"execution_count":21}]},{"cell_type":"code","metadata":{"id":"PQq0lkWIfVoE","executionInfo":{"status":"ok","timestamp":1615311656221,"user_tz":300,"elapsed":451,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}}},"source":["train, val, test = datasets"],"execution_count":22,"outputs":[]},{"cell_type":"markdown","metadata":{"id":"GNilV3VXnB_j"},"source":["### Training the model"]},{"cell_type":"markdown","metadata":{"id":"WufupHBPnB_k"},"source":["Now that we've got our dataset, let's go ahead and initialize an `AtomicConvModel` to train. Keep the input parameters the same as those used in `AtomicConvFeaturizer`, or else we'll get errors. `layer_sizes` controls the number of layers and the size of each dense layer in the network. We choose these hyperparameters to be the same as those used in the [original paper](https://arxiv.org/pdf/1703.10603.pdf)."]},{"cell_type":"code","metadata":{"id":"ErBNNGH55-_B","executionInfo":{"status":"ok","timestamp":1615311664472,"user_tz":300,"elapsed":925,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}}},"source":["acm = AtomicConvModel(n_tasks=1,\r\n","                      frag1_num_atoms=f1_num_atoms,\r\n","                      frag2_num_atoms=f2_num_atoms,\r\n","                      complex_num_atoms=f1_num_atoms+f2_num_atoms,\r\n","                      max_num_neighbors=max_num_neighbors,\r\n","                      batch_size=12,\r\n","                      layer_sizes=[32, 32, 16],\r\n","                      learning_rate=0.003,\r\n","                      )"],"execution_count":23,"outputs":[]},{"cell_type":"code","metadata":{"id":"4cNdP1b1hEQM","executionInfo":{"status":"ok","timestamp":1615311665685,"user_tz":300,"elapsed":749,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}}},"source":["losses, val_losses = [], []"],"execution_count":24,"outputs":[]},{"cell_type":"code","metadata":{"id":"5g6b2qEwNwdL","colab":{"base_uri":"https://localhost:8080/"},"executionInfo":{"status":"ok","timestamp":1615312383216,"user_tz":300,"elapsed":714793,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}},"outputId":"3caa11ac-18dd-4528-f966-dee61d2c508d"},"source":["%%time\r\n","max_epochs = 50\r\n","\r\n","for epoch in range(max_epochs):\r\n","  loss = acm.fit(train, nb_epoch=1, max_checkpoints_to_keep=1, all_losses=losses)\r\n","  metric = dc.metrics.Metric(dc.metrics.score_function.rms_score)\r\n","  val_losses.append(acm.evaluate(val, metrics=[metric])['rms_score']**2)  # L2 Loss"],"execution_count":25,"outputs":[{"output_type":"stream","text":["CPU times: user 9min 5s, sys: 1min 58s, total: 11min 4s\n","Wall time: 11min 54s\n"],"name":"stdout"}]},{"cell_type":"markdown","metadata":{"id":"aTFdba_KDDUQ"},"source":["The loss curves are not exactly smooth, which is unsurprising because we are using 154 training and 19 validation datapoints. Increasing the dataset size may help with this, but will also require greater computational resources."]},{"cell_type":"code","metadata":{"colab":{"base_uri":"https://localhost:8080/","height":265},"id":"pn4QWM1bizw0","executionInfo":{"status":"ok","timestamp":1615312487303,"user_tz":300,"elapsed":1030,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}},"outputId":"f6399595-4622-41d0-80d1-92df68850cc2"},"source":["f, ax = plt.subplots()\r\n","ax.scatter(range(len(losses)), losses, label='train loss')\r\n","ax.scatter(range(len(val_losses)), val_losses, label='val loss')\r\n","plt.legend(loc='upper right');"],"execution_count":26,"outputs":[{"output_type":"display_data","data":{"image/png":"iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deZQV5bnv8e9j24Z2ogmiUQYh9xoH6BZiY7iHOCeCxgFNHIi5R3Oj/mM0JudwbTMox5Oz1JAVE9Yx18XyGocVFZZBYhxCEoWgieYwgxNxDt16ZIjNldieNM1z/9i7sWmqdu/qXbV3VfXvsxaL3tXVu96qXfupt553KHN3REQk+/aqdQFERCQeCugiIjmhgC4ikhMK6CIiOaGALiKSE3vXasMHHXSQjx07tlabFxHJpJUrV25x9xFBv6tZQB87diwrVqyo1eZFRDLJzN4K+51SLiIiOaGALiKSEwroIiI5UbMcuojkV1dXF21tbXz44Ye1LkpmDRkyhFGjRlFfX1/23yigi0js2traOOCAAxg7dixmVuviZI67s3XrVtra2hg3blzZf5epgL5odTtzFm/g7Y5ODmtsYNa0I5kxaWStiyUifXz44YcK5hUwM4YPH87mzZsj/V1mAvqi1e1cv3A9nV3dALR3dHL9wvUACuoiKaRgXpmBHL/MNIrOWbxhVzDv0dnVzZzFG2pUIhGRdMlMQH+7ozPSchEZvDo6OvjpT386oL8988wz6ejoKHv92bNn88Mf/nBA24pbZgL6YY0NkZaLyOBVKqDv2LGj5N8+/vjjNDY2JlGsxGUmoM+adiQN9XW7LWuor2PWtCNrVCIRicui1e1MveUpxrU+xtRbnmLR6vaK3q+1tZXXXnuNiRMnMmvWLJYuXcoJJ5zAOeecwzHHHAPAjBkzOO644xg/fjzz5s3b9bdjx45ly5YtvPnmmxx99NFcccUVjB8/ntNPP53OztIZgTVr1jBlyhSam5s577zzeO+99wCYO3cuxxxzDM3NzVx88cUA/P73v2fixIlMnDiRSZMm8f7771e0z0Che0wt/h133HEe1cOr2vwfbn7Sx173qP/DzU/6w6vaIr+HiCTvxRdfLHvdh1e1+VHffcIPv+7RXf+O+u4TFX2/33jjDR8/fvyu10uWLPF9993XX3/99V3Ltm7d6u7uH3zwgY8fP963bNni7u6HH364b9682d944w2vq6vz1atXu7v7BRdc4Pfdd98e27rxxht9zpw57u7e1NTkS5cudXf3733ve/6Nb3zD3d0PPfRQ//DDD93d/b333nN397POOsufeeYZd3d///33vaura4/3DjqOwAoPiauZ6eUChd4s6tEiki+lOjzE+X0//vjjd+vTPXfuXB5++GEANm7cyCuvvMLw4cN3+5tx48YxceJEAI477jjefPPN0Pfftm0bHR0dnHTSSQBceumlXHDBBQA0NzdzySWXMGPGDGbMmAHA1KlT+da3vsUll1zC+eefz6hRoyrex8ykXEQkn6rV4WG//fbb9fPSpUv53e9+x7PPPsvatWuZNGlS4KjWj33sY7t+rqur6zf/Huaxxx7jqquuYtWqVUyePJkdO3bQ2trKnXfeSWdnJ1OnTuXll18e0Hv3poAuIjWVRIeHAw44oGROetu2bQwbNox9992Xl19+meeee27A2+oxdOhQhg0bxtNPPw3Afffdx0knncTOnTvZuHEjp5xyCrfeeivbtm1j+/btvPbaazQ1NXHdddcxefLk6gR0M7vLzDaZ2fMl1jnZzNaY2Qtm9vuKSyUig0YSHR6GDx/O1KlTmTBhArNmzdrj99OnT2fHjh0cffTRtLa2MmXKlAFvq7d77rmHWbNm0dzczJo1a7jhhhvo7u7mK1/5Ck1NTUyaNIlrrrmGxsZGfvzjHzNhwgSam5upr6/njDPOqHj7Vsixl1jB7ERgO3Cvu08I+H0j8Edgurv/xcwOdvdN/W24paXF9YALkXx66aWXOProo8teX9N6BAs6jma20t1bgtbvt1HU3ZeZ2dgSq3wZWOjufymu328wFxHpTR0e4hFHDv1TwDAzW2pmK83sH8NWNLMrzWyFma2IOumMiIiUFkdA3xs4DvgCMA34npl9KmhFd5/n7i3u3jJiROAzTkVEZIDi6IfeBmx1978BfzOzZcCxwJ9jeG8RESlTHDX0XwKfNbO9zWxf4DPASzG8r4iIRNBvDd3MHgBOBg4yszbgRqAewN3vcPeXzOzXwDpgJ3Cnu4d2cRQRkWSU08tlZhnrzAHmxFIiEZEa2H///dm+fXvZy9NII0VFRHJCAV1Eam/dArhtAsxuLPy/bkFFb9fa2srtt9++63XPQyi2b9/Oaaedxqc//Wmampr45S9/WfZ7ujuzZs1iwoQJNDU1MX/+fADeeecdTjzxRCZOnMiECRN4+umn6e7u5rLLLtu17m233VbR/pQrU7MtikgOrVsAv7oGuoqTcW3bWHgN0HzhgN7yoosu4tprr+Wqq64CYMGCBSxevJghQ4bw8MMPc+CBB7JlyxamTJnCOeecU9bzOxcuXMiaNWtYu3YtW7ZsYfLkyZx44oncf//9TJs2je985zt0d3fzwQcfsGbNGtrb23n++UJzYpQnIFVCNXQRqa0nb/oomPfo6iwsH6BJkyaxadMm3n77bdauXcuwYcMYPXo07s63v/1tmpub+dznPkd7ezvvvvtuWe/5zDPPMHPmTOrq6jjkkEM46aSTWL58OZMnT+ZnP/sZs2fPZv369RxwwAF88pOf5PXXX+fqq6/m17/+NQceeOCA9yUKBXQRqa1tbdGWl+mCCy7goYceYv78+Vx00UUA/PznP2fz5s2sXLmSNWvWcMghhwROmxvFiSeeyLJlyxg5ciSXXXYZ9957L8OGDWPt2rWcfPLJ3HHHHVx++eUVbaNcCugiUltDQx7sELa8TBdddBEPPvggDz300K4HTWzbto2DDz6Y+vp6lixZwltvvVX2+51wwgnMnz+f7u5uNm/ezLJlyzj++ON56623OOSQQ7jiiiu4/PLLWbVqFVu2bGHnzp188Ytf5Pvf/z6rVq2qaF/KpRy6iNTWaTfsnkMHqG8oLK/A+PHjef/99xk5ciSHHnooAJdccglnn302TU1NtLS0cNRRR5X9fueddx7PPvssxx57LGbGD37wAz7xiU9wzz33MGfOHOrr69l///259957aW9v56tf/So7d+4E4Oabb65oX8rV7/S5SdH0uSL5FXX6XNYtKOTMt7UVauan3TDgBtE8iX36XBGRxDVfqAAeA+XQRURyQgFdRBJRq3RuXgzk+Cmgi0jshgwZwtatWxXUB8jd2bp1K0OGDIn0d8qhi0jsRo0aRVtbG3oy2cANGTKEUaOidd1UQBeR2NXX1zNu3LhaF2PQUcpFRCQnFNBFRHJCAV1EJCcU0EVEckIBXUQkJxTQRURyot+AbmZ3mdkmM3u+n/Umm9kOM/tSfMUTEZFylVNDvxuYXmoFM6sDbgV+E0OZRERkAPoN6O6+DPhrP6tdDfwC2BRHoUREJLqKc+hmNhI4D/g/Zax7pZmtMLMVGhIsIhKvOBpFfwxc5+47+1vR3ee5e4u7t4wYMSKGTYuISI845nJpAR40M4CDgDPNbIe7L4rhvUVEpEwVB3R33zUDj5ndDTyqYC4iUn39BnQzewA4GTjIzNqAG4F6AHe/I9HSiYhI2foN6O4+s9w3c/fLKiqNiIgMmEaKiojkhAK6iEhOKKCLiOSEArqISE4ooIuI5IQCuohITiigi4jkhAK6iEhOKKCLiOSEArqISE5kK6CvWwC3TYDZjYX/1y2odYlERFIjjulzq2PdAvjVNdDVWXi9bWPhNUDzhbUrl4hISmSnhv7kTR8F8x5dnYXlIiKSoYC+rS3achGRQSY7AX3oqGjLRUQGmewE9NNugPqG3ZfVNxSWi4hIhgJ684Vw9lwYOhqwwv9nz1WDqIhIUXZ6uUAheCuAi4gEyk4NXURESuo3oJvZXWa2ycyeD/n9JWa2zszWm9kfzezY+IspIiL9KaeGfjcwvcTv3wBOcvcm4F+BeTGUS0REIuo3h+7uy8xsbInf/7HXy+cA9SMUEamBuHPoXwOeCPulmV1pZivMbMXmzZtj3rSIyOAWW0A3s1MoBPTrwtZx93nu3uLuLSNGjIhr0yIiQkzdFs2sGbgTOMPdt8bxniIiEk3FNXQzGwMsBP6nu/+58iKJiMhA9FtDN7MHgJOBg8ysDbgRqAdw9zuAG4DhwE/NDGCHu7ckVWAREQlWTi+Xmf38/nLg8thKJCIiA6KRoiIiOaGALiKSEwroIiI5oYAuIpITCugiIjmhgC4ikhMK6CIiOaGALiKSEwroIiI5oYAu/Vu3AG6bALMbC/+vW1DrEolIgGw9JFqqb90C+NU10NVZeL1tY+E16IHdIimjGrqU9uRNHwXzHl2dheUikiq5qKEvWt3OnMUbeLujk8MaG5g17UhmTBpZ62Jl07oFhWC9rQ2GjirUyINsa6tuuUSkX5kP6ItWt3P9wvV0dnUD0N7RyfUL1wMoqEcVlF7BAN9z3aExPTq27wXktBuUyhEZoMwH9DmLN+wK5j06u7qZs3iDAnpUQekVnD2Cen1DIfBWKiw//5fn4JXfKMgPRrrAVyTzAf3tjr4BqPRyKSE0jeIwdHT8X7Kw/PyKu9h1AVEj7OChBviKZT6gH9bYQHtA8L50//+A267TlT6KsJz50NHwzefj316pC0hvPY2w+vzyrVQDvD77smS+l8usaUfSUF+327Iv7fNHvut3FIOTf3SlV//p0k67oZBO6S2u9EqQKHl4NcLmX9hnrM++bJkP6DMmjeTm85sY2diAASMbG7hpv1+wd/eHu6+ornb9a74Qzp5bqJFjhf/Pnptc7SjoAoIFrxtXI6wkq5JBaGGfsT77smU+5QKFoL5bA+js/wxeUVf6/jVfWL3b257t9G4EO+J0WHv/7rfeSd4lSHwqzYGfdsPufw/9f/ZqRN1NvwHdzO4CzgI2ufuEgN8b8BPgTOAD4DJ3XxV3QSMJzQVn8Eof5YQNWzepkz6O9w26gIyZku8vaV6DUKU58KALfKlzGNSI2oe5B/Qx7r2C2YnAduDekIB+JnA1hYD+GeAn7v6Z/jbc0tLiK1asGFCh+9W3pgCFK32S6YMkRNmPsHWP/XJwjbfSY5GXY1xteT5usxsJHLOAweyOgb9v2DHbuwE6/7rn+kk14qeEma1095ag3/WbQ3f3ZUDAUdvlXArB3t39OaDRzA4dWFFjUu1ccFKiDLsPW3fl3ckM3c/ilABpmGQsi8etXEnlwMOOWVAwh0GdWo0jhz4S6J3faCsue6fvimZ2JXAlwJgxY2LYdAnVzAUnJUqrf9i63h28vNKTPu09EvreovfNzfe+PYfqpUDSftwqMZAceDmiHpssplZjUtVGUXefB8yDQsqlmtvOpChtAWHrWl1wUK/0pE9LO0W5udXeg5V6dHXCE9fBjs7q5WHTctySUCoHXomwY9bw8d0/OyhcQI44vXAHVq22pBSJo9tiOzC61+tRxWVSqSj9wsPWPe6y4OU9J/1A0w/V7rMepCe32ne8wRPXhUxhEKDzr9FSIJWmbZI8bmlIKTVfWMhfz+4o/B9HwAw7ZmfcumdqtafNqO858ei3gs+VnI1NiaOG/gjwdTN7kEKj6DZ33yPdIgMQpcZTat2+vUZKpR/K/QImVRuLIiy3ukcwH4Cg2/w4hqZHPW7l1irzPGy+v2PWe/9umxDeltT3TjWHo1DL6eXyAHAycBDwLnAjUA/g7ncUuy3+OzCdQrfFr7p7v91XEu3lIqXdNqG6Q/yTEtqrIkzAJGNRekpU+7hF6RETVraGj8M+++U6zbCbgZwTlfTAqYFSvVz6raG7+8x+fu/AVQMsm9RCXhrmouZWj/3ynrM4QvkNedU+blH6dYeVofOvH12w8lRrD1PttqSUyfzQfxmAvAyxjpJbPXsunPWjPfO7Ubq4Vvu4RbmAlFuGvHSRDBO1LSlnI5BzMfQ/N+IYFVqOpLqXJS1on8+eW15utZRyu7iGHbewXhWVitIjJqhsYbJ2JxZFlLakHKaf+s2hJyUTOfRqdnOKY1RolMFTWevClZYRlv31b4+zXFH3uW/Z/v63dI+kzNo5mBKlcugK6GGqHUCiNLjlpVEzirTuc9LlCutnP5CeLzCwcziJwJuWC3QGVTT0f9Cq9hDtOEaF5vlWOq37nHS5+vbrhvL7U8cxBUZYX/9K+2/neQqEGlIOPUypL2oSNZY4RoWmpVGz1scnDuXuQ7XLFXVGw0qnwAjb3hPXVfYZp/UCnXGDr4Ze7mi6sC9kw7BkaixxjApNQ6NmWI3u0W+ld4RlX1FqpdX+LKodCEt1h6zkO5CXnlYpk9uAvmh1O1NveYpxrY8x9ZanWLS6PZ4vKoTXWIICVrkXkCi3x2meTbLUg58rCQDV3Oco6YBS5YoyFL/SikYcgTCoDEl1h0xzpSTDctkoumh1O9cvXE9n10cDCRrq61i5/7Xs2xkwK0FYA1bQbffCKylrJFqSc5GnWZSRerVu0AwTx7zeSfVaSqoxMcp8+qFCjk+1H7yScxWNFM2iOYs37BbMATq7uhnSGfHRdEH5xydvCs6Z9jWI5o/YTVhOOUha86Vx5MWj5LqjrJvUHDphZXjlN3v29Q/tDhlwfPqbYyav34MayWXK5e2O4NrE2zuHB/9BlC9q4IONQ4TORb6x9rPiJSUPD36OIx2QZK+lJGY0LFWGvts749byj496s1RVLgP6YY3BAffOfb5S+Rc1KGfa8PHgda0u5E0sv9N4Bh2flv+VrXxpHPn6KLnuWjQQ9s2XNwwrvwxRjo96s1RVPnLofXJxy//b1fzj8sP3yKHffH4TM+r+UL1BEoH5xz4z/vVIaz45LoMtX5qGvHiUsu1VD2bQ/fd4y5DWAWEZlu+RoiFfhuVN/8K1Lx7B2x2dHNbYwKxpRzJj0sjKt1eqHOU0/ITml7M3jaf0o1pz80RVzal2NSI0dvkO6FmrAWStvJI/cfTiiWKw3Z0lLN+9XOLK0VXrpMvqTIeSH9Ue3areLFWT/UbROBqUkpqvIkiaBwXJ4KBBPbmV/Rp6HDXeqPNjVEo1FqmlNDwPVhKR/YAex8mprlUy2KhSkUtlBXQzmw78BKgD7nT3W/r8fgxwD9BYXKfV3R+PuazhKj050z57oYhIGfrNoZtZHXA7cAZwDDDTzI7ps9p3gQXuPgm4GPhp3AVNlHKKIpID5TSKHg+86u6vu/vfgQeBc/us48CBxZ+HAm/HV8QqUEOliORAOSmXkUDvfEQb8Jk+68wGfmNmVwP7AZ8LeiMzuxK4EmDMmDFRyxqLRavbmbN4w54DjpRTFJGMi6vb4kzgbncfBZwJ3Gdme7y3u89z9xZ3bxkxYkRMmy5fz7S67R2dONDe0cn1C9cX5koXEcm4cgJ6OzC61+tRxWW9fQ1YAODuzwJDgIPiKGCcwqbVnbN4Q41KJCISn3IC+nLgCDMbZ2b7UGj0fKTPOn8BTgMws6MpBPTNcRY0DqHT6oYsFxHJkn4DurvvAL4OLAZeotCb5QUzu8nMzimu9k/AFWa2FngAuMxrNUlMCWHT6oYtFxHJkrL6oRf7lD/eZ9kNvX5+EZgab9HiN2vakYGPpps17cgalkpEJB7ZHykaQc/0uYG9XEREMm5QBXQoBHUFcBHJo+zPtigiIoACuohIbiigi4jkhAK6iEhOKKCLiOSEArqISE4Mum6LYUJnYRQRyQgFdD6ahbFnBGnPLIyAgvoA6OIoUhtKuaBZGOOkKYpFakcBHc3CGCddHEVqRwEdzcIYJ10cRWpHAZ3CLIwN9XW7LdMsjAOji6NI7SigU2j4vPn8JkY2NmDAyMYGbj6/SQ15AxB2cTzlqBFMveUpxrU+xtRbnlJOXSQB6uVSFDQLo3prRBc0RfEpR43gFyvb1YtIJGEK6CHUlXHg+l4cp97yVGhDqY6lSHyUcgmh3hrxUUOpSHWohh6iVBCqNBUz2FI5hzU20B5wPNVQKhIv1dBDhAWboQ31FQ2cGYwDb9SLSKQ6ygroZjbdzDaY2atm1hqyzoVm9qKZvWBm98dbzOoLC0JmVJSKGYypHPUiEqmOflMuZlYH3A58HmgDlpvZI+7+Yq91jgCuB6a6+3tmdnBSBa6WsAdKf3P+msD1y80HD9Z8sp7lKpK8cnLoxwOvuvvrAGb2IHAu8GKvda4Abnf39wDcfVPcBa2FoCA0Z/GGivLByieLSFLKSbmMBDb2et1WXNbbp4BPmdkfzOw5M5se9EZmdqWZrTCzFZs3bx5YiWus0nyw8skikpS4ernsDRwBnAyMApaZWZO7d/Reyd3nAfMAWlpaPKZtV1VYKqbcdEKlfy8iEqacgN4OjO71elRxWW9twJ/cvQt4w8z+TCHAL4+llClTaT5Y+WQRSUI5AX05cISZjaMQyC8GvtxnnUXATOBnZnYQhRTM63EWVCRIHH36B9u4AMmvfgO6u+8ws68Di4E64C53f8HMbgJWuPsjxd+dbmYvAt3ALHffmmTBZU+DLTDFMT2DpniQPDH32qSyW1pafMWKFTXZdh71DUxQaGzNc3/vqbc8FdhjaGRjA39oPbVq7yFSTWa20t1bgn6nof8pUkkNu9SApaD3yENtPo4+/YN1XIDkkwJ6SlR66x8lMOUlzRBHn/6o75GHC6Hkl+ZySYmoUwIsWt2+2wMjGvetD1wvKDDlZfqBOPr0R3mPwTgPj2SLaugpUWkNu34vo77O6Or+qE2kJzD1rVUG1UhLlSFJldR44+jTH+U9oqa1RKpNAT0lotz6BwWWrp1OY0M9+31s790CE7BH8DcgqCm82tMPRE39hAX/SoNpue+RxXy7UkQDk9XjpoCeErOmHRnYSyXo1j8sgGzr7GLNjafvtizoaUEOewT1Wkw/EKXGm4a8f9bm4UnymGU14JUjDefaQCmHnhJRppgNCyBBy8OCvxe3UcvpbKPUeNOQ96/FPDx920qi5OuTOmZpakuo5PiEScO5NlCqoadIubf+UWrzYbXKNPSzjlLjjZruSKIGWe15eKrZ8ymKtLQlJFWTzmJqrYdq6BkUpTaf5tkdo5Qtyl1JkjXIGZNG8ofWU3njli/wh9ZTEw1gldYUoxyzKNIS8JKqSSd13KpBNfSUK9UQWE4wSfPsjlHKFuWupNo1yKTyyZUGzijHLIq0tCUkdWFJ6rhVgwJ6isV1S5nm2R2TuDBVswaZZANapYEzrot53wvWKUeN4Bcr22se8JK6sKS5EtQfzeWSYppnZGCqedyS3FYa5ucJK8MXjxvJkpc31zTgpeH41ILmcsmotOQqs6aat8xJfkZpqCmGpa+WvLy55pWKNBwfSFcXTgX0FEtLrjJMmk7k3qr5RU/6M6p1uiztlYqg41PN8zJtfdYV0FMszY0zaTuR+6r0i17uumn6jJLYv7RXKvqq9nmZli6cPdRtMSZJDHCI0j2x2rI2+CJKV8Yo66blM0pq/9Lc7TVIpZPcRf3epu0ORjX0GCRZK6j1LXeYtJ3I/YlSk4pa60rDZ5TU/mUtT13taaTTdgejgB6DtN12VUPaTuT+RPmiZ+1iBcnuX60vWFECb6WT3EX93oal3E45agRTb3mq6hdBBfQYZDEARBFUO0pT7rgcUb7oSV+skmi0S9P+lavc4xAl8JY6L5OYRjroDqZvP/1qti+VlUM3s+lmtsHMXjWz1hLrfdHM3MwC+0jmVamhwknk1qspLN8KJJY7TuKYRckFJ5k3TmpagrTsX7nCjsN3F63f47OPUmEKa9MA9tiehZQt6oWt73QQS17eXLP2pX4HFplZHfBn4PNAG7AcmOnuL/ZZ7wDgMWAf4OvuXnLUUJ4GFpUafBE0oi4tDZvlqPbgpiQHiyTRCyTq9uYs3pDoQKRq7l8lws6roGmdh9TvxXsfdO2xbhwPAw/aXqXn2rjWxwKfN2DAbRdNrPi4Vzqw6HjgVXd/vfhmDwLnAi/2We9fgVuBWZFKlwNhDUd5yK1XO52U5DGLkguuNG8clvftu2894hqIVK39iyLo4lFqWufeOru6+djee9FQX1dReq+/aaSrkf4a2lCfeJfKcgL6SGBjr9dtwGd6r2BmnwZGu/tjZjboAjoEf0G+OX9N4Lppzq33/fI17lsfWDtKKt+al/aIsAtTnRndAXfFaW1MrlTYhS3svAqyrbOr4pptNaeRDsvjm5F4Ba/iRlEz2wv4EXBZGeteCVwJMGbMmEo3nXppaXwqV9RnlSYha8csTNgFqNu94tpmloRd2IJq3aUejVjpHUUcjfjlpqnC7tirUcErp1G0HRjd6/Wo4rIeBwATgKVm9iYwBXgkqGHU3ee5e4u7t4wYMWLgpc6INDQ+RRH2rNL99tm7agNnsnbMwoRdgHqOX60HIiWlb4N2WE+SbZ1dexyHS6aMSeyzr3QAWNTG7KB586sxz3o5jaJ7U2gUPY1CIF8OfNndXwhZfynwz4OpUbSUWjc+RVGqMeeNW75QtXJk6ZiFidq4m9d9Dqt1h6U60noc4ugcEFeDf0WNou6+w8y+DiwG6oC73P0FM7sJWOHuj5RdkkGo1oMyokhLuiNLxyxMlBGWaZ8Xp1xBd3hRH0ie1s8+jradaoy6LSuH7u6PA4/3WXZDyLonV14sqYWsDRZKu3KDUx56Q0F1e5JUW1yVnaQvWBopKrukZd6OwSYtPXsqTXek+YHklcpKZUcBXXaT1lvePEtDqiuOtE9Wgt5AZKWyo4AuUmNpCIRxpH2yEvQGKguVHQV0kRpLQyCMK+2ThaCXZwroIilQ60CYhrSPVE5PLBKR3AzoGuxUQxeRVKR9pHIK6CIC1D7tI5VTQBfJmLQOj5faU0AXyZC8TBMgyVCjqEiGlOovLqKALpIhaZkmQNJJAV0kQ6oxp7ZklwK6SIaov7iUokZRkQxRf3EpRQFdJGPUX1zCKOUiIpITCugiIjmhgC4ikhMK6CIiOaGALiKSE+butdmw2WbgrQH++UHAlhiLkzZ53j/tW3blef+ytG+Hu/uIoF/ULKBXwsxWuHtLrcuRlDzvn/Ytu6TM9EMAAAN3SURBVPK8f3nZN6VcRERyQgFdRCQnshrQ59W6AAnL8/5p37Irz/uXi33LZA5dRET2lNUauoiI9KGALiKSE5kL6GY23cw2mNmrZtZa6/JUyszuMrNNZvZ8r2UfN7Pfmtkrxf+H1bKMA2Vmo81siZm9aGYvmNk3isszv39mNsTM/sPM1hb37V+Ky8eZ2Z+K5+d8M9un1mUdKDOrM7PVZvZo8XWe9u1NM1tvZmvMbEVxWebPy0wFdDOrA24HzgCOAWaa2TG1LVXF7gam91nWCjzp7kcATxZfZ9EO4J/c/RhgCnBV8fPKw/79F3Cqux8LTASmm9kU4FbgNnf/78B7wNdqWMZKfQN4qdfrPO0bwCnuPrFX//PMn5eZCujA8cCr7v66u/8deBA4t8Zlqoi7LwP+2mfxucA9xZ/vAWZUtVAxcfd33H1V8ef3KQSHkeRg/7xge/FlffGfA6cCDxWXZ3LfAMxsFPAF4M7iayMn+1ZC5s/LrAX0kcDGXq/bisvy5hB3f6f4838Ch9SyMHEws7HAJOBP5GT/iimJNcAm4LfAa0CHu+8orpLl8/PHwP8GdhZfDyc/+waFi+9vzGylmV1ZXJb581JPLEo5d3czy3TfUjPbH/gFcK27/79CZa8gy/vn7t3ARDNrBB4GjqpxkWJhZmcBm9x9pZmdXOvyJOSz7t5uZgcDvzWzl3v/MqvnZdZq6O3A6F6vRxWX5c27ZnYoQPH/TTUuz4CZWT2FYP5zd19YXJyb/QNw9w5gCfA/gEYz66koZfX8nAqcY2ZvUkhrngr8hHzsGwDu3l78fxOFi/Hx5OC8zFpAXw4cUWxt3we4GHikxmVKwiPApcWfLwV+WcOyDFgx7/p/gZfc/Ue9fpX5/TOzEcWaOWbWAHyeQhvBEuBLxdUyuW/ufr27j3L3sRS+Y0+5+yXkYN8AzGw/Mzug52fgdOB58nBeZm2kqJmdSSG/Vwfc5e7/VuMiVcTMHgBOpjB957vAjcAiYAEwhsIUwxe6e9+G09Qzs88CTwPr+SgX+20KefRM75+ZNVNoOKujUDFa4O43mdknKdRqPw6sBr7i7v9Vu5JWpphy+Wd3Pysv+1bcj4eLL/cG7nf3fzOz4WT9vMxaQBcRkWBZS7mIiEgIBXQRkZxQQBcRyQkFdBGRnFBAFxHJCQV0EZGcUEAXEcmJ/w+ABHktnNLPuQAAAABJRU5ErkJggg==\n","text/plain":["<Figure size 432x288 with 1 Axes>"]},"metadata":{"tags":[],"needs_background":"light"}}]},{"cell_type":"markdown","metadata":{"id":"KzGW3ztODYzV"},"source":["The [ACNN paper](https://arxiv.org/pdf/1703.10603.pdf) showed a Pearson $R^2$ score of 0.912 and 0.448 for a random 80/20 split of the PDBbind core train/test sets. Here, we've used an 80/10/10 training/validation/test split and achieved similar performance for the training set (0.943). We can see from the performance on the training, validation, and test sets (and from the results in the paper) that the ACNN can learn chemical interactions from small training datasets, but struggles to generalize. Still, it is pretty amazing that we can train an `AtomicConvModel` with only a few lines of code and start predicting binding affinities!  \r\n","From here, you can experiment with different hyperparameters, more challenging splits, and the \"refined\" set of PDBbind to see if you can reduce overfitting and come up with a more robust model."]},{"cell_type":"code","metadata":{"colab":{"base_uri":"https://localhost:8080/"},"id":"VcDLwf-20tci","executionInfo":{"status":"ok","timestamp":1615312510518,"user_tz":300,"elapsed":12196,"user":{"displayName":"Nathan Frey","photoUrl":"https://lh3.googleusercontent.com/a-/AOh14GiCEtTj6AL3entEShxjitkGUQo5YhZ7CJA0917VzA=s64","userId":"14838914823565259795"}},"outputId":"35ae9353-5dd8-4397-bbf0-d58cfebb6584"},"source":["score = dc.metrics.Metric(dc.metrics.score_function.pearson_r2_score)\r\n","for tvt, ds in zip(['train', 'val', 'test'], datasets):\r\n","  print(tvt, acm.evaluate(ds, metrics=[score]))"],"execution_count":27,"outputs":[{"output_type":"stream","text":["train {'pearson_r2_score': 0.9437584772241725}\n","val {'pearson_r2_score': 0.16399398585969166}\n","test {'pearson_r2_score': 0.25027177101277903}\n"],"name":"stdout"}]},{"cell_type":"markdown","metadata":{"id":"FrIO9CSgAHlz"},"source":["### Further reading\r\n","We have explored the ACNN architecture and used the PDBbind dataset to train an ACNN to predict protein-ligand binding energies. For more information, read the original paper that introduced ACNNs: Gomes, Joseph, et al. \"Atomic convolutional networks for predicting protein-ligand binding affinity.\" [arXiv preprint arXiv:1703.10603](https://arxiv.org/abs/1703.10603) (2017). There are many other methods and papers on predicting binding affinities. Here are a few interesting ones to check out: predictions using [only ligands or proteins](https://www.frontiersin.org/articles/10.3389/fphar.2020.00069/full), [molecular docking with deep learning](https://chemrxiv.org/articles/preprint/GNINA_1_0_Molecular_Docking_with_Deep_Learning/13578140), and [AtomNet](https://arxiv.org/abs/1510.02855)."]},{"cell_type":"markdown","metadata":{"id":"wqS0gGXunB_s"},"source":["# Congratulations! Time to join the Community!\n","\n","Congratulations on completing this tutorial notebook! If you enjoyed working through the tutorial, and want to continue working with DeepChem, we encourage you to finish the rest of the tutorials in this series. You can also help the DeepChem community in the following ways:\n","\n","## Star DeepChem on [GitHub](https://github.com/deepchem/deepchem)\n","This helps build awareness of the DeepChem project and the tools for open source drug discovery that we're trying to build.\n","\n","## Join the DeepChem Gitter\n","The DeepChem [Gitter](https://gitter.im/deepchem/Lobby) hosts a number of scientists, developers, and enthusiasts interested in deep learning for the life sciences. Join the conversation!"]}]}
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.6.10"
+    },
+    "colab": {
+      "name": "14_Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb",
+      "provenance": [],
+      "collapsed_sections": [],
+      "toc_visible": true
+    },
+    "accelerator": "GPU"
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "f7FPLsj4nB-6"
+      },
+      "source": [
+        "# Tutorial Part 14: Modeling Protein-Ligand Interactions with Atomic Convolutions\n",
+        "By [Nathan C. Frey](https://ncfrey.github.io/) | [Twitter](https://twitter.com/nc_frey) and [Bharath Ramsundar](https://rbharath.github.io/) | [Twitter](https://twitter.com/rbhar90)\n",
+        "\n",
+        "This DeepChem tutorial introduces the [Atomic Convolutional Neural Network](https://arxiv.org/pdf/1703.10603.pdf). We'll see the structure of the `AtomicConvModel` and write a simple program to run Atomic Convolutions.\n",
+        "\n",
+        "### ACNN Architecture\n",
+        "ACNN’s directly exploit the local three-dimensional structure of molecules to hierarchically learn more complex chemical features by optimizing both the model and featurization simultaneously in an end-to-end fashion.\n",
+        "\n",
+        "The atom type convolution makes use of a neighbor-listed distance matrix to extract features encoding local chemical environments from an input representation (Cartesian atomic coordinates) that does not necessarily contain spatial locality. The following methods are used to build the ACNN architecture:\n",
+        "\n",
+        "- __Distance Matrix__  \n",
+        "The distance matrix $R$ is constructed from the Cartesian atomic coordinates $X$. It calculates distances from the distance tensor $D$. The distance matrix construction accepts as input a $(N, 3)$ coordinate matrix $C$. This matrix is “neighbor listed” into a $(N, M)$ matrix $R$.\n",
+        "\n",
+        "```python\n",
+        "    R = tf.reduce_sum(tf.multiply(D, D), 3)     # D: Distance Tensor\n",
+        "    R = tf.sqrt(R)                              # R: Distance Matrix\n",
+        "    return R\n",
+        "```\n",
+        "\n",
+        "- **Atom type convolution**  \n",
+        "The output of the atom type convolution is constructed from the distance matrix $R$ and atomic number matrix $Z$. The matrix $R$ is fed into a (1x1) filter with stride 1 and depth of $N_{at}$ , where $N_{at}$ is the number of unique atomic numbers (atom types) present in the molecular system. The atom type convolution kernel is a step function that operates on the neighbor distance matrix $R$.\n",
+        "\n",
+        "- **Radial Pooling layer**  \n",
+        "Radial Pooling is basically a dimensionality reduction process that down-samples the output of the atom type convolutions. The reduction process prevents overfitting by providing an abstracted form of representation through feature binning, as well as reducing the number of parameters learned.\n",
+        "Mathematically, radial pooling layers pool over tensor slices (receptive fields) of size (1x$M$x1) with stride 1 and a depth of $N_r$, where $N_r$ is the number of desired radial filters and $M$ is the maximum number of neighbors.\n",
+        "\n",
+        "- **Atomistic fully connected network**  \n",
+        "Atomic Convolution layers are stacked by feeding the flattened ($N$, $N_{at}$ $\\cdot$ $N_r$) output of the radial pooling layer into the atom type convolution operation. Finally, we feed the tensor row-wise (per-atom) into a fully-connected network. The\n",
+        "same fully connected weights and biases are used for each atom in a given molecule.\n",
+        "\n",
+        "Now that we have seen the structural overview of ACNNs, we'll try to get deeper into the model and see how we can train it and what we expect as the output.\n",
+        "\n",
+        "For the training, we will use the publicly available PDBbind dataset. In this example, every row reflects a protein-ligand complex and the target is the binding affinity ($K_i$) of the ligand to the protein in the complex.\n",
+        "\n",
+        "## Colab\n",
+        "\n",
+        "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/14_Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb)\n",
+        "\n",
+        "## Setup\n",
+        "\n",
+        "To run DeepChem within Colab, you'll need to run the following cell of installation commands. This will take about 5 minutes to run to completion and install your environment."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Y2xCQyOInB_D"
+      },
+      "source": [
+        "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
+        "import conda_installer\n",
+        "conda_installer.install()\n",
+        "!/root/miniconda/bin/conda info -e"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "WKxOGlhhMrC7"
+      },
+      "source": [
+        "!/root/miniconda/bin/conda install -c conda-forge mdtraj -y -q  # needed for AtomicConvs"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "jFQmra_fFE8U"
+      },
+      "source": [
+        "!pip install --pre deepchem\n",
+        "import deepchem\n",
+        "deepchem.__version__"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "W1cCOOYXnB_L"
+      },
+      "source": [
+        "import deepchem as dc\n",
+        "import os\n",
+        "\n",
+        "import numpy as np\n",
+        "import tensorflow as tf\n",
+        "\n",
+        "import matplotlib.pyplot as plt\n",
+        "\n",
+        "from rdkit import Chem\n",
+        "\n",
+        "from deepchem.molnet import load_pdbbind\n",
+        "from deepchem.models import AtomicConvModel\n",
+        "from deepchem.feat import AtomicConvFeaturizer"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "fACLMson_-vk"
+      },
+      "source": [
+        "### Getting protein-ligand data\r\n",
+        "If you worked through [Tutorial 13](https://github.com/deepchem/deepchem/blob/master/examples/tutorials/13_Modeling_Protein_Ligand_Interactions.ipynb) on modeling protein-ligand interactions, you'll already be familiar with how to obtain a set of data from PDBbind for training our model. Since we explored molecular complexes in detail in the [previous tutorial]((https://github.com/deepchem/deepchem/blob/master/examples/tutorials/13_Modeling_Protein_Ligand_Interactions.ipynb)), this time we'll simply initialize an `AtomicConvFeaturizer` and load the PDBbind dataset directly using MolNet."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "_qu5DlVa3aV3"
+      },
+      "source": [
+        "f1_num_atoms = 100  # maximum number of atoms to consider in the ligand\r\n",
+        "f2_num_atoms = 1000  # maximum number of atoms to consider in the protein\r\n",
+        "max_num_neighbors = 12  # maximum number of spatial neighbors for an atom\r\n",
+        "\r\n",
+        "acf = AtomicConvFeaturizer(frag1_num_atoms=f1_num_atoms,\r\n",
+        "                      frag2_num_atoms=f2_num_atoms,\r\n",
+        "                      complex_num_atoms=f1_num_atoms+f2_num_atoms,\r\n",
+        "                      max_num_neighbors=max_num_neighbors,\r\n",
+        "                      neighbor_cutoff=4)"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "pyH9KUkvxlxk"
+      },
+      "source": [
+        "`load_pdbbind` allows us to specify if we want to use the entire protein or only the binding pocket (`pocket=True`) for featurization. Using only the pocket saves memory and speeds up the featurization. We can also use the \"core\" dataset of ~200 high-quality complexes for rapidly testing our model, or the larger \"refined\" set of nearly 5000 complexes for more datapoints and more robust training/validation. On Colab, it takes only a minute to featurize the core PDBbind set! This is pretty incredible, and it means you can quickly experiment with different featurizations and model architectures."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "Z9eyanh35qyj",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "1bdc22d2-bf73-48cc-9f31-ecc0f56cf4bc"
+      },
+      "source": [
+        "%%time\r\n",
+        "tasks, datasets, transformers = load_pdbbind(featurizer=acf,\r\n",
+        "                                             save_dir='.',\r\n",
+        "                                             data_dir='.',\r\n",
+        "                                             pocket=True,\r\n",
+        "                                             reload=False,\r\n",
+        "                                             set_name='core')"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "/usr/local/lib/python3.7/dist-packages/numpy/core/_asarray.py:83: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray\n",
+            "  return array(a, dtype, copy=False, order=order)\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "CPU times: user 43.2 s, sys: 18.6 s, total: 1min 1s\n",
+            "Wall time: 1min 10s\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "EaGn9UbwEdyY",
+        "outputId": "6b235d21-88a2-45b0-d6ba-55a4d6a72dd9"
+      },
+      "source": [
+        "datasets"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "(<DiskDataset X.shape: (154, 9), y.shape: (154,), w.shape: (154,), ids: ['1mq6' '3pe2' '2wtv' ... '3f3c' '4gqq' '2x00'], task_names: [0]>,\n",
+              " <DiskDataset X.shape: (19, 9), y.shape: (19,), w.shape: (19,), ids: ['3ivg' '4de1' '4tmn' ... '2vw5' '1w3l' '2zjw'], task_names: [0]>,\n",
+              " <DiskDataset X.shape: (20, 9), y.shape: (20,), w.shape: (20,), ids: ['1kel' '2w66' '2xnb' ... '2qbp' '3lka' '1qi0'], task_names: [0]>)"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "PQq0lkWIfVoE"
+      },
+      "source": [
+        "train, val, test = datasets"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "GNilV3VXnB_j"
+      },
+      "source": [
+        "### Training the model"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "WufupHBPnB_k"
+      },
+      "source": [
+        "Now that we've got our dataset, let's go ahead and initialize an `AtomicConvModel` to train. Keep the input parameters the same as those used in `AtomicConvFeaturizer`, or else we'll get errors. `layer_sizes` controls the number of layers and the size of each dense layer in the network. We choose these hyperparameters to be the same as those used in the [original paper](https://arxiv.org/pdf/1703.10603.pdf)."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "ErBNNGH55-_B"
+      },
+      "source": [
+        "acm = AtomicConvModel(n_tasks=1,\r\n",
+        "                      frag1_num_atoms=f1_num_atoms,\r\n",
+        "                      frag2_num_atoms=f2_num_atoms,\r\n",
+        "                      complex_num_atoms=f1_num_atoms+f2_num_atoms,\r\n",
+        "                      max_num_neighbors=max_num_neighbors,\r\n",
+        "                      batch_size=12,\r\n",
+        "                      layer_sizes=[32, 32, 16],\r\n",
+        "                      learning_rate=0.003,\r\n",
+        "                      )"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "4cNdP1b1hEQM"
+      },
+      "source": [
+        "losses, val_losses = [], []"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "id": "5g6b2qEwNwdL",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "3caa11ac-18dd-4528-f966-dee61d2c508d"
+      },
+      "source": [
+        "%%time\r\n",
+        "max_epochs = 50\r\n",
+        "\r\n",
+        "for epoch in range(max_epochs):\r\n",
+        "  loss = acm.fit(train, nb_epoch=1, max_checkpoints_to_keep=1, all_losses=losses)\r\n",
+        "  metric = dc.metrics.Metric(dc.metrics.score_function.rms_score)\r\n",
+        "  val_losses.append(acm.evaluate(val, metrics=[metric])['rms_score']**2)  # L2 Loss"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "CPU times: user 9min 5s, sys: 1min 58s, total: 11min 4s\n",
+            "Wall time: 11min 54s\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "aTFdba_KDDUQ"
+      },
+      "source": [
+        "The loss curves are not exactly smooth, which is unsurprising because we are using 154 training and 19 validation datapoints. Increasing the dataset size may help with this, but will also require greater computational resources."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 265
+        },
+        "id": "pn4QWM1bizw0",
+        "outputId": "f6399595-4622-41d0-80d1-92df68850cc2"
+      },
+      "source": [
+        "f, ax = plt.subplots()\r\n",
+        "ax.scatter(range(len(losses)), losses, label='train loss')\r\n",
+        "ax.scatter(range(len(val_losses)), val_losses, label='val loss')\r\n",
+        "plt.legend(loc='upper right');"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "display_data",
+          "data": {
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAD4CAYAAAD8Zh1EAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjIsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+WH4yJAAAgAElEQVR4nO3deZQV5bnv8e9j24Z2ogmiUQYh9xoH6BZiY7iHOCeCxgFNHIi5R3Oj/mM0JudwbTMox5Oz1JAVE9Yx18XyGocVFZZBYhxCEoWgieYwgxNxDt16ZIjNldieNM1z/9i7sWmqdu/qXbV3VfXvsxaL3tXVu96qXfupt553KHN3REQk+/aqdQFERCQeCugiIjmhgC4ikhMK6CIiOaGALiKSE3vXasMHHXSQjx07tlabFxHJpJUrV25x9xFBv6tZQB87diwrVqyo1eZFRDLJzN4K+51SLiIiOaGALiKSEwroIiI5UbMcuojkV1dXF21tbXz44Ye1LkpmDRkyhFGjRlFfX1/23yigi0js2traOOCAAxg7dixmVuviZI67s3XrVtra2hg3blzZf5epgL5odTtzFm/g7Y5ODmtsYNa0I5kxaWStiyUifXz44YcK5hUwM4YPH87mzZsj/V1mAvqi1e1cv3A9nV3dALR3dHL9wvUACuoiKaRgXpmBHL/MNIrOWbxhVzDv0dnVzZzFG2pUIhGRdMlMQH+7ozPSchEZvDo6OvjpT386oL8988wz6ejoKHv92bNn88Mf/nBA24pbZgL6YY0NkZaLyOBVKqDv2LGj5N8+/vjjNDY2JlGsxGUmoM+adiQN9XW7LWuor2PWtCNrVCIRicui1e1MveUpxrU+xtRbnmLR6vaK3q+1tZXXXnuNiRMnMmvWLJYuXcoJJ5zAOeecwzHHHAPAjBkzOO644xg/fjzz5s3b9bdjx45ly5YtvPnmmxx99NFcccUVjB8/ntNPP53OztIZgTVr1jBlyhSam5s577zzeO+99wCYO3cuxxxzDM3NzVx88cUA/P73v2fixIlMnDiRSZMm8f7771e0z0Che0wt/h133HEe1cOr2vwfbn7Sx173qP/DzU/6w6vaIr+HiCTvxRdfLHvdh1e1+VHffcIPv+7RXf+O+u4TFX2/33jjDR8/fvyu10uWLPF9993XX3/99V3Ltm7d6u7uH3zwgY8fP963bNni7u6HH364b9682d944w2vq6vz1atXu7v7BRdc4Pfdd98e27rxxht9zpw57u7e1NTkS5cudXf3733ve/6Nb3zD3d0PPfRQ//DDD93d/b333nN397POOsufeeYZd3d///33vaura4/3DjqOwAoPiauZ6eUChd4s6tEiki+lOjzE+X0//vjjd+vTPXfuXB5++GEANm7cyCuvvMLw4cN3+5tx48YxceJEAI477jjefPPN0Pfftm0bHR0dnHTSSQBceumlXHDBBQA0NzdzySWXMGPGDGbMmAHA1KlT+da3vsUll1zC+eefz6hRoyrex8ykXEQkn6rV4WG//fbb9fPSpUv53e9+x7PPPsvatWuZNGlS4KjWj33sY7t+rqur6zf/Huaxxx7jqquuYtWqVUyePJkdO3bQ2trKnXfeSWdnJ1OnTuXll18e0Hv3poAuIjWVRIeHAw44oGROetu2bQwbNox9992Xl19+meeee27A2+oxdOhQhg0bxtNPPw3Afffdx0knncTOnTvZuHEjp5xyCrfeeivbtm1j+/btvPbaazQ1NXHdddcxefLk6gR0M7vLzDaZ2fMl1jnZzNaY2Qtm9vuKSyUig0YSHR6GDx/O1KlTmTBhArNmzdrj99OnT2fHjh0cffTRtLa2MmXKlAFvq7d77rmHWbNm0dzczJo1a7jhhhvo7u7mK1/5Ck1NTUyaNIlrrrmGxsZGfvzjHzNhwgSam5upr6/njDPOqHj7Vsixl1jB7ERgO3Cvu08I+H0j8Edgurv/xcwOdvdN/W24paXF9YALkXx66aWXOProo8teX9N6BAs6jma20t1bgtbvt1HU3ZeZ2dgSq3wZWOjufymu328wFxHpTR0e4hFHDv1TwDAzW2pmK83sH8NWNLMrzWyFma2IOumMiIiUFkdA3xs4DvgCMA34npl9KmhFd5/n7i3u3jJiROAzTkVEZIDi6IfeBmx1978BfzOzZcCxwJ9jeG8RESlTHDX0XwKfNbO9zWxf4DPASzG8r4iIRNBvDd3MHgBOBg4yszbgRqAewN3vcPeXzOzXwDpgJ3Cnu4d2cRQRkWSU08tlZhnrzAHmxFIiEZEa2H///dm+fXvZy9NII0VFRHJCAV1Eam/dArhtAsxuLPy/bkFFb9fa2srtt9++63XPQyi2b9/Oaaedxqc//Wmampr45S9/WfZ7ujuzZs1iwoQJNDU1MX/+fADeeecdTjzxRCZOnMiECRN4+umn6e7u5rLLLtu17m233VbR/pQrU7MtikgOrVsAv7oGuoqTcW3bWHgN0HzhgN7yoosu4tprr+Wqq64CYMGCBSxevJghQ4bw8MMPc+CBB7JlyxamTJnCOeecU9bzOxcuXMiaNWtYu3YtW7ZsYfLkyZx44oncf//9TJs2je985zt0d3fzwQcfsGbNGtrb23n++UJzYpQnIFVCNXQRqa0nb/oomPfo6iwsH6BJkyaxadMm3n77bdauXcuwYcMYPXo07s63v/1tmpub+dznPkd7ezvvvvtuWe/5zDPPMHPmTOrq6jjkkEM46aSTWL58OZMnT+ZnP/sZs2fPZv369RxwwAF88pOf5PXXX+fqq6/m17/+NQceeOCA9yUKBXQRqa1tbdGWl+mCCy7goYceYv78+Vx00UUA/PznP2fz5s2sXLmSNWvWcMghhwROmxvFiSeeyLJlyxg5ciSXXXYZ9957L8OGDWPt2rWcfPLJ3HHHHVx++eUVbaNcCugiUltDQx7sELa8TBdddBEPPvggDz300K4HTWzbto2DDz6Y+vp6lixZwltvvVX2+51wwgnMnz+f7u5uNm/ezLJlyzj++ON56623OOSQQ7jiiiu4/PLLWbVqFVu2bGHnzp188Ytf5Pvf/z6rVq2qaF/KpRy6iNTWaTfsnkMHqG8oLK/A+PHjef/99xk5ciSHHnooAJdccglnn302TU1NtLS0cNRRR5X9fueddx7PPvssxx57LGbGD37wAz7xiU9wzz33MGfOHOrr69l///259957aW9v56tf/So7d+4E4Oabb65oX8rV7/S5SdH0uSL5FXX6XNYtKOTMt7UVauan3TDgBtE8iX36XBGRxDVfqAAeA+XQRURyQgFdRBJRq3RuXgzk+Cmgi0jshgwZwtatWxXUB8jd2bp1K0OGDIn0d8qhi0jsRo0aRVtbG3oy2cANGTKEUaOidd1UQBeR2NXX1zNu3LhaF2PQUcpFRCQnFNBFRHJCAV1EJCcU0EVEckIBXUQkJxTQRURyot+AbmZ3mdkmM3u+n/Umm9kOM/tSfMUTEZFylVNDvxuYXmoFM6sDbgV+E0OZRERkAPoN6O6+DPhrP6tdDfwC2BRHoUREJLqKc+hmNhI4D/g/Zax7pZmtMLMVGhIsIhKvOBpFfwxc5+47+1vR3ee5e4u7t4wYMSKGTYuISI845nJpAR40M4CDgDPNbIe7L4rhvUVEpEwVB3R33zUDj5ndDTyqYC4iUn39BnQzewA4GTjIzNqAG4F6AHe/I9HSiYhI2foN6O4+s9w3c/fLKiqNiIgMmEaKiojkhAK6iEhOKKCLiOSEArqISE4ooIuI5IQCuohITiigi4jkhAK6iEhOKKCLiOSEArqISE5kK6CvWwC3TYDZjYX/1y2odYlERFIjjulzq2PdAvjVNdDVWXi9bWPhNUDzhbUrl4hISmSnhv7kTR8F8x5dnYXlIiKSoYC+rS3achGRQSY7AX3oqGjLRUQGmewE9NNugPqG3ZfVNxSWi4hIhgJ684Vw9lwYOhqwwv9nz1WDqIhIUXZ6uUAheCuAi4gEyk4NXURESuo3oJvZXWa2ycyeD/n9JWa2zszWm9kfzezY+IspIiL9KaeGfjcwvcTv3wBOcvcm4F+BeTGUS0REIuo3h+7uy8xsbInf/7HXy+cA9SMUEamBuHPoXwOeCPulmV1pZivMbMXmzZtj3rSIyOAWW0A3s1MoBPTrwtZx93nu3uLuLSNGjIhr0yIiQkzdFs2sGbgTOMPdt8bxniIiEk3FNXQzGwMsBP6nu/+58iKJiMhA9FtDN7MHgJOBg8ysDbgRqAdw9zuAG4DhwE/NDGCHu7ckVWAREQlWTi+Xmf38/nLg8thKJCIiA6KRoiIiOaGALiKSEwroIiI5oYAuIpITCugiIjmhgC4ikhMK6CIiOaGALiKSEwroIiI5oYAu/Vu3AG6bALMbC/+vW1DrEolIgGw9JFqqb90C+NU10NVZeL1tY+E16IHdIimjGrqU9uRNHwXzHl2dheUikiq5qKEvWt3OnMUbeLujk8MaG5g17UhmTBpZ62Jl07oFhWC9rQ2GjirUyINsa6tuuUSkX5kP6ItWt3P9wvV0dnUD0N7RyfUL1wMoqEcVlF7BAN9z3aExPTq27wXktBuUyhEZoMwH9DmLN+wK5j06u7qZs3iDAnpUQekVnD2Cen1DIfBWKiw//5fn4JXfKMgPRrrAVyTzAf3tjr4BqPRyKSE0jeIwdHT8X7Kw/PyKu9h1AVEj7OChBviKZT6gH9bYQHtA8L50//+A267TlT6KsJz50NHwzefj316pC0hvPY2w+vzyrVQDvD77smS+l8usaUfSUF+327Iv7fNHvut3FIOTf3SlV//p0k67oZBO6S2u9EqQKHl4NcLmX9hnrM++bJkP6DMmjeTm85sY2diAASMbG7hpv1+wd/eHu6+ornb9a74Qzp5bqJFjhf/Pnptc7SjoAoIFrxtXI6wkq5JBaGGfsT77smU+5QKFoL5bA+js/wxeUVf6/jVfWL3b257t9G4EO+J0WHv/7rfeSd4lSHwqzYGfdsPufw/9f/ZqRN1NvwHdzO4CzgI2ufuEgN8b8BPgTOAD4DJ3XxV3QSMJzQVn8Eof5YQNWzepkz6O9w26gIyZku8vaV6DUKU58KALfKlzGNSI2oe5B/Qx7r2C2YnAduDekIB+JnA1hYD+GeAn7v6Z/jbc0tLiK1asGFCh+9W3pgCFK32S6YMkRNmPsHWP/XJwjbfSY5GXY1xteT5usxsJHLOAweyOgb9v2DHbuwE6/7rn+kk14qeEma1095ag3/WbQ3f3ZUDAUdvlXArB3t39OaDRzA4dWFFjUu1ccFKiDLsPW3fl3ckM3c/ilABpmGQsi8etXEnlwMOOWVAwh0GdWo0jhz4S6J3faCsue6fvimZ2JXAlwJgxY2LYdAnVzAUnJUqrf9i63h28vNKTPu09EvreovfNzfe+PYfqpUDSftwqMZAceDmiHpssplZjUtVGUXefB8yDQsqlmtvOpChtAWHrWl1wUK/0pE9LO0W5udXeg5V6dHXCE9fBjs7q5WHTctySUCoHXomwY9bw8d0/OyhcQI44vXAHVq22pBSJo9tiOzC61+tRxWVSqSj9wsPWPe6y4OU9J/1A0w/V7rMepCe32ne8wRPXhUxhEKDzr9FSIJWmbZI8bmlIKTVfWMhfz+4o/B9HwAw7ZmfcumdqtafNqO858ei3gs+VnI1NiaOG/gjwdTN7kEKj6DZ33yPdIgMQpcZTat2+vUZKpR/K/QImVRuLIiy3ukcwH4Cg2/w4hqZHPW7l1irzPGy+v2PWe/9umxDeltT3TjWHo1DL6eXyAHAycBDwLnAjUA/g7ncUuy3+OzCdQrfFr7p7v91XEu3lIqXdNqG6Q/yTEtqrIkzAJGNRekpU+7hF6RETVraGj8M+++U6zbCbgZwTlfTAqYFSvVz6raG7+8x+fu/AVQMsm9RCXhrmouZWj/3ynrM4QvkNedU+blH6dYeVofOvH12w8lRrD1PttqSUyfzQfxmAvAyxjpJbPXsunPWjPfO7Ubq4Vvu4RbmAlFuGvHSRDBO1LSlnI5BzMfQ/N+IYFVqOpLqXJS1on8+eW15utZRyu7iGHbewXhWVitIjJqhsYbJ2JxZFlLakHKaf+s2hJyUTOfRqdnOKY1RolMFTWevClZYRlv31b4+zXFH3uW/Z/v63dI+kzNo5mBKlcugK6GGqHUCiNLjlpVEzirTuc9LlCutnP5CeLzCwcziJwJuWC3QGVTT0f9Cq9hDtOEaF5vlWOq37nHS5+vbrhvL7U8cxBUZYX/9K+2/neQqEGlIOPUypL2oSNZY4RoWmpVGz1scnDuXuQ7XLFXVGw0qnwAjb3hPXVfYZp/UCnXGDr4Ze7mi6sC9kw7BkaixxjApNQ6NmWI3u0W+ld4RlX1FqpdX+LKodCEt1h6zkO5CXnlYpk9uAvmh1O1NveYpxrY8x9ZanWLS6PZ4vKoTXWIICVrkXkCi3x2meTbLUg58rCQDV3Oco6YBS5YoyFL/SikYcgTCoDEl1h0xzpSTDctkoumh1O9cvXE9n10cDCRrq61i5/7Xs2xkwK0FYA1bQbffCKylrJFqSc5GnWZSRerVu0AwTx7zeSfVaSqoxMcp8+qFCjk+1H7yScxWNFM2iOYs37BbMATq7uhnSGfHRdEH5xydvCs6Z9jWI5o/YTVhOOUha86Vx5MWj5LqjrJvUHDphZXjlN3v29Q/tDhlwfPqbYyav34MayWXK5e2O4NrE2zuHB/9BlC9q4IONQ4TORb6x9rPiJSUPD36OIx2QZK+lJGY0LFWGvts749byj496s1RVLgP6YY3BAffOfb5S+Rc1KGfa8PHgda0u5E0sv9N4Bh2flv+VrXxpHPn6KLnuWjQQ9s2XNwwrvwxRjo96s1RVPnLofXJxy//b1fzj8sP3yKHffH4TM+r+UL1BEoH5xz4z/vVIaz45LoMtX5qGvHiUsu1VD2bQ/fd4y5DWAWEZlu+RoiFfhuVN/8K1Lx7B2x2dHNbYwKxpRzJj0sjKt1eqHOU0/ITml7M3jaf0o1pz80RVzal2NSI0dvkO6FmrAWStvJI/cfTiiWKw3Z0lLN+9XOLK0VXrpMvqTIeSH9Ue3areLFWT/UbROBqUkpqvIkiaBwXJ4KBBPbmV/Rp6HDXeqPNjVEo1FqmlNDwPVhKR/YAex8mprlUy2KhSkUtlBXQzmw78BKgD7nT3W/r8fgxwD9BYXKfV3R+PuazhKj050z57oYhIGfrNoZtZHXA7cAZwDDDTzI7ps9p3gQXuPgm4GPhp3AVNlHKKIpID5TSKHg+86u6vu/vfgQeBc/us48CBxZ+HAm/HV8QqUEOliORAOSmXkUDvfEQb8Jk+68wGfmNmVwP7AZ8LeiMzuxK4EmDMmDFRyxqLRavbmbN4w54DjpRTFJGMi6vb4kzgbncfBZwJ3Gdme7y3u89z9xZ3bxkxYkRMmy5fz7S67R2dONDe0cn1C9cX5koXEcm4cgJ6OzC61+tRxWW9fQ1YAODuzwJDgIPiKGCcwqbVnbN4Q41KJCISn3IC+nLgCDMbZ2b7UGj0fKTPOn8BTgMws6MpBPTNcRY0DqHT6oYsFxHJkn4DurvvAL4OLAZeotCb5QUzu8nMzimu9k/AFWa2FngAuMxrNUlMCWHT6oYtFxHJkrL6oRf7lD/eZ9kNvX5+EZgab9HiN2vakYGPpps17cgalkpEJB7ZHykaQc/0uYG9XEREMm5QBXQoBHUFcBHJo+zPtigiIoACuohIbiigi4jkhAK6iEhOKKCLiOSEArqISE4Mum6LYUJnYRQRyQgFdD6ahbFnBGnPLIyAgvoA6OIoUhtKuaBZGOOkKYpFakcBHc3CGCddHEVqRwEdzcIYJ10cRWpHAZ3CLIwN9XW7LdMsjAOji6NI7SigU2j4vPn8JkY2NmDAyMYGbj6/SQ15AxB2cTzlqBFMveUpxrU+xtRbnlJOXSQB6uVSFDQLo3prRBc0RfEpR43gFyvb1YtIJGEK6CHUlXHg+l4cp97yVGhDqY6lSHyUcgmh3hrxUUOpSHWohh6iVBCqNBUz2FI5hzU20B5wPNVQKhIv1dBDhAWboQ31FQ2cGYwDb9SLSKQ6ygroZjbdzDaY2atm1hqyzoVm9qKZvWBm98dbzOoLC0JmVJSKGYypHPUiEqmOflMuZlYH3A58HmgDlpvZI+7+Yq91jgCuB6a6+3tmdnBSBa6WsAdKf3P+msD1y80HD9Z8sp7lKpK8cnLoxwOvuvvrAGb2IHAu8GKvda4Abnf39wDcfVPcBa2FoCA0Z/GGivLByieLSFLKSbmMBDb2et1WXNbbp4BPmdkfzOw5M5se9EZmdqWZrTCzFZs3bx5YiWus0nyw8skikpS4ernsDRwBnAyMApaZWZO7d/Reyd3nAfMAWlpaPKZtV1VYKqbcdEKlfy8iEqacgN4OjO71elRxWW9twJ/cvQt4w8z+TCHAL4+llClTaT5Y+WQRSUI5AX05cISZjaMQyC8GvtxnnUXATOBnZnYQhRTM63EWVCRIHH36B9u4AMmvfgO6u+8ws68Di4E64C53f8HMbgJWuPsjxd+dbmYvAt3ALHffmmTBZU+DLTDFMT2DpniQPDH32qSyW1pafMWKFTXZdh71DUxQaGzNc3/vqbc8FdhjaGRjA39oPbVq7yFSTWa20t1bgn6nof8pUkkNu9SApaD3yENtPo4+/YN1XIDkkwJ6SlR66x8lMOUlzRBHn/6o75GHC6Hkl+ZySYmoUwIsWt2+2wMjGvetD1wvKDDlZfqBOPr0R3mPwTgPj2SLaugpUWkNu34vo77O6Or+qE2kJzD1rVUG1UhLlSFJldR44+jTH+U9oqa1RKpNAT0lotz6BwWWrp1OY0M9+31s790CE7BH8DcgqCm82tMPRE39hAX/SoNpue+RxXy7UkQDk9XjpoCeErOmHRnYSyXo1j8sgGzr7GLNjafvtizoaUEOewT1Wkw/EKXGm4a8f9bm4UnymGU14JUjDefaQCmHnhJRppgNCyBBy8OCvxe3UcvpbKPUeNOQ96/FPDx920qi5OuTOmZpakuo5PiEScO5NlCqoadIubf+UWrzYbXKNPSzjlLjjZruSKIGWe15eKrZ8ymKtLQlJFWTzmJqrYdq6BkUpTaf5tkdo5Qtyl1JkjXIGZNG8ofWU3njli/wh9ZTEw1gldYUoxyzKNIS8JKqSSd13KpBNfSUK9UQWE4wSfPsjlHKFuWupNo1yKTyyZUGzijHLIq0tCUkdWFJ6rhVgwJ6isV1S5nm2R2TuDBVswaZZANapYEzrot53wvWKUeN4Bcr22se8JK6sKS5EtQfzeWSYppnZGCqedyS3FYa5ucJK8MXjxvJkpc31zTgpeH41ILmcsmotOQqs6aat8xJfkZpqCmGpa+WvLy55pWKNBwfSFcXTgX0FEtLrjJMmk7k3qr5RU/6M6p1uiztlYqg41PN8zJtfdYV0FMszY0zaTuR+6r0i17uumn6jJLYv7RXKvqq9nmZli6cPdRtMSZJDHCI0j2x2rI2+CJKV8Yo66blM0pq/9Lc7TVIpZPcRf3epu0ORjX0GCRZK6j1LXeYtJ3I/YlSk4pa60rDZ5TU/mUtT13taaTTdgejgB6DtN12VUPaTuT+RPmiZ+1iBcnuX60vWFECb6WT3EX93oal3E45agRTb3mq6hdBBfQYZDEARBFUO0pT7rgcUb7oSV+skmi0S9P+lavc4xAl8JY6L5OYRjroDqZvP/1qti+VlUM3s+lmtsHMXjWz1hLrfdHM3MwC+0jmVamhwknk1qspLN8KJJY7TuKYRckFJ5k3TmpagrTsX7nCjsN3F63f47OPUmEKa9MA9tiehZQt6oWt73QQS17eXLP2pX4HFplZHfBn4PNAG7AcmOnuL/ZZ7wDgMWAf4OvuXnLUUJ4GFpUafBE0oi4tDZvlqPbgpiQHiyTRCyTq9uYs3pDoQKRq7l8lws6roGmdh9TvxXsfdO2xbhwPAw/aXqXn2rjWxwKfN2DAbRdNrPi4Vzqw6HjgVXd/vfhmDwLnAi/2We9fgVuBWZFKlwNhDUd5yK1XO52U5DGLkguuNG8clvftu2894hqIVK39iyLo4lFqWufeOru6+djee9FQX1dReq+/aaSrkf4a2lCfeJfKcgL6SGBjr9dtwGd6r2BmnwZGu/tjZjboAjoEf0G+OX9N4Lppzq33/fI17lsfWDtKKt+al/aIsAtTnRndAXfFaW1MrlTYhS3svAqyrbOr4pptNaeRDsvjm5F4Ba/iRlEz2wv4EXBZGeteCVwJMGbMmEo3nXppaXwqV9RnlSYha8csTNgFqNu94tpmloRd2IJq3aUejVjpHUUcjfjlpqnC7tirUcErp1G0HRjd6/Wo4rIeBwATgKVm9iYwBXgkqGHU3ee5e4u7t4wYMWLgpc6INDQ+RRH2rNL99tm7agNnsnbMwoRdgHqOX60HIiWlb4N2WE+SbZ1dexyHS6aMSeyzr3QAWNTG7KB586sxz3o5jaJ7U2gUPY1CIF8OfNndXwhZfynwz4OpUbSUWjc+RVGqMeeNW75QtXJk6ZiFidq4m9d9Dqt1h6U60noc4ugcEFeDf0WNou6+w8y+DiwG6oC73P0FM7sJWOHuj5RdkkGo1oMyokhLuiNLxyxMlBGWaZ8Xp1xBd3hRH0ie1s8+jradaoy6LSuH7u6PA4/3WXZDyLonV14sqYWsDRZKu3KDUx56Q0F1e5JUW1yVnaQvWBopKrukZd6OwSYtPXsqTXek+YHklcpKZUcBXXaT1lvePEtDqiuOtE9Wgt5AZKWyo4AuUmNpCIRxpH2yEvQGKguVHQV0kRpLQyCMK+2ThaCXZwroIilQ60CYhrSPVE5PLBKR3AzoGuxUQxeRVKR9pHIK6CIC1D7tI5VTQBfJmLQOj5faU0AXyZC8TBMgyVCjqEiGlOovLqKALpIhaZkmQNJJAV0kQ6oxp7ZklwK6SIaov7iUokZRkQxRf3EpRQFdJGPUX1zCKOUiIpITCugiIjmhgC4ikhMK6CIiOaGALiKSE+butdmw2WbgrQH++UHAlhiLkzZ53j/tW3blef+ytG+Hu/uIoF/ULKBXwsxWuHtLrcuRlDzvn/Ytu6TM9EMAAAN3SURBVPK8f3nZN6VcRERyQgFdRCQnshrQ59W6AAnL8/5p37Irz/uXi33LZA5dRET2lNUauoiI9KGALiKSE5kL6GY23cw2mNmrZtZa6/JUyszuMrNNZvZ8r2UfN7Pfmtkrxf+H1bKMA2Vmo81siZm9aGYvmNk3isszv39mNsTM/sPM1hb37V+Ky8eZ2Z+K5+d8M9un1mUdKDOrM7PVZvZo8XWe9u1NM1tvZmvMbEVxWebPy0wFdDOrA24HzgCOAWaa2TG1LVXF7gam91nWCjzp7kcATxZfZ9EO4J/c/RhgCnBV8fPKw/79F3Cqux8LTASmm9kU4FbgNnf/78B7wNdqWMZKfQN4qdfrPO0bwCnuPrFX//PMn5eZCujA8cCr7v66u/8deBA4t8Zlqoi7LwP+2mfxucA9xZ/vAWZUtVAxcfd33H1V8ef3KQSHkeRg/7xge/FlffGfA6cCDxWXZ3LfAMxsFPAF4M7iayMn+1ZC5s/LrAX0kcDGXq/bisvy5hB3f6f4838Ch9SyMHEws7HAJOBP5GT/iimJNcAm4LfAa0CHu+8orpLl8/PHwP8GdhZfDyc/+waFi+9vzGylmV1ZXJb581JPLEo5d3czy3TfUjPbH/gFcK27/79CZa8gy/vn7t3ARDNrBB4GjqpxkWJhZmcBm9x9pZmdXOvyJOSz7t5uZgcDvzWzl3v/MqvnZdZq6O3A6F6vRxWX5c27ZnYoQPH/TTUuz4CZWT2FYP5zd19YXJyb/QNw9w5gCfA/gEYz66koZfX8nAqcY2ZvUkhrngr8hHzsGwDu3l78fxOFi/Hx5OC8zFpAXw4cUWxt3we4GHikxmVKwiPApcWfLwV+WcOyDFgx7/p/gZfc/Ue9fpX5/TOzEcWaOWbWAHyeQhvBEuBLxdUyuW/ufr27j3L3sRS+Y0+5+yXkYN8AzGw/Mzug52fgdOB58nBeZm2kqJmdSSG/Vwfc5e7/VuMiVcTMHgBOpjB957vAjcAiYAEwhsIUwxe6e9+G09Qzs88CTwPr+SgX+20KefRM75+ZNVNoOKujUDFa4O43mdknKdRqPw6sBr7i7v9Vu5JWpphy+Wd3Pysv+1bcj4eLL/cG7nf3fzOz4WT9vMxaQBcRkWBZS7mIiEgIBXQRkZxQQBcRyQkFdBGRnFBAFxHJCQV0EZGcUEAXEcmJ/w+ABHktnNLPuQAAAABJRU5ErkJggg==\n",
+            "text/plain": [
+              "<Figure size 432x288 with 1 Axes>"
+            ]
+          },
+          "metadata": {
+            "tags": [],
+            "needs_background": "light"
+          }
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "KzGW3ztODYzV"
+      },
+      "source": [
+        "The [ACNN paper](https://arxiv.org/pdf/1703.10603.pdf) showed a Pearson $R^2$ score of 0.912 and 0.448 for a random 80/20 split of the PDBbind core train/test sets. Here, we've used an 80/10/10 training/validation/test split and achieved similar performance for the training set (0.943). We can see from the performance on the training, validation, and test sets (and from the results in the paper) that the ACNN can learn chemical interactions from small training datasets, but struggles to generalize. Still, it is pretty amazing that we can train an `AtomicConvModel` with only a few lines of code and start predicting binding affinities!  \r\n",
+        "From here, you can experiment with different hyperparameters, more challenging splits, and the \"refined\" set of PDBbind to see if you can reduce overfitting and come up with a more robust model."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "id": "VcDLwf-20tci",
+        "outputId": "35ae9353-5dd8-4397-bbf0-d58cfebb6584"
+      },
+      "source": [
+        "score = dc.metrics.Metric(dc.metrics.score_function.pearson_r2_score)\r\n",
+        "for tvt, ds in zip(['train', 'val', 'test'], datasets):\r\n",
+        "  print(tvt, acm.evaluate(ds, metrics=[score]))"
+      ],
+      "execution_count": null,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "train {'pearson_r2_score': 0.9437584772241725}\n",
+            "val {'pearson_r2_score': 0.16399398585969166}\n",
+            "test {'pearson_r2_score': 0.25027177101277903}\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "FrIO9CSgAHlz"
+      },
+      "source": [
+        "### Further reading\r\n",
+        "We have explored the ACNN architecture and used the PDBbind dataset to train an ACNN to predict protein-ligand binding energies. For more information, read the original paper that introduced ACNNs: Gomes, Joseph, et al. \"Atomic convolutional networks for predicting protein-ligand binding affinity.\" [arXiv preprint arXiv:1703.10603](https://arxiv.org/abs/1703.10603) (2017). There are many other methods and papers on predicting binding affinities. Here are a few interesting ones to check out: predictions using [only ligands or proteins](https://www.frontiersin.org/articles/10.3389/fphar.2020.00069/full), [molecular docking with deep learning](https://chemrxiv.org/articles/preprint/GNINA_1_0_Molecular_Docking_with_Deep_Learning/13578140), and [AtomNet](https://arxiv.org/abs/1510.02855)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "wqS0gGXunB_s"
+      },
+      "source": [
+        "# Congratulations! Time to join the Community!\n",
+        "\n",
+        "Congratulations on completing this tutorial notebook! If you enjoyed working through the tutorial, and want to continue working with DeepChem, we encourage you to finish the rest of the tutorials in this series. You can also help the DeepChem community in the following ways:\n",
+        "\n",
+        "## Star DeepChem on [GitHub](https://github.com/deepchem/deepchem)\n",
+        "This helps build awareness of the DeepChem project and the tools for open source drug discovery that we're trying to build.\n",
+        "\n",
+        "## Join the DeepChem Gitter\n",
+        "The DeepChem [Gitter](https://gitter.im/deepchem/Lobby) hosts a number of scientists, developers, and enthusiasts interested in deep learning for the life sciences. Join the conversation!"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Description

There was an errant `}` that got left into a line in Tutorial 14. Also the `RdkitGridFeaturizer` failed featurization handling caused an error for `AtomicConvFeaturizer`, so I've fixed that. I wanted to do this quickly because of the 2.5.0 release, but there should probably be more robust handling for failured complex featurizations because the output for complex featurizers is not standard. This addresses #2438 


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)

CCing @rbharath 
