### PR TITLE
Improve SmilesToImage Error Message for long molecules

### DIFF
--- a/deepchem/feat/molecule_featurizers/smiles_to_image.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_image.py
@@ -7,7 +7,6 @@ import numpy as np
 from deepchem.utils.typing import RDKitMol
 from deepchem.feat.base_classes import MolecularFeaturizer
 
-
 class SmilesToImage(MolecularFeaturizer):
   """Convert SMILES string to an image.
 
@@ -152,14 +151,20 @@ class SmilesToImage(MolecularFeaturizer):
         (line_coords[:, 0] + self.embed) / self.res).astype(int)
     bond_line_idys = np.ceil(
         (line_coords[:, 1] + self.embed) / self.res).astype(int)
-    # Set the bond line coordinates to the bond property used.
-    img[bond_line_idxs, bond_line_idys, 0] = bond_props[:, 0]
-
     # Turn atomic coordinates into image positions
     atom_idxs = np.round(
-        (atom_coords[:, 0] + self.embed) / self.res).astype(int)
+      (atom_coords[:, 0] + self.embed) / self.res).astype(int)
     atom_idys = np.round(
-        (atom_coords[:, 1] + self.embed) / self.res).astype(int)
-    # Set the atom positions in image to different atomic properties in channels
-    img[atom_idxs, atom_idys, :] = atom_props
+      (atom_coords[:, 1] + self.embed) / self.res).astype(int)
+
+    try:
+      # Set the bond line coordinates to the bond property used.
+      img[bond_line_idxs, bond_line_idys, 0] = bond_props[:, 0]
+
+      # Set the atom positions in image to different atomic properties in channels
+      img[atom_idxs, atom_idys, :] = atom_props
+
+    except IndexError:
+      # With fixed res and img_size some molecules (e.g. long chains) may not fit.
+      raise IndexError("The molecule does not fit into the image. Consider increasing img_size or res of the SmilesToImage featurizer.")
     return img

--- a/deepchem/feat/molecule_featurizers/smiles_to_image.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_image.py
@@ -7,6 +7,7 @@ import numpy as np
 from deepchem.utils.typing import RDKitMol
 from deepchem.feat.base_classes import MolecularFeaturizer
 
+
 class SmilesToImage(MolecularFeaturizer):
   """Convert SMILES string to an image.
 
@@ -153,9 +154,9 @@ class SmilesToImage(MolecularFeaturizer):
         (line_coords[:, 1] + self.embed) / self.res).astype(int)
     # Turn atomic coordinates into image positions
     atom_idxs = np.round(
-      (atom_coords[:, 0] + self.embed) / self.res).astype(int)
+        (atom_coords[:, 0] + self.embed) / self.res).astype(int)
     atom_idys = np.round(
-      (atom_coords[:, 1] + self.embed) / self.res).astype(int)
+        (atom_coords[:, 1] + self.embed) / self.res).astype(int)
 
     try:
       # Set the bond line coordinates to the bond property used.
@@ -166,5 +167,7 @@ class SmilesToImage(MolecularFeaturizer):
 
     except IndexError:
       # With fixed res and img_size some molecules (e.g. long chains) may not fit.
-      raise IndexError("The molecule does not fit into the image. Consider increasing img_size or res of the SmilesToImage featurizer.")
+      raise IndexError(
+          "The molecule does not fit into the image. Consider increasing img_size or res of the SmilesToImage featurizer."
+      )
     return img

--- a/deepchem/feat/tests/test_smiles_featurizers.py
+++ b/deepchem/feat/tests/test_smiles_featurizers.py
@@ -43,6 +43,13 @@ class TestSmilesToImage(unittest.TestCase):
   def setUp(self):
     """Setup."""
     self.smiles = ["Cn1c(=O)c2c(ncn2C)n(C)c1=O", "CC(=O)N1CN(C(C)=O)C(O)C1O"]
+    self.long_molecule_smiles = ["CCCCCCCCCCCCCCCCCCCC(=O)OCCCNC(=O)c1ccccc1SSc1ccccc1C(=O)NCCCOC(=O)CCCCCCCCCCCCCCCCCCC"]
+
+  def test_smiles_to_image(self):
+    """Test default SmilesToImage"""
+    featurizer = SmilesToImage()
+    features = featurizer.featurize(self.smiles)
+    assert features.shape == (2, 80, 80, 1)
 
   def test_smiles_to_image(self):
     """Test default SmilesToImage"""
@@ -82,3 +89,13 @@ class TestSmilesToImage(unittest.TestCase):
     features = featurizer.featurize(self.smiles)
     assert features.shape == (2, 80, 80, 4)
     assert not np.allclose(base_features, features)
+
+  def test_smiles_to_image_long_molecule(self):
+    """Test SmilesToImage for a molecule which does not fit the image"""
+    featurizer = SmilesToImage(
+               img_size=80,
+               res=0.5,
+               max_len=250,
+               img_spec="std")
+    features = featurizer.featurize(self.long_molecule_smiles)
+    assert features.shape == (1, 0)

--- a/deepchem/feat/tests/test_smiles_featurizers.py
+++ b/deepchem/feat/tests/test_smiles_featurizers.py
@@ -13,12 +13,11 @@ class TestSmilesToSeq(unittest.TestCase):
     """Setup."""
     pad_len = 5
     max_len = 35
-    filename = os.path.join(os.path.dirname(__file__), "data",
-                            "chembl_25_small.csv")
+    filename = os.path.join(
+        os.path.dirname(__file__), "data", "chembl_25_small.csv")
     char_to_idx = create_char_to_idx(filename, max_len=max_len)
-    self.feat = SmilesToSeq(char_to_idx=char_to_idx,
-                            max_len=max_len,
-                            pad_len=pad_len)
+    self.feat = SmilesToSeq(
+        char_to_idx=char_to_idx, max_len=max_len, pad_len=pad_len)
 
   def test_smiles_to_seq_featurize(self):
     """Test SmilesToSeq featurization."""
@@ -47,12 +46,6 @@ class TestSmilesToImage(unittest.TestCase):
     self.long_molecule_smiles = [
         "CCCCCCCCCCCCCCCCCCCC(=O)OCCCNC(=O)c1ccccc1SSc1ccccc1C(=O)NCCCOC(=O)CCCCCCCCCCCCCCCCCCC"
     ]
-
-  def test_smiles_to_image(self):
-    """Test default SmilesToImage"""
-    featurizer = SmilesToImage()
-    features = featurizer.featurize(self.smiles)
-    assert features.shape == (2, 80, 80, 1)
 
   def test_smiles_to_image(self):
     """Test default SmilesToImage"""
@@ -95,9 +88,7 @@ class TestSmilesToImage(unittest.TestCase):
 
   def test_smiles_to_image_long_molecule(self):
     """Test SmilesToImage for a molecule which does not fit the image"""
-    featurizer = SmilesToImage(img_size=80,
-                               res=0.5,
-                               max_len=250,
-                               img_spec="std")
+    featurizer = SmilesToImage(
+        img_size=80, res=0.5, max_len=250, img_spec="std")
     features = featurizer.featurize(self.long_molecule_smiles)
     assert features.shape == (1, 0)

--- a/deepchem/feat/tests/test_smiles_featurizers.py
+++ b/deepchem/feat/tests/test_smiles_featurizers.py
@@ -13,11 +13,12 @@ class TestSmilesToSeq(unittest.TestCase):
     """Setup."""
     pad_len = 5
     max_len = 35
-    filename = os.path.join(
-        os.path.dirname(__file__), "data", "chembl_25_small.csv")
+    filename = os.path.join(os.path.dirname(__file__), "data",
+                            "chembl_25_small.csv")
     char_to_idx = create_char_to_idx(filename, max_len=max_len)
-    self.feat = SmilesToSeq(
-        char_to_idx=char_to_idx, max_len=max_len, pad_len=pad_len)
+    self.feat = SmilesToSeq(char_to_idx=char_to_idx,
+                            max_len=max_len,
+                            pad_len=pad_len)
 
   def test_smiles_to_seq_featurize(self):
     """Test SmilesToSeq featurization."""
@@ -43,7 +44,9 @@ class TestSmilesToImage(unittest.TestCase):
   def setUp(self):
     """Setup."""
     self.smiles = ["Cn1c(=O)c2c(ncn2C)n(C)c1=O", "CC(=O)N1CN(C(C)=O)C(O)C1O"]
-    self.long_molecule_smiles = ["CCCCCCCCCCCCCCCCCCCC(=O)OCCCNC(=O)c1ccccc1SSc1ccccc1C(=O)NCCCOC(=O)CCCCCCCCCCCCCCCCCCC"]
+    self.long_molecule_smiles = [
+        "CCCCCCCCCCCCCCCCCCCC(=O)OCCCNC(=O)c1ccccc1SSc1ccccc1C(=O)NCCCOC(=O)CCCCCCCCCCCCCCCCCCC"
+    ]
 
   def test_smiles_to_image(self):
     """Test default SmilesToImage"""
@@ -92,10 +95,9 @@ class TestSmilesToImage(unittest.TestCase):
 
   def test_smiles_to_image_long_molecule(self):
     """Test SmilesToImage for a molecule which does not fit the image"""
-    featurizer = SmilesToImage(
-               img_size=80,
-               res=0.5,
-               max_len=250,
-               img_spec="std")
+    featurizer = SmilesToImage(img_size=80,
+                               res=0.5,
+                               max_len=250,
+                               img_spec="std")
     features = featurizer.featurize(self.long_molecule_smiles)
     assert features.shape == (1, 0)


### PR DESCRIPTION
# Pull Request Template
## Description

Issue #2430:
I changed error message of the SmilesToImageFeaturizer for long molecules that do not fit the image:

```python
Failed to featurize datapoint 2, COc1ccc(C=CC(=O)N2CC(CCl)c3c2cc(NC(=O)C(CCCCN)NC(=O)C(NC(=O)CCOCCOCCOCCOCCNC(=O)CBr)C(C)C)c2ccccc32)cc1.O=C(O)C(F)(F)F. Appending empty array
Exception message: index 80 is out of bounds for axis 0 with size 80
```
to
```python
Failed to featurize datapoint 2, COc1ccc(C=CC(=O)N2CC(CCl)c3c2cc(NC(=O)C(CCCCN)NC(=O)C(NC(=O)CCOCCOCCOCCOCCNC(=O)CBr)C(C)C)c2ccccc32)cc1.O=C(O)C(F)(F)F. Appending empty array
Exception message: The molecule does not fit into the image. Consider increasing img_size or res of the SmilesToImage featurizer.

```


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
