### PR TITLE
Fix pymatgen subclasses import error

### DIFF
--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -319,7 +319,7 @@ class MaterialStructureFeaturizer(Featurizer):
 
     Parameters
     ----------
-    structures: Iterable[Union[Dict, pymatgen.Structure]]
+    structures: Iterable[Union[Dict, pymatgen.core.Structure]]
       Iterable sequence of pymatgen structure dictionaries
       or pymatgen.core.Structure. Please confirm the dictionary representations
       of pymatgen.core.Structure from https://pymatgen.org/pymatgen.core.structure.html.

--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -321,8 +321,8 @@ class MaterialStructureFeaturizer(Featurizer):
     ----------
     structures: Iterable[Union[Dict, pymatgen.Structure]]
       Iterable sequence of pymatgen structure dictionaries
-      or pymatgen.Structure. Please confirm the dictionary representations
-      of pymatgen.Structure from https://pymatgen.org/pymatgen.core.structure.html.
+      or pymatgen.core.Structure. Please confirm the dictionary representations
+      of pymatgen.core.Structure from https://pymatgen.org/pymatgen.core.structure.html.
     log_every_n: int, default 1000
       Logging messages reported every `log_every_n` samples.
 
@@ -333,7 +333,7 @@ class MaterialStructureFeaturizer(Featurizer):
       `structures`.
     """
     try:
-      from pymatgen import Structure
+      from pymatgen.core import Structure
     except ModuleNotFoundError:
       raise ImportError("This class requires pymatgen to be installed.")
 
@@ -395,7 +395,7 @@ class MaterialCompositionFeaturizer(Featurizer):
       `compositions`.
     """
     try:
-      from pymatgen import Composition
+      from pymatgen.core import Composition
     except ModuleNotFoundError:
       raise ImportError("This class requires pymatgen to be installed.")
 

--- a/deepchem/feat/material_featurizers/cgcnn_featurizer.py
+++ b/deepchem/feat/material_featurizers/cgcnn_featurizer.py
@@ -35,8 +35,8 @@ class CGCNNFeaturizer(MaterialStructureFeaturizer):
   Examples
   --------
   >>> import pymatgen as mg
-  >>> lattice = mg.Lattice.cubic(4.2)
-  >>> structure = mg.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+  >>> lattice = mg.core.Lattice.cubic(4.2)
+  >>> structure = mg.core.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
   >>> featurizer = CGCNNFeaturizer()
   >>> features = featurizer.featurize([structure])
   >>> feature = features[0]
@@ -86,7 +86,7 @@ class CGCNNFeaturizer(MaterialStructureFeaturizer):
 
     Parameters
     ----------
-    struct: pymatgen.Structure
+    struct: pymatgen.core.Structure
       A periodic crystal composed of a lattice and a sequence of atomic
       sites with 3D coordinates and elements.
 
@@ -108,7 +108,7 @@ class CGCNNFeaturizer(MaterialStructureFeaturizer):
 
     Parameters
     ----------
-    struct: pymatgen.Structure
+    struct: pymatgen.core.Structure
       A periodic crystal composed of a lattice and a sequence of atomic
       sites with 3D coordinates and elements.
 
@@ -131,7 +131,7 @@ class CGCNNFeaturizer(MaterialStructureFeaturizer):
 
     Parameters
     ----------
-    struct: pymatgen.Structure
+    struct: pymatgen.core.Structure
       A periodic crystal composed of a lattice and a sequence of atomic
       sites with 3D coordinates and elements.
 

--- a/deepchem/feat/material_featurizers/element_property_fingerprint.py
+++ b/deepchem/feat/material_featurizers/element_property_fingerprint.py
@@ -34,7 +34,7 @@ class ElementPropertyFingerprint(MaterialCompositionFeaturizer):
   Examples
   --------
   >>> import pymatgen as mg
-  >>> comp = mg.Composition("Fe2O3")
+  >>> comp = mg.core.Composition("Fe2O3")
   >>> featurizer = ElementPropertyFingerprint()
   >>> features = featurizer.featurize([comp])
 
@@ -60,7 +60,7 @@ class ElementPropertyFingerprint(MaterialCompositionFeaturizer):
 
     Parameters
     ----------
-    composition: pymatgen.Composition object
+    composition: pymatgen.core.Composition object
       Composition object.
 
     Returns

--- a/deepchem/feat/material_featurizers/elemnet_featurizer.py
+++ b/deepchem/feat/material_featurizers/elemnet_featurizer.py
@@ -70,7 +70,7 @@ class ElemNetFeaturizer(MaterialCompositionFeaturizer):
 
     Parameters
     ----------
-    composition: pymatgen.Composition object
+    composition: pymatgen.core.Composition object
       Composition object.
 
     Returns

--- a/deepchem/feat/material_featurizers/lcnn_featurizer.py
+++ b/deepchem/feat/material_featurizers/lcnn_featurizer.py
@@ -61,7 +61,7 @@ class LCNNFeaturizer(MaterialStructureFeaturizer):
   Examples
   --------
   >>> import deepchem as dc
-  >>> from pymatgen import Structure
+  >>> from pymatgen.core import Structure
   >>> import numpy as np
   >>> PRIMITIVE_CELL = {
   ...   "lattice": [[2.818528, 0.0, 0.0],
@@ -147,7 +147,7 @@ class LCNNFeaturizer(MaterialStructureFeaturizer):
       used down to 2 digits.
     """
     try:
-      from pymatgen import Structure
+      from pymatgen.core import Structure
     except:
       raise ImportError("This class requires pymatgen to be installed.")
 
@@ -626,7 +626,7 @@ def _get_SiteEnvironments(struct: PymatgenStructure,
     list of local_env class
   """
   try:
-    from pymatgen import Molecule
+    from pymatgen.core import Molecule
     from pymatgen.symmetry.analyzer import PointGroupAnalyzer
   except:
     raise ImportError("This class requires pymatgen to be installed.")

--- a/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
+++ b/deepchem/feat/material_featurizers/sine_coulomb_matrix.py
@@ -35,8 +35,8 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
   Examples
   --------
   >>> import pymatgen as mg
-  >>> lattice = mg.Lattice.cubic(4.2)
-  >>> structure = mg.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+  >>> lattice = mg.core.Lattice.cubic(4.2)
+  >>> structure = mg.core.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
   >>> featurizer = SineCoulombMatrix(max_atoms=2)
   >>> features = featurizer.featurize([structure])
 
@@ -65,7 +65,7 @@ class SineCoulombMatrix(MaterialStructureFeaturizer):
 
     Parameters
     ----------
-    struct: pymatgen.Structure
+    struct: pymatgen.core.Structure
       A periodic crystal composed of a lattice and a sequence of atomic
       sites with 3D coordinates and elements.
 

--- a/deepchem/models/torch_models/lcnn.py
+++ b/deepchem/models/torch_models/lcnn.py
@@ -242,7 +242,7 @@ class LCNN(nn.Module):
   Examples
   --------
   >>> import deepchem as dc
-  >>> from pymatgen import Structure
+  >>> from pymatgen.core import Structure
   >>> import numpy as np
   >>> PRIMITIVE_CELL = {
   ...   "lattice": [[2.818528, 0.0, 0.0],
@@ -406,7 +406,7 @@ class LCNNModel(TorchModel):
   --------
   >>>
   >> import deepchem as dc
-  >> from pymatgen import Structure
+  >> from pymatgen.core import Structure
   >> import numpy as np
   >> from deepchem.feat import LCNNFeaturizer
   >> from deepchem.molnet import load_Platinum_Adsorption


### PR DESCRIPTION
## Description

Fix #(2459)
I am fixing sub class import error issue.
I changed all the  import statements of pymatgen that are importing classes relates to pymatgen.core module :
` from pymatgen import Structure`
 to
`from pymatgen.core import Structure`

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
