### PR TITLE
Added updating website to release instructions

### DIFF
--- a/notes/release.md
+++ b/notes/release.md
@@ -50,3 +50,8 @@ The publish process is automated by GitHub Actions and it is in `docker` section
 We should manually modify documents for installing a new package before pushing a new tag.
 Basically, we modify `README.md` and `docs/get_started/installation.rst`. (include `docs/index.rst` in some cases)
 After pushing a new tag, we go to [the project page](https://readthedocs.org/projects/deepchem/versions) in ReadTheDocs and publish the documents for a new tag.
+
+## Website
+
+We should manually modify the DeepChem website's installation instructions after each new stable release.
+This can be done by modifying the text strings in the jQuery code at the bottom of deepchem.io/website/index.html. When the changes are pushed to github.com/deepchem/deepchem.io, the website will automatically update.


### PR DESCRIPTION
# Added item to release checklist

## Description

The DeepChem website has install instructions of DeepChem. However, these instructions have been outdated for a long time. 

Adding modifying the website to the release checklist will make sure that our website can stay up to date. This will make it more difficult for our users to run into bugs. 


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings

@rbharath 