### PR TITLE
Fixed Documentation for Graph Convolution Featurizers - MolGanFeaturizer

### DIFF
--- a/docs/source/api_reference/featurizers.rst
+++ b/docs/source/api_reference/featurizers.rst
@@ -43,7 +43,7 @@ with graph convolution models  which inherited :code:`KerasModel`.
 except :code:`WeaveModel`. :code:`WeaveFeaturizer` are only used with :code:`WeaveModel`.
 On the other hand, :code:`MolGraphConvFeaturizer` is used
 with graph convolution models which inherited :code:`TorchModel`.
-:code: `MolGanFeaturizer` will be used with MolGAN model,
+:code:`MolGanFeaturizer` will be used with MolGAN model,
 a GAN model for generation of small molecules.
 
 ConvMolFeaturizer


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #(issue)

This PR fixes issue #2472 .
`MolGanFeaturizer` was not showing up in a block due to an extra space.
The page currently looks like:
![Screenshot from 2021-04-13 22-04-13](https://user-images.githubusercontent.com/14348863/114588500-618afb80-9ca4-11eb-9a05-1a3d1c01d03f.png)



## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

@rbharath 