### PR TITLE
PAGTN featurisation support for Molecular Graph Conv

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -25,6 +25,7 @@ from deepchem.feat.molecule_featurizers import MACCSKeysFingerprint
 from deepchem.feat.molecule_featurizers import MordredDescriptors
 from deepchem.feat.molecule_featurizers import Mol2VecFingerprint
 from deepchem.feat.molecule_featurizers import MolGraphConvFeaturizer
+from deepchem.feat.molecule_featurizers import PagtnMolGraphFeaturizer
 from deepchem.feat.molecule_featurizers import MolGanFeaturizer
 from deepchem.feat.molecule_featurizers import OneHotFeaturizer
 from deepchem.feat.molecule_featurizers import PubChemFingerprint

--- a/deepchem/feat/molecule_featurizers/__init__.py
+++ b/deepchem/feat/molecule_featurizers/__init__.py
@@ -15,4 +15,5 @@ from deepchem.feat.molecule_featurizers.rdkit_descriptors import RDKitDescriptor
 from deepchem.feat.molecule_featurizers.smiles_to_image import SmilesToImage
 from deepchem.feat.molecule_featurizers.smiles_to_seq import SmilesToSeq, create_char_to_idx
 from deepchem.feat.molecule_featurizers.mol_graph_conv_featurizer import MolGraphConvFeaturizer
+from deepchem.feat.molecule_featurizers.mol_graph_conv_featurizer import PagtnMolGraphFeaturizer
 from deepchem.feat.molecule_featurizers.molgan_featurizer import MolGanFeaturizer

--- a/deepchem/feat/tests/test_mol_graph_conv_featurizer.py
+++ b/deepchem/feat/tests/test_mol_graph_conv_featurizer.py
@@ -1,6 +1,7 @@
 import unittest
 
 from deepchem.feat import MolGraphConvFeaturizer
+from deepchem.feat import PagtnMolGraphFeaturizer
 
 
 class TestMolGraphConvFeaturizer(unittest.TestCase):
@@ -70,3 +71,24 @@ class TestMolGraphConvFeaturizer(unittest.TestCase):
     assert graph_feat[1].num_nodes == 22
     assert graph_feat[1].num_node_features == 31
     assert graph_feat[1].num_edges == 44
+
+
+class TestPagtnMolGraphConvFeaturizer(unittest.TestCase):
+
+  def test_default_featurizer(self):
+    smiles = ["C1=CC=CN=C1", "O=C(NCc1cc(OC)c(O)cc1)CCCC/C=C/C(C)C"]
+    featurizer = PagtnMolGraphFeaturizer(max_length=5)
+    graph_feat = featurizer.featurize(smiles)
+    assert len(graph_feat) == 2
+
+    # assert "C1=CC=CN=C1"
+    assert graph_feat[0].num_nodes == 6
+    assert graph_feat[0].num_node_features == 94
+    assert graph_feat[0].num_edges == 36
+    assert graph_feat[0].num_edge_features == 42
+
+    # assert "O=C(NCc1cc(OC)c(O)cc1)CCCC/C=C/C(C)C"
+    assert graph_feat[1].num_nodes == 22
+    assert graph_feat[1].num_node_features == 94
+    assert graph_feat[1].num_edges == 484
+    assert graph_feat[0].num_edge_features == 42

--- a/deepchem/utils/molecule_feature_utils.py
+++ b/deepchem/utils/molecule_feature_utils.py
@@ -30,6 +30,7 @@ DEFAULT_ATOM_TYPE_SET = [
 ]
 DEFAULT_HYBRIDIZATION_SET = ["SP", "SP2", "SP3"]
 DEFAULT_TOTAL_NUM_Hs_SET = [0, 1, 2, 3, 4]
+DEFAULT_FORMAL_CHARGE_SET = [-2, -1, 0, 1, 2]
 DEFAULT_TOTAL_DEGREE_SET = [0, 1, 2, 3, 4, 5]
 DEFAULT_RING_SIZE_SET = [3, 4, 5, 6, 7, 8]
 DEFAULT_BOND_TYPE_SET = ["SINGLE", "DOUBLE", "TRIPLE", "AROMATIC"]
@@ -306,6 +307,31 @@ def get_atom_formal_charge(atom: RDKitAtom) -> List[float]:
     A vector of the formal charge.
   """
   return [float(atom.GetFormalCharge())]
+
+
+def get_atom_formal_charge_one_hot(
+    atom: RDKitAtom,
+    allowable_set: List[int] = DEFAULT_FORMAL_CHARGE_SET,
+    include_unknown_set: bool = True) -> List[float]:
+  """Get one hot encoding of formal charge of an atom.
+
+  Parameters
+  ---------
+  atom: rdkit.Chem.rdchem.Atom
+    RDKit atom object
+  allowable_set: List[int]
+    The degree to consider. The default set is `[-2, -1, ..., 2]`
+  include_unknown_set: bool, default True
+    If true, the index of all types not in `allowable_set` is `len(allowable_set)`.
+
+
+  Returns
+  -------
+  List[float]
+    A vector of the formal charge.
+  """
+  return one_hot_encode(atom.GetFormalCharge(), allowable_set,
+                        include_unknown_set)
 
 
 def get_atom_partial_charge(atom: RDKitAtom) -> List[float]:

--- a/deepchem/utils/test/test_molecule_feature_utils.py
+++ b/deepchem/utils/test/test_molecule_feature_utils.py
@@ -9,6 +9,8 @@ from deepchem.utils.molecule_feature_utils import get_atom_total_num_Hs_one_hot
 from deepchem.utils.molecule_feature_utils import get_atom_is_in_aromatic_one_hot
 from deepchem.utils.molecule_feature_utils import get_atom_chirality_one_hot
 from deepchem.utils.molecule_feature_utils import get_atom_formal_charge
+from deepchem.utils.molecule_feature_utils import get_atom_formal_charge_one_hot
+
 from deepchem.utils.molecule_feature_utils import get_atom_partial_charge
 from deepchem.utils.molecule_feature_utils import get_atom_total_degree_one_hot
 from deepchem.utils.molecule_feature_utils import get_atom_implicit_valence_one_hot
@@ -118,6 +120,12 @@ class TestGraphConvUtils(unittest.TestCase):
     assert atoms[0].GetSymbol() == "C"
     formal_charge = get_atom_formal_charge(atoms[0])
     assert formal_charge == [0.0]
+
+  def test_get_atom_formal_charge_one_hot(self):
+    atoms = self.mol.GetAtoms()
+    assert atoms[0].GetSymbol() == "C"
+    formal_charge = get_atom_formal_charge_one_hot(atoms[0])
+    assert formal_charge == [0.0, 0.0, 1.0, 0.0, 0.0, 0.0]
 
   def test_get_atom_partial_charge(self):
     from rdkit.Chem import AllChem

--- a/docs/source/api_reference/featurizers.rst
+++ b/docs/source/api_reference/featurizers.rst
@@ -74,6 +74,13 @@ MolGraphConvFeaturizer
   :members:
   :inherited-members:
 
+PagtnMolGraphFeaturizer
+**********************
+
+.. autoclass:: deepchem.feat.PagtnMolGraphFeaturizer
+  :members:
+  :inherited-members:
+
 Utilities
 *********
 


### PR DESCRIPTION
Building the wrapper function for PAGTN model https://github.com/deepchem/deepchem/issues/2389
The model and featurisers are already built in DGL-Lifesci [#138](https://github.com/awslabs/dgl-lifesci/pull/138) [#139](https://github.com/awslabs/dgl-lifesci/pull/139) and now needs a wrapping function.

In this PR I'm adding - 
1) PAGTN featurisation (constructs a complete MolGraph)
2) A useful utility for building MolGraphs -> One hot encoding of formal charge of an Rdkit.Atom