### PR TITLE
Tokenizer fix

### DIFF
--- a/deepchem/feat/smiles_tokenizer.py
+++ b/deepchem/feat/smiles_tokenizer.py
@@ -86,8 +86,8 @@ class SmilesTokenizer(BertTokenizer):
 
     super().__init__(vocab_file, **kwargs)
     # take into account special tokens in max length
-    self.max_len_single_sentence = self.max_len - 2
-    self.max_len_sentences_pair = self.max_len - 3
+    self.max_len_single_sentence = self.model_max_length - 2
+    self.max_len_sentences_pair = self.model_max_length - 3
 
     if not os.path.isfile(vocab_file):
       raise ValueError(
@@ -98,7 +98,7 @@ class SmilesTokenizer(BertTokenizer):
     self.ids_to_tokens = collections.OrderedDict(
         [(ids, tok) for tok, ids in self.vocab.items()])
     self.basic_tokenizer = BasicSmilesTokenizer()
-    self.init_kwargs["max_len"] = self.max_len
+    self.init_kwargs["model_max_length"] = self.model_max_length
 
   @property
   def vocab_size(self):


### PR DESCRIPTION

## Description

Fix #2519 where max_len is deprecated in Huggingface transformer library.

<!-- Please include a summary of the change and which issue is fixed.
modified max_len variable name in smiles_tokenizer.py to model_max_length
List any dependencies that are required for this change. -->
none

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
