### PR TITLE
Update rdkit_utils.py

### DIFF
--- a/deepchem/utils/rdkit_utils.py
+++ b/deepchem/utils/rdkit_utils.py
@@ -277,6 +277,7 @@ def load_molecule(molecule_file,
     raise ValueError("Unable to read non None Molecule Object")
 
   if add_hydrogens or calc_charges:
+    my_mol.UpdatePropertyCache(strict=False)
     my_mol = apply_pdbfixer(
         my_mol, hydrogenate=add_hydrogens, is_protein=is_protein)
   if sanitize:


### PR DESCRIPTION

## Description

Fix #(issue)

This change resolves the RuntimeError: Pre-condition Violation
	getExplicitValence() called without call to calcExplicitValence() error in Docking PoseGenerator.



## Type of change

Please check the option that is related to your PR.

- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [* ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [* ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ *] Run `mypy -p deepchem` and check no errors
  - [ *] Run `flake8 <modified file> --count` and check no errors
- [ *] I have performed a self-review of my own code
- [ *] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ *] I have checked my code and corrected any misspellings
