### PR TITLE
Fixed errors in training models with uncertainty

### DIFF
--- a/deepchem/models/graph_models.py
+++ b/deepchem/models/graph_models.py
@@ -693,8 +693,19 @@ class DAGModel(KerasModel):
         output_types = ['prediction', 'variance', 'loss', 'loss']
 
         def loss(outputs, labels, weights):
-          diff = labels[0] - outputs[0]
-          return tf.reduce_mean(diff * diff / tf.exp(outputs[1]) + outputs[1])
+          output, labels = dc.models.losses._make_tf_shapes_consistent(
+              outputs[0], labels[0])
+          output, labels = dc.models.losses._ensure_float(output, labels)
+          losses = tf.square(output - labels) / tf.exp(outputs[1]) + outputs[1]
+          w = weights[0]
+          if len(w.shape) < len(losses.shape):
+            if tf.is_tensor(w):
+              shape = tuple(w.shape.as_list())
+            else:
+              shape = w.shape
+            shape = tuple(-1 if x is None else x for x in shape)
+            w = tf.reshape(w, shape + (1,) * (len(losses.shape) - len(w.shape)))
+          return tf.reduce_mean(losses * w) + sum(self.model.losses)
       else:
         outputs = [output]
         output_types = ['prediction']
@@ -961,8 +972,19 @@ class GraphConvModel(KerasModel):
         output_types = ['prediction', 'variance', 'loss', 'loss', 'embedding']
 
         def loss(outputs, labels, weights):
-          diff = labels[0] - outputs[0]
-          return tf.reduce_mean(diff * diff / tf.exp(outputs[1]) + outputs[1])
+          output, labels = dc.models.losses._make_tf_shapes_consistent(
+              outputs[0], labels[0])
+          output, labels = dc.models.losses._ensure_float(output, labels)
+          losses = tf.square(output - labels) / tf.exp(outputs[1]) + outputs[1]
+          w = weights[0]
+          if len(w.shape) < len(losses.shape):
+            if tf.is_tensor(w):
+              shape = tuple(w.shape.as_list())
+            else:
+              shape = w.shape
+            shape = tuple(-1 if x is None else x for x in shape)
+            w = tf.reshape(w, shape + (1,) * (len(losses.shape) - len(w.shape)))
+          return tf.reduce_mean(losses * w) + sum(self.model.losses)
       else:
         output_types = ['prediction', 'embedding']
         loss = L2Loss()
@@ -1102,8 +1124,19 @@ class MPNNModel(KerasModel):
         output_types = ['prediction', 'variance', 'loss', 'loss']
 
         def loss(outputs, labels, weights):
-          diff = labels[0] - outputs[0]
-          return tf.reduce_mean(diff * diff / tf.exp(outputs[1]) + outputs[1])
+          output, labels = dc.models.losses._make_tf_shapes_consistent(
+              outputs[0], labels[0])
+          output, labels = dc.models.losses._ensure_float(output, labels)
+          losses = tf.square(output - labels) / tf.exp(outputs[1]) + outputs[1]
+          w = weights[0]
+          if len(w.shape) < len(losses.shape):
+            if tf.is_tensor(w):
+              shape = tuple(w.shape.as_list())
+            else:
+              shape = w.shape
+            shape = tuple(-1 if x is None else x for x in shape)
+            w = tf.reshape(w, shape + (1,) * (len(losses.shape) - len(w.shape)))
+          return tf.reduce_mean(losses * w) + sum(self.model.losses)
       else:
         outputs = [output]
         output_types = ['prediction']

--- a/deepchem/models/tests/test_overfit.py
+++ b/deepchem/models/tests/test_overfit.py
@@ -679,6 +679,17 @@ def test_multitask_regressor_uncertainty():
   assert noise < np.mean(std) < 1.0
 
 
+def test_multitask_regressor_delaney_uncertainty():
+  """Test computing uncertainty on a larger dataset."""
+  tasks, datasets, transformers = dc.molnet.load_delaney('ECFP')
+  train_dataset, valid_dataset, test_dataset = datasets
+  model = dc.models.MultitaskRegressor(len(tasks), 1024, uncertainty=True)
+  model.fit(train_dataset, nb_epoch=20)
+  metric = dc.metrics.Metric(dc.metrics.pearsonr)
+  scores = model.evaluate(test_dataset, [metric], transformers)
+  assert scores['pearsonr'] > 0.5
+
+
 @pytest.mark.slow
 def test_DAG_singletask_regression_overfit():
   """Test DAG regressor multitask overfits tiny data."""


### PR DESCRIPTION
Fixes #2422.

The specific problem that caused that error was not calling `_make_tf_shapes_consistent()`.  It also wasn't handling weights correctly, but that didn't affect that example since the dataset didn't use weights.  To be thorough, I just copied all the relevant code from the default loss function in KerasModel.