### PR TITLE
Chemberta lm

### DIFF
--- a/deepchem/models/torch_models/chemberta.py
+++ b/deepchem/models/torch_models/chemberta.py
@@ -5,13 +5,71 @@ Huggingface/transformers RoBERTa model for sequence-based property prediction.
 import torch.nn as nn
 import torch.nn.functional as F
 
-import transformers
-from transformers import RobertaForMaskedLM
-
-
 class ChemBERTa(nn.Module):
-    def __init__(self):
+    # defaults here match HF model: DeepChem/SmilesTokenizer_PubChem_1M.
+    # TODO - figure out which to use as default, and which to pass to model class
+    def __init__(self,
+                vocab_size =600,
+                max_position_embedddings = 515,
+                number_attention_heads = 12,
+                num_hidden_layers = 6,
+                type_vocab_size = 1,
+                mode = 'pre-trained',
+                model_path = 'DeepChem/SmilesTokenizer_PubChem_1M',
+                tokenizer_path = 'tokenizers/',
+                tokenizer_type = 0, # if 0 - BPE, else if 1 - ST
+                max_tokenizer_len = 512,
+                **kwargs):
+
         try:
             import transformers
         except:
             raise ImportError('This class requires transformers.')
+
+
+    from transformers import RobertaForMaskedLM
+    from transformers import RobertaConfig
+    from transformers import RobertaTokenizerFast
+
+    ''' basic flow -
+
+    if loading pre-trained weights:
+        grab pre-trained model
+        grab pre-trained tokenizer (this will soon call dc.feat.RobertaFeaturizer)
+
+    else: (from scratch training):
+        generate config with suitable model params
+        load model with given config
+    '''
+
+    if mode not in ['pre-trained', 'non-trained']:
+        raise ValueError("mode must be either 'pre-trained' or 'non-trained'")
+
+
+    if mode == 'pre-trained':
+        self.model = RobertaForMaskedLM.from_pretrained(model_path)
+
+        # this will be replaaced when the RobertaFeautirzer (Walid's PR) is merged.
+        self.tokenizer = RobertaTokenizerFast.from_pretrained(model_path, max_len=max_tokenizer_len)
+
+    else:
+        self.config = RobertaConfig(
+            vocab_size=vocab_size,
+            max_position_embeddings=max_position_embeddings,
+            num_attention_heads=num_attention_heads,
+            num_hidden_layers=num_hidden_layers,
+            type_vocab_size=type_vocab_size,
+        )
+
+        self.model = RobertaForMaskedLM(config=config)
+
+        if tokenizer_type == 0:
+            print('hey')
+
+        else:
+            print ('load ST tokenizer')
+
+
+    super(ChemBERTa, self).__init__(
+        model, **kwargs)
+

--- a/deepchem/models/torch_models/chemberta.py
+++ b/deepchem/models/torch_models/chemberta.py
@@ -4,6 +4,7 @@ Huggingface/transformers RoBERTa model for sequence-based property prediction.
 
 import torch.nn as nn
 import torch.nn.functional as F
+import os
 
 class ChemBERTa(nn.Module):
     # defaults here match HF model: DeepChem/SmilesTokenizer_PubChem_1M.
@@ -14,11 +15,14 @@ class ChemBERTa(nn.Module):
                 number_attention_heads = 12,
                 num_hidden_layers = 6,
                 type_vocab_size = 1,
+                dataset_path = '',
                 mode = 'pre-trained',
                 model_path = 'DeepChem/SmilesTokenizer_PubChem_1M',
-                tokenizer_path = 'tokenizers/',
+                tokenizer_output_dir = 'tokenizer/',
+                model_output_dir = 'model/',
                 tokenizer_type = 0, # if 0 - BPE, else if 1 - ST
                 max_tokenizer_len = 512,
+                BPE_min_frequency = 2,
                 **kwargs):
 
         try:
@@ -27,49 +31,58 @@ class ChemBERTa(nn.Module):
             raise ImportError('This class requires transformers.')
 
 
-    from transformers import RobertaForMaskedLM
-    from transformers import RobertaConfig
-    from transformers import RobertaTokenizerFast
+        from transformers import RobertaForMaskedLM
+        from transformers import RobertaConfig
+        from transformers import RobertaTokenizerFast
 
-    ''' basic flow -
+        ''' basic flow -
 
-    if loading pre-trained weights:
-        grab pre-trained model
-        grab pre-trained tokenizer (this will soon call dc.feat.RobertaFeaturizer)
+        if loading pre-trained weights:
+            grab pre-trained model
+            grab pre-trained tokenizer (this will soon call dc.feat.RobertaFeaturizer)
 
-    else: (from scratch training):
-        generate config with suitable model params
-        load model with given config
-    '''
+        else: (from scratch training):
+            generate config with suitable model params
+            load model with given config
+        '''
 
-    if mode not in ['pre-trained', 'non-trained']:
-        raise ValueError("mode must be either 'pre-trained' or 'non-trained'")
+        if mode not in ['pre-trained', 'non-trained']:
+            raise ValueError("mode must be either 'pre-trained' or 'non-trained'")
 
 
-    if mode == 'pre-trained':
-        self.model = RobertaForMaskedLM.from_pretrained(model_path)
+        if mode == 'pre-trained':
+            self.model = RobertaForMaskedLM.from_pretrained(model_path)
 
-        # this will be replaaced when the RobertaFeautirzer (Walid's PR) is merged.
-        self.tokenizer = RobertaTokenizerFast.from_pretrained(model_path, max_len=max_tokenizer_len)
-
-    else:
-        self.config = RobertaConfig(
-            vocab_size=vocab_size,
-            max_position_embeddings=max_position_embeddings,
-            num_attention_heads=num_attention_heads,
-            num_hidden_layers=num_hidden_layers,
-            type_vocab_size=type_vocab_size,
-        )
-
-        self.model = RobertaForMaskedLM(config=config)
-
-        if tokenizer_type == 0:
-            print('hey')
+            # this will be replaaced when the RobertaFeautirzer (Walid's PR) is merged.
+            self.tokenizer = RobertaTokenizerFast.from_pretrained(model_path, max_len=max_tokenizer_len)
 
         else:
-            print ('load ST tokenizer')
+            self.config = RobertaConfig(
+                vocab_size=vocab_size,
+                max_position_embeddings=max_position_embedddings,
+                num_attention_heads=number_attention_heads,
+                num_hidden_layers=num_hidden_layers,
+                type_vocab_size=type_vocab_size,
+            )
 
+            self.model = RobertaForMaskedLM(config=self.config)
 
-    super(ChemBERTa, self).__init__(
-        model, **kwargs)
+            if tokenizer_type == 0: # generate novel BPE tokenizer for dataset
+                from transformers import ByteLevelBPETokenizer
+
+                tokenizer_path = tokenizer_output_dir
+                if not os.path.isdir(tokenizer_path):
+                    os.makedirs(tokenizer_path)
+
+                tokenizer = ByteLevelBPETokenizer()
+                tokenizer.train(files=dataset_path, vocab_size=vocab_size, min_frequency=BPE_min_frequency, special_tokens=["<s>","<pad>","</s>","<unk>","<mask>"])
+                tokenizer.save_model(tokenizer_path)
+            else: # just assign huggingface hub model path
+                tokenizer_path = model_path
+                print ('load ST tokenizer')
+
+        tokenizer = RobertaTokenizerFast.from_pretrained(tokenizer_path, max_tokenizer_len)
+
+        super(ChemBERTa, self).__init__(
+            model, **kwargs)
 

--- a/deepchem/models/torch_models/chemberta.py
+++ b/deepchem/models/torch_models/chemberta.py
@@ -1,0 +1,17 @@
+"""
+Huggingface/transformers RoBERTa model for sequence-based property prediction.
+"""
+
+import torch.nn as nn
+import torch.nn.functional as F
+
+import transformers
+from transformers import RobertaForMaskedLM
+
+
+class ChemBERTa(nn.Module):
+    def __init__(self):
+        try:
+            import transformers
+        except:
+            raise ImportError('This class requires transformers.')


### PR DESCRIPTION
# Pull Request Template

## Description

Add a wrapper for ChemBERTa's Masked language model.

Relies on ChemBERTa for base torch model with masked head, but wraps training + dataset functionalities into model class.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist
This is a WIP PR so styling, comments, etc have not been added yet.

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings


The main thing I'm wondering about is whether I can overwrite TorchModel's `fit()` method as done so here, so I can pass the train and eval dataset to HuggingFace's trainer API (this is the basic flow of how ChemBERTa models, datasets and metrics are passed to the Trainer class).

@rbharath Would love your thoughts here! Its still not finished and need to tidy up a lot of the code but wanted to push this here to get your thoughts on the fit() method.