### PR TITLE
FASTALoader accepting arbitrary featurizers

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -924,7 +924,6 @@ class FASTALoader(DataLoader):
       yield X, None, None, ids # TODO discuss shape
 
     def _read_file(input_file: str, auto_add_annotations: bool=False):
-      sequences = np.array([])
       """
       Convert the FASTA file to a numpy array of FASTA-format strings.
       """
@@ -932,20 +931,21 @@ class FASTALoader(DataLoader):
         """
         Uses a fasta_file to create a numpy array of annotated FASTA-format strings 
         """
+        sequences = np.array([])
         protein = []
         header_read = False
         for line in fasta_file:
           # Check if line is a header
           if line.startswith(header_mark): # New header line
             header_read = True
-            sequences = _add_sequence(protein)
+            sequences = _add_sequence(sequences, protein)
             protein = []
           elif header_read == True: # Line contains protein sequence in FASTA format 
             protein.append(line)
-        sequences = _add_sequence(protein)
+        sequences = _add_sequence(sequences, protein)
         return sequences
 
-      def _add_sequence(protein: list) -> np.array:
+      def _add_sequence(sequences: np.array, protein: list) -> np.array:
         if protein == None or len(protein) <= 0:
           logger.warning("Attempting to add empty protein sequence, returning empty array...")
           return np.array([])

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -955,7 +955,6 @@ class FASTALoader(DataLoader):
       for input_file in input_files:
         sequences = np.append(sequences, _read_file(input_file))
       X = self.featurizer(sequences)
-      logger.warning(X)
       ids = np.ones(len(X))
       # (X, y, w, ids)
       yield X, None, None, ids 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -17,6 +17,7 @@ from deepchem.utils.data_utils import load_image_files, load_csv_files, load_jso
 from deepchem.utils.genomics_utils import encode_bio_sequence
 from deepchem.feat import UserDefinedFeaturizer, Featurizer
 from deepchem.data import Dataset, DiskDataset, NumpyDataset, ImageDataset
+from deepchem.feat.molecule_featurizers import OneHotFeaturizer
 
 from more-itertools import peekable
 
@@ -877,7 +878,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer: Featurizer):
+  def __init__(self, featurizer: Featurizer = OneHotFeaturizer()):
     self.user_specified_features = None
     if isinstance(featurizer, UserDefinedFeaturizer):
       self.user_specified_features = featurizer.feature_fields
@@ -916,7 +917,7 @@ class FASTALoader(DataLoader):
       sequences = np.array([])
       for input_file in input_files:
         np.append(sequences, _read_file(input_file))
-      yield self.featurizer(sequences)
+      yield self.featurizer(sequences), None, None, ids # TODO discuss shape
       """
       X = encode_bio_sequence(input_file)
       ids = np.ones(len(X))

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -905,7 +905,7 @@ class FASTALoader(DataLoader):
 
     try:
       self.charset = charsets[charset]
-    except KeyError:
+    except:
       logger.exception("charset is invalid. Charset must be "protein", "nucleic", or "ATCGN".")
     max_length = len(self.charset)
 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -959,7 +959,7 @@ class FASTALoader(DataLoader):
         if sequence == None or len(sequence) <= 0:
           logger.warning("Attempting to add empty sequence, returning empty array...")
           return np.array([])
-        # Annotate start/stop of sequence 
+        # Annotate start/stop of sequence
         if auto_add_annotations:
           sequence.insert(0, "[CLS]")
           sequence.append("[SEP]")

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer = OneHotFeaturizer, charset: str = "ATCGN"):
+  def __init__(self, featurizer = OneHotFeaturizer, charset: str = "ATCGN", max_length = 58):
     """Initialize FASTALoader.
 
     Parameters
@@ -902,12 +902,10 @@ class FASTALoader(DataLoader):
                   'B', 'D', 'H', 'V', 'N', '-'),
       "ATCGN": ('A', 'T', 'C', 'G', 'N')
     }
-
     try:
       self.charset = charsets[charset]
     except:
       logger.exception("charset is invalid. charset must be 'protein', 'nucleic', or 'ATCGN'.")
-    max_length = len(self.charset)  # TODO: Figure out how to set max length
 
     self.user_specified_features = None
     if isinstance(featurizer, UserDefinedFeaturizer):

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -876,6 +876,13 @@ class FASTALoader(DataLoader):
   """
 
   def __init__(self, featurizer: Featurizer = OneHotFeaturizer()):
+    """Initialize FASTALoader.
+
+    Parameters
+    ----------
+    featurizer: Featurizer (default: OneHotFeaturizer())
+      The Featurizer to be used for the loaded FASTA data.
+    """
     self.user_specified_features = None
     if isinstance(featurizer, UserDefinedFeaturizer):
       self.user_specified_features = featurizer.feature_fields

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -911,7 +911,6 @@ class FASTALoader(DataLoader):
       self.user_specified_features = featurizer.feature_fields
 
     if (featurizer == OneHotFeaturizer):
-      logger.warning(f"CHARSET IS {self.charset}")
       featurizer = OneHotFeaturizer(self.charset, max_length)
     else:
       featurizer = featurizer()

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -914,7 +914,6 @@ class FASTALoader(DataLoader):
       self.user_specified_features = featurizer.feature_fields
 
     if (featurizer == OneHotFeaturizer):
-      logger.warning(f"CHARSET IS {self.charset}")
       featurizer = OneHotFeaturizer(self.charset, max_length)
     else:
       featurizer = featurizer()

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer = OneHotFeaturizer, charset: Optional[str] = "ATCGN", max_length: Optional[int] = None):
+  def __init__(self, featurizer = OneHotFeaturizer, charset: Optional[str] = "ATCGN", max_length: Optional[int] = None, validate: bool = True):
     """Initialize FASTALoader.
 
     Parameters
@@ -892,7 +892,6 @@ class FASTALoader(DataLoader):
       full FASTA-format protein sequences, and full FASTA format nucleic acid
       sequences.
       Currently acceptable charsets are: "protein", "nucleic", and "ATCGN".
-      This argument is currently only used if featurizer = OneHotFeaturizer.
 
     max_length: Optional[int] (default: None)
       max_length is only used if featurizer = OneHotFeaturizer.
@@ -920,10 +919,7 @@ class FASTALoader(DataLoader):
     if isinstance(featurizer, UserDefinedFeaturizer):
       self.user_specified_features = featurizer.feature_fields
 
-    if (featurizer == OneHotFeaturizer):
-      featurizer = OneHotFeaturizer(self.charset, max_length)
-    else:
-      featurizer = featurizer()
+    featurizer = featurizer(charset = self.charset, max_length = max_length)
 
     self.featurizer = featurizer
 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -898,6 +898,10 @@ class FASTALoader(DataLoader):
     ----------
     input_files: List[str]
       List of fasta files.
+    auto_add_annotations: bool (default False)
+      Whether create_dataset will automatically add [CLS] and [SEP] annotations
+      to the protein sequences it reads in order to assist tokenization.
+      Keep False if your FASTA file already includes [CLS] and [SEP] annotations.
     data_dir: str, optional (default None)
       Name of directory where featurized data is stored.
     shard_size: int, optional (default None)

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer: Featurizer = OneHotFeaturizer, protein = False):
+  def __init__(self, featurizer: Featurizer = OneHotFeaturizer, protein = False, max_length = 100):
     """Initialize FASTALoader.
 
     Parameters
@@ -886,6 +886,10 @@ class FASTALoader(DataLoader):
     protein: bool (default: False)
       Whether or not the sequence passed in is a protein sequence. If False,
       it is treated as a nucleic acid sequence.
+
+    max_length: int (default: 100)
+      The maximum length of a string in the FASTA file. If Featurizer = OneHotFeaturizer,
+      all one hot encodings will be padded to this length.
     """
     protein_charset = ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K',
                        'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V',
@@ -898,9 +902,11 @@ class FASTALoader(DataLoader):
       self.user_specified_features = featurizer.feature_fields
     if (featurizer == OneHotFeaturizer):
       if (protein):
-        featurizer = OneHotFeaturizer(protein_charset)
+        featurizer = OneHotFeaturizer(protein_charset, max_length)
       else:
-        featurizer = OneHotFeaturizer(nucleic_charset)
+        featurizer = OneHotFeaturizer(nucleic_charset, max_length)
+    else:
+      featurizer = featurizer()
     self.featurizer = featurizer
 
   def create_dataset(self,
@@ -944,7 +950,7 @@ class FASTALoader(DataLoader):
       X = self.featurizer(sequences)
       logger.warning(f"**TESTING** FINAL FEATURIZED ARRAY: {X}")
       ids = np.ones(len(X))
-      # (X, y, w, ids) TODO discuss shape
+      # (X, y, w, ids)
       yield X, None, None, ids 
 
     def _read_file(input_file: str, auto_add_annotations: bool=False):

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -938,7 +938,7 @@ class FASTALoader(DataLoader):
           # Check if line is a header
           if line.startswith(header_mark): # New header line
             header_read = True
-            _add_sequence(protein)
+            sequences = _add_sequence(protein)
             protein = []
           elif header_read == True: # Line contains protein sequence in FASTA format 
             protein.append(line)

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -21,6 +21,7 @@ from deepchem.feat.molecule_featurizers import OneHotFeaturizer
 
 logger = logging.getLogger(__name__)
 
+
 def _convert_df_to_numpy(df: pd.DataFrame,
                          tasks: List[str]) -> Tuple[np.ndarray, np.ndarray]:
   """Transforms a dataframe containing deepchem input into numpy arrays
@@ -488,8 +489,8 @@ class UserCSVLoader(CSVLoader):
     shard[feature_fields] = shard[feature_fields].apply(pd.to_numeric)
     X_shard = shard[feature_fields].to_numpy()
     time2 = time.time()
-    logger.info(
-        "TIMING: user specified processing took %0.3f s" % (time2 - time1))
+    logger.info("TIMING: user specified processing took %0.3f s" %
+                (time2 - time1))
     return (X_shard, np.ones(len(X_shard), dtype=bool))
 
 
@@ -831,11 +832,10 @@ class SDFLoader(DataLoader):
     Iterator[pd.DataFrame]
       Iterator over shards
     """
-    return load_sdf_files(
-        input_files=input_files,
-        clean_mols=self.sanitize,
-        tasks=self.tasks,
-        shard_size=shard_size)
+    return load_sdf_files(input_files=input_files,
+                          clean_mols=self.sanitize,
+                          tasks=self.tasks,
+                          shard_size=shard_size)
 
   def _featurize_shard(self,
                        shard: pd.DataFrame) -> Tuple[np.ndarray, np.ndarray]:
@@ -875,7 +875,9 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer: Featurizer = OneHotFeaturizer, charset: str = "ATCGN"):
+  def __init__(self,
+               featurizer: Featurizer = OneHotFeaturizer,
+               charset: str = "ATCGN"):
     """Initialize FASTALoader.
 
     Parameters
@@ -895,12 +897,12 @@ class FASTALoader(DataLoader):
       Currently acceptable charsets are: "protein", "nucleic", and "ATCGN".
     """
     charsets = {
-      "protein": ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-                  'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-                  'Y', 'Z', '*', '-'),
-      "nucleic": ('A', 'C', 'G', 'T', 'U', '(i)', 'R', 'Y', 'K', 'M', 'S', 'W',
-                  'B', 'D', 'H', 'V', 'N', '-'),
-      "ATCGN": ('A', 'T', 'C', 'G', 'N')
+        "protein": ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
+                    'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+                    'Y', 'Z', '*', '-'),
+        "nucleic": ('A', 'C', 'G', 'T', 'U', '(i)', 'R', 'Y', 'K', 'M', 'S',
+                    'W', 'B', 'D', 'H', 'V', 'N', '-'),
+        "ATCGN": ('A', 'T', 'C', 'G', 'N')
     }
 
     self.charset = charsets.get(charset)
@@ -957,13 +959,14 @@ class FASTALoader(DataLoader):
       X = self.featurizer(sequences)
       ids = np.ones(len(X))
       # (X, y, w, ids)
-      yield X, None, None, ids 
+      yield X, None, None, ids
 
-    def _read_file(input_file: str, auto_add_annotations: bool=False):
+    def _read_file(input_file: str, auto_add_annotations: bool = False):
       """
       Convert the FASTA file to a numpy array of FASTA-format strings.
       """
-      def _generate_sequences(fasta_file, header_mark = ">") -> np.array:
+
+      def _generate_sequences(fasta_file, header_mark=">") -> np.array:
         """
         Uses a fasta_file to create a numpy array of annotated FASTA-format strings 
         """
@@ -972,13 +975,13 @@ class FASTALoader(DataLoader):
         header_read = False
         for line in fasta_file:
           # Check if line is a header
-          if line.startswith(header_mark): # New header line
+          if line.startswith(header_mark):  # New header line
             header_read = True
             sequences = _add_sequence(sequences, sequence)
             sequence = []
-          elif header_read == True: # Line contains sequence in FASTA format
-            if line[-1:] == '\n': # Check last character in string
-              line = line[0:-1] # Remove last character
+          elif header_read == True:  # Line contains sequence in FASTA format
+            if line[-1:] == '\n':  # Check last character in string
+              line = line[0:-1]  # Remove last character
             sequence.append(line)
         sequences = _add_sequence(sequences, sequence)
         return sequences
@@ -986,7 +989,8 @@ class FASTALoader(DataLoader):
       def _add_sequence(sequences: np.array, sequence: list) -> np.array:
         # Handle empty sequence
         if sequence == None or len(sequence) <= 0:
-          logger.warning("Attempting to add empty sequence, returning empty array...")
+          logger.warning(
+              "Attempting to add empty sequence, returning empty array...")
           return np.array([])
         # Annotate start/stop of sequence
         if auto_add_annotations:
@@ -995,10 +999,11 @@ class FASTALoader(DataLoader):
         new_sequence = ''.join(sequence)
         return np.append(sequences, new_sequence)
 
-      with open(input_file, 'r') as f: # Read FASTA file
+      with open(input_file, 'r') as f:  # Read FASTA file
         return _generate_sequences(f)
 
     return DiskDataset.create_dataset(shard_generator(), data_dir)
+
 
 class ImageLoader(DataLoader):
   """Handles loading of image files.
@@ -1115,16 +1120,17 @@ class ImageLoader(DataLoader):
 
     if in_memory:
       if data_dir is None:
-        return NumpyDataset(
-            load_image_files(image_files), y=labels, w=weights, ids=image_files)
+        return NumpyDataset(load_image_files(image_files),
+                            y=labels,
+                            w=weights,
+                            ids=image_files)
       else:
-        dataset = DiskDataset.from_numpy(
-            load_image_files(image_files),
-            y=labels,
-            w=weights,
-            ids=image_files,
-            tasks=self.tasks,
-            data_dir=data_dir)
+        dataset = DiskDataset.from_numpy(load_image_files(image_files),
+                                         y=labels,
+                                         w=weights,
+                                         ids=image_files,
+                                         tasks=self.tasks,
+                                         data_dir=data_dir)
         if shard_size is not None:
           dataset.reshard(shard_size)
         return dataset
@@ -1268,8 +1274,8 @@ class InMemoryLoader(DataLoader):
 
   # FIXME: Signature of "_featurize_shard" incompatible with supertype "DataLoader"
   def _featurize_shard(  # type: ignore[override]
-      self, shard: List, global_index: int
-  ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+      self, shard: List, global_index: int) -> Tuple[np.ndarray, np.ndarray,
+                                                     np.ndarray, np.ndarray]:
     """Featurizes a shard of an input data.
 
     Parameters

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -947,20 +947,23 @@ class FASTALoader(DataLoader):
             header_read = True
             sequences = _add_sequence(sequences, protein)
             protein = []
-          elif header_read == True: # Line contains protein sequence in FASTA format 
+          elif header_read == True: # Line contains protein sequence in FASTA format
+            if line[-1:] == '\n': # Check last character in string
+              line = line[0:-1] # Remove last character
             protein.append(line)
         sequences = _add_sequence(sequences, protein)
         return sequences
 
       def _add_sequence(sequences: np.array, protein: list) -> np.array:
+        # Handle empty sequence
         if protein == None or len(protein) <= 0:
           logger.warning("Attempting to add empty protein sequence, returning empty array...")
           return np.array([])
-        if auto_add_annotations: # Annotate start/stop of protein
+        # Annotate start/stop of protein
+        if auto_add_annotations:
           protein.insert(0, "[CLS]")
           protein.append("[SEP]")
         new_sequence = ''.join(protein)
-        logger.warning(sequences)
         return np.append(sequences, new_sequence)
 
       with open(input_file, 'r') as f: # Read FASTA file

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -933,7 +933,7 @@ class FASTALoader(DataLoader):
       """
       Convert the FASTA file to a numpy array of FASTA-format strings.
       """
-      def _generate_sequences(fasta_file, header_mark = ">") -> numpy.array:
+      def _generate_sequences(fasta_file, header_mark = ">") -> np.array:
         """
         Uses a fasta_file to create a numpy array of annotated FASTA-format strings 
         """

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -19,7 +19,7 @@ from deepchem.feat import UserDefinedFeaturizer, Featurizer
 from deepchem.data import Dataset, DiskDataset, NumpyDataset, ImageDataset
 from deepchem.feat.molecule_featurizers import OneHotFeaturizer
 
-from more-itertools import peekable
+from more_itertools import peekable
 
 logger = logging.getLogger(__name__)
 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -905,7 +905,7 @@ class FASTALoader(DataLoader):
 
     try:
       self.charset = charsets[charset]
-    except:
+    except KeyError:
       logger.exception("charset is invalid. Charset must be "protein", "nucleic", or "ATCGN".")
     max_length = len(self.charset)
 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer: Featurizer = OneHotFeaturizer, charset: str = "ATCGN"):
+  def __init__(self, featurizer = OneHotFeaturizer, charset: str = "ATCGN"):
     """Initialize FASTALoader.
 
     Parameters

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -904,7 +904,7 @@ class FASTALoader(DataLoader):
       List of fasta files.
     auto_add_annotations: bool (default False)
       Whether create_dataset will automatically add [CLS] and [SEP] annotations
-      to the protein sequences it reads in order to assist tokenization.
+      to the sequences it reads in order to assist tokenization.
       Keep False if your FASTA file already includes [CLS] and [SEP] annotations.
     data_dir: str, optional (default None)
       Name of directory where featurized data is stored.
@@ -939,31 +939,31 @@ class FASTALoader(DataLoader):
         Uses a fasta_file to create a numpy array of annotated FASTA-format strings 
         """
         sequences = np.array([])
-        protein = []
+        sequence = []
         header_read = False
         for line in fasta_file:
           # Check if line is a header
           if line.startswith(header_mark): # New header line
             header_read = True
-            sequences = _add_sequence(sequences, protein)
-            protein = []
-          elif header_read == True: # Line contains protein sequence in FASTA format
+            sequences = _add_sequence(sequences, sequence)
+            sequence = []
+          elif header_read == True: # Line contains sequence in FASTA format
             if line[-1:] == '\n': # Check last character in string
               line = line[0:-1] # Remove last character
-            protein.append(line)
-        sequences = _add_sequence(sequences, protein)
+            sequence.append(line)
+        sequences = _add_sequence(sequences, sequence)
         return sequences
 
-      def _add_sequence(sequences: np.array, protein: list) -> np.array:
+      def _add_sequence(sequences: np.array, sequence: list) -> np.array:
         # Handle empty sequence
-        if protein == None or len(protein) <= 0:
-          logger.warning("Attempting to add empty protein sequence, returning empty array...")
+        if sequence == None or len(sequence) <= 0:
+          logger.warning("Attempting to add empty sequence, returning empty array...")
           return np.array([])
-        # Annotate start/stop of protein
+        # Annotate start/stop of sequence 
         if auto_add_annotations:
-          protein.insert(0, "[CLS]")
-          protein.append("[SEP]")
-        new_sequence = ''.join(protein)
+          sequence.insert(0, "[CLS]")
+          sequence.append("[SEP]")
+        new_sequence = ''.join(sequence)
         return np.append(sequences, new_sequence)
 
       with open(input_file, 'r') as f: # Read FASTA file

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer = OneHotFeaturizer, charset: str = "ATCGN", max_length = 58):
+  def __init__(self, featurizer = OneHotFeaturizer, charset: str = "ATCGN", max_length = 58): # TODO: REMOVE MAX_LENGTH ARGUMENT BEFORE PR MERGE
     """Initialize FASTALoader.
 
     Parameters

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -906,8 +906,8 @@ class FASTALoader(DataLoader):
     try:
       self.charset = charsets[charset]
     except:
-      logger.exception("charset is invalid. Charset must be "protein", "nucleic", or "ATCGN".")
-    max_length = len(self.charset)
+      logger.exception("charset is invalid. charset must be 'protein', 'nucleic', or 'ATCGN'.")
+    max_length = len(self.charset)  # TODO: Figure out how to set max length
 
     self.user_specified_features = None
     if isinstance(featurizer, UserDefinedFeaturizer):

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer = OneHotFeaturizer, charset: Optional[str] = "ATCGN", max_length: Optional[int] = None, validate: bool = True):
+  def __init__(self, featurizer = OneHotFeaturizer, charset: Optional[str] = "ATCGN", max_length: Optional[int] = None):
     """Initialize FASTALoader.
 
     Parameters
@@ -920,7 +920,6 @@ class FASTALoader(DataLoader):
       self.user_specified_features = featurizer.feature_fields
 
     featurizer = featurizer(charset = self.charset, max_length = max_length)
-
     self.featurizer = featurizer
 
   def create_dataset(self,

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -905,12 +905,12 @@ class FASTALoader(DataLoader):
                   'Y', 'Z', '*', '-'),
       "nucleic": ('A', 'C', 'G', 'T', 'U', '(i)', 'R', 'Y', 'K', 'M', 'S', 'W',
                   'B', 'D', 'H', 'V', 'N', '-'),
-      "ATCGN": ('A', 'T', 'C', 'G', 'N')
+      "ATCGN": ('A', 'T', 'C', 'G')
     }
     try:
       self.charset = charsets[charset]
     except KeyError:
-      if (featurizer == OneHotFeaturizer):
+      if (featurizer == OneHotFeaturizer): # TODO EXPLICITLY CHECK IF FEATURIZER USES CHARSET
         logger.exception("charset is invalid. charset must be 'protein', 'nucleic', or 'ATCGN'.")
       else:
         logger.warning("charset is invalid, ignoring...")
@@ -919,7 +919,7 @@ class FASTALoader(DataLoader):
     if isinstance(featurizer, UserDefinedFeaturizer):
       self.user_specified_features = featurizer.feature_fields
 
-    featurizer = featurizer(charset = self.charset, max_length = max_length)
+    featurizer = featurizer(charset = self.charset, max_length = max_length) # TODO EXPLICITLY CHECK IF MAX_LENGTH IS DESIRED
     self.featurizer = featurizer
 
   def create_dataset(self,

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -903,7 +903,10 @@ class FASTALoader(DataLoader):
       "ATCGN": ('A', 'T', 'C', 'G', 'N')
     }
 
-    self.charset = charsets.get(charset)
+    try:
+      self.charset = charsets[charset]
+    except:
+      logger.exception("charset is invalid. Charset must be "protein", "nucleic", or "ATCGN".")
     max_length = len(self.charset)
 
     self.user_specified_features = None

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer = OneHotFeaturizer, charset: str = "ATCGN", max_length = 58): # TODO: REMOVE MAX_LENGTH ARGUMENT BEFORE PR MERGE
+  def __init__(self, featurizer = OneHotFeaturizer, charset: Optional[str] = "ATCGN", max_length: Optional[int] = None):
     """Initialize FASTALoader.
 
     Parameters
@@ -887,12 +887,18 @@ class FASTALoader(DataLoader):
       Whether or not the sequence passed in is a protein sequence. If False,
       it is treated as a nucleic acid sequence.
 
-    charset: str (default: ATCGN)
+    charset: Optional[str] (default: "ATCGN")
       The charset used in the loaded FASTA file. Currently, we support ATCGN,
       full FASTA-format protein sequences, and full FASTA format nucleic acid
       sequences.
-
       Currently acceptable charsets are: "protein", "nucleic", and "ATCGN".
+      This argument is currently only used if featurizer = OneHotFeaturizer.
+
+    max_length: Optional[int] (default: None)
+      max_length is only used if featurizer = OneHotFeaturizer.
+      The length that all strings are padded to before featurization.
+      max_length must be larger than the length of the longest string that is
+      being featurized.
     """
     charsets = {
       "protein": ('A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
@@ -904,8 +910,11 @@ class FASTALoader(DataLoader):
     }
     try:
       self.charset = charsets[charset]
-    except:
-      logger.exception("charset is invalid. charset must be 'protein', 'nucleic', or 'ATCGN'.")
+    except KeyError:
+      if (featurizer == OneHotFeaturizer):
+        logger.exception("charset is invalid. charset must be 'protein', 'nucleic', or 'ATCGN'.")
+      else:
+        logger.warning("charset is invalid, ignoring...")
 
     self.user_specified_features = None
     if isinstance(featurizer, UserDefinedFeaturizer):

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -875,7 +875,7 @@ class FASTALoader(DataLoader):
   learning tasks.
   """
 
-  def __init__(self, featurizer: Featurizer = OneHotFeaturizer, protein = True):
+  def __init__(self, featurizer: Featurizer = OneHotFeaturizer, protein = False):
     """Initialize FASTALoader.
 
     Parameters
@@ -883,7 +883,7 @@ class FASTALoader(DataLoader):
     featurizer: Featurizer (default: OneHotFeaturizer)
       The Featurizer to be used for the loaded FASTA data.
 
-    protein: bool (default: True)
+    protein: bool (default: False)
       Whether or not the sequence passed in is a protein sequence. If False,
       it is treated as a nucleic acid sequence.
     """

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -30,4 +30,4 @@ class TestFASTALoader(unittest.TestCase):
     if legacy:
       assert sequences.X.shape == (3, 5, 58, 1)
     else:
-      assert sequences.X.shape == (3, 58, 6)
+      assert sequences.X.shape == (3, 58, 5)

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -17,7 +17,7 @@ class TestFASTALoader(unittest.TestCase):
     self.current_dir = os.path.dirname(os.path.abspath(__file__))
 
   def test_fasta_load(self):
-    legacy = False # Whether to assume legacy one hot encoding shape from FASTA loader.
+    legacy = False  # Whether to assume legacy one hot encoding shape from FASTA loader.
 
     input_file = os.path.join(self.current_dir,
                               "../../data/tests/example.fasta")
@@ -27,7 +27,7 @@ class TestFASTALoader(unittest.TestCase):
     # example.fasta contains 3 sequences each of length 58.
     # The one-hot encoding turns base-pairs into vectors of length 5 (ATCGN).
     # There is one "image channel".
-    if (legacy == True):
+    if legacy:
       assert sequences.X.shape == (3, 5, 58, 1)
     else:
       assert sequences.X.shape == (3, 58, 6)

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -17,6 +17,8 @@ class TestFASTALoader(unittest.TestCase):
     self.current_dir = os.path.dirname(os.path.abspath(__file__))
 
   def test_fasta_load(self):
+    legacy = False
+
     input_file = os.path.join(self.current_dir,
                               "../../data/tests/example.fasta")
     loader = dc.data.FASTALoader()
@@ -25,4 +27,7 @@ class TestFASTALoader(unittest.TestCase):
     # example.fasta contains 3 sequences each of length 58.
     # The one-hot encoding turns base-pairs into vectors of length 5 (ATCGN).
     # There is one "image channel".
-    assert sequences.X.shape == (3, 5, 58, 1)
+    if (legacy == True):
+      assert sequences.X.shape == (3, 5, 58, 1)
+    else:
+      assert sequences.X.shape == (3, 58, 6)

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -17,7 +17,7 @@ class TestFASTALoader(unittest.TestCase):
     self.current_dir = os.path.dirname(os.path.abspath(__file__))
 
   def test_fasta_load(self):
-    legacy = False
+    legacy = False # Whether to assume legacy one hot encoding shape from FASTA loader.
 
     input_file = os.path.join(self.current_dir,
                               "../../data/tests/example.fasta")

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -97,7 +97,13 @@ class OneHotFeaturizer(Featurizer):
       The index of unknown character is `len(charset)`.
     """
     if max_length is not none:
+      if (len(string) > self.max_length):
+        logger.info(
+            "The length of {} is longer than `max_length`. So we return an empty array."
+        )
+        return np.array([])
       string = self.pad_string(string)  # Padding
+
     return np.array([
         one_hot_encode(val, self.charset, include_unknown_set=True)
         for val in string

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -48,7 +48,8 @@ class OneHotFeaturizer(Featurizer):
     self.charset = charset
     self.max_length = max_length
 
-  def featurize(self, datapoints: Iterable[Any],
+  def featurize(self,
+                datapoints: Iterable[Any],
                 log_every_n: int = 1000) -> np.ndarray:
     """Featurize strings or mols.
 
@@ -64,7 +65,9 @@ class OneHotFeaturizer(Featurizer):
       return np.array([])
 
     if (len(self.charset) > self.max_length):
-      logger.warning("Invalid for max_length to be larger than len(charset). Returning empty array.")
+      logger.warning(
+          "Invalid for max_length to be larger than len(charset). Returning empty array."
+      )
       return np.array([])
 
     # Featurize data using featurize() in parent class

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -72,7 +72,7 @@ class OneHotFeaturizer(Featurizer):
 
   def _featurize(self, datapoint: Any):
     # Featurize str data
-    if (isinstance(datapoint, (str, numpy.str_)):
+    if (isinstance(datapoint, (str, numpy.str_))):
       return self._featurize_string(datapoint)
     # Featurize mol data
     else:

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -62,12 +62,17 @@ class OneHotFeaturizer(Featurizer):
     datapoints = list(datapoints)
     if (len(datapoints) < 1):
       return np.array([])
+
+    if (len(self.charset) > self.max_length):
+      logger.warning("Invalid for max_length to be larger than len(charset). Returning empty array.")
+      return np.array([])
+
     # Featurize data using featurize() in parent class
     return Featurizer.featurize(self, datapoints, log_every_n)
 
   def _featurize(self, datapoint: Any):
     # Featurize str data
-    if (type(datapoint) == str):
+    if (isinstance(datapoint, (str, numpy.str_)):
       return self._featurize_string(datapoint)
     # Featurize mol data
     else:
@@ -88,13 +93,6 @@ class OneHotFeaturizer(Featurizer):
       The shape is `(max_length, len(charset) + 1)`.
       The index of unknown character is `len(charset)`.
     """
-    # validation
-    if (len(string) > self.max_length):
-      logger.info(
-          "The length of {} is longer than `max_length`. So we return an empty array."
-      )
-      return np.array([])
-
     string = self.pad_string(string)  # Padding
     return np.array([
         one_hot_encode(val, self.charset, include_unknown_set=True)

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -64,12 +64,6 @@ class OneHotFeaturizer(Featurizer):
     if (len(datapoints) < 1):
       return np.array([])
 
-    if (len(self.charset) > self.max_length):
-      logger.warning(
-          "Invalid for max_length to be larger than len(charset). Returning empty array."
-      )
-      return np.array([])
-
     # Featurize data using featurize() in parent class
     return Featurizer.featurize(self, datapoints, log_every_n)
 

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -62,7 +62,7 @@ class OneHotFeaturizer(Featurizer):
     datapoints = list(datapoints)
     if (len(datapoints) < 1):
       return np.array([])
-    # Featurize data using featurize() in grandparent class
+    # Featurize data using featurize() in parent class
     return Featurizer.featurize(self, datapoints, log_every_n)
 
   def _featurize(self, datapoint: Any):

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -72,7 +72,7 @@ class OneHotFeaturizer(Featurizer):
 
   def _featurize(self, datapoint: Any):
     # Featurize str data
-    if (isinstance(datapoint, (str, np.str_))):
+    if isinstance(datapoint, (str, np.str_)):
       return self._featurize_string(datapoint)
     # Featurize mol data
     else:

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -96,9 +96,9 @@ class OneHotFeaturizer(Featurizer):
       The shape is `(max_length, len(charset) + 1)`.
       The index of unknown character is `len(charset)`.
     """
-    if max_length is not none:
-      if (len(string) > self.max_length):
-        logger.info(
+    if self.max_length is not None:
+      if (len(string) > self.max_length):  # Validation
+        logger.warning(
             "The length of {} is longer than `max_length`. So we return an empty array."
         )
         return np.array([])

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -96,7 +96,8 @@ class OneHotFeaturizer(Featurizer):
       The shape is `(max_length, len(charset) + 1)`.
       The index of unknown character is `len(charset)`.
     """
-    string = self.pad_string(string)  # Padding
+    if max_length is not none:
+      string = self.pad_string(string)  # Padding
     return np.array([
         one_hot_encode(val, self.charset, include_unknown_set=True)
         for val in string

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -41,7 +41,7 @@ class OneHotFeaturizer(Featurizer):
       A list of strings, where each string is length 1 and unique.
     max_length: Optional[int], optional (default 100)
       The max length for string. If the length of string is shorter than
-      max_length, the SMILES is padded using space.
+      max_length, the string is padded using space.
     """
     if len(charset) != len(set(charset)):
       raise ValueError("All values in charset must be unique.")

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -6,7 +6,7 @@ import numpy as np
 from deepchem.utils.typing import RDKitMol
 from deepchem.utils.molecule_feature_utils import one_hot_encode
 from deepchem.feat.base_classes import Featurizer
-from typing import Any, Iterable
+from typing import Any, Iterable, Optional
 
 logger = logging.getLogger(__name__)
 

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -40,8 +40,8 @@ class OneHotFeaturizer(Featurizer):
     charset: List[str], optional (default ZINC_CHARSET)
       A list of strings, where each string is length 1 and unique.
     max_length: int, optional (default 100)
-      The max length for SMILES string. If the length of SMILES string is
-      shorter than max_length, the SMILES is padded using space.
+      The max length for string. If the length of string is shorter than
+      max_length, the SMILES is padded using space.
     """
     if len(charset) != len(set(charset)):
       raise ValueError("All values in charset must be unique.")

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -55,7 +55,7 @@ class OneHotFeaturizer(Featurizer):
     Parameters
     ----------
     datapoints: list
-      A list of either strings or RDKit molecules.
+      A list of either strings (str or numpy.str_) or RDKit molecules.
     log_every_n: int, optional (default 1000)
       How many elements are featurized every time a featurization is logged.
     """

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -72,7 +72,7 @@ class OneHotFeaturizer(Featurizer):
 
   def _featurize(self, datapoint: Any):
     # Featurize str data
-    if (isinstance(datapoint, (str, numpy.str_))):
+    if (isinstance(datapoint, (str, np.str_))):
       return self._featurize_string(datapoint)
     # Featurize mol data
     else:

--- a/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/one_hot_featurizer.py
@@ -32,14 +32,14 @@ class OneHotFeaturizer(Featurizer):
   It does not need RDKit to be installed to work with arbitrary strings.
   """
 
-  def __init__(self, charset: List[str] = ZINC_CHARSET, max_length: int = 100):
+  def __init__(self, charset: List[str] = ZINC_CHARSET, max_length: Optional[int] = 100):
     """Initialize featurizer.
 
     Parameters
     ----------
-    charset: List[str], optional (default ZINC_CHARSET)
+    charset: List[str] (default ZINC_CHARSET)
       A list of strings, where each string is length 1 and unique.
-    max_length: int, optional (default 100)
+    max_length: Optional[int], optional (default 100)
       The max length for string. If the length of string is shorter than
       max_length, the SMILES is padded using space.
     """


### PR DESCRIPTION
# Update FASTA Loader to accept arbitrary featurizers

## Description

Currently, the FASTALoader class only uses one hot encoding to featurize FASTA files.

It would be useful if the loader could be agnostic to featurizer, and allow users to use whatever featurizer they'd like.

This change is currently breaking, but I hope to make it non-breaking by making the default featurizer the one hot featurizer and thereby allowing one hot featurization by default.

- [X] Working with one hot featurizer
  - [X] Migrating from Biopython tools to DeepChem one hot featurizer
  - [X] Tests passing for one hot featurization
- [ ] Working with protein tokenizer 
  - [X] Making FASTALoader read FASTA files into numpy arrays of strings
  - [ ] Testing and iteration to ensure compatibility
- [X] Check OneHotFeaturizer tests still passing
- [ ] Working with arbitrary featurizers
  - [ ] New unit tests
- [ ] FASTA string validation (check that strings are FASTA format)
- [ ] Test on real-world FASTA files

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
