### PR TITLE
Setup for Jax dependency

### DIFF
--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -134,5 +134,5 @@ jobs:
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}
-      run: pytest -v -m "jax" --cov=deepchem --cov-report=xml deepchem
+      run: pytest -v -m jax --cov=deepchem --cov-report=xml deepchem
 

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -134,5 +134,4 @@ jobs:
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}
-      run: pytest -v -m jax --cov=deepchem --cov-report=xml deepchem
-
+      run: pytest -v -m jax

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -134,5 +134,5 @@ jobs:
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}
-      run: pytest -v -m "jax and not slow" --cov=deepchem --cov-report=xml deepchem
+      run: pytest -v -m "jax" --cov=deepchem --cov-report=xml deepchem
 

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Build DeepChem
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow'>=2.3,<2.4'
+        pip install tensorflow==2.4
         pip install -e '.[jax]'
     - name: Import checking
       run: python -c "import deepchem; import jax;"
@@ -134,4 +134,4 @@ jobs:
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}
-      run: pytest -v -m jax
+      run: pytest -v -m jax deepchem

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -94,6 +94,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Create env.yml
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip;
+        pip install conda-merge;
+        if [ "$(uname)" == 'Darwin' ]; then
+          conda-merge env_jax.yml env.test.yml > env.yml
+        else
+          conda-merge env_jax.yml env.test.yml > env.yml
+        fi;
     - name: Install all dependencies
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -102,7 +112,7 @@ jobs:
         activate-environment: deepchem
         channels: omnia,conda-forge,defaults
         python-version: ${{ matrix.python-version }}
-        environment-file: env_jax.yml
+        environment-file: env.yml
     - name: Install DeepChem
       id: install
       shell: bash -l {0}

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -1,4 +1,4 @@
-name: Test for DeepChem Core
+name: Test for DeepChem Jax
 on:
   push: # ci work when pushing master branch
     branches:
@@ -30,9 +30,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install tensorflow'>=2.3,<2.4'
-        pip install -e .
+        pip install -e '.[jax]'
     - name: Import checking
-      run: python -c "import deepchem"
+      run: python -c "import deepchem; import jax;"
 
   test:
     runs-on: ${{ matrix.os }}
@@ -94,19 +94,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install prerequisites for XGBoost and LightGBM (MacOS)
-      if: startsWith(runner.os, 'macOS')
-      run: brew update && brew install libomp
-    - name: Create env.yml
-      shell: bash
-      run: |
-        python -m pip install --upgrade pip;
-        pip install conda-merge;
-        if [ "$(uname)" == 'Darwin' ]; then
-          conda-merge env.common.yml env.cpu.mac.yml env.test.yml > env.yml
-        else
-          conda-merge env.common.yml env.cpu.yml env.test.yml > env.yml
-        fi;
     - name: Install all dependencies
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -115,11 +102,11 @@ jobs:
         activate-environment: deepchem
         channels: omnia,conda-forge,defaults
         python-version: ${{ matrix.python-version }}
-        environment-file: env.yml
+        environment-file: env_jax.yml
     - name: Install DeepChem
       id: install
       shell: bash -l {0}
-      run: pip install -e .
+      run: pip install -e '.[jax]'
     - name: Yapf (version 0.22.0)
       id: yapf
       # on Windows, yapf raise the strange error..., so ignore
@@ -134,75 +121,8 @@ jobs:
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}
       run: source scripts/flake8_for_ci.sh
-    - name: Mypy
-      if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
-      shell: bash -l {0}
-      run: mypy -p deepchem
-    - name: Doctest
-      if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
-      shell: bash -l {0}
-      run: DGLBACKEND=pytorch pytest -v --ignore-glob='deepchem/**/test*.py' --doctest-modules deepchem
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}
-      run: pytest -v -m "not slow and not jax" --cov=deepchem --cov-report=xml deepchem
-    - name: Upload coverage to Codecov
-      if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
+      run: pytest -v -m "jax and not slow" --cov=deepchem --cov-report=xml deepchem
 
-  pypi-build:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: '3.7'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install setuptools wheel twine
-    - name: Publish (Nightly)
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python setup.py sdist bdist_wheel
-        twine upload dist/*
-
-  docker-build:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [build, pypi-build]
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Docker Buildx
-      id: buildx
-      uses: docker/setup-buildx-action@master
-    - name: Cache Docker layers
-      uses: actions/cache@v2
-      with:
-        path: /tmp/.buildx-cache
-        key: ${{ runner.os }}-buildx-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-buildx-
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKER_HUB_USERNAME }}
-        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-    - name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
-      with:
-        builder: ${{ steps.buildx.outputs.name }}
-        context: ./docker/nightly
-        push: true
-        tags: deepchemio/deepchem:latest
-        cache-from: type=local,src=/tmp/.buildx-cache
-        cache-to: type=local,dest=/tmp/.buildx-cache
-    - name: Image digest
-      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/deepchem/feat/tests/test_smiles_tokenizer.py
+++ b/deepchem/feat/tests/test_smiles_tokenizer.py
@@ -1,13 +1,19 @@
 # Requirements - transformers, tokenizers
 import os
+import unittest
 from unittest import TestCase
-from deepchem.feat.smiles_tokenizer import SmilesTokenizer
-from transformers import RobertaForMaskedLM
+try:
+  from transformers import RobertaForMaskedLM
+  from deepchem.feat.smiles_tokenizer import SmilesTokenizer
+  has_transformers = True
+except:
+  has_transformers = False
 
 
 class TestSmilesTokenizer(TestCase):
   """Tests the SmilesTokenizer to load the USPTO vocab file and a ChemBERTa Masked LM model with pre-trained weights.."""
 
+  @unittest.skipIf(not has_transformers, 'transformers are not installed')
   def test_tokenize(self):
     current_dir = os.path.dirname(os.path.realpath(__file__))
     vocab_path = os.path.join(current_dir, 'data', 'vocab.txt')

--- a/deepchem/models/tests/test_attentivefp.py
+++ b/deepchem/models/tests/test_attentivefp.py
@@ -5,13 +5,13 @@ import numpy as np
 
 import deepchem as dc
 from deepchem.feat import MolGraphConvFeaturizer
-from deepchem.models import AttentiveFPModel
 from deepchem.models.tests.test_graph_models import get_dataset
 
 try:
   import dgl
   import dgllife
   import torch
+  from deepchem.models import AttentiveFPModel
   has_torch_and_dgl = True
 except:
   has_torch_and_dgl = False

--- a/deepchem/models/tests/test_cgcnn.py
+++ b/deepchem/models/tests/test_cgcnn.py
@@ -7,11 +7,11 @@ import numpy as np
 from deepchem.feat import CGCNNFeaturizer
 from deepchem.molnet import load_perovskite, load_mp_metallicity
 from deepchem.metrics import Metric, mae_score, roc_auc_score
-from deepchem.models import CGCNNModel
 
 try:
   import dgl  # noqa
   import torch  # noqa
+  from deepchem.models import CGCNNModel
   has_pytorch_and_dgl = True
 except:
   has_pytorch_and_dgl = False

--- a/deepchem/models/tests/test_gat.py
+++ b/deepchem/models/tests/test_gat.py
@@ -4,14 +4,14 @@ import tempfile
 import numpy as np
 
 import deepchem as dc
-from deepchem.models import GATModel
+from deepchem.feat import MolGraphConvFeaturizer
 from deepchem.models.tests.test_graph_models import get_dataset
 
 try:
   import dgl
   import dgllife
   import torch
-  from deepchem.feat import MolGraphConvFeaturizer
+  from deepchem.models import GATModel
   has_torch_and_dgl = True
 except:
   has_torch_and_dgl = False

--- a/deepchem/models/tests/test_gat.py
+++ b/deepchem/models/tests/test_gat.py
@@ -4,7 +4,6 @@ import tempfile
 import numpy as np
 
 import deepchem as dc
-from deepchem.feat import MolGraphConvFeaturizer
 from deepchem.models import GATModel
 from deepchem.models.tests.test_graph_models import get_dataset
 
@@ -12,6 +11,7 @@ try:
   import dgl
   import dgllife
   import torch
+  from deepchem.feat import MolGraphConvFeaturizer
   has_torch_and_dgl = True
 except:
   has_torch_and_dgl = False

--- a/deepchem/models/tests/test_gbdt_model.py
+++ b/deepchem/models/tests/test_gbdt_model.py
@@ -3,16 +3,22 @@ Tests to make sure deepchem models can fit models on easy datasets.
 """
 
 import tempfile
-
+import unittest
 import numpy as np
-import xgboost
-import lightgbm
 from sklearn.datasets import load_diabetes, load_digits
 from sklearn.model_selection import train_test_split
+try:
+  import xgboost
+  import lightgbm
+  has_xgboost_and_lightgbm = True
+except:
+  has_xgboost_and_lightgbm = False
 
 import deepchem as dc
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_singletask_regression_with_xgboost():
   np.random.seed(123)
 
@@ -41,6 +47,8 @@ def test_singletask_regression_with_xgboost():
   assert scores[regression_metric.name] < 55
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_singletask_regression_with_lightgbm():
   np.random.seed(123)
 
@@ -69,6 +77,8 @@ def test_singletask_regression_with_lightgbm():
   assert scores[regression_metric.name] < 55
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_multitask_regression_with_xgboost():
   np.random.seed(123)
 
@@ -104,6 +114,8 @@ def test_multitask_regression_with_xgboost():
   assert score < 55
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_multitask_regression_with_lightgbm():
   np.random.seed(123)
 
@@ -139,6 +151,8 @@ def test_multitask_regression_with_lightgbm():
   assert score < 55
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_classification_with_xgboost():
   """Test that sklearn models can learn on simple classification datasets."""
   np.random.seed(123)
@@ -167,6 +181,8 @@ def test_classification_with_xgboost():
   assert scores[classification_metric.name] > .9
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_classification_with_lightgbm():
   """Test that sklearn models can learn on simple classification datasets."""
   np.random.seed(123)
@@ -195,6 +211,8 @@ def test_classification_with_lightgbm():
   assert scores[classification_metric.name] > .9
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_reload_with_xgboost():
   np.random.seed(123)
 
@@ -231,6 +249,8 @@ def test_reload_with_xgboost():
   assert scores[regression_metric.name] < 55
 
 
+@unittest.skipIf(not has_xgboost_and_lightgbm,
+                 'xgboost or lightgbm are not installed')
 def test_reload_with_lightgbm():
   np.random.seed(123)
 

--- a/deepchem/models/tests/test_gcn.py
+++ b/deepchem/models/tests/test_gcn.py
@@ -5,13 +5,13 @@ import numpy as np
 
 import deepchem as dc
 from deepchem.feat import MolGraphConvFeaturizer
-from deepchem.models import GCNModel
 from deepchem.models.tests.test_graph_models import get_dataset
 
 try:
   import dgl
   import dgllife
   import torch
+  from deepchem.models import GCNModel
   has_torch_and_dgl = True
 except:
   has_torch_and_dgl = False

--- a/deepchem/models/tests/test_jax_import.py
+++ b/deepchem/models/tests/test_jax_import.py
@@ -1,0 +1,24 @@
+"""
+checking jax imports for new CI build
+"""
+import jax.numpy as jnp
+from jax import random
+import numpy as np
+import deepchem as dc
+import pytest
+
+
+@pytest.mark.jax
+def test_jax_import():
+  key = random.PRNGKey(0)
+  x = random.normal(key, (10, 10), dtype=jnp.float32)
+  y = random.normal(key, (10, 10), dtype=jnp.float32)
+  assert jnp.all(x == y)
+
+  n_data_points = 10
+  n_features = 2
+  np.random.seed(1234)
+  X = np.random.rand(n_data_points, n_features)
+  y = (X[:, 0] > X[:, 1]).astype(np.float32)
+  dataset = dc.data.NumpyDataset(X, y)
+  assert dataset.X.shape == (10, 2)

--- a/deepchem/models/tests/test_jax_import.py
+++ b/deepchem/models/tests/test_jax_import.py
@@ -1,11 +1,16 @@
 """
 checking jax imports for new CI build
 """
-import jax.numpy as jnp
-from jax import random
-import numpy as np
 import deepchem as dc
 import pytest
+
+try:
+  import jax.numpy as jnp
+  from jax import random
+  import numpy as np
+  has_jax = True
+except:
+  has_jax = False
 
 
 @pytest.mark.jax

--- a/deepchem/models/tests/test_lcnn.py
+++ b/deepchem/models/tests/test_lcnn.py
@@ -4,11 +4,11 @@ from os import path
 import numpy as np
 from deepchem.utils import load_dataset_from_disk, download_url, untargz_file
 from deepchem.metrics import Metric, mae_score
-from deepchem.models import LCNNModel
 
 try:
   import dgl
   import torch
+  from deepchem.models import LCNNModel
   has_pytorch_and_dgl = True
 except:
   has_pytorch_and_dgl = False

--- a/deepchem/models/tests/test_mpnn.py
+++ b/deepchem/models/tests/test_mpnn.py
@@ -5,13 +5,13 @@ import numpy as np
 
 import deepchem as dc
 from deepchem.feat import MolGraphConvFeaturizer
-from deepchem.models.torch_models import MPNNModel
 from deepchem.models.tests.test_graph_models import get_dataset
 
 try:
   import dgl
   import dgllife
   import torch
+  from deepchem.models.torch_models import MPNNModel
   has_torch_and_dgl = True
 except:
   has_torch_and_dgl = False

--- a/deepchem/models/tests/test_normalizing_flows.py
+++ b/deepchem/models/tests/test_normalizing_flows.py
@@ -9,17 +9,21 @@ import pytest
 import deepchem
 import numpy as np
 import tensorflow as tf
-import tensorflow_probability as tfp
 import unittest
-import numpy as np
-
 from deepchem.data import NumpyDataset
-from deepchem.models.normalizing_flows import NormalizingFlow, NormalizingFlowModel
 
-tfd = tfp.distributions
-tfb = tfp.bijectors
+try:
+  import tensorflow_probability as tfp
+  from deepchem.models.normalizing_flows import NormalizingFlow, NormalizingFlowModel
+  tfd = tfp.distributions
+  tfb = tfp.bijectors
+  has_tensorflow_probablity = True
+except:
+  has_tensorflow_probablity = False
 
 
+@unittest.skipIf(not has_tensorflow_probablity,
+                 'tensorflow_probability not installed')
 def test_normalizing_flow():
 
   flow_layers = [

--- a/deepchem/models/tests/test_pagtn.py
+++ b/deepchem/models/tests/test_pagtn.py
@@ -5,13 +5,13 @@ import numpy as np
 
 import deepchem as dc
 from deepchem.feat import PagtnMolGraphFeaturizer
-from deepchem.models import PagtnModel
 from deepchem.models.tests.test_graph_models import get_dataset
 
 try:
   import dgl
   import dgllife
   import torch
+  from deepchem.models import PagtnModel
   has_torch_and_dgl = True
 except:
   has_torch_and_dgl = False

--- a/deepchem/models/tests/test_pretrained_torch.py
+++ b/deepchem/models/tests/test_pretrained_torch.py
@@ -7,20 +7,23 @@ from deepchem.feat.mol_graphs import ConvMol
 
 try:
   import torch
+
+  class MLP(dc.models.TorchModel):
+
+    def __init__(self,
+                 n_tasks=1,
+                 feature_dim=100,
+                 hidden_layer_size=64,
+                 **kwargs):
+      pytorch_model = torch.nn.Sequential(
+          torch.nn.Linear(feature_dim, hidden_layer_size), torch.nn.ReLU(),
+          torch.nn.Linear(hidden_layer_size, n_tasks), torch.nn.Sigmoid())
+      loss = dc.models.losses.BinaryCrossEntropy()
+      super(MLP, self).__init__(model=pytorch_model, loss=loss, **kwargs)
+
   has_pytorch = True
 except:
   has_pytorch = False
-
-
-class MLP(dc.models.TorchModel):
-
-  def __init__(self, n_tasks=1, feature_dim=100, hidden_layer_size=64,
-               **kwargs):
-    pytorch_model = torch.nn.Sequential(
-        torch.nn.Linear(feature_dim, hidden_layer_size), torch.nn.ReLU(),
-        torch.nn.Linear(hidden_layer_size, n_tasks), torch.nn.Sigmoid())
-    loss = dc.models.losses.BinaryCrossEntropy()
-    super(MLP, self).__init__(model=pytorch_model, loss=loss, **kwargs)
 
 
 @unittest.skipIf(not has_pytorch, 'PyTorch is not installed')

--- a/env_jax.yml
+++ b/env_jax.yml
@@ -1,0 +1,10 @@
+name: deepchem
+channels:
+  - omnia
+  - conda-forge
+  - defaults
+dependencies:
+  - numpy==1.19.*
+  - pip==20.2.*
+  - pip:
+    - tensorflow~=2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [tool:pytest]
 markers =
+    jax: marks tests for deepchem-jax only (deselect with '-m "not jax"')
     slow: marks tests as slow (deselect with '-m "not slow"')
     serial
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,9 @@ else:
   IS_RELEASE = False
 
 # Environment-specific dependencies.
-extras = {'jax': ['jax==0.2.14', 'jaxlib==0.1.66', 'dm-haiku==0.0.4', 'optax==0.0.8']}
+extras = {
+    'jax': ['jax==0.2.14', 'jaxlib==0.1.66', 'dm-haiku==0.0.4', 'optax==0.0.8']
+}
 
 
 # get the version from deepchem/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 # Environment-specific dependencies.
 extras = {
-    'jax': ['jax==0.2.14', 'jaxlib==0.1.66', 'dm-haiku==0.0.4', 'optax==0.0.8']
+    'jax': ['jax==0.2.14', 'jaxlib==0.1.67', 'dm-haiku==0.0.4', 'optax==0.0.8']
 }
 
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,9 @@ else:
   # Build a nightly package by default.
   IS_RELEASE = False
 
+# Environment-specific dependencies.
+extras = {'jax': ['dm-haiku==0.0.3', 'optax==0.0.8']}
+
 
 # get the version from deepchem/__init__.py
 def _get_version():
@@ -69,4 +72,5 @@ setup(
         'scikit-learn',
         'scipy',
     ],
+    extras_require=extras,
     python_requires='>=3.5')

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ else:
   IS_RELEASE = False
 
 # Environment-specific dependencies.
-extras = {'jax': ['dm-haiku==0.0.3', 'optax==0.0.8']}
+extras = {'jax': ['dm-haiku==0.0.4', 'optax==0.0.8']}
 
 
 # get the version from deepchem/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ else:
   IS_RELEASE = False
 
 # Environment-specific dependencies.
-extras = {'jax': ['dm-haiku==0.0.4', 'optax==0.0.8']}
+extras = {'jax': ['jax==0.2.14', 'jaxlib==0.1.66', 'dm-haiku==0.0.4', 'optax==0.0.8']}
 
 
 # get the version from deepchem/__init__.py


### PR DESCRIPTION
Creating this based on the reviews from https://github.com/deepchem/deepchem/pull/2549

I have added `deepchem` Jax support. Installs can be made either using

```
pip install -e `.[jax]`
```
or
```
pip install 'deepchem[jax]'
```
This is just a temporary solution - 
- `jax_setup.yml` has been copied from `main.yml` 
- `env_jax.yml` also has `TensorFlow` dependency because `deepchem` is dependent on `TensorFlow` and I cant run `import deepchem` without tensorflow installed.