### PR TITLE
[WIP] FASTA loader unit test fix

### DIFF
--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -18,11 +18,7 @@ class TestFASTALoader(unittest.TestCase):
     self.current_dir = os.path.dirname(os.path.abspath(__file__))
 
   def test_legacy_fasta_one_hot(self):
-    input_file = os.path.join(self.current_dir,
-                              "..",
-                              "..",
-                              "data",
-                              "tests",
+    input_file = os.path.join(self.current_dir, "..", "..", "data", "tests",
                               "example.fasta")
     loader = dc.data.FASTALoader(legacy=True)
     sequences = loader.create_dataset(input_file)
@@ -34,11 +30,7 @@ class TestFASTALoader(unittest.TestCase):
     assert sequences.X.shape == (3, 5, 58, 1)
 
   def test_fasta_one_hot(self):
-    input_file = os.path.join(self.current_dir,
-                              "..",
-                              "..",
-                              "data",
-                              "tests",
+    input_file = os.path.join(self.current_dir, "..", "..", "data", "tests",
                               "example.fasta")
     loader = dc.data.FASTALoader(legacy=False)
     sequences = loader.create_dataset(input_file)
@@ -52,11 +44,7 @@ class TestFASTALoader(unittest.TestCase):
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
         'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '*', '-'
     ]
-    input_file = os.path.join(self.current_dir,
-                              "..",
-                              "..",
-                              "data",
-                              "tests",
+    input_file = os.path.join(self.current_dir, "..", "..", "data", "tests",
                               "uniprot_truncated.fasta")
     loader = dc.data.FASTALoader(
         OneHotFeaturizer(charset=protein, max_length=1000), legacy=False)

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -19,7 +19,11 @@ class TestFASTALoader(unittest.TestCase):
 
   def test_legacy_fasta_one_hot(self):
     input_file = os.path.join(self.current_dir,
-                              "../../data/tests/example.fasta")
+                              "..",
+                              "..",
+                              "data",
+                              "tests",
+                              "example.fasta")
     loader = dc.data.FASTALoader(legacy=True)
     sequences = loader.create_dataset(input_file)
 
@@ -31,7 +35,11 @@ class TestFASTALoader(unittest.TestCase):
 
   def test_fasta_one_hot(self):
     input_file = os.path.join(self.current_dir,
-                              "../../data/tests/example.fasta")
+                              "..",
+                              "..",
+                              "data",
+                              "tests",
+                              "example.fasta")
     loader = dc.data.FASTALoader(legacy=False)
     sequences = loader.create_dataset(input_file)
 
@@ -45,7 +53,11 @@ class TestFASTALoader(unittest.TestCase):
         'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '*', '-'
     ]
     input_file = os.path.join(self.current_dir,
-                              "../../data/tests/uniprot_truncated.fasta")
+                              "..",
+                              "..",
+                              "data",
+                              "tests",
+                              "uniprot_truncated.fasta")
     loader = dc.data.FASTALoader(
         OneHotFeaturizer(charset=protein, max_length=1000), legacy=False)
     sequences = loader.create_dataset(input_file)

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -18,8 +18,7 @@ class TestFASTALoader(unittest.TestCase):
     self.current_dir = os.path.dirname(os.path.abspath(__file__))
 
   def test_legacy_fasta_one_hot(self):
-    input_file = os.path.join(self.current_dir, "..", "..", "data", "tests",
-                              "example.fasta")
+    input_file = os.path.join(self.current_dir, "example.fasta")
     loader = dc.data.FASTALoader(legacy=True)
     sequences = loader.create_dataset(input_file)
 
@@ -30,8 +29,7 @@ class TestFASTALoader(unittest.TestCase):
     assert sequences.X.shape == (3, 5, 58, 1)
 
   def test_fasta_one_hot(self):
-    input_file = os.path.join(self.current_dir, "..", "..", "data", "tests",
-                              "example.fasta")
+    input_file = os.path.join(self.current_dir, "example.fasta")
     loader = dc.data.FASTALoader(legacy=False)
     sequences = loader.create_dataset(input_file)
 
@@ -44,8 +42,7 @@ class TestFASTALoader(unittest.TestCase):
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N',
         'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '*', '-'
     ]
-    input_file = os.path.join(self.current_dir, "..", "..", "data", "tests",
-                              "uniprot_truncated.fasta")
+    input_file = os.path.join(self.current_dir, "uniprot_truncated.fasta")
     loader = dc.data.FASTALoader(
         OneHotFeaturizer(charset=protein, max_length=1000), legacy=False)
     sequences = loader.create_dataset(input_file)


### PR DESCRIPTION
# FASTA Loader fix

## Description

There was a bug in the unit test for the FASTA loader that led to the unit tests failing sporadically on the CI. 

The problem is suspected to be due to how python unit tests handle relative paths.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
