### PR TITLE
Generalizing the typing for the loaders

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -310,7 +310,7 @@ class CSVLoader(DataLoader):
                featurizer: Featurizer,
                feature_field: Optional[List[str]] = None,
                id_field: Optional[List[str]] = None,
-              smiles_field: Optional[List[str]] = None,
+               smiles_field: Optional[List[str]] = None,
                log_every_n: int = 1000):
     """Initializes CSVLoader.
 

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -91,7 +91,7 @@ class DataLoader(object):
   def __init__(self,
                tasks: List[str],
                featurizer: Featurizer,
-               id_field: Optional[str] = None,
+               id_field: Optional[List[str]] = None,
                log_every_n: int = 1000):
     """Construct a DataLoader object.
 
@@ -308,9 +308,9 @@ class CSVLoader(DataLoader):
   def __init__(self,
                tasks: List[str],
                featurizer: Featurizer,
-               feature_field: Optional[str] = None,
-               id_field: Optional[str] = None,
-               smiles_field: Optional[str] = None,
+               feature_field: Optional[List[str]] = None,
+               id_field: Optional[List[str]] = None,
+              smiles_field: Optional[List[str]] = None,
                log_every_n: int = 1000):
     """Initializes CSVLoader.
 
@@ -535,9 +535,9 @@ class JsonLoader(DataLoader):
                tasks: List[str],
                feature_field: str,
                featurizer: Featurizer,
-               label_field: Optional[str] = None,
-               weight_field: Optional[str] = None,
-               id_field: Optional[str] = None,
+               label_field: Optional[List[str]] = None,
+               weight_field: Optional[List[str]] = None,
+               id_field: Optional[List[str]] = None,
                log_every_n: int = 1000):
     """Initializes JsonLoader.
 
@@ -736,7 +736,7 @@ class SDFLoader(DataLoader):
     # The field in which dc.utils.save.load_sdf_files stores RDKit mol objects
     self.mol_field = "mol"
     # The field in which load_sdf_files return value stores smiles
-    self.id_field = "smiles"
+    self.id_field = ["smiles"]
     self.log_every_n = log_every_n
 
   def create_dataset(self,


### PR DESCRIPTION


## Description
This is an attempt at generalizing the typing for the feature fields on the loader method. This addresses the typing issues that the USPTOLoader was facing due to passing in a ```List[str]``` in place of ```Optional[str]```. The list of strings is still logically consistent because having a list of columns is still valid for a shard since its just a pandas dataframe. 

There still needs to be some discussion done on whether this is a necessary change and what benefits this change might bring in apart from handling the edge case of the CSVLoader.  Comments and suggestions are welcome @rbharath, @ncfrey, @vsomnath 



## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
