### PR TITLE
Added 'transformers' argument to ValidationCallback

### DIFF
--- a/deepchem/models/callbacks.py
+++ b/deepchem/models/callbacks.py
@@ -26,7 +26,8 @@ class ValidationCallback(object):
                output_file=sys.stdout,
                save_dir=None,
                save_metric=0,
-               save_on_minimum=True):
+               save_on_minimum=True,
+               transformers=[]):
     """Create a ValidationCallback.
 
     Parameters
@@ -58,6 +59,7 @@ class ValidationCallback(object):
     self.save_metric = save_metric
     self.save_on_minimum = save_on_minimum
     self._best_score = None
+    self.transformers = transformers
 
   def __call__(self, model, step):
     """This is invoked by the KerasModel after every step of fitting.
@@ -71,7 +73,7 @@ class ValidationCallback(object):
     """
     if step % self.interval != 0:
       return
-    scores = model.evaluate(self.dataset, self.metrics)
+    scores = model.evaluate(self.dataset, self.metrics, self.transformers)
     message = 'Step %d validation:' % step
     for key in scores:
       message += ' %s=%g' % (key, scores[key])

--- a/deepchem/models/callbacks.py
+++ b/deepchem/models/callbacks.py
@@ -50,6 +50,10 @@ class ValidationCallback(object):
       if True, the best model is considered to be the one that minimizes the
       validation metric.  If False, the best model is considered to be the one
       that maximizes it.
+    transformers: List[Transformer]
+      List of `dc.trans.Transformer` objects. These transformations
+      must have been applied to `dataset` previously. The dataset will
+      be untransformed for metric evaluation.
     """
     self.dataset = dataset
     self.interval = interval

--- a/deepchem/models/tests/test_callbacks.py
+++ b/deepchem/models/tests/test_callbacks.py
@@ -2,7 +2,6 @@ import unittest
 import tempfile
 import deepchem as dc
 import numpy as np
-import tensorflow as tf
 try:
   from StringIO import StringIO
 except ImportError:
@@ -28,7 +27,8 @@ class TestCallbacks(unittest.TestCase):
         30, [metric],
         log,
         save_dir=save_dir,
-        save_on_minimum=False)
+        save_on_minimum=False,
+        transformers=transformers)
     model.fit(train_dataset, callbacks=callback)
 
     # Parse the log to pull out the AUC scores.


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds an optional "transformers" flag to ValidationCallback, which allows users to pass in transformations to be used in ValidationCallback:
`scores = model.evaluate(self.dataset, self.metrics, self.transformers)`

Previously, the `model.evaluate()` in ValidationCallback did not know about the transformations applied to the dataset. This meant that validation scoring could not untransform.

Motivation:
Standalone evaluation code support transformers:
```
print('Training set score:', model.evaluate(train_dataset, [metric], transformers))
print('Test set score:', model.evaluate(test_dataset, [metric], transformers))
```
However running evaluation using ValidationCallback did not support it transformers in model.evaluate(): https://github.com/deepchem/deepchem/blob/9fa623f71554846a103b467632fdddc86aa71a73/deepchem/models/callbacks.py#L74

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
