### PR TITLE
Add section on setting up symbolic link

### DIFF
--- a/docs/source/development_guide/coding.rst
+++ b/docs/source/development_guide/coding.rst
@@ -87,9 +87,9 @@ current development directory. To do this, simply run
 
   python setup.py develop
 
-while installing the package from source. This will let you to test out
-features that are in development, and in particular lets you import new test
-classes/methods.
+while installing the package from source. This will let you see changes that you
+make to the source code when you import the package and, in particular, it
+allows you to import the new classes/methods for unit tests.
 
 Testing Machine Learning Models
 -------------------------------

--- a/docs/source/development_guide/coding.rst
+++ b/docs/source/development_guide/coding.rst
@@ -80,6 +80,17 @@ that break them may sometimes slip through and get merged into the repository.
 We still try to run them regularly, so hopefully the problem will be discovered
 fairly soon.
 
+To test your code locally, you will have to setup a symbolic link to your
+current development directory. To do this, simply run
+
+.. code-block:: bash
+
+  python setup.py develop
+
+while installing the package from source. This will let you to test out
+features that are in development, and in particular lets you import new test
+classes/methods.
+
 Testing Machine Learning Models
 -------------------------------
 


### PR DESCRIPTION

## Description

Adds a small section to the docs regarding setting up a symbolic link to the current development directory when installing DeepChem from source. This will be useful for developers to test their feature locally. 

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
