### PR TITLE
Fasta loader sharding (some more cleanup needed before merge)

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -999,7 +999,7 @@ class FASTALoader(DataLoader):
                   (THERE SHOULD BE NO SHARDS)
 
             Solutions:
-              [ ] Clear `sequences` in _generate_sequences
+              [X] Clear `sequences` in _generate_sequences
               [ ] Change how shards are counted
             """
             X = self.featurizer(shard)
@@ -1035,16 +1035,18 @@ class FASTALoader(DataLoader):
               sequences = _add_sequence(sequences, sequence)
               count_sequences += 1
               sequence = np.array([])
+              if shard_size > 0 and count_sequences % shard_size == 0:
+                yield sequences
+                sequences = np.array([])
             elif header_read:  # Line contains sequence in FASTA format
               if line[-1:] == '\n':  # Check last character in string
                 line = line[0:-1]  # Remove last character
               sequence = np.append(sequence, line)
               count_sequences += 1
-            if shard_size != 0 and count_sequences % shard_size == 0:
-              yield sequences
         sequences = _add_sequence(sequences, sequence)  # Add last sequence
         count_sequences += 1
         yield sequences
+        sequences = np.array([])
 
       def _add_sequence(sequences: np.array, sequence: np.array) -> np.array:
         # Handle empty sequence

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -1033,11 +1033,12 @@ class FASTALoader(DataLoader):
             if line.startswith(header_mark):  # New header line
               header_read = True
               sequences = _add_sequence(sequences, sequence)
-              count_sequences += 1
               sequence = np.array([])
-              if shard_size > 0 and count_sequences % shard_size == 0:
-                yield sequences
-                sequences = np.array([])
+              if sequences.size > 0:
+                count_sequences += 1
+                if shard_size > 0 and count_sequences % shard_size == 0:
+                  yield sequences
+                  sequences = np.array([])
             elif header_read:  # Line contains sequence in FASTA format
               if line[-1:] == '\n':  # Check last character in string
                 line = line[0:-1]  # Remove last character

--- a/deepchem/data/tests/test_fasta_loader.py
+++ b/deepchem/data/tests/test_fasta_loader.py
@@ -50,4 +50,14 @@ class TestFASTALoader(unittest.TestCase):
 
     assert sequences.X.shape
 
+  def test_fasta_sharding(self):
+    input_file = os.path.join(self.current_dir,
+                              "../../data/tests/example.fasta")
+    loader = dc.data.FASTALoader(legacy=False)
+    sequences = loader.create_dataset(input_file, shard_size=1)
+
+    # Due to FASTALoader redesign, expected shape is now (3, 58, 5)
+
+    assert sequences.X.shape == (3, 58, 5)
+   
   # TODO: test with full uniprot file once sharding support is added.


### PR DESCRIPTION
# Add sharding to FASTA loader

## Description

This PR improves our existing FASTA loader by allowing users who use the non-legacy logic to enable sharding for FASTA files.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
