### PR TITLE
Remove pin for matminer

### DIFF
--- a/env.common.yml
+++ b/env.common.yml
@@ -14,7 +14,7 @@ dependencies:
     - biopython
     - dgllife==0.2.8
     - lightgbm==3.*
-    - matminer==0.6.5
+    - matminer
     - mordred
     - networkx
     - pillow


### PR DESCRIPTION
The latest version of matminer supposedly fixes the problem in #2564.  Pinning to an old version should no longer be necessary.