### PR TITLE
Fixed errors caused by new Pandas version

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1217,7 +1217,8 @@ class DiskDataset(Dataset):
       tasks_filename, metadata_filename = self._get_metadata_filename()
       with open(tasks_filename) as fin:
         tasks = json.load(fin)
-      metadata_df = pd.read_csv(metadata_filename, compression='gzip')
+      metadata_df = pd.read_csv(
+          metadata_filename, compression='gzip', dtype=object)
       metadata_df = metadata_df.where((pd.notnull(metadata_df)), None)
       return tasks, metadata_df
     except Exception:


### PR DESCRIPTION
This fixes many of the errors in #2588.  They were caused by a change in behavior between Pandas 1.2 and 1.3.  When loading a DiskDataset, we load the metadata from a csv file and set any missing values to None:

https://github.com/deepchem/deepchem/blob/f3ba82cd015a7c59753baf4042092f1e01c56ea2/deepchem/data/datasets.py#L1220-L1221

In Pandas 1.3, if a column is completely empty, it sets the dtype for that column to float64 with every element being NaN.  Because None is not a legal value for a float64 column, the call to `where()` sets them to NaN instead.  This leads to errors later when we check for None values.

The fix is to tell it to use `object` as the dtype for all columns.