### PR TITLE
Made behavior of GaussianProcessHyperparamOpt more consistent

### DIFF
--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -269,6 +269,12 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
           f.write('\n')
 
       hp_str = _convert_hyperparam_dict_to_filename(hyper_parameters)
+      if hp_str in all_results:
+        # We have already evaluated the model for these hyperparameters.
+        if use_max:
+          return all_results[hp_str]
+        else:
+          return -all_results[hp_str]
       if logdir is not None:
         filename = "model%s" % hp_str
         model_dir = os.path.join(logdir, filename)


### PR DESCRIPTION
Fixes #2615.  If pyGPGO asks for the score more than once for the same set of hyperparameters, this ensures we will always return the same value.