### PR TITLE
Fixed examples for loading perovskite dataset

### DIFF
--- a/deepchem/models/torch_models/cgcnn.py
+++ b/deepchem/models/torch_models/cgcnn.py
@@ -253,12 +253,14 @@ class CGCNNModel(TorchModel):
   Here is a simple example of code that uses the CGCNNModel with
   materials dataset.
 
-  >> import deepchem as dc
-  >> dataset_config = {"reload": False, "featurizer": dc.feat.CGCNNFeaturizer, "transformers": []}
-  >> tasks, datasets, transformers = dc.molnet.load_perovskite(**dataset_config)
-  >> train, valid, test = datasets
-  >> model = dc.models.CGCNNModel(mode='regression', batch_size=32, learning_rate=0.001)
-  >> model.fit(train, nb_epoch=50)
+  Examples
+  --------
+  >>> import deepchem as dc
+  >>> dataset_config = {"reload": False, "featurizer": dc.feat.CGCNNFeaturizer(), "transformers": []}
+  >>> tasks, datasets, transformers = dc.molnet.load_perovskite(**dataset_config)
+  >>> train, valid, test = datasets
+  >>> model = dc.models.CGCNNModel(mode='regression', batch_size=32, learning_rate=0.001)
+  >>> avg_loss = model.fit(train, nb_epoch=50)
 
   This model takes arbitary crystal structures as an input, and predict material properties
   using the element information and connection of atoms in the crystal. If you want to get

--- a/deepchem/molnet/load_function/material_datasets/load_perovskite.py
+++ b/deepchem/molnet/load_function/material_datasets/load_perovskite.py
@@ -18,13 +18,14 @@ class _PerovskiteLoader(_MolnetLoader):
     targz_file = os.path.join(self.data_dir, 'perovskite.tar.gz')
     if not os.path.exists(dataset_file):
       if not os.path.exists(targz_file):
-        dc.utils.data_utils.download_url(url=PEROVSKITE_URL,
-                                         dest_dir=self.data_dir)
+        dc.utils.data_utils.download_url(
+            url=PEROVSKITE_URL, dest_dir=self.data_dir)
       dc.utils.data_utils.untargz_file(targz_file, self.data_dir)
-    loader = dc.data.JsonLoader(tasks=self.tasks,
-                                feature_field="structure",
-                                label_field="formation_energy",
-                                featurizer=self.featurizer)
+    loader = dc.data.JsonLoader(
+        tasks=self.tasks,
+        feature_field="structure",
+        label_field="formation_energy",
+        featurizer=self.featurizer)
     return loader.create_dataset(dataset_file)
 
 

--- a/deepchem/molnet/load_function/material_datasets/load_perovskite.py
+++ b/deepchem/molnet/load_function/material_datasets/load_perovskite.py
@@ -18,19 +18,18 @@ class _PerovskiteLoader(_MolnetLoader):
     targz_file = os.path.join(self.data_dir, 'perovskite.tar.gz')
     if not os.path.exists(dataset_file):
       if not os.path.exists(targz_file):
-        dc.utils.data_utils.download_url(
-            url=PEROVSKITE_URL, dest_dir=self.data_dir)
+        dc.utils.data_utils.download_url(url=PEROVSKITE_URL,
+                                         dest_dir=self.data_dir)
       dc.utils.data_utils.untargz_file(targz_file, self.data_dir)
-    loader = dc.data.JsonLoader(
-        tasks=self.tasks,
-        feature_field="structure",
-        label_field="formation_energy",
-        featurizer=self.featurizer)
+    loader = dc.data.JsonLoader(tasks=self.tasks,
+                                feature_field="structure",
+                                label_field="formation_energy",
+                                featurizer=self.featurizer)
     return loader.create_dataset(dataset_file)
 
 
 def load_perovskite(
-    featurizer: Union[dc.feat.Featurizer, str] = dc.feat.SineCoulombMatrix(),
+    featurizer: Union[dc.feat.Featurizer, str] = dc.feat.CGCNNFeaturizer(),
     splitter: Union[dc.splits.Splitter, str, None] = 'random',
     transformers: List[Union[TransformerGenerator, str]] = ['normalization'],
     reload: bool = True,
@@ -93,13 +92,10 @@ def load_perovskite(
 
   Examples
   --------
-  >>>
-  >> import deepchem as dc
-  >> tasks, datasets, transformers = dc.molnet.load_perovskite()
-  >> train_dataset, val_dataset, test_dataset = datasets
-  >> n_tasks = len(tasks)
-  >> n_features = train_dataset.get_data_shape()[0]
-  >> model = dc.models.MultitaskRegressor(n_tasks, n_features)
+  >>> import deepchem as dc
+  >>> tasks, datasets, transformers = dc.molnet.load_perovskite()
+  >>> train_dataset, val_dataset, test_dataset = datasets
+  >>> model = dc.models.CGCNNModel(mode='regression', batch_size=32, learning_rate=0.001)
 
   """
   loader = _PerovskiteLoader(featurizer, splitter, transformers,


### PR DESCRIPTION
Two main (related) contributions of this PR:

1. Fixed examples for loading perovskite dataset
2. Changed default featurizer for perovskite dataset to cgcnn featurizer from sine coulomb matrix featurizer

# Pull Request Template

## Description

Fix #(issue)


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
