### PR TITLE
Added Loggers and Weights & Biases Logger section into docs

### DIFF
--- a/deepchem/models/wandblogger.py
+++ b/deepchem/models/wandblogger.py
@@ -17,9 +17,28 @@ class WandbLogger(object):
     will log the specified metrics calculated on the specific datasets
     to the user's W&B dashboard.
 
-    If a WandbLogger is provided to the wandb_logger flag,
+    If a WandbLogger is provided to the wandb_logger flag of the model,
     the metrics are logged to Weights & Biases, along with other information
     such as epoch number, losses, sample counts, and model configuration data.
+
+    Usage
+    --------
+    Here's how WandbLogger can be used with KerasModel training and validation.
+    Apart from initialization, you do not need to call any other methods.
+    All other methods (such as setup, log_data, update_config) are part of the
+    logging API and are already integrated in the KerasModel/TorchModel classes.
+
+    >>> from deepchem.models import KerasModel, ValidationCallback
+    ... from deepchem.models import WandbLogger
+    ... logger = WandbLogger(entity="my_entity", project="my_project")
+    ... vc = ValidationCallback(...)
+    ... model = KerasModel(some_model, wandb_logger=logger)
+    ... model.fit(some_dataset, nb_epochs=10, callbacks=[vc]) # WandbLogger will automatically detect callbacks
+    >>> logger.finish() # closes the wandb process
+
+    Notes
+    -----
+    This class requires wandb to be installed.
     """
 
   def __init__(self,
@@ -141,6 +160,7 @@ class WandbLogger(object):
 
   def update_config(self, config_data):
     """Updates the W&B configuration.
+
     Parameters
     ----------
     config_data: dict

--- a/docs/source/api_reference/loggers.rst
+++ b/docs/source/api_reference/loggers.rst
@@ -1,0 +1,14 @@
+Loggers
+=====================
+
+An important part of machine learning is the ability to track your experiments
+and model performance. Many of DeepChem's models calculate various values and metrics
+during training and evaluation. This data along with run configurations and
+hyperparameters can be logged to third party loggers such as Weights & Biases.
+
+Weights & Biases Logger
+-------------------------------
+
+.. autoclass:: deepchem.models.WandbLogger
+  :members:
+

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -126,3 +126,4 @@ To listen in, please email X.Y@gmail.com, where X=bharath and Y=ramsundar to int
    api_reference/rl
    api_reference/docking
    api_reference/utils
+   api_reference/loggers


### PR DESCRIPTION
# Pull Request Template

## Description

Currently there is no section in the documentation for the Loggers. The only documentation on logging exists in the [KerasModel section](https://deepchem.readthedocs.io/en/latest/api_reference/models.html#kerasmodel) since this was left over from an old Weights & Biases documentation effort. This is not ideal and also very unclear for new users who wish to get more information about logger integrations in DeepChem.

Changes:
- Added a section to the DeepChem docs called Loggers. Currently it only contains the WandbLogger documentation. Future third party loggers can add their documentation in this section too.
- Minor changes to text/wording in WandbLogger, Added example in WandbLogger init docstring


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
