### PR TITLE
Update PR template and docs with doctest, pytest

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -25,6 +25,7 @@ Please check the option that is related to your PR.
   - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
   - [ ] Run `mypy -p deepchem` and check no errors
   - [ ] Run `flake8 <modified file> --count` and check no errors
+  - [ ] Run `python -m doctest <modified file>` and check no errors
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation

--- a/docs/source/development_guide/coding.rst
+++ b/docs/source/development_guide/coding.rst
@@ -53,8 +53,12 @@ appropriate, cite the relevant publications.
 
 .. _`numpy`: https://numpydoc.readthedocs.io/en/latest/format.html#docstring-standard
 
-All docstrings should follow the `numpy`_ docstring formatting conventions.
+All docstrings should follow the `numpy`_ docstring formatting conventions. To
+ensure that the code examples in the docstrings are working as expected, run
 
+.. code-block:: bash
+
+  python -m doctest <modified file>
 
 Unit Tests
 ----------

--- a/docs/source/development_guide/coding.rst
+++ b/docs/source/development_guide/coding.rst
@@ -40,7 +40,7 @@ Whenever you modify a file, run :code:`flake8` on it.
 
   flake8 <modified file> --count
 
-If the command return 0, it means your code pass Flake8 check.
+If the command returns 0, it means your code passes the Flake8 check.
 
 Docstrings
 ----------
@@ -94,6 +94,12 @@ current development directory. To do this, simply run
 while installing the package from source. This will let you see changes that you
 make to the source code when you import the package and, in particular, it
 allows you to import the new classes/methods for unit tests.
+
+Ensure that the tests pass locally! Check this by running
+
+.. code-block:: bash
+
+  python -m pytest <modified file>
 
 Testing Machine Learning Models
 -------------------------------


### PR DESCRIPTION

## Description

Small changes to the documentation and the PR template, which adds a section on running unit tests and doctests locally. 

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
