### PR TITLE
installation clarification for zsh [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ If GPU support is required, then make sure CUDA is installed and then install th
 2. pytorch - https://pytorch.org/get-started/locally/#start-locally
 3. jax - https://github.com/google/jax#pip-installation-gpu-cuda
 
+In `zsh` square brackets are used for globbing/pattern matching. This means you
+need to escape the square brackets in the above installation. You can do so
+by including the dependencies in quotes like `pip install --pre 'deepchem[jax]'`
+
 ### Docker
 
 If you want to install deepchem using a docker, you can pull two kinds of images.  

--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -66,6 +66,9 @@ If GPU support is required, then make sure CUDA is installed and then install th
 2. pytorch - https://pytorch.org/get-started/locally/#start-locally
 3. jax - https://github.com/google/jax#pip-installation-gpu-cuda
 
+In :code:`zsh` square brackets are used for globbing/pattern matching. This means
+you need to escape the square brackets in the above installation. You can do so by
+including the dependencies in quotes like :code:`pip install --pre 'deepchem[jax]'`
 
 Google Colab
 ------------


### PR DESCRIPTION
Fix #2633 

Installation of deepchem with backend specification like `pip install --pre deepchem[torch]` throws an error in `zsh: no match found` in `zsh`. Hence, updated installation steps in README.md to use quotes as in `pip install --pre 'deepchem[torch]'` while installing.