### PR TITLE
fixes attribute error from sklearn in print model

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -175,6 +175,9 @@ class KerasModel(Model):
       the Weights & Biases logger object used to log data and metrics
     """
     super(KerasModel, self).__init__(model=model, model_dir=model_dir, **kwargs)
+    self.loss = loss  # not used
+    self.learning_rate = learning_rate  # not used
+    self.output_types = output_types  # not used
     if isinstance(loss, Loss):
       self._loss_fn: LossFn = _StandardLoss(model, loss)
     else:

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -175,6 +175,9 @@ class TorchModel(Model):
       the Weights & Biases logger object used to log data and metrics
     """
     super(TorchModel, self).__init__(model=model, model_dir=model_dir, **kwargs)
+    self.loss = loss  # not used
+    self.learning_rate = learning_rate  # not used
+    self.output_types = output_types  # not used
     if isinstance(loss, Loss):
       self._loss_fn: LossFn = _StandardLoss(self, loss)
     else:


### PR DESCRIPTION
Fix #2665

## Description

This PR ensures that an attribute error is not raised during printing of a model when using deepchem with sklearn 0.24 onwards.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [X] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
