### PR TITLE
remove dual inheritance in robertafeaturizer, add RobertaTokenizerFast as tokenizer attribute

### DIFF
--- a/deepchem/feat/roberta_tokenizer.py
+++ b/deepchem/feat/roberta_tokenizer.py
@@ -37,14 +37,15 @@ class RobertaFeaturizer(Featurizer):
   Note
   -----
   This class requires transformers to be installed.
-  RobertaFeaturizer uses inheritance with DeepChem's 
-  Featurizer class while instantiating RobertaTokenizerFast 
+  RobertaFeaturizer uses inheritance with DeepChem's
+  Featurizer class while instantiating RobertaTokenizerFast
   in Huggingface as an attribute for rapid tokenization.
   """
 
   def __init__(self, tokenizer: RobertaTokenizerFast):
     if not isinstance(tokenizer, RobertaTokenizerFast):
-      raise TypeError(f"""`tokenizer` must be a constructed `RobertaTokenizerFast`
+      raise TypeError(
+          f"""`tokenizer` must be a constructed `RobertaTokenizerFast`
                        object, not {type(tokenizer)}""")
     else:
       self.tokenizer = tokenizer

--- a/deepchem/feat/roberta_tokenizer.py
+++ b/deepchem/feat/roberta_tokenizer.py
@@ -1,5 +1,5 @@
 from deepchem.feat import Featurizer
-from typing import Dict, List
+from typing import List
 try:
   from transformers import RobertaTokenizerFast
 except ModuleNotFoundError:
@@ -8,21 +8,24 @@ except ModuleNotFoundError:
   pass
 
 
-class RobertaFeaturizer(RobertaTokenizerFast, Featurizer):
+class RobertaFeaturizer(Featurizer):
   """Roberta Featurizer.
 
   The Roberta Featurizer is a wrapper class of the Roberta Tokenizer,
   which is used by Huggingface's transformers library for tokenizing large corpuses for Roberta Models.
-  Please confirm the details in [1]_.
+  This class intends to allow users to use the RobertaTokenizer API while
+  remaining inside the DeepChem ecosystem.
 
   Please see https://github.com/huggingface/transformers
   and https://github.com/seyonechithrananda/bert-loves-chemistry for more details.
 
   Examples
   --------
+  >>> from transformers import RobertaTokenizerFast
   >>> from deepchem.feat import RobertaFeaturizer
+  >>> tokenizer = RobertaTokenizerFast.from_pretrained("seyonec/SMILES_tokenized_PubChem_shard00_160k", do_lower_case=False)
+  >>> featurizer = RobertaFeaturizer(tokenizer)
   >>> smiles = ["Cn1c(=O)c2c(ncn2C)n(C)c1=O", "CC(=O)N1CN(C(C)=O)C(O)C1O"]
-  >>> featurizer = RobertaFeaturizer.from_pretrained("seyonec/SMILES_tokenized_PubChem_shard00_160k")
   >>> out = featurizer.featurize(smiles, add_special_tokens=True, truncation=True)
 
   References
@@ -34,31 +37,32 @@ class RobertaFeaturizer(RobertaTokenizerFast, Featurizer):
   Note
   -----
   This class requires transformers to be installed.
-  RobertaFeaturizer uses dual inheritance with RobertaTokenizerFast in Huggingface for rapid tokenization,
-  as well as DeepChem's MolecularFeaturizer class.
+  RobertaFeaturizer uses inheritance with DeepChem's 
+  Featurizer class while instantiating RobertaTokenizerFast 
+  in Huggingface as an attribute for rapid tokenization.
   """
 
-  def __init__(self, **kwargs):
-    super().__init__(**kwargs)
-    return
+  def __init__(self, tokenizer: RobertaTokenizerFast):
+    if not isinstance(tokenizer, RobertaTokenizerFast):
+      raise TypeError(f"""`tokenizer` must be a constructed `RobertaTokenizerFast`
+                       object, not {type(tokenizer)}""")
+    else:
+      self.tokenizer = tokenizer
 
   def _featurize(self, datapoint: str, **kwargs) -> List[List[int]]:
     """Calculate encoding using HuggingFace's RobertaTokenizerFast
 
     Parameters
     ----------
-    sequence: str
+    datapoint: str
       Arbitrary string sequence to be tokenized.
 
     Returns
     -------
-    datapoint: List
+    encoding: List
       List containing two lists; the `input_ids` and the `attention_mask`
     """
 
     # the encoding is natively a dictionary with keys 'input_ids' and 'attention_mask'
     encoding = list(self(datapoint, **kwargs).values())
     return encoding
-
-  def __call__(self, *args, **kwargs) -> Dict[str, List[int]]:
-    return super().__call__(*args, **kwargs)

--- a/deepchem/feat/tests/test_roberta_tokenizer.py
+++ b/deepchem/feat/tests/test_roberta_tokenizer.py
@@ -1,4 +1,5 @@
 import pytest
+from transformers.tokenization_roberta import RobertaTokenizerFast
 
 
 @pytest.mark.torch
@@ -9,8 +10,9 @@ def test_smiles_call():
   long_molecule_smiles = [
       "CCCCCCCCCCCCCCCCCCCC(=O)OCCCNC(=O)c1ccccc1SSc1ccccc1C(=O)NCCCOC(=O)CCCCCCCCCCCCCCCCCCC"
   ]
-  featurizer = RobertaFeaturizer.from_pretrained(
-      "seyonec/SMILES_tokenized_PubChem_shard00_160k")
+  tokenizer = RobertaTokenizerFast.from_pretrained(
+      "seyonec/SMILES_tokenized_PubChem_shard00_160k", do_lower_case=False)
+  featurizer = RobertaFeaturizer(tokenizer)
   embedding = featurizer(smiles, add_special_tokens=True, truncation=True)
   embedding_long = featurizer(
       long_molecule_smiles * 2, add_special_tokens=True, truncation=True)
@@ -31,8 +33,9 @@ def test_smiles_featurize():
   long_molecule_smiles = [
       "CCCCCCCCCCCCCCCCCCCC(=O)OCCCNC(=O)c1ccccc1SSc1ccccc1C(=O)NCCCOC(=O)CCCCCCCCCCCCCCCCCCC"
   ]
-  featurizer = RobertaFeaturizer.from_pretrained(
-      "seyonec/SMILES_tokenized_PubChem_shard00_160k")
+  tokenizer = RobertaTokenizerFast.from_pretrained(
+      "seyonec/SMILES_tokenized_PubChem_shard00_160k", do_lower_case=False)
+  featurizer = RobertaFeaturizer(tokenizer)
   feats = featurizer.featurize(smiles, add_special_tokens=True, truncation=True)
   assert (len(feats) == 2)
   assert (all([len(f) == 2 for f in feats]))


### PR DESCRIPTION
# Pull Request Template

Removing dual inheritance support as done by @alat-rights in BertTokenizer #2642. Now the main utility of the class is to pass a tokenizer into a DeepChem featurizer object so they can use it within the DeepChem ecosystem (pass to loaders, train on deepchem models, etc). Modified doctest + unit test to reflect this.



## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [x ] Run `mypy -p deepchem` and check no errors
  - [x ] Run `flake8 <modified file> --count` and check no errors
  - [ x] Run `python -m doctest <modified file>` and check no errors
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] New unit tests pass locally with my changes
- [x ] I have checked my code and corrected any misspellings

@rbharath @alat-rights 