### PR TITLE
removed Model being an sklearn BaseEstimator

### DIFF
--- a/deepchem/models/models.py
+++ b/deepchem/models/models.py
@@ -9,7 +9,6 @@ import logging
 from typing import List, Optional, Sequence
 
 import numpy as np
-from sklearn.base import BaseEstimator
 
 from deepchem.data import Dataset
 from deepchem.metrics import Metric
@@ -20,7 +19,7 @@ from deepchem.utils.typing import ArrayLike
 logger = logging.getLogger(__name__)
 
 
-class Model(BaseEstimator):
+class Model(object):
   """
   Abstract base class for DeepChem models.
   """


### PR DESCRIPTION
Fix #2617 

When we are printing some models, we get `AttributeError` from sklearn version 0.24 onwards. DeepChem's models inherit sklearn.base.BaseEstimator. For the children classes of BaseEstimator, it requires that the parameters in `__init__` to be retrieved as an instance attribute of the same name which raises the error.

In this PR, I removed Model class from being an sklearn.base.BaseEstimator. The BaseEstimator was introduced in this [PR](https://github.com/deepchem/deepchem/pull/544) to try out different parameters for hyper-parameter optimization via the library [osprey](https://github.com/msmbuilder/osprey). Since DeepChem is currently not using osprey as it has its own support for hyper-parameter optimization and we are also not using get_params() and set_params() provided by BaseEstimator, we can remove this dependency.

CC @peastman @rbharath 
