### PR TITLE
Pinned torch scatter to 2.0.8

### DIFF
--- a/env.cpu.mac.yml
+++ b/env.cpu.mac.yml
@@ -5,6 +5,6 @@ dependencies:
     - dgl==0.6.*
     - torch==1.8.1
     - torchvision==0.9.1
-    - torch-scatter
+    - torch-scatter==2.0.8
     - torch-sparse
     - jax[cpu]

--- a/env.cpu.yml
+++ b/env.cpu.yml
@@ -5,6 +5,6 @@ dependencies:
     - dgl==0.6.*
     - torch==1.8.1+cpu
     - torchvision==0.9.1+cpu
-    - torch-scatter
+    - torch-scatter==2.0.8
     - torch-sparse
     - jax[cpu]

--- a/env.gpu.yml
+++ b/env.gpu.yml
@@ -5,6 +5,6 @@ dependencies:
     - dgl-cu110==0.6.*
     - torch==1.8.1+cu111
     - torchvision==0.9.1+cu111
-    - torch-scatter
+    - torch-scatter==2.0.8
     - torch-sparse
     - jax[cuda111]


### PR DESCRIPTION
Fix #2730 

This PR pins torch-scatter to 2.0.8. The latest version of torch-scatter 2.0.9 is causing installation errors in DeepChem's Core CI, hence torch-scatter is pinned to 2.0.8.

## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
