### PR TITLE
Added rdkit-pypi to install requires in setup.py

### DIFF
--- a/examples/tutorials/Advanced_Model_Training.ipynb
+++ b/examples/tutorials/Advanced_Model_Training.ipynb
@@ -19,27 +19,7 @@
     "\n",
     "## Setup\n",
     "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "tS3siM3Ch11-",
-    "outputId": "3a96e0a7-46c1-4baa-91da-f98ca5a33d6d"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "To run DeepChem within Colab, you'll need to run the following installation commands. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install DeepChem in your local machine again."
    ]
   },
   {

--- a/examples/tutorials/An_Introduction_To_MoleculeNet.ipynb
+++ b/examples/tutorials/An_Introduction_To_MoleculeNet.ipynb
@@ -23,19 +23,7 @@
     "\n",
     "## Setup\n",
     "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "To run DeepChem within Colab, you'll need to run the following installation commands. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install DeepChem again on your local machine."
    ]
   },
   {

--- a/examples/tutorials/Conditional_Generative_Adversarial_Networks.ipynb
+++ b/examples/tutorials/Conditional_Generative_Adversarial_Networks.ipynb
@@ -19,29 +19,6 @@
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Conditional_Generative_Adversarial_Networks.ipynb)\n",
     "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following cell of installation commands. This will take about 5 minutes to run to completion and install your environment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "gXeKc6O9qSSw",
-    "outputId": "9872d3b7-bf6d-4977-d064-ca122f539751"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
    ]
   },
   {

--- a/examples/tutorials/Creating_Models_with_TensorFlow_and_PyTorch.ipynb
+++ b/examples/tutorials/Creating_Models_with_TensorFlow_and_PyTorch.ipynb
@@ -13,22 +13,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Creating_Models_with_TensorFlow_and_PyTorch.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Creating_a_high_fidelity_model_from_experimental_data.ipynb
+++ b/examples/tutorials/Creating_a_high_fidelity_model_from_experimental_data.ipynb
@@ -16,30 +16,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Creating_a_high_fidelity_model_from_experimental_data.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 323
-    },
-    "colab_type": "code",
-    "id": "tbLbuh6wl8tX",
-    "outputId": "5ddc020c-80ff-42fe-fe5b-85dd0b25446f"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Exploring_Quantum_Chemistry_with_GDB1k.ipynb
+++ b/examples/tutorials/Exploring_Quantum_Chemistry_with_GDB1k.ipynb
@@ -25,30 +25,7 @@
     "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Exploring_Quantum_Chemistry_with_GDB1k.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 153
-    },
-    "colab_type": "code",
-    "id": "hiRnnJpG2UJY",
-    "outputId": "4ccce479-ab8f-4b55-a00b-9554d53d874d"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
+++ b/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
@@ -16,30 +16,7 @@
     "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "tS3siM3Ch11-",
-    "outputId": "3a96e0a7-46c1-4baa-91da-f98ca5a33d6d"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Introduction_To_Material_Science.ipynb
+++ b/examples/tutorials/Introduction_To_Material_Science.ipynb
@@ -29,29 +29,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4ee5af00",
-   "metadata": {},
-   "source": [
-    "## Setup <a class=\"anchor\" id=\"setup\"></a>\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e5b36a4e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b3a2e5d4",

--- a/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
+++ b/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
@@ -20,30 +20,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 156
-    },
-    "colab_type": "code",
-    "id": "EoCLxSnBcj1N",
-    "outputId": "d0555806-a13b-4522-c845-c36a7f910fca"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Introduction_to_Model_Interpretability.ipynb
+++ b/examples/tutorials/Introduction_to_Model_Interpretability.ipynb
@@ -32,30 +32,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Introduction_to_Model_Interpretability.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 323
-    },
-    "colab_type": "code",
-    "id": "xdgY3YQLkP1m",
-    "outputId": "19d8cbca-1cdb-48ba-d951-7b365506fc6f"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Introduction_to_Molecular_Attention_Transformer.ipynb
+++ b/examples/tutorials/Introduction_to_Molecular_Attention_Transformer.ipynb
@@ -16,23 +16,8 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Introduction_to_Molecular_Attention_Transformer.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
+    "\n"
    ],
-   "metadata": {}
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
-   ],
-   "outputs": [],
    "metadata": {}
   },
   {

--- a/examples/tutorials/Learning_Unsupervised_Embeddings_for_Molecules.ipynb
+++ b/examples/tutorials/Learning_Unsupervised_Embeddings_for_Molecules.ipynb
@@ -16,30 +16,7 @@
     "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Learning_Unsupervised_Embeddings_for_Molecules.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine. This notebook can take up to a few hours to run on a GPU, so we encourage you to run it on Google colab unless you have a good GPU machine available."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "ci69aRSm2aoO",
-    "outputId": "9071e7f3-15a7-4e3e-add8-fb1b7134a85a"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Molecular_Fingerprints.ipynb
+++ b/examples/tutorials/Molecular_Fingerprints.ipynb
@@ -17,30 +17,7 @@
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Molecular_Fingerprints.ipynb)\n",
     "\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "OyxRVW5X5zF0",
-    "outputId": "affd23f1-1929-456a-f8a6-e53a874c84b4"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Putting_Multitask_Learning_to_Work.ipynb
+++ b/examples/tutorials/Putting_Multitask_Learning_to_Work.ipynb
@@ -16,31 +16,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Putting_Multitask_Learning_to_Work.ipynb)\n",
-    "\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following cell of installation commands. This will take about 5 minutes to run to completion and install your environment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "Fc_4bSWJg37l",
-    "outputId": "dce34f1f-e14f-42d0-ccb6-c0893d0fda3f"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Synthetic_Feasibility_Scoring.ipynb
+++ b/examples/tutorials/Synthetic_Feasibility_Scoring.ipynb
@@ -22,31 +22,7 @@
     "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Synthetic_Feasibility_Scoring.ipynb)\n",
-    "\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 323
-    },
-    "colab_type": "code",
-    "id": "IlFeRa3qpbFz",
-    "outputId": "2836932a-eae7-487c-b20d-54607c452046"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -80,22 +80,8 @@
         "\n",
         "## Setup\n",
         "\n",
-        "The first step is to get DeepChem up and running. We recommend using Google Colab to work through this tutorial series. You'll need to run the following commands to get DeepChem installed on your colab notebook. Note that this will take something like 5 minutes to run on your colab instance."
+        "The first step is to get DeepChem up and running. We recommend using Google Colab to work through this tutorial series. You'll need to run the following commands to get DeepChem installed on your colab notebook.
       ]
-    },
-    {
-      "cell_type": "code",
-      "metadata": {
-        "id": "OyxRVW5X5zF0"
-      },
-      "source": [
-        "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-        "import conda_installer\n",
-        "conda_installer.install()\n",
-        "!/root/miniconda/bin/conda info -e"
-      ],
-      "execution_count": null,
-      "outputs": []
     },
     {
       "cell_type": "code",

--- a/examples/tutorials/Training_a_Generative_Adversarial_Network_on_MNIST.ipynb
+++ b/examples/tutorials/Training_a_Generative_Adversarial_Network_on_MNIST.ipynb
@@ -18,30 +18,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Training_a_Generative_Adversarial_Network_on_MNIST.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following cell of installation commands. This will take about 5 minutes to run to completion and install your environment."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "4qlydaTAr0bv",
-    "outputId": "d7d00b64-4281-4476-9912-822012906168"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Uncertainty_In_Deep_Learning.ipynb
+++ b/examples/tutorials/Uncertainty_In_Deep_Learning.ipynb
@@ -18,30 +18,7 @@
     "This tutorial and the rest in this sequence are designed to be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Uncertainty_In_Deep_Learning.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 323
-    },
-    "colab_type": "code",
-    "id": "p0MdAUAvkMdD",
-    "outputId": "e73f824a-cd0b-4c73-d2e7-ef70df9e4baf"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Using_Reinforcement_Learning_to_Play_Pong.ipynb
+++ b/examples/tutorials/Using_Reinforcement_Learning_to_Play_Pong.ipynb
@@ -18,30 +18,7 @@
     "This tutorial and the rest in this sequence can be done in Google Colab (although the visualization at the end doesn't work correctly on Colab, so you might prefer to run this tutorial locally). If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Using_Reinforcement_Learning_to_Play_Pong.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following cell of installation commands. This will take about 5 minutes to run to completion and install your environment. To install `gym` you should also use `pip install 'gym[atari]'` (We need the extra modifier since we'll be using an atari game). We'll add this command onto our usual Colab installation commands for you"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "qXdmcnhtst-z",
-    "outputId": "5c7cf904-0f5c-41d8-c404-75258bafca86"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Working_With_Datasets.ipynb
+++ b/examples/tutorials/Working_With_Datasets.ipynb
@@ -16,31 +16,7 @@
     "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Working_With_Datasets.ipynb)\n",
-    "\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "OyxRVW5X5zF0",
-    "outputId": "affd23f1-1929-456a-f8a6-e53a874c84b4"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/examples/tutorials/Working_With_Splitters.ipynb
+++ b/examples/tutorials/Working_With_Splitters.ipynb
@@ -16,30 +16,7 @@
     "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
     "\n",
     "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Working_With_Splitters.ipynb)\n",
-    "\n",
-    "## Setup\n",
-    "\n",
-    "To run DeepChem within Colab, you'll need to run the following installation commands. This will take about 5 minutes to run to completion and install your environment. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install Anaconda on your local machine."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "colab": {
-     "base_uri": "https://localhost:8080/",
-     "height": 170
-    },
-    "colab_type": "code",
-    "id": "tS3siM3Ch11-",
-    "outputId": "3a96e0a7-46c1-4baa-91da-f98ca5a33d6d"
-   },
-   "outputs": [],
-   "source": [
-    "!curl -Lo conda_installer.py https://raw.githubusercontent.com/deepchem/deepchem/master/scripts/colab_install.py\n",
-    "import conda_installer\n",
-    "conda_installer.install()\n",
-    "!/root/miniconda/bin/conda info -e"
+    "\n"
    ]
   },
   {

--- a/scripts/colab_install.py
+++ b/scripts/colab_install.py
@@ -16,10 +16,8 @@ logger.setLevel(INFO)
 
 default_channels = [
     "conda-forge",
-    "omnia",
 ]
 default_packages = [
-    "rdkit=2020.09.02",
     "openmm",
     "pdbfixer",
 ]
@@ -107,7 +105,7 @@ def install(
   subprocess.check_call(["bash", file_name, "-b", "-p", conda_path])
   logger.info('done')
 
-  logger.info("installing rdkit, openmm, pdbfixer")
+  logger.info("installing openmm, pdbfixer")
   channels = list(set(default_channels + additional_channels))
   for channel in channels:
     subprocess.check_call([

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
         'pandas',
         'scikit-learn',
         'scipy',
+        'rdkit-pypi',
     ],
     extras_require=extras,
     python_requires='>=3.5')


### PR DESCRIPTION
Fix #2629 

In this PR, I have added `rdkit-pypi` to install-requires in `setup.py`. With this change, `rdkit` will be a primary dependency for deepchem and it will be installed along with deepchem when deepchem is installed via pip. A couple of months back, `rdkit` can only be managed using `conda` but with the installation of `pypi` built by RDKit team, this change is possible now.

As rdkit can be installed using pip, it is removed from `colab_install.py`. Now, the script `colab_install.py` is used for installing openmm and pdbfixer.

As a consequence of above changes, installation in colab is made simpler and hence tutorial notebooks are updated for the same. Install via `colab_install.py` remains only for notebooks with openmm and pdbfixer dependencies.

This PR also fixes #2613 , #2727 (redundant issues).