### PR TITLE
Update qm8_datasets.py - fixes #2747

### DIFF
--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -8,7 +8,7 @@ from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
 GDB8_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb8.tar.gz"
-QM8_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm8.csv"
+QM8_CSV_URL = "https://gist.githubusercontent.com/ellagale/9e632c9fcf11aaa803ae8a86f9c2a82d/raw/dd862e24858fe68141021c843069ecd0350b5d13/qm8.csv"
 QM8_TASKS = [
     "E1-CC2", "E2-CC2", "f1-CC2", "f2-CC2", "E1-PBE0", "E2-PBE0", "f1-PBE0",
     "f2-PBE0", "E1-PBE0", "E2-PBE0", "f1-PBE0", "f2-PBE0", "E1-CAM", "E2-CAM",


### PR DESCRIPTION
## Description

Fix #2747
update qm8 so it pulls a version of qm8.csv generated from the Quantum-Machine.org data that correctly includes the `LR-TDPBE0/def2TZVP` data

Although hosting it like this on github should be fine, it ought to be imported into the deepchem aws by someone with access.

## Type of change

Please check the option that is related to your PR.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [n/a] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [n/a] Run `mypy -p deepchem` and check no errors
  - [n/a] Run `flake8 <modified file> --count` and check no errors
  - [n/a] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] New unit tests pass locally with my changes
- [n/a] I have checked my code and corrected any misspellings

most of these are n/a since there are no actual code changes here.