### PR TITLE
fixes loading of hppb dataset with RawFeaturizer

### DIFF
--- a/deepchem/molnet/load_function/hppb_datasets.py
+++ b/deepchem/molnet/load_function/hppb_datasets.py
@@ -2,6 +2,7 @@
 HPPB Dataset Loader.
 """
 import os
+import numpy as np
 import deepchem as dc
 from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _MolnetLoader
 from deepchem.data import Dataset
@@ -18,7 +19,19 @@ def remove_missing_entries(dataset):
   feature vectors. Get rid of them.
   """
   for i, (X, y, w, ids) in enumerate(dataset.itershards()):
-    available_rows = X.any(axis=1)
+    if X.ndim == 1:
+      X = np.expand_dims(X, axis=1)
+
+    if isinstance(X.flat[0], object):
+      available_rows = []
+      for obj in X:
+        if obj.flat[0] is not None:
+          available_rows.append(True)
+        else:
+          available_rows.append(False)
+    else:
+      available_rows = X.any(axis=1)
+
     X = X[available_rows]
     y = y[available_rows]
     w = w[available_rows]


### PR DESCRIPTION
Fix #2350

For the `hppb` dataset, previously using `dc.feat.RawFeaturizer` as featurizer raised an `AxisError` in `remove_missing_entries` because the `X` attribute had only one column. To fix that, I added few lines to expand dims when `X` has only one column.

Also, missing entries where searched using `np.any` utility but it works only one the data type of the entries is float. `RawFeaturizer` returns an object of type `rdkit.Chem.rdchem.Mol`. Hence, added an additional `for` loop to search for `None` entries in the molecules to detect missing entries.


<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
