### PR TITLE
added assertion for number of atoms in MolGraphConvFeaturizer

### DIFF
--- a/deepchem/feat/molecule_featurizers/mol_graph_conv_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/mol_graph_conv_featurizer.py
@@ -181,6 +181,8 @@ class MolGraphConvFeaturizer(MolecularFeaturizer):
     graph: GraphData
       A molecule graph with some features.
     """
+    assert datapoint.GetNumAtoms(
+    ) > 1, "More than one atom should be present in the molecule for this featurizer to work."
     if 'mol' in kwargs:
       datapoint = kwargs.get("mol")
       raise DeprecationWarning(


### PR DESCRIPTION
Fix #2363 

`MolGraphConvFeaturizer` fails for simple molecules like 'C' etc. In this small PR, I have added an more informative exception on why it fails.

Example:

```
feat = dc.feat.MolGraphConvFeaturizer()
feat.featurize(["C"])
```
Previous failure message:
```
Failed to featurize datapoint 0, O. Appending empty array
Exception message: zero-size array to reduction operation maximum which has no identity
```
After this fix, the error message will be:
```
Failed to featurize datapoint 0, C. Appending empty array
Exception message: More than one atom should be present in the molecule for this featurizer to work.
```

