### PR TITLE
Doc fixes

### DIFF
--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -98,7 +98,6 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
   --------
   This example shows the type of constructor function expected.
 
-  >>> import sklearn
   >>> import deepchem as dc
   >>> optimizer = dc.hyper.GaussianProcessHyperparamOpt(lambda **p: dc.models.GraphConvModel(n_tasks=1, **p))
 
@@ -109,17 +108,26 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
   (in this case, `n_tasks` and `n_features` which are properties of a
   dataset and not hyperparameters to search over.)
 
+  >>> import numpy as np
+  >>> from sklearn.ensemble import RandomForestRegressor as RF
   >>> def model_builder(**model_params):
-  ...   n_layers = model_params['layers']
-  ...   layer_width = model_params['width']
-  ...   dropout = model_params['dropout']
-  ...   return dc.models.MultitaskClassifier(
-  ...     n_tasks=5,
-  ...     n_features=100,
-  ...     layer_sizes=[layer_width]*n_layers,
-  ...     dropouts=dropout
-  ...   )
+  ...   n_estimators = model_params['n_estimators']
+  ...   min_samples_split = model_params['min_samples_split']
+  ...   rf_model = RF(n_estimators=n_estimators, min_samples_split=min_samples_split)
+  ...   rf_model = RF(n_estimators=n_estimators)
+  ...   return dc.models.SklearnModel(rf_model)
   >>> optimizer = dc.hyper.GaussianProcessHyperparamOpt(model_builder)
+  >>> params_dict = {"n_estimators":100, "min_samples_split":2}
+  >>> train_dataset = dc.data.NumpyDataset(X=np.random.rand(50, 5),
+  ...   y=np.random.rand(50, 1))
+  >>> valid_dataset = dc.data.NumpyDataset(X=np.random.rand(20, 5),
+  ...   y=np.random.rand(20, 1))
+  >>> metric = dc.metrics.Metric(dc.metrics.pearson_r2_score)
+
+  >> best_model, best_hyperparams, all_results =\
+  optimizer.hyperparam_search(params_dict, train_dataset, valid_dataset, metric, max_iter=2)
+  >> type(best_hyperparams)
+  <class 'dict'>
 
   Notes
   -----

--- a/docs/source/development_guide/coding.rst
+++ b/docs/source/development_guide/coding.rst
@@ -84,6 +84,12 @@ that break them may sometimes slip through and get merged into the repository.
 We still try to run them regularly, so hopefully the problem will be discovered
 fairly soon.
 
+The full suite of slow tests can be run from the root directory of the source code as
+
+.. code-block:: bash
+
+  pytest -v -m 'slow' deepchem
+
 To test your code locally, you will have to setup a symbolic link to your
 current development directory. To do this, simply run
 
@@ -121,6 +127,36 @@ DeepChem, you should add at least a few basic types of unit tests:
 Note that unit tests are not sufficient to gauge the real performance
 of a model. You should benchmark your model on larger datasets as well
 and report your benchmarking tests in the PR comments.
+
+For testing tensorflow models and pytorch models, we recommend testing in
+different conda environments. Tensorflow 2.6 supports numpy 1.19 while
+pytorch supports numpy 1.21. This version mismatch on numpy dependency
+sometimes causes trouble in installing tensorflow and pytorch backends in
+the same environment.
+
+For testing tensorflow models of deepchem, we create a tensorflow test environment
+and then run the test as follows:
+
+.. code-block:: bash
+
+  conda create -n tf-test python=3.8
+  conda activate tf-test
+  pip install conda-merge
+  conda-merge requirements/tensorflow/env_tensorflow.yml env.test.yml > env.yml
+  conda env update --file env.yml --prune
+  pytest -v -m 'tensorflow' deepchem
+
+For testing pytorch models of deepchem, first create a pytorch test environment
+and then run the tests as follows:
+
+.. code-block:: bash
+
+  conda create -n pytorch-test python=3.8
+  conda activate pytorch-test
+  pip install conda-merge
+  conda-merge requirements/torch/env_torch.yml requirements/torch/env_torch.cpu.yml env.test.yml > env.yml
+  conda env update --file env.yml --prune
+  pytest -v -m 'torch' deepchem
 
 Type Annotations
 ----------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -101,17 +101,6 @@ To listen in, please email X.Y@gmail.com, where X=bharath and Y=ramsundar to int
 .. toctree::
    :glob:
    :maxdepth: 1
-   :caption: Development Guide
-
-   development_guide/licence
-   development_guide/scientists
-   development_guide/coding
-   development_guide/ci
-   development_guide/infra
-
-.. toctree::
-   :glob:
-   :maxdepth: 1
    :caption: API Reference
 
    api_reference/data
@@ -127,3 +116,14 @@ To listen in, please email X.Y@gmail.com, where X=bharath and Y=ramsundar to int
    api_reference/rl
    api_reference/docking
    api_reference/utils
+
+.. toctree::
+   :glob:
+   :maxdepth: 1
+   :caption: Development Guide
+
+   development_guide/licence
+   development_guide/scientists
+   development_guide/coding
+   development_guide/ci
+   development_guide/infra


### PR DESCRIPTION
In this PR, I have made improvements to documentation of deepchem.

Summary of the changes made:

- Moved `api reference` section before `development guide` section in docs. IMO, I felt that this style will make it quicker to access the api reference section (currently, to access the bottom content of api reference, it requires a scroll - not a big deal but a minor usability point) which I think is used by more people than development guide section. I am okay to any suggestions on this fix.
- Fixes to #2521 - on how to run full slow test suite
- Fixes to #2353 - added examples for GaussianProcessHyperparamOpt