### PR TITLE
Removing package pins

### DIFF
--- a/deepchem/models/torch_models/cgcnn.py
+++ b/deepchem/models/torch_models/cgcnn.py
@@ -19,9 +19,9 @@ class CGCNNLayer(nn.Module):
   Examples
   --------
   >>> import deepchem as dc
-  >>> import pymatgen as mg
-  >>> lattice = mg.Lattice.cubic(4.2)
-  >>> structure = mg.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+  >>> from pymatgen.core import Lattice, Structure
+  >>> lattice = Lattice.cubic(4.2)
+  >>> structure = Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
   >>> featurizer = dc.feat.CGCNNFeaturizer()
   >>> cgcnn_graph = featurizer.featurize([structure])[0]
   >>> cgcnn_graph.num_node_features
@@ -118,9 +118,9 @@ class CGCNN(nn.Module):
   Examples
   --------
   >>> import deepchem as dc
-  >>> import pymatgen as mg
-  >>> lattice = mg.Lattice.cubic(4.2)
-  >>> structure = mg.Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
+  >>> from pymatgen.core import Lattice, Structure
+  >>> lattice = Lattice.cubic(4.2)
+  >>> structure = Structure(lattice, ["Cs", "Cl"], [[0, 0, 0], [0.5, 0.5, 0.5]])
   >>> featurizer = dc.feat.CGCNNFeaturizer()
   >>> cgcnn_feat = featurizer.featurize([structure])[0]
   >>> print(type(cgcnn_feat))

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -8,7 +8,7 @@ dependencies:
   - rdkit
   - mdtraj
   - numpy>=1.21
-  - pip==20.2.*
+  - pip
   - pip:
     - pre-commit
     - biopython

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -20,7 +20,7 @@ dependencies:
     - pillow
     - pubchempy
     - pyGPGO
-    - pymatgen==2020.12.31
+    - pymatgen
     - simdna
     - transformers==4.6.*
     - xgboost

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -23,6 +23,6 @@ dependencies:
     - pymatgen==2020.12.31
     - simdna
     - transformers==4.6.*
-    - xgboost==1.*
+    - xgboost
     - git+https://github.com/samoturk/mol2vec
     - tensorboard


### PR DESCRIPTION
DeepChem has a number of packages in dependencies which are pinned to specific versions. In the long run, it is not good to pin packages. In this PR, I am experimenting with removing those pins. Final goal is to bump tensorflow to 2.7.