### PR TITLE
Multi-gpu distributed training for deepchem

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -52,6 +52,7 @@ tutorials discuss about using DeepChem for specific applications.
 * [13 Modeling Protein Ligand Interactions with Atomic Convolutions](Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb)
 * [14 Conditional Generative Adversarial Networks](Conditional_Generative_Adversarial_Networks.ipynb)
 * [15 Training a Generative Adversarial Network on MNIST](Training_a_Generative_Adversarial_Network_on_MNIST.ipynb)
+* [16 Distributed Multi-GPU Training of DeepChem Models with LitMatter](https://github.com/ncfrey/litmatter/blob/main/LitDeepChem.ipynb)
 
 ### Molecular Machine Learning
 * [1 Molecular Fingerprints](Molecular_Fingerprints.ipynb)


### PR DESCRIPTION
## Description
I have updated the DeepChem tutorial series to link to a [notebook](https://github.com/ncfrey/litmatter/blob/main/LitDeepChem.ipynb) in the [LitMatter repo](https://github.com/ncfrey/litmatter) which shows how to do distributed, multi-GPU training of DeepChem models. 

Rather than add new dependencies to DeepChem, I propose simply linking to the LitMatter codebase and tutorial. LitMatter provides example wrappers for DeepChem's `TorchModel` and MolNet datasets. Porting specific models that subclass `TorchModel` should be straightforward, following the LitMatter template and examples.

Addresses #2594 and #2514 

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)
