### PR TITLE
Fix bug for dataset.get_shape() after dataset.set_shard()

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2286,6 +2286,7 @@ class DiskDataset(Dataset):
     basename = "shard-%d" % shard_num
     DiskDataset.write_data_to_disk(self.data_dir, basename, X, y, w, ids)
     self._cached_shards = None
+    self.legacy_metadata = True
 
   def select(self,
              indices: Sequence[int],

--- a/deepchem/data/tests/test_setshard.py
+++ b/deepchem/data/tests/test_setshard.py
@@ -3,17 +3,19 @@ import numpy as np
 
 
 def test_setshard_with_X_y():
-  """Test setharding on a simple example"""
+  """Test setsharding on a simple example"""
   X = np.random.rand(10, 3)
   y = np.random.rand(10,)
   dataset = dc.data.DiskDataset.from_numpy(X, y)
-  assert dataset.get_shape()[0][0] == 10
-  assert dataset.get_shape()[1][0] == 10
+  X_shape, y_shape, _, _ = dataset.get_shape()
+  assert X_shape[0] == 10
+  assert y_shape[0] == 10
   for i, (X, y, w, ids) in enumerate(dataset.itershards()):
     X = X[1:]
     y = y[1:]
     w = w[1:]
     ids = ids[1:]
     dataset.set_shard(i, X, y, w, ids)
-  assert dataset.get_shape()[0][0] == 9
-  assert dataset.get_shape()[1][0] == 9
+  X_shape, y_shape, _, _ = dataset.get_shape()
+  assert X_shape[0] == 9
+  assert y_shape[0] == 9

--- a/deepchem/data/tests/test_setshard.py
+++ b/deepchem/data/tests/test_setshard.py
@@ -1,0 +1,19 @@
+import deepchem as dc
+import numpy as np
+
+
+def test_setshard_with_X_y():
+  """Test setharding on a simple example"""
+  X = np.random.rand(10, 3)
+  y = np.random.rand(10,)
+  dataset = dc.data.DiskDataset.from_numpy(X, y)
+  assert dataset.get_shape()[0][0] == 10
+  assert dataset.get_shape()[1][0] == 10
+  for i, (X, y, w, ids) in enumerate(dataset.itershards()):
+    X = X[1:]
+    y = y[1:]
+    w = w[1:]
+    ids = ids[1:]
+    dataset.set_shard(i, X, y, w, ids)
+  assert dataset.get_shape()[0][0] == 9
+  assert dataset.get_shape()[1][0] == 9


### PR DESCRIPTION
## Description

Fix #2772 @arunppsg 

Change `self.legacy_metadata` into `True` after `dataset.set_shard()`, meaning that shape metadata has changed.  `dataset.get_shape()` should fall back to loading data from disk and acquire the shape.
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
