### PR TITLE
Minor Release 2.6.1

### DIFF
--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -3,7 +3,7 @@ Imports all submodules
 """
 
 # If you push the tag, please remove `.dev`
-__version__ = '2.6.0'
+__version__ = '2.6.1'
 
 import deepchem.data
 import deepchem.feat

--- a/docker/tag/Dockerfile
+++ b/docker/tag/Dockerfile
@@ -15,11 +15,10 @@ ENV PATH /miniconda/bin:$PATH
 
 # install latest version deepchem
 RUN conda update -n base conda && \
-    conda create -y --name deepchem python=3.6 && \
+    conda create -y --name deepchem python=3.7 && \
     . /miniconda/etc/profile.d/conda.sh && \
     conda activate deepchem && \
-    pip install tensorflow~=2.4 deepchem && \
-    conda install -c conda-forge rdkit && \
+    pip install tensorflow~=2.7 deepchem && \
     conda clean -afy && \
     rm -rf ~/.cache/pip
 


### PR DESCRIPTION
The minor release is to reflect changes in the numpy version bumping after 2.6.0 release. Numpy version bumping is required to set the tutorials working.