### PR TITLE
tighten test_lcnn_regression bound

### DIFF
--- a/deepchem/models/tests/test_lcnn.py
+++ b/deepchem/models/tests/test_lcnn.py
@@ -36,7 +36,8 @@ def test_lcnn_regression():
   # check overfit
   regression_metric = Metric(mae_score)
   scores = model.evaluate(test, [regression_metric], transformers)
-  assert scores[regression_metric.name] < 0.6
+  assert scores[regression_metric.name] < 0.4
+  assert scores[regression_metric.name] > 0.01
 
 
 @pytest.mark.torch


### PR DESCRIPTION
## Description

The test `test_lcnn_regression` in `test_lcnn.py` has an assertion bound (`assert scores[regression_metric.name] < 0.6`) that is too loose. This means potential bug in the code could still pass the original test.

To quantify this I conducted some experiments where I generated multiple mutations of the source code under test and ran each mutant and the original code 100 times to build a distribution of their outputs. I used KS-test to find mutants that produced a different distribution from the original and use those mutants as a proxy for bugs that could be introduced. In the graph below I show the distribution of both the original code and also the mutants with a different distribution.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150042282-1a8f1c2a-56e4-4302-bfae-af02c4605de9.png" width="450">
</p>

Here we see that the bound of `0.6` is too loose since the original distribution (in orange) is much less than `0.6`. Furthermore in this graph we can observe that there are many mutants (proxy for bugs) that are below the bound as well and that is undesirable since the test should aim to catch potential bugs in code. I quantify the "bug detection" of this assertion by varying the bound in a trade-off graph below.

<p align="center">
<img src="https://user-images.githubusercontent.com/95935342/150042315-08a48579-f8ed-4e46-a227-c7739fa489ad.png" width="450">
</p>

In this graph, I plot the mutant catch rate (ratio of mutant outputs that fail the test) and the original pass rate (ratio of original output that pass the test). The original bound of `0.6` (red dotted line) has a catch rate of 0.06

To improve this test, I propose to tighten the bound to `0.4` (the blue dotted line). Furthermore I proposed to set a lower bound for this test at 0.01, since I noticed there are mutants where their output value falls below 0.01. By introducing this additional lower bound we can also catch those mutants.

The new set of bounds has a catch rate of 0.37 (+0.31 increase compare to original) while still has >99 % pass rate (test is not flaky, I ran the updated test 500 times and did not have any failures). I think this is a good balance between improving the bug-detection ability of the test while keep the flakiness of the test low.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions or questions. 

My Environment:
```
python=3.7.11
pytorch=1.10.1
tensorflow=2.7.0
```

my deepchem Experiment SHA:
`8a9efc3249992b87cf9729850c8f35ddf65d42c0`


<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
