### PR TITLE
adding jax dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,6 @@ sphinx_rtd_theme>=0.5,<1
 tensorflow>=2.4
 transformers>=4.6.*
 torch>=1.8.1
+jax
+dm-haiku
+optax


### PR DESCRIPTION
Potential fix for #2827 

Adding jax dependencies to sphinx requirements. From my understanding, the docs are not rendering for Jax Model because autodoc is not able to import jax  as jax is not installed. Hopefully, installing jax should fix the issue.

Now, one may wonder how the docs are getting rendered for classes/modules which use `rdkit`, `pymatgen` and other packages. It seems that in most of those cases, the import statement is local to the class and covered around by a try-catch statement and hence, autodoc was able to render the docs.