### PR TITLE
Bugfix: bayesian hyperparameter optimization casting to int

### DIFF
--- a/deepchem/hyper/gaussian_process.py
+++ b/deepchem/hyper/gaussian_process.py
@@ -266,7 +266,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
         if param_range[hp][0] == "int":
           # param values are always float in BO, so this line converts float to int
           # see : https://github.com/josejimenezluna/pyGPGO/issues/10
-          hyper_parameters[hp] = int(placeholders[hp])
+          hyper_parameters[hp] = int(round(laceholders[hp]))
         else:
           hyper_parameters[hp] = float(placeholders[hp])
       logger.info("Running hyperparameter set: %s" % str(hyper_parameters))
@@ -362,7 +362,7 @@ class GaussianProcessHyperparamOpt(HyperparamOpt):
     hyper_parameters = {}
     for hp in param_keys:
       if param_range[hp][0] == "int":
-        hyper_parameters[hp] = int(hp_opt[hp])
+        hyper_parameters[hp] = int(round(hp_opt[hp]))
       else:
         # FIXME: Incompatible types in assignment
         hyper_parameters[hp] = float(hp_opt[hp])  # type: ignore


### PR DESCRIPTION
# Pull Request Template

## Description

Fix bug in Bayesian hyperparameter optimization class. Even when specifying hyperparams as class 'int', GPGO still returns floats. The existing logic to cast hyperparameters to int doesn't round, thus all hyperparams will be implicitly floored.

## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.22.0**)
  - [X] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [X] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
