### PR TITLE
Fixing broken CI on windows - Jax and Vina

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,15 +147,15 @@ jobs:
       shell: bash -l {0}
       run: |
         mypy -p deepchem
-    - name: Doctest
-      if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
+    - name: Doctest Linux
+      if: runner.os == 'Linux'
       shell: bash -l {0}
-      run: DGLBACKEND=pytorch pytest -v --ignore-glob='deepchem/**/test*.py' --doctest-modules deepchem
-      # These tests are handled by new CI runs
-      #- name: PyTest
-      #  if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
-      #  shell: bash -l {0}
-      #  run: pytest -v -m "not slow and not jax and not torch and not tensorflow" --cov=deepchem --cov-report=xml deepchem
+      run: DGLBACKEND=pytorch pytest -v --ignore-glob='deepchem/**/test*.py' --doctest-modules deepchem --doctest-continue-on-failure
+    - name: Doctest Windows
+      if: runner.os == 'Windows'
+      # Seperate test avoiding Jax in windows since Jax is not supported in Windows
+      shell: bash -l {0}
+      run: DGLBACKEND=pytorch pytest -v --ignore-glob='deepchem/**/test*.py' --ignore-glob='deepchem/models/jax_models/*' --doctest-modules deepchem --doctest-continue-on-failure
     - name: Upload coverage to Codecov
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       uses: codecov/codecov-action@v1

--- a/deepchem/dock/pose_generation.py
+++ b/deepchem/dock/pose_generation.py
@@ -200,8 +200,9 @@ class GninaPoseGenerator(PoseGenerator):
     if not ligand_file.endswith('.sdf'):
       raise ValueError('Ligand file must be in .sdf format.')
 
-    protein_mol = load_molecule(
-        protein_file, calc_charges=True, add_hydrogens=True)
+    protein_mol = load_molecule(protein_file,
+                                calc_charges=True,
+                                add_hydrogens=True)
     ligand_name = os.path.basename(ligand_file).split(".")[0]
 
     # Define locations of log and output files
@@ -211,13 +212,12 @@ class GninaPoseGenerator(PoseGenerator):
 
     # Write GNINA conf file
     conf_file = os.path.join(out_dir, "conf.txt")
-    write_gnina_conf(
-        protein_filename=protein_file,
-        ligand_filename=ligand_file,
-        conf_filename=conf_file,
-        num_modes=num_modes,
-        exhaustiveness=exhaustiveness,
-        **kwargs)
+    write_gnina_conf(protein_filename=protein_file,
+                     ligand_filename=ligand_file,
+                     conf_filename=conf_file,
+                     num_modes=num_modes,
+                     exhaustiveness=exhaustiveness,
+                     **kwargs)
 
     # Run GNINA
     args = [
@@ -259,7 +259,9 @@ class VinaPoseGenerator(PoseGenerator):
 
   Note
   ----
-  This class requires RDKit and vina to be installed.
+  This class requires RDKit and vina to be installed. As on 9-March-22,
+  Vina is not available on Windows. Hence, this utility is currently
+  available only on Ubuntu and MacOS.
   """
 
   def __init__(self, pocket_finder: Optional[BindingPocketFinder] = None):
@@ -372,8 +374,9 @@ class VinaPoseGenerator(PoseGenerator):
     protein_name = os.path.basename(protein_file).split(".")[0]
     protein_hyd = os.path.join(out_dir, "%s_hyd.pdb" % protein_name)
     protein_pdbqt = os.path.join(out_dir, "%s.pdbqt" % protein_name)
-    protein_mol = load_molecule(
-        protein_file, calc_charges=True, add_hydrogens=True)
+    protein_mol = load_molecule(protein_file,
+                                calc_charges=True,
+                                add_hydrogens=True)
     write_molecule(protein_mol[1], protein_hyd, is_protein=True)
     write_molecule(protein_mol[1], protein_pdbqt, is_protein=True)
 
@@ -403,8 +406,9 @@ class VinaPoseGenerator(PoseGenerator):
           dimensions.append(np.array((x_box, y_box, z_box)))
 
     if num_pockets is not None:
-      logger.info("num_pockets = %d so selecting this many pockets for docking."
-                  % num_pockets)
+      logger.info(
+          "num_pockets = %d so selecting this many pockets for docking." %
+          num_pockets)
       centroids = centroids[:num_pockets]
       dimensions = dimensions[:num_pockets]
 
@@ -412,28 +416,28 @@ class VinaPoseGenerator(PoseGenerator):
     ligand_name = os.path.basename(ligand_file).split(".")[0]
     ligand_pdbqt = os.path.join(out_dir, "%s.pdbqt" % ligand_name)
 
-    ligand_mol = load_molecule(
-        ligand_file, calc_charges=True, add_hydrogens=True)
+    ligand_mol = load_molecule(ligand_file,
+                               calc_charges=True,
+                               add_hydrogens=True)
     write_molecule(ligand_mol[1], ligand_pdbqt)
 
     docked_complexes = []
     all_scores = []
     vpg = Vina(sf_name='vina', cpu=cpu, seed=0, no_refine=False, verbosity=1)
-    for i, (protein_centroid, box_dims) in enumerate(
-        zip(centroids, dimensions)):
+    for i, (protein_centroid, box_dims) in enumerate(zip(centroids,
+                                                         dimensions)):
       logger.info("Docking in pocket %d/%d" % (i + 1, len(centroids)))
       logger.info("Docking with center: %s" % str(protein_centroid))
       logger.info("Box dimensions: %s" % str(box_dims))
       # Write Vina conf file
       conf_file = os.path.join(out_dir, "conf.txt")
-      write_vina_conf(
-          protein_pdbqt,
-          ligand_pdbqt,
-          protein_centroid,
-          box_dims,
-          conf_file,
-          num_modes=num_modes,
-          exhaustiveness=exhaustiveness)
+      write_vina_conf(protein_pdbqt,
+                      ligand_pdbqt,
+                      protein_centroid,
+                      box_dims,
+                      conf_file,
+                      num_modes=num_modes,
+                      exhaustiveness=exhaustiveness)
 
       # Define locations of output files
       out_pdbqt = os.path.join(out_dir, "%s_docked.pdbqt" % ligand_name)
@@ -443,16 +447,14 @@ class VinaPoseGenerator(PoseGenerator):
       vpg.set_ligand_from_file(ligand_pdbqt)
 
       vpg.compute_vina_maps(center=protein_centroid, box_size=box_dims)
-      vpg.dock(
-          exhaustiveness=exhaustiveness,
-          n_poses=num_modes,
-          min_rmsd=min_rmsd,
-          max_evals=max_evals)
-      vpg.write_poses(
-          out_pdbqt,
-          n_poses=num_modes,
-          energy_range=energy_range,
-          overwrite=True)
+      vpg.dock(exhaustiveness=exhaustiveness,
+               n_poses=num_modes,
+               min_rmsd=min_rmsd,
+               max_evals=max_evals)
+      vpg.write_poses(out_pdbqt,
+                      n_poses=num_modes,
+                      energy_range=energy_range,
+                      overwrite=True)
 
       ligands, scores = load_docked_ligands(out_pdbqt)
       docked_complexes += [(protein_mol[1], ligand) for ligand in ligands]

--- a/deepchem/dock/tests/test_docking.py
+++ b/deepchem/dock/tests/test_docking.py
@@ -2,6 +2,7 @@
 Tests for Docking
 """
 import os
+import platform
 import unittest
 import pytest
 import logging
@@ -11,6 +12,8 @@ from deepchem.feat import ComplexFeaturizer
 from deepchem.models import Model
 from deepchem.dock.pose_generation import PoseGenerator
 
+
+IS_WINDOWS = platform.system() == 'Windows'
 
 class TestDocking(unittest.TestCase):
   """
@@ -28,6 +31,7 @@ class TestDocking(unittest.TestCase):
     vpg = dc.dock.VinaPoseGenerator()
     dc.dock.Docker(vpg)
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_docker_dock(self):
     """Test that Docker can dock."""
@@ -43,6 +47,7 @@ class TestDocking(unittest.TestCase):
     # Check only one output since num_modes==1
     assert len(list(docked_outputs)) == 1
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_docker_pose_generator_scores(self):
     """Test that Docker can get scores from pose_generator."""
@@ -61,6 +66,7 @@ class TestDocking(unittest.TestCase):
     assert len(docked_outputs) == 1
     assert len(docked_outputs[0]) == 2
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_docker_specified_pocket(self):
     """Test that Docker can dock into spec. pocket."""
@@ -79,6 +85,7 @@ class TestDocking(unittest.TestCase):
     # Check returned files exist
     assert len(list(docked_outputs)) == 1
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_pocket_docker_dock(self):
     """Test that Docker can find pockets and dock dock."""

--- a/deepchem/dock/tests/test_docking.py
+++ b/deepchem/dock/tests/test_docking.py
@@ -12,8 +12,8 @@ from deepchem.feat import ComplexFeaturizer
 from deepchem.models import Model
 from deepchem.dock.pose_generation import PoseGenerator
 
-
 IS_WINDOWS = platform.system() == 'Windows'
+
 
 class TestDocking(unittest.TestCase):
   """
@@ -38,11 +38,10 @@ class TestDocking(unittest.TestCase):
     # We provide no scoring model so the docker won't score
     vpg = dc.dock.VinaPoseGenerator()
     docker = dc.dock.Docker(vpg)
-    docked_outputs = docker.dock(
-        (self.protein_file, self.ligand_file),
-        exhaustiveness=1,
-        num_modes=1,
-        out_dir="/tmp")
+    docked_outputs = docker.dock((self.protein_file, self.ligand_file),
+                                 exhaustiveness=1,
+                                 num_modes=1,
+                                 out_dir="/tmp")
 
     # Check only one output since num_modes==1
     assert len(list(docked_outputs)) == 1
@@ -54,12 +53,11 @@ class TestDocking(unittest.TestCase):
     # We provide no scoring model so the docker won't score
     vpg = dc.dock.VinaPoseGenerator()
     docker = dc.dock.Docker(vpg)
-    docked_outputs = docker.dock(
-        (self.protein_file, self.ligand_file),
-        exhaustiveness=1,
-        num_modes=1,
-        out_dir="/tmp",
-        use_pose_generator_scores=True)
+    docked_outputs = docker.dock((self.protein_file, self.ligand_file),
+                                 exhaustiveness=1,
+                                 num_modes=1,
+                                 out_dir="/tmp",
+                                 use_pose_generator_scores=True)
 
     # Check only one output since num_modes==1
     docked_outputs = list(docked_outputs)
@@ -74,13 +72,12 @@ class TestDocking(unittest.TestCase):
     logging.basicConfig(level=logging.INFO)
     vpg = dc.dock.VinaPoseGenerator()
     docker = dc.dock.Docker(vpg)
-    docked_outputs = docker.dock(
-        (self.protein_file, self.ligand_file),
-        centroid=(10, 10, 10),
-        box_dims=(10, 10, 10),
-        exhaustiveness=1,
-        num_modes=1,
-        out_dir="/tmp")
+    docked_outputs = docker.dock((self.protein_file, self.ligand_file),
+                                 centroid=(10, 10, 10),
+                                 box_dims=(10, 10, 10),
+                                 exhaustiveness=1,
+                                 num_modes=1,
+                                 out_dir="/tmp")
 
     # Check returned files exist
     assert len(list(docked_outputs)) == 1
@@ -94,12 +91,11 @@ class TestDocking(unittest.TestCase):
     pocket_finder = dc.dock.ConvexHullPocketFinder()
     vpg = dc.dock.VinaPoseGenerator(pocket_finder=pocket_finder)
     docker = dc.dock.Docker(vpg)
-    docked_outputs = docker.dock(
-        (self.protein_file, self.ligand_file),
-        exhaustiveness=1,
-        num_modes=1,
-        num_pockets=1,
-        out_dir="/tmp")
+    docked_outputs = docker.dock((self.protein_file, self.ligand_file),
+                                 exhaustiveness=1,
+                                 num_modes=1,
+                                 num_pockets=1,
+                                 out_dir="/tmp")
 
     # Check returned files exist
     assert len(list(docked_outputs)) == 1

--- a/deepchem/dock/tests/test_pose_generation.py
+++ b/deepchem/dock/tests/test_pose_generation.py
@@ -49,12 +49,11 @@ class TestPoseGeneration(unittest.TestCase):
 
     vpg = dc.dock.VinaPoseGenerator(pocket_finder=None)
     with tempfile.TemporaryDirectory() as tmp:
-      poses, scores = vpg.generate_poses(
-          (protein_file, ligand_file),
-          exhaustiveness=1,
-          num_modes=1,
-          out_dir=tmp,
-          generate_scores=True)
+      poses, scores = vpg.generate_poses((protein_file, ligand_file),
+                                         exhaustiveness=1,
+                                         num_modes=1,
+                                         out_dir=tmp,
+                                         generate_scores=True)
 
     assert len(poses) == 1
     assert len(scores) == 1
@@ -79,11 +78,10 @@ class TestPoseGeneration(unittest.TestCase):
 
     gpg = dc.dock.GninaPoseGenerator()
     with tempfile.TemporaryDirectory() as tmp:
-      poses, scores = gpg.generate_poses(
-          (protein_file, ligand_file),
-          exhaustiveness=1,
-          num_modes=1,
-          out_dir=tmp)
+      poses, scores = gpg.generate_poses((protein_file, ligand_file),
+                                         exhaustiveness=1,
+                                         num_modes=1,
+                                         out_dir=tmp)
 
     assert len(poses) == 1
     assert len(scores) == 1
@@ -108,12 +106,11 @@ class TestPoseGeneration(unittest.TestCase):
 
     vpg = dc.dock.VinaPoseGenerator(pocket_finder=None)
     with tempfile.TemporaryDirectory() as tmp:
-      poses = vpg.generate_poses(
-          (protein_file, ligand_file),
-          exhaustiveness=1,
-          num_modes=1,
-          out_dir=tmp,
-          generate_scores=False)
+      poses = vpg.generate_poses((protein_file, ligand_file),
+                                 exhaustiveness=1,
+                                 num_modes=1,
+                                 out_dir=tmp,
+                                 generate_scores=False)
 
     assert len(poses) == 1
     protein, ligand = poses[0]
@@ -139,14 +136,13 @@ class TestPoseGeneration(unittest.TestCase):
     box_dims = np.array([51.354, 51.243, 55.608])
     vpg = dc.dock.VinaPoseGenerator(pocket_finder=None)
     with tempfile.TemporaryDirectory() as tmp:
-      poses, scores = vpg.generate_poses(
-          (protein_file, ligand_file),
-          centroid=centroid,
-          box_dims=box_dims,
-          exhaustiveness=1,
-          num_modes=1,
-          out_dir=tmp,
-          generate_scores=True)
+      poses, scores = vpg.generate_poses((protein_file, ligand_file),
+                                         centroid=centroid,
+                                         box_dims=box_dims,
+                                         exhaustiveness=1,
+                                         num_modes=1,
+                                         out_dir=tmp,
+                                         generate_scores=True)
 
     assert len(poses) == 1
     assert len(scores) == 1
@@ -173,13 +169,12 @@ class TestPoseGeneration(unittest.TestCase):
     convex_finder = dc.dock.ConvexHullPocketFinder()
     vpg = dc.dock.VinaPoseGenerator(pocket_finder=convex_finder)
     with tempfile.TemporaryDirectory() as tmp:
-      poses, scores = vpg.generate_poses(
-          (protein_file, ligand_file),
-          exhaustiveness=1,
-          num_modes=1,
-          num_pockets=2,
-          out_dir=tmp,
-          generate_scores=True)
+      poses, scores = vpg.generate_poses((protein_file, ligand_file),
+                                         exhaustiveness=1,
+                                         num_modes=1,
+                                         num_pockets=2,
+                                         out_dir=tmp,
+                                         generate_scores=True)
 
     assert len(poses) == 2
     assert len(scores) == 2

--- a/deepchem/dock/tests/test_pose_generation.py
+++ b/deepchem/dock/tests/test_pose_generation.py
@@ -33,6 +33,7 @@ class TestPoseGeneration(unittest.TestCase):
     pocket_finder = dc.dock.ConvexHullPocketFinder()
     dc.dock.VinaPoseGenerator(pocket_finder=pocket_finder)
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_vina_poses_and_scores(self):
     """Test that VinaPoseGenerator generates poses and scores
@@ -91,6 +92,7 @@ class TestPoseGeneration(unittest.TestCase):
     assert isinstance(protein, Chem.Mol)
     assert isinstance(ligand, Chem.Mol)
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_vina_poses_no_scores(self):
     """Test that VinaPoseGenerator generates poses.
@@ -119,6 +121,7 @@ class TestPoseGeneration(unittest.TestCase):
     assert isinstance(protein, Chem.Mol)
     assert isinstance(ligand, Chem.Mol)
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_vina_pose_specified_centroid(self):
     """Test that VinaPoseGenerator creates pose files with specified centroid/box dims.
@@ -152,6 +155,7 @@ class TestPoseGeneration(unittest.TestCase):
     assert isinstance(protein, Chem.Mol)
     assert isinstance(ligand, Chem.Mol)
 
+  @unittest.skipIf(IS_WINDOWS, "vina is not supported in windows")
   @pytest.mark.slow
   def test_pocket_vina_poses(self):
     """Test that VinaPoseGenerator creates pose files.

--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -75,8 +75,8 @@ class InteratomicL2Distances(tf.keras.layers.Layer):
     # Shape (N_atoms, M_nbrs, ndim)
     nbr_coords = tf.gather(coords, nbr_list)
     # Shape (N_atoms, M_nbrs, ndim)
-    tiled_coords = tf.tile(
-        tf.reshape(coords, (N_atoms, 1, ndim)), (1, M_nbrs, 1))
+    tiled_coords = tf.tile(tf.reshape(coords, (N_atoms, 1, ndim)),
+                           (1, M_nbrs, 1))
     # Shape (N_atoms, M_nbrs)
     return tf.reduce_sum((tiled_coords - nbr_coords)**2, axis=2)
 
@@ -130,18 +130,16 @@ class GraphConv(tf.keras.layers.Layer):
     # Generate the nb_affine weights and biases
     num_deg = 2 * self.max_degree + (1 - self.min_degree)
     self.W_list = [
-        self.add_weight(
-            name='kernel' + str(k),
-            shape=(int(input_shape[0][-1]), self.out_channel),
-            initializer='glorot_uniform',
-            trainable=True) for k in range(num_deg)
+        self.add_weight(name='kernel' + str(k),
+                        shape=(int(input_shape[0][-1]), self.out_channel),
+                        initializer='glorot_uniform',
+                        trainable=True) for k in range(num_deg)
     ]
     self.b_list = [
-        self.add_weight(
-            name='bias' + str(k),
-            shape=(self.out_channel,),
-            initializer='zeros',
-            trainable=True) for k in range(num_deg)
+        self.add_weight(name='bias' + str(k),
+                        shape=(self.out_channel,),
+                        initializer='zeros',
+                        trainable=True) for k in range(num_deg)
     ]
     self.built = True
 
@@ -670,8 +668,10 @@ class MolGANMultiConvolutionLayer(tf.keras.layers.Layer):
     self.dropout_rate = dropout_rate
     self.edges = edges
 
-    self.first_convolution = MolGANConvolutionLayer(
-        self.units[0], self.activation, self.dropout_rate, self.edges)
+    self.first_convolution = MolGANConvolutionLayer(self.units[0],
+                                                    self.activation,
+                                                    self.dropout_rate,
+                                                    self.edges)
     self.gcl = [
         MolGANConvolutionLayer(u, self.activation, self.dropout_rate,
                                self.edges) for u in self.units[1:]
@@ -908,10 +908,10 @@ class LSTMStep(tf.keras.layers.Layer):
     self.W = init((self.input_dim, 4 * self.output_dim))
     self.U = inner_init((self.output_dim, 4 * self.output_dim))
 
-    self.b = tf.Variable(
-        np.hstack((np.zeros(self.output_dim), np.ones(self.output_dim),
-                   np.zeros(self.output_dim), np.zeros(self.output_dim))),
-        dtype=tf.float32)
+    self.b = tf.Variable(np.hstack(
+        (np.zeros(self.output_dim), np.ones(self.output_dim),
+         np.zeros(self.output_dim), np.zeros(self.output_dim))),
+                         dtype=tf.float32)
     self.built = True
 
   def call(self, inputs):
@@ -1294,9 +1294,9 @@ class WeightedLinearCombo(tf.keras.layers.Layer):
   def build(self, input_shape):
     init = tf.keras.initializers.RandomNormal(stddev=self.std)
     self.input_weights = [
-        self.add_weight(
-            'weight_%d' % (i + 1), (1,), initializer=init, trainable=True)
-        for i in range(len(input_shape))
+        self.add_weight('weight_%d' % (i + 1), (1,),
+                        initializer=init,
+                        trainable=True) for i in range(len(input_shape))
     ]
     self.built = True
 
@@ -1347,8 +1347,10 @@ class CombineMeanStd(tf.keras.layers.Layer):
     mean_parent, std_parent = inputs[0], inputs[1]
     noise_scale = tf.cast(training or not self.training_only, tf.float32)
     from tensorflow.python.ops import array_ops
-    sample_noise = tf.random.normal(
-        array_ops.shape(mean_parent), 0, self.noise_epsilon, dtype=tf.float32)
+    sample_noise = tf.random.normal(array_ops.shape(mean_parent),
+                                    0,
+                                    self.noise_epsilon,
+                                    dtype=tf.float32)
     return mean_parent + noise_scale * std_parent * sample_noise
 
 
@@ -1613,8 +1615,8 @@ class NeighborList(tf.keras.layers.Layer):
     nbr_coords = [tf.gather(coords, atom_nbrs) for atom_nbrs in nbrs]
 
     # Add phantom atoms that exist far outside the box
-    coord_padding = tf.cast(
-        tf.fill((self.M_nbrs, self.ndim), 2 * self.stop), tf.float32)
+    coord_padding = tf.cast(tf.fill((self.M_nbrs, self.ndim), 2 * self.stop),
+                            tf.float32)
     padded_nbr_coords = [
         tf.concat([nbr_coord, coord_padding], 0) for nbr_coord in nbr_coords
     ]
@@ -1707,8 +1709,8 @@ class NeighborList(tf.keras.layers.Layer):
     N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells, self.ndim,
                                       self.M_nbrs)
     # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
-    tiled_cells = tf.reshape(
-        tf.tile(cells, (1, N_atoms)), (N_atoms * n_cells, ndim))
+    tiled_cells = tf.reshape(tf.tile(cells, (1, N_atoms)),
+                             (N_atoms * n_cells, ndim))
 
     # Shape (N_atoms*n_cells, ndim) after tile
     tiled_coords = tf.tile(coords, (n_cells, 1))
@@ -1745,8 +1747,8 @@ class NeighborList(tf.keras.layers.Layer):
     tiled_cells = tf.tile(cells, (N_atoms, 1))
 
     # Shape (N_atoms*n_cells, 1) after tile
-    tiled_coords = tf.reshape(
-        tf.tile(coords, (1, n_cells)), (n_cells * N_atoms, ndim))
+    tiled_coords = tf.reshape(tf.tile(coords, (1, n_cells)),
+                              (n_cells * N_atoms, ndim))
     coords_vec = tf.reduce_sum((tiled_coords - tiled_cells)**2, axis=1)
     coords_norm = tf.reshape(coords_vec, (N_atoms, n_cells))
 
@@ -1790,8 +1792,8 @@ class NeighborList(tf.keras.layers.Layer):
     # Tile cells to form arrays of size (n_cells*n_cells, ndim)
     # Two tilings (a, b, c, a, b, c, ...) vs. (a, a, a, b, b, b, etc.)
     # Tile (a, a, a, b, b, b, etc.)
-    tiled_centers = tf.reshape(
-        tf.tile(cells, (1, n_cells)), (n_cells * n_cells, ndim))
+    tiled_centers = tf.reshape(tf.tile(cells, (1, n_cells)),
+                               (n_cells * n_cells, ndim))
     # Tile (a, b, c, a, b, c, ...)
     tiled_cells = tf.tile(cells, (n_cells, 1))
 
@@ -1816,9 +1818,8 @@ class NeighborList(tf.keras.layers.Layer):
     start, stop, nbr_cutoff = self.start, self.stop, self.nbr_cutoff
     mesh_args = [tf.range(start, stop, nbr_cutoff) for _ in range(self.ndim)]
     return tf.cast(
-        tf.reshape(
-            tf.transpose(tf.stack(tf.meshgrid(*mesh_args))),
-            (self.n_cells, self.ndim)), tf.float32)
+        tf.reshape(tf.transpose(tf.stack(tf.meshgrid(*mesh_args))),
+                   (self.n_cells, self.ndim)), tf.float32)
 
 
 class AtomicConvolution(tf.keras.layers.Layer):
@@ -2068,8 +2069,8 @@ class AlphaShareLayer(tf.keras.layers.Layer):
 
   def build(self, input_shape):
     n_alphas = 2 * len(input_shape)
-    self.alphas = tf.Variable(
-        tf.random.normal([n_alphas, n_alphas]), name='alphas')
+    self.alphas = tf.Variable(tf.random.normal([n_alphas, n_alphas]),
+                              name='alphas')
     self.built = True
 
   def call(self, inputs):
@@ -2230,12 +2231,11 @@ class ANIFeat(tf.keras.layers.Layer):
     radial_sym = self.radial_symmetry(d_radial_cutoff, d, atom_numbers)
     angular_sym = self.angular_symmetry(d_angular_cutoff, d, atom_numbers,
                                         coordinates)
-    return tf.concat(
-        [
-            tf.cast(tf.expand_dims(atom_numbers, 2), tf.float32), radial_sym,
-            angular_sym
-        ],
-        axis=2)
+    return tf.concat([
+        tf.cast(tf.expand_dims(atom_numbers, 2), tf.float32), radial_sym,
+        angular_sym
+    ],
+                     axis=2)
 
   def distance_matrix(self, coordinates, flags):
     """ Generate distance matrix """
@@ -2289,9 +2289,9 @@ class ANIFeat(tf.keras.layers.Layer):
     if self.atomic_number_differentiated:
       out_tensors = []
       for atom_type in self.atom_cases:
-        selected_atoms = tf.expand_dims(
-            tf.expand_dims(atom_numbers_embedded[:, :, atom_type], axis=1),
-            axis=3)
+        selected_atoms = tf.expand_dims(tf.expand_dims(
+            atom_numbers_embedded[:, :, atom_type], axis=1),
+                                        axis=3)
         out_tensors.append(tf.reduce_sum(out * selected_atoms, axis=2))
       return tf.concat(out_tensors, axis=2)
     else:
@@ -2345,8 +2345,9 @@ class ANIFeat(tf.keras.layers.Layer):
         for atom_type_k in self.atom_cases[id_j:]:
           selected_atoms = tf.stack([atom_numbers_embedded[:, :, atom_type_j]] * max_atoms, axis=2) * \
                            tf.stack([atom_numbers_embedded[:, :, atom_type_k]] * max_atoms, axis=1)
-          selected_atoms = tf.expand_dims(
-              tf.expand_dims(selected_atoms, axis=1), axis=4)
+          selected_atoms = tf.expand_dims(tf.expand_dims(selected_atoms,
+                                                         axis=1),
+                                          axis=4)
           out_tensors.append(
               tf.reduce_sum(out_tensor * selected_atoms, axis=(2, 3)))
       return tf.concat(out_tensors, axis=2)
@@ -2385,12 +2386,10 @@ class GraphEmbedPoolLayer(tf.keras.layers.Layer):
 
   def build(self, input_shape):
     no_features = int(input_shape[0][-1])
-    self.W = tf.Variable(
-        tf.random.truncated_normal(
-            [no_features, self.num_vertices],
-            stddev=1.0 / np.sqrt(no_features)),
-        name='weights',
-        dtype=tf.float32)
+    self.W = tf.Variable(tf.random.truncated_normal(
+        [no_features, self.num_vertices], stddev=1.0 / np.sqrt(no_features)),
+                         name='weights',
+                         dtype=tf.float32)
     self.b = tf.Variable(tf.constant(0.1), name='bias', dtype=tf.float32)
     self.built = True
 
@@ -2502,18 +2501,16 @@ class GraphCNN(tf.keras.layers.Layer):
   def build(self, input_shape):
     no_features = int(input_shape[0][2])
     no_A = int(input_shape[1][2])
-    self.W = tf.Variable(
-        tf.random.truncated_normal(
-            [no_features * no_A, self.num_filters],
-            stddev=np.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
-        name='weights',
-        dtype=tf.float32)
-    self.W_I = tf.Variable(
-        tf.random.truncated_normal(
-            [no_features, self.num_filters],
-            stddev=np.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
-        name='weights_I',
-        dtype=tf.float32)
+    self.W = tf.Variable(tf.random.truncated_normal(
+        [no_features * no_A, self.num_filters],
+        stddev=np.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
+                         name='weights',
+                         dtype=tf.float32)
+    self.W_I = tf.Variable(tf.random.truncated_normal(
+        [no_features, self.num_filters],
+        stddev=np.sqrt(1.0 / (no_features * (no_A + 1) * 1.0))),
+                           name='weights_I',
+                           dtype=tf.float32)
     self.b = tf.Variable(tf.constant(0.1), name='bias', dtype=tf.float32)
     self.built = True
 
@@ -2823,11 +2820,10 @@ class WeaveLayer(tf.keras.layers.Layer):
     """
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     self.W_AA = init([self.n_atom_input_feat, self.n_hidden_AA])
     self.b_AA = backend.zeros(shape=[
@@ -2903,16 +2899,14 @@ class WeaveLayer(tf.keras.layers.Layer):
       # Note that AP_ij and AP_ji share the same self.AP_bn batch
       # normalization
       AP_ij = tf.matmul(
-          tf.reshape(
-              tf.gather(atom_features, atom_to_pair),
-              [-1, 2 * self.n_atom_input_feat]), self.W_AP) + self.b_AP
+          tf.reshape(tf.gather(atom_features, atom_to_pair),
+                     [-1, 2 * self.n_atom_input_feat]), self.W_AP) + self.b_AP
       if self.batch_normalize:
         AP_ij = self.AP_bn(AP_ij)
       AP_ij = activation(AP_ij)
       AP_ji = tf.matmul(
-          tf.reshape(
-              tf.gather(atom_features, tf.reverse(atom_to_pair, [1])),
-              [-1, 2 * self.n_atom_input_feat]), self.W_AP) + self.b_AP
+          tf.reshape(tf.gather(atom_features, tf.reverse(atom_to_pair, [1])),
+                     [-1, 2 * self.n_atom_input_feat]), self.W_AP) + self.b_AP
       if self.batch_normalize:
         AP_ji = self.AP_bn(AP_ji)
       AP_ji = activation(AP_ji)
@@ -3051,11 +3045,10 @@ class WeaveGather(tf.keras.layers.Layer):
     if self.compress_post_gaussian_expansion:
 
       def init(input_shape):
-        return self.add_weight(
-            name='kernel',
-            shape=(input_shape[0], input_shape[1]),
-            initializer=self.init,
-            trainable=True)
+        return self.add_weight(name='kernel',
+                               shape=(input_shape[0], input_shape[1]),
+                               initializer=self.init,
+                               trainable=True)
 
       self.W = init([self.n_input * 11, self.n_input])
       self.b = backend.zeros(shape=[self.n_input])
@@ -3165,11 +3158,10 @@ class DTNNEmbedding(tf.keras.layers.Layer):
   def build(self, input_shape):
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     self.embedding_list = init([self.periodic_table_length, self.n_embedding])
     self.built = True
@@ -3225,11 +3217,10 @@ class DTNNStep(tf.keras.layers.Layer):
   def build(self, input_shape):
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     self.W_cf = init([self.n_embedding, self.n_hidden])
     self.W_df = init([self.n_distance, self.n_hidden])
@@ -3317,11 +3308,10 @@ class DTNNGather(tf.keras.layers.Layer):
     self.b_list = []
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     prev_layer_size = self.n_embedding
     for i, layer_size in enumerate(self.layer_sizes):
@@ -3449,34 +3439,30 @@ class DAGLayer(tf.keras.layers.Layer):
     prev_layer_size = self.n_inputs
     for layer_size in self.layer_sizes:
       self.W_list.append(
-          self.add_weight(
-              name='kernel',
-              shape=(prev_layer_size, layer_size),
-              initializer=self.init,
-              trainable=True))
+          self.add_weight(name='kernel',
+                          shape=(prev_layer_size, layer_size),
+                          initializer=self.init,
+                          trainable=True))
       self.b_list.append(
-          self.add_weight(
-              name='bias',
-              shape=(layer_size,),
-              initializer='zeros',
-              trainable=True))
+          self.add_weight(name='bias',
+                          shape=(layer_size,),
+                          initializer='zeros',
+                          trainable=True))
       if self.dropout is not None and self.dropout > 0.0:
         self.dropouts.append(Dropout(rate=self.dropout))
       else:
         self.dropouts.append(None)
       prev_layer_size = layer_size
     self.W_list.append(
-        self.add_weight(
-            name='kernel',
-            shape=(prev_layer_size, self.n_outputs),
-            initializer=self.init,
-            trainable=True))
+        self.add_weight(name='kernel',
+                        shape=(prev_layer_size, self.n_outputs),
+                        initializer=self.init,
+                        trainable=True))
     self.b_list.append(
-        self.add_weight(
-            name='bias',
-            shape=(self.n_outputs,),
-            initializer='zeros',
-            trainable=True))
+        self.add_weight(name='bias',
+                        shape=(self.n_outputs,),
+                        initializer='zeros',
+                        trainable=True))
     if self.dropout is not None and self.dropout > 0.0:
       self.dropouts.append(Dropout(rate=self.dropout))
     else:
@@ -3508,16 +3494,16 @@ class DAGLayer(tf.keras.layers.Layer):
 
       # generating index for graph features used in the inputs
       stack1 = tf.reshape(
-          tf.stack(
-              [tf.boolean_mask(tf.range(n_atoms), mask)] * (self.max_atoms - 1),
-              axis=1), [-1])
+          tf.stack([tf.boolean_mask(tf.range(n_atoms), mask)] *
+                   (self.max_atoms - 1),
+                   axis=1), [-1])
       stack2 = tf.reshape(tf.boolean_mask(parents[:, count, 1:], mask), [-1])
       index = tf.stack([stack1, stack2], axis=1)
       # extracting graph features for parents of the target atoms, then flatten
       # shape: (batch_size*max_atoms) * [(max_atoms-1)*n_graph_features]
       batch_graph_features = tf.reshape(
-          tf.gather_nd(graph_features, index),
-          [-1, (self.max_atoms - 1) * self.n_graph_feat])
+          tf.gather_nd(graph_features,
+                       index), [-1, (self.max_atoms - 1) * self.n_graph_feat])
 
       # concat into the input tensor: (batch_size*max_atoms) * n_inputs
       batch_inputs = tf.concat(
@@ -3597,34 +3583,30 @@ class DAGGather(tf.keras.layers.Layer):
     prev_layer_size = self.n_graph_feat
     for layer_size in self.layer_sizes:
       self.W_list.append(
-          self.add_weight(
-              name='kernel',
-              shape=(prev_layer_size, layer_size),
-              initializer=self.init,
-              trainable=True))
+          self.add_weight(name='kernel',
+                          shape=(prev_layer_size, layer_size),
+                          initializer=self.init,
+                          trainable=True))
       self.b_list.append(
-          self.add_weight(
-              name='bias',
-              shape=(layer_size,),
-              initializer='zeros',
-              trainable=True))
+          self.add_weight(name='bias',
+                          shape=(layer_size,),
+                          initializer='zeros',
+                          trainable=True))
       if self.dropout is not None and self.dropout > 0.0:
         self.dropouts.append(Dropout(rate=self.dropout))
       else:
         self.dropouts.append(None)
       prev_layer_size = layer_size
     self.W_list.append(
-        self.add_weight(
-            name='kernel',
-            shape=(prev_layer_size, self.n_outputs),
-            initializer=self.init,
-            trainable=True))
+        self.add_weight(name='kernel',
+                        shape=(prev_layer_size, self.n_outputs),
+                        initializer=self.init,
+                        trainable=True))
     self.b_list.append(
-        self.add_weight(
-            name='bias',
-            shape=(self.n_outputs,),
-            initializer='zeros',
-            trainable=True))
+        self.add_weight(name='bias',
+                        shape=(self.n_outputs,),
+                        initializer='zeros',
+                        trainable=True))
     if self.dropout is not None and self.dropout > 0.0:
       self.dropouts.append(Dropout(rate=self.dropout))
     else:
@@ -3730,11 +3712,10 @@ class EdgeNetwork(tf.keras.layers.Layer):
   def build(self, input_shape):
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     n_pair_features = self.n_pair_features
     n_hidden = self.n_hidden
@@ -3769,11 +3750,10 @@ class GatedRecurrentUnit(tf.keras.layers.Layer):
     n_hidden = self.n_hidden
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     self.Wz = init([n_hidden, n_hidden])
     self.Wr = init([n_hidden, n_hidden])
@@ -3831,17 +3811,16 @@ class SetGather(tf.keras.layers.Layer):
   def build(self, input_shape):
 
     def init(input_shape):
-      return self.add_weight(
-          name='kernel',
-          shape=(input_shape[0], input_shape[1]),
-          initializer=self.init,
-          trainable=True)
+      return self.add_weight(name='kernel',
+                             shape=(input_shape[0], input_shape[1]),
+                             initializer=self.init,
+                             trainable=True)
 
     self.U = init((2 * self.n_hidden, 4 * self.n_hidden))
-    self.b = tf.Variable(
-        np.concatenate((np.zeros(self.n_hidden), np.ones(self.n_hidden),
-                        np.zeros(self.n_hidden), np.zeros(self.n_hidden))),
-        dtype=tf.float32)
+    self.b = tf.Variable(np.concatenate(
+        (np.zeros(self.n_hidden), np.ones(self.n_hidden),
+         np.zeros(self.n_hidden), np.zeros(self.n_hidden))),
+                         dtype=tf.float32)
     self.built = True
 
   def call(self, inputs):

--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -974,6 +974,7 @@ def cosine_dist(x, y):
   `y` are each of shape `(n,p)`, where each element in `x` and `y` is the same, then
   the output tensor would be a tensor of shape `(n,n)` with 1 in every entry.
 
+  >>> import numpy as np
   >>> import tensorflow as tf
   >>> import deepchem.models.layers as layers
   >>> x = tf.ones((6, 4), dtype=tf.dtypes.float32, name=None)
@@ -985,8 +986,8 @@ def cosine_dist(x, y):
   always be 1. The output tensor will be of shape (6,6).
 
   >>> diff = cos_sim_same - tf.ones((6, 6), dtype=tf.dtypes.float32, name=None)
-  >>> tf.reduce_sum(diff) == 0 # True
-  <tf.Tensor: shape=(), dtype=bool, numpy=True>
+  >>> np.allclose(0.0, tf.reduce_sum(diff).numpy(), atol=1e-05)
+  True
   >>> cos_sim_same.shape
   TensorShape([6, 6])
 
@@ -1005,8 +1006,8 @@ def cosine_dist(x, y):
   shape of the input tensors are both of shape `(256,512)`, the output tensor will
   be of shape `(256,256)`.
 
-  >>> tf.reduce_sum(cos_sim_orth) == 0 # True
-  <tf.Tensor: shape=(), dtype=bool, numpy=True>
+  >>> np.allclose(0.0, tf.reduce_sum(cos_sim_orth).numpy(), atol=1e-05)
+  True
   >>> cos_sim_orth.shape
   TensorShape([256, 256])
 

--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -1,11 +1,11 @@
 dependencies:
   - pip:
-    - -f https://download.pytorch.org/whl/torch_stable.html
-    - -f https://pytorch-geometric.com/whl/torch-1.9.0+cpu.html
-    - dgl==0.6.*
-    - torch==1.9.0+cpu
-    - torchvision==0.10.0+cpu
+    - -f https://download.pytorch.org/whl/cpu/torch_stable.html
+    - -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
+    - -f https://data.dgl.ai/wheels/repo.html
+    - dgl
+    - torch==1.11.0+cpu
+    - torchvision==0.12.0+cpu
     - torch-scatter
     - torch-sparse
-    - transformers==4.6.*
     - torch-geometric

--- a/requirements/torch/env_torch.gpu.yml
+++ b/requirements/torch/env_torch.gpu.yml
@@ -1,11 +1,11 @@
 dependencies:
   - pip:
-    - -f https://download.pytorch.org/whl/torch_stable.html
-    - -f https://pytorch-geometric.com/whl/torch-1.9.0+cu111.html
+    - -f https://download.pytorch.org/whl/cu113/torch_stable.html
+    - -f https://data.pyg.org/whl/torch-1.11.0+cu113.html
     - -f https://data.dgl.ai/wheels/repo.html
     - dgl-cu111
-    - torch==1.9.0+cu111
-    - torchvision==0.10.0+cu111
+    - torch==1.11.0+cu113
+    - torchvision==0.11.0+cu113
     - torch-scatter
     - torch-sparse
     - torch-geometric

--- a/requirements/torch/env_torch.mac.cpu.yml
+++ b/requirements/torch/env_torch.mac.cpu.yml
@@ -1,13 +1,10 @@
 channels:
   - pytorch
 dependencies:
-  - pytorch
-  - torchvision
+  - pytorch==1.10.*
   - pip:
     - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
-    - dgl==0.6.*
+    - dgl
     - torch-scatter
     - torch-sparse
-    - torch-cluster
-    - torch-spline-conv
     - torch-geometric


### PR DESCRIPTION
Summary of changes:

- Skipping pytest test in windows for vina since autodock vina is supported only in linux and macos
- Ignoring doctest for `deepchem/models/jax_models/*` in windows since jax is not supported in windows currently.