### PR TITLE
Adding FutureWarning to depreciate deepchem.utils.evaluate.relative_difference

### DIFF
--- a/deepchem/data/tests/test_reload.py
+++ b/deepchem/data/tests/test_reload.py
@@ -30,8 +30,9 @@ class TestReload(unittest.TestCase):
         'MUV-852', 'MUV-600', 'MUV-810', 'MUV-712', 'MUV-737', 'MUV-858',
         'MUV-713', 'MUV-733', 'MUV-652', 'MUV-466', 'MUV-832'
     ]
-    loader = dc.data.CSVLoader(
-        tasks=MUV_tasks, feature_field="smiles", featurizer=featurizer)
+    loader = dc.data.CSVLoader(tasks=MUV_tasks,
+                               feature_field="smiles",
+                               featurizer=featurizer)
     dataset = loader.create_dataset(dataset_file)
     assert len(dataset) == len(raw_dataset)
 
@@ -44,9 +45,15 @@ class TestReload(unittest.TestCase):
             frac_test=frac_test, frac_valid=frac_valid)
     # Do an approximate comparison since splits are sometimes slightly off from
     # the exact fraction.
-    assert math.isclose(len(train_dataset), frac_train * len(dataset), rel_tol = 1e-3) == True
-    assert math.isclose(len(valid_dataset), frac_valid * len(dataset), rel_tol = 1e-3) == True
-    assert math.isclose(len(test_dataset), frac_test * len(dataset), rel_tol = 1e-3) == True
+    assert math.isclose(len(train_dataset),
+                        frac_train * len(dataset),
+                        rel_tol=1e-3)
+    assert math.isclose(len(valid_dataset),
+                        frac_valid * len(dataset),
+                        rel_tol=1e-3)
+    assert math.isclose(len(test_dataset),
+                        frac_test * len(dataset),
+                        rel_tol=1e-3)
 
     # TODO(rbharath): Transformers don't play nice with reload! Namely,
     # reloading will cause the transform to be reapplied. This is undesirable in
@@ -66,8 +73,8 @@ class TestReload(unittest.TestCase):
     dataset_file = os.path.join(current_dir,
                                 "../../../datasets/mini_muv.csv.gz")
     logger.info("Running experiment for first time without reload.")
-    (len_train, len_valid, len_test) = self._run_muv_experiment(
-        dataset_file, reload)
+    (len_train, len_valid,
+     len_test) = self._run_muv_experiment(dataset_file, reload)
 
     logger.info("Running experiment for second time with reload.")
     reload = True
@@ -84,8 +91,8 @@ class TestReload(unittest.TestCase):
     dataset_file = os.path.join(current_dir,
                                 "../../../datasets/mini_muv.csv.gz")
     logger.info("Running experiment for first time with reload.")
-    (len_train, len_valid, len_test) = self._run_muv_experiment(
-        dataset_file, reload)
+    (len_train, len_valid,
+     len_test) = self._run_muv_experiment(dataset_file, reload)
 
     logger.info("Running experiment for second time with reload.")
     (len_reload_train, len_reload_valid,

--- a/deepchem/data/tests/test_reload.py
+++ b/deepchem/data/tests/test_reload.py
@@ -6,6 +6,7 @@ __copyright__ = "Copyright 2016, Stanford University"
 __license__ = "MIT"
 
 import os
+import math
 import logging
 import unittest
 import deepchem as dc
@@ -43,12 +44,9 @@ class TestReload(unittest.TestCase):
             frac_test=frac_test, frac_valid=frac_valid)
     # Do an approximate comparison since splits are sometimes slightly off from
     # the exact fraction.
-    assert dc.utils.evaluate.relative_difference(
-        len(train_dataset), frac_train * len(dataset)) < 1e-3
-    assert dc.utils.evaluate.relative_difference(
-        len(valid_dataset), frac_valid * len(dataset)) < 1e-3
-    assert dc.utils.evaluate.relative_difference(
-        len(test_dataset), frac_test * len(dataset)) < 1e-3
+    assert math.isclose(len(train_dataset), frac_train * len(dataset), rel_tol = 1e-3) == True
+    assert math.isclose(len(valid_dataset), frac_valid * len(dataset), rel_tol = 1e-3) == True
+    assert math.isclose(len(test_dataset), frac_test * len(dataset), rel_tol = 1e-3) == True
 
     # TODO(rbharath): Transformers don't play nice with reload! Namely,
     # reloading will cause the transform to be reapplied. This is undesirable in

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -131,7 +131,8 @@ def relative_difference(x: np.ndarray, y: np.ndarray) -> np.ndarray:
   z: np.ndarray
     We will have `z == np.abs(x-y) / np.abs(max(x, y))`.
   """
-  z = np.abs(x - y) / np.abs(max(x, y))
+  warnings.warn("Directly use `(x - y) / np.abs(y)` or `np.isclose`, `np.allclose` for testing tolerance", FutureWarning)
+  z = (x - y) / abs(y)
   return z
 
 

--- a/deepchem/utils/evaluate.py
+++ b/deepchem/utils/evaluate.py
@@ -3,6 +3,7 @@ Utility functions to evaluate models on datasets.
 """
 import csv
 import logging
+import warnings
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import numpy as np
@@ -131,7 +132,9 @@ def relative_difference(x: np.ndarray, y: np.ndarray) -> np.ndarray:
   z: np.ndarray
     We will have `z == np.abs(x-y) / np.abs(max(x, y))`.
   """
-  warnings.warn("Directly use `(x - y) / np.abs(y)` or `np.isclose`, `np.allclose` for testing tolerance", FutureWarning)
+  warnings.warn(
+      "Directly use `(x - y) / np.abs(y)` or `np.isclose`, `np.allclose` for testing tolerance",
+      FutureWarning)
   z = (x - y) / abs(y)
   return z
 
@@ -307,14 +310,13 @@ class Evaluator(object):
 
     # Compute multitask metrics
     for metric in metrics:
-      results = metric.compute_metric(
-          y,
-          y_pred,
-          w,
-          per_task_metrics=per_task_metrics,
-          n_tasks=n_tasks,
-          n_classes=n_classes,
-          use_sample_weights=use_sample_weights)
+      results = metric.compute_metric(y,
+                                      y_pred,
+                                      w,
+                                      per_task_metrics=per_task_metrics,
+                                      n_tasks=n_tasks,
+                                      n_classes=n_classes,
+                                      use_sample_weights=use_sample_weights)
       if per_task_metrics:
         multitask_scores[metric.name], computed_metrics = results
         all_task_scores[metric.name] = computed_metrics
@@ -476,13 +478,12 @@ class GeneratorEvaluator(object):
 
     # Compute multitask metrics
     for metric in metrics:
-      results = metric.compute_metric(
-          y_true,
-          y_pred,
-          w,
-          per_task_metrics=per_task_metrics,
-          n_classes=n_classes,
-          use_sample_weights=use_sample_weights)
+      results = metric.compute_metric(y_true,
+                                      y_pred,
+                                      w,
+                                      per_task_metrics=per_task_metrics,
+                                      n_classes=n_classes,
+                                      use_sample_weights=use_sample_weights)
       if per_task_metrics:
         multitask_scores[metric.name], computed_metrics = results
         all_task_scores[metric.name] = computed_metrics


### PR DESCRIPTION
The `relative_difference` method is not accurate and it is not used in the codebase except for a test function, where it is used for checking relative tolerance. Instead of it, developers/users can always use `(x - y) / abs(y)` to compute relative difference between two arrays element wise or use `math.isclose`, `np.allclose`, `np.isclose` method for finding relative tolerance. This PR adds a depreciation notice and replacing `relative_difference` call with `math.isclose` in the codebase. A large number of modified lines are due to yapf fixes.