### PR TITLE
Fixing CI errors

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v2
     - name: Cache pip packages for Linux

--- a/deepchem/utils/test/test_geometry_utils.py
+++ b/deepchem/utils/test/test_geometry_utils.py
@@ -55,8 +55,8 @@ class TestGeometryUtils(unittest.TestCase):
     distance = compute_pairwise_distances(coords1, coords2)
     self.assertEqual(distance.shape, (n1, n2))
     self.assertTrue((distance >= 0).all())
-    # random coords between 0 and 1, so the max possible distance in sqrt(2)
-    self.assertTrue((distance <= 2.0**0.5).all())
+    # random coords between 0 and 1, so the max possible distance in sqrt(3)
+    self.assertTrue((distance <= 3.0**0.5).all())
 
     # check if correct distance metric was used
     coords1 = np.array([[0, 0, 0], [1, 0, 0]])

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,10 @@
 pandas
 scikit-learn
-sphinx>=3.2,<4
-sphinx_rtd_theme>=0.5,<1
-tensorflow>=2.4
+sphinx
+sphinx_rtd_theme
+tensorflow
 transformers>=4.6.*
-torch>=1.8.1
+torch
 jax
 dm-haiku
 optax

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -25,4 +25,4 @@ dependencies:
     - transformers==4.6.*
     - xgboost
     - git+https://github.com/samoturk/mol2vec
-    - tensorboard
+    - tb-nightly # @arunppsg shift to tensorboard stable version once tb 2.9.1 is released


### PR DESCRIPTION
Changes in this PR:
- The torch CI has been failing for some time due to an import error in `tensorboard`. tensorboard team made a fix which was available in the nightly version, hence updated requirements to use tensorboard nightly version. This should be reverted back to tb stable when tb 2.9.1/2.10.0 is released.