### PR TITLE
add count-based morgan fingerprint featurizer and suitable unit tests

### DIFF
--- a/deepchem/feat/molecule_featurizers/circular_fingerprint.py
+++ b/deepchem/feat/molecule_featurizers/circular_fingerprint.py
@@ -141,7 +141,9 @@ class CircularFingerprint(MolecularFeaturizer):
             useChirality=self.chiral,
             useBondTypes=self.bonds,
             useFeatures=self.features)
-        fp = np.zeros((1,))
+        fp = np.zeros(
+            (self.size,), dtype=float
+        )  # initialise numpy array of zeros (shape: (required size,))
         DataStructs.ConvertToNumpyArray(fp_sparse, fp)
       else:
         fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(

--- a/deepchem/feat/molecule_featurizers/circular_fingerprint.py
+++ b/deepchem/feat/molecule_featurizers/circular_fingerprint.py
@@ -55,7 +55,8 @@ class CircularFingerprint(MolecularFeaturizer):
                bonds: bool = True,
                features: bool = False,
                sparse: bool = False,
-               smiles: bool = False):
+               smiles: bool = False,
+               is_counts_based: bool = False):
     """
     Parameters
     ----------
@@ -76,6 +77,8 @@ class CircularFingerprint(MolecularFeaturizer):
     smiles: bool, optional (default False)
       Whether to calculate SMILES strings for fragment IDs (only applicable
       when calculating sparse fingerprints).
+    is_counts_based: bool, optional (default False)
+      Whether to generates a counts-based fingerprint.
     """
     self.radius = radius
     self.size = size
@@ -84,6 +87,7 @@ class CircularFingerprint(MolecularFeaturizer):
     self.features = features
     self.sparse = sparse
     self.smiles = smiles
+    self.is_counts_based = is_counts_based
 
   def _featurize(self, datapoint: RDKitMol, **kwargs) -> np.ndarray:
     """Calculate circular fingerprint.
@@ -99,7 +103,7 @@ class CircularFingerprint(MolecularFeaturizer):
       A numpy array of circular fingerprint.
     """
     try:
-      from rdkit import Chem
+      from rdkit import Chem, DataStructs
       from rdkit.Chem import rdMolDescriptors
     except ModuleNotFoundError:
       raise ImportError("This class requires RDKit to be installed.")
@@ -110,13 +114,12 @@ class CircularFingerprint(MolecularFeaturizer):
       )
     if self.sparse:
       info: Dict = {}
-      fp = rdMolDescriptors.GetMorganFingerprint(
-          datapoint,
-          self.radius,
-          useChirality=self.chiral,
-          useBondTypes=self.bonds,
-          useFeatures=self.features,
-          bitInfo=info)
+      fp = rdMolDescriptors.GetMorganFingerprint(datapoint,
+                                                 self.radius,
+                                                 useChirality=self.chiral,
+                                                 useBondTypes=self.bonds,
+                                                 useFeatures=self.features,
+                                                 bitInfo=info)
       fp = fp.GetNonzeroElements()  # convert to a dict
 
       # generate SMILES for fragments
@@ -130,14 +133,25 @@ class CircularFingerprint(MolecularFeaturizer):
           fp_smiles[fragment_id] = {'smiles': smiles, 'count': count}
         fp = fp_smiles
     else:
-      fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(
-          datapoint,
-          self.radius,
-          nBits=self.size,
-          useChirality=self.chiral,
-          useBondTypes=self.bonds,
-          useFeatures=self.features)
-      fp = np.asarray(fp, dtype=float)
+      if self.is_counts_based:
+        fp_sparse = rdMolDescriptors.GetHashedMorganFingerprint(
+            datapoint,
+            self.radius,
+            nBits=self.size,
+            useChirality=self.chiral,
+            useBondTypes=self.bonds,
+            useFeatures=self.features)
+        fp = np.zeros((1,))
+        DataStructs.ConvertToNumpyArray(fp_sparse, fp)
+      else:
+        fp = rdMolDescriptors.GetMorganFingerprintAsBitVect(
+            datapoint,
+            self.radius,
+            nBits=self.size,
+            useChirality=self.chiral,
+            useBondTypes=self.bonds,
+            useFeatures=self.features)
+        fp = np.asarray(fp, dtype=float)
     return fp
 
   def __hash__(self):

--- a/deepchem/feat/tests/test_circular_fingerprints.py
+++ b/deepchem/feat/tests/test_circular_fingerprints.py
@@ -3,41 +3,56 @@ Test topological fingerprints.
 """
 import unittest
 from deepchem.feat import CircularFingerprint
+import numpy as np
 
 
 class TestCircularFingerprint(unittest.TestCase):
   """
-    Tests for CircularFingerprint.
-    """
+  Tests for CircularFingerprint.
+  """
 
   def setUp(self):
     """
-        Set up tests.
-        """
+    Set up tests.
+    """
     from rdkit import Chem
     smiles = 'CC(=O)OC1=CC=CC=C1C(=O)O'
     self.mol = Chem.MolFromSmiles(smiles)
 
   def test_circular_fingerprints(self):
     """
-        Test CircularFingerprint.
-        """
+    Test CircularFingerprint.
+    """
     featurizer = CircularFingerprint()
     rval = featurizer([self.mol])
     assert rval.shape == (1, 2048)
 
+    # number of indices, where feature count is more than 1, should be 0
+    assert len(np.where(rval[0] > 1.0)[0]) == 0
+
+  def test_count_based_circular_fingerprints(self):
+    """
+    Test CircularFingerprint with counts-based encoding
+    """
+    featurizer = CircularFingerprint(is_counts_based=True)
+    rval = featurizer([self.mol])
+    assert rval.shape == (1, 2048)
+
+    # number of indices where feature count is more than 1
+    assert len(np.where(rval[0] > 1.0)[0]) == 8
+
   def test_circular_fingerprints_with_1024(self):
     """
-        Test CircularFingerprint with 1024 size.
-        """
+    Test CircularFingerprint with 1024 size.
+    """
     featurizer = CircularFingerprint(size=1024)
     rval = featurizer([self.mol])
     assert rval.shape == (1, 1024)
 
   def test_sparse_circular_fingerprints(self):
     """
-        Test CircularFingerprint with sparse encoding.
-        """
+    Test CircularFingerprint with sparse encoding.
+    """
     featurizer = CircularFingerprint(sparse=True)
     rval = featurizer([self.mol])
     assert rval.shape == (1,)
@@ -46,9 +61,9 @@ class TestCircularFingerprint(unittest.TestCase):
 
   def test_sparse_circular_fingerprints_with_smiles(self):
     """
-        Test CircularFingerprint with sparse encoding and SMILES for each
-        fragment.
-        """
+    Test CircularFingerprint with sparse encoding and SMILES for each
+    fragment.
+    """
     featurizer = CircularFingerprint(sparse=True, smiles=True)
     rval = featurizer([self.mol])
     assert rval.shape == (1,)


### PR DESCRIPTION
# Pull Request Template
## Description
This  PR adds a facility to calculate count-based morgan features in `CircularFingerprint` class using `rdMolDescriptors.GetHashedMorganFingerprint()`  method. It also adds suitable unit tests.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
