### PR TITLE
Added pytorch-lightning in mac requirements

### DIFF
--- a/requirements/torch/env_torch.mac.cpu.yml
+++ b/requirements/torch/env_torch.mac.cpu.yml
@@ -8,3 +8,4 @@ dependencies:
     - torch-scatter
     - torch-sparse
     - torch-geometric
+    - pytorch-lightning 


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #3002 
This PR adds `pytorch-lightning`, a missing requirement when installing from source in MacOS.
<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- N/A New feature (non-breaking change which adds functionality)
- N/A Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- N/A Documentations (modification for documents)

## Checklist

- N/A My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - N/A Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - N/A Run `mypy -p deepchem` and check no errors
  - N/A Run `flake8 <modified file> --count` and check no errors
  - N/A Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- N/A I have commented my code, particularly in hard-to-understand areas
- N/A I have made corresponding changes to the documentation
- N/A I have added tests that prove my fix is effective or that my feature works
- N/A New unit tests pass locally with my changes
- N/A I have checked my code and corrected any misspellings
