### PR TITLE
:octocat: Porting GAN Tensorflow ➡️  PyTorch

### DIFF
--- a/deepchem/models/torch_models/gan.py
+++ b/deepchem/models/torch_models/gan.py
@@ -4,22 +4,12 @@ import torch.nn.functional as F
 import numpy as np
 import deepchem as dc
 from deepchem.models.torch_models import TorchModel
-from typing import Callable
+from deepchem.models.torch_models.layers import Lambda
 
 
 def _list_or_tensor(inputs):
 
   return inputs[0] if len(inputs) == 1 else inputs
-
-
-class LambdaLayer(nn.Module):
-
-  def __init__(self, lambda_func: Callable):
-    super(LambdaLayer, self).__init__()
-    self.lambda_func = lambda_func
-
-  def forward(self, x):
-    return self.lambda_func(x)
 
 
 class GAN(nn.Module):
@@ -99,10 +89,9 @@ class GAN(nn.Module):
     return discriminator(inputs + self.conditional_input_layers)
 
   def create_generator_loss(self, discrim_output):
-    return LambdaLayer(lambda x: -torch.mean(torch.log(x + 1e-10)))(
-        discrim_output)
+    return Lambda(lambda x: -torch.mean(torch.log(x + 1e-10)))(discrim_output)
 
   def create_discriminator_loss(self, discrim_output_train, discrim_output_gen):
-    return LambdaLayer(lambda x: -torch.mean(
+    return Lambda(lambda x: -torch.mean(
         torch.log(x[0] + 1e-10) + torch.log(1 - x[1] + 1e-10)))(
             [discrim_output_train, discrim_output_gen])

--- a/deepchem/models/torch_models/gan.py
+++ b/deepchem/models/torch_models/gan.py
@@ -1,0 +1,108 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import numpy as np
+import deepchem as dc
+from deepchem.models.torch_models import TorchModel
+from typing import Callable
+
+
+def _list_or_tensor(inputs):
+
+  return inputs[0] if len(inputs) == 1 else inputs
+
+
+class LambdaLayer(nn.Module):
+
+  def __init__(self, lambda_func: Callable):
+    super(LambdaLayer, self).__init__()
+    self.lambda_func = lambda_func
+
+  def forward(self, x):
+    return self.lambda_func(x)
+
+
+class GAN(nn.Module):
+
+  def __init__(self, n_generators, n_discriminators):
+
+    self.n_generators, self.n_discriminators = n_generators, n_discriminators
+
+    self.generators = []
+    self.gen_variables = []
+
+    for i in range(n_generators):
+      generator = self.create_generator()
+      self.generators.append(generator)
+      #generator_outputs.append(generator(_list_or_tensor([self.noise_input] + self.conditional_input_layers)))
+      self.gen_variables += generator.trainable_variables
+
+    self.discriminators = []
+    self.discrim_variables = []
+
+    for _ in range(n_discriminators):
+      discriminator = self.create_discriminator()
+      self.discriminators.append(discriminator)
+
+      self.discrim_variables += discriminator.trainable_variables
+
+  def forward(self, inputs):
+
+    noise_input, data_input, conditional_input = inputs
+    generator_outputs = []
+
+    for generator in self.generators:
+      generator_outputs.append(
+          generator(_list_or_tensor([noise_input] + conditional_input)))
+
+    discrim_train_outputs = []
+    discrim_gen_outputs = []
+
+    for discriminator in self.discriminators:
+      discrim_train_outputs.append(
+          self._forward_discriminator(discriminator, data_input, True))
+
+      for gen_output in generator_outputs:
+        if isinstance(gen_output, torch.Tensor):
+          gen_output = [gen_output]
+        discrim_gen_outputs.append(
+            self._forward_discriminator(discriminator, gen_output, False))
+
+    gen_losses = [self.create_generator_loss(d) for d in discrim_gen_outputs]
+
+    discrim_losses = []
+
+    for i in range(self.n_discriminators):
+      for j in range(self.n_generators):
+        discrim_losses.append(
+            self.create_discriminator_loss(
+                discrim_train_outputs[1],
+                discrim_gen_outputs[i * self.n_generators + j]))
+
+    if self.n_generators == 1 and self.n_discriminators == 1:
+      total_gen_loss = gen_losses[0]
+      total_discrim_loss = discrim_losses[0]
+    else:
+      gen_alpha = torch.Tensor(torch.ones(1, self.n_generators))
+      gen_weights = F.softmax(gen_alpha[noise_input])
+
+      discrim_alpha = torch.Tensor(torch.ones(1, self.n_discriminators))
+      discrim_weights = F.softmax(discrim_alpha[noise_input])
+
+  def create_generator(self):
+    raise NotImplementedError()
+
+  def create_discriminator(self):
+    raise NotImplementedError()
+
+  def _forward_discriminator(self, discriminator, inputs, train):
+    return discriminator(inputs + self.conditional_input_layers)
+
+  def create_generator_loss(self, discrim_output):
+    return LambdaLayer(lambda x: -torch.mean(torch.log(x + 1e-10)))(
+        discrim_output)
+
+  def create_discriminator_loss(self, discrim_output_train, discrim_output_gen):
+    return LambdaLayer(lambda x: -torch.mean(
+        torch.log(x[0] + 1e-10) + torch.log(1 - x[1] + 1e-10)))(
+            [discrim_output_train, discrim_output_gen])

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -1,6 +1,6 @@
 import math
 import numpy as np
-from typing import Any, Tuple, Optional, Sequence, List, Union
+from typing import Any, Tuple, Optional, Sequence, List, Union, Callable
 
 try:
   import torch
@@ -1005,3 +1005,33 @@ class InteratomicL2Distances(nn.Module):
                               (1, M_nbrs, 1))
     # Shape (N_atoms, M_nbrs)
     return torch.sum((tiled_coords - nbr_coords)**2, dim=2)
+
+
+class Lambda(nn.Module):
+  """This layer is analogous to tf.keras.layers.Lambda
+  It wraps function in nn.Module enabling pure functional operations to be performed
+  on Torch layers
+  """
+
+  def __init__(self, lambda_func: Callable):
+    """Constructor of this layer
+
+    Parameters
+    ----------
+    lambda_func: Callable
+      lambda function, to be wrapped in nn.Module
+    
+    """
+    super(Lambda, self).__init__()
+    self.lambda_func = lambda_func
+
+  def forward(self, x):
+    """
+    Invokes this layer
+    
+    Parameters
+    ----------
+    x : torch.Tensor
+      The output tensor of previous layer on which function is to be called upon
+    """
+    return self.lambda_func(x)


### PR DESCRIPTION
Porting GAN to PyTorch is a subproject under, `Deepchem Open Source Fellowship` funded by [Deep Forest Sciences](https://deepforestsci.com/)
This PR adds `GAN` and `WGAN` class and adds suitable unit tests.

# Description
## What are we doing here?
============================
`GAN class is PyTorch translation of deepchem's Keras GAN implementation [here](https://github.com/deepchem/deepchem/blob/master/deepchem/models/gan.py)
Removing the old Tensorflow GAN implementation from deepchem.

# Why are we doing this ?
===========================
Deepchem is moving on to PyTorch from Tensorflow as backend.

