### PR TITLE
Multigpu

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -48,6 +48,7 @@ try:
   from deepchem.models.fcnet import MultitaskRegressor, MultitaskClassifier, MultitaskFitTransformRegressor
   from deepchem.models.torch_models import MEGNetModel
   from deepchem.models.torch_models import CNN
+  from deepchem.models.lightning import DCLightningModule, DCLightningDatasetModule
 except ModuleNotFoundError as e:
   logger.warning(
       f'Skipped loading some PyTorch models, missing a dependency. {e}')

--- a/deepchem/models/lightning/dc_lightning_module.py
+++ b/deepchem/models/lightning/dc_lightning_module.py
@@ -58,6 +58,7 @@ class DCLightningModule(pl.LightningModule):
     if isinstance(inputs, list):
       assert len(inputs) == 1
       inputs = inputs[0]
+    inputs = inputs.to(self.device)
 
     outputs = self.pt_model(inputs)
 
@@ -66,6 +67,9 @@ class DCLightningModule(pl.LightningModule):
 
     if self.dc_model._loss_outputs is not None:
       outputs = [outputs[i] for i in self.dc_model._loss_outputs]
+    outputs = [out.to(self.device) for out in outputs]
+    labels = [label.to(self.device) for label in labels]
+    weights = [weight.to(self.device) for weight in weights]
 
     loss_outputs = self.loss(outputs, labels, weights)
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,6 +8,7 @@ sphinx_rtd_theme>=1.0
 tensorflow
 transformers>=4.6.*
 torch
+pytorch-lightning==1.5.10
 jax
 dm-haiku
 optax

--- a/examples/benchmark/gcnmodel_benchmark.py
+++ b/examples/benchmark/gcnmodel_benchmark.py
@@ -4,9 +4,16 @@ from deepchem.models.lightning.dc_lightning_module import DCLightningModule
 from deepchem.models.lightning.dc_lightning_dataset_module import DCLightningDatasetModule, collate_dataset_wrapper
 from deepchem.feat import MolGraphConvFeaturizer
 import pytorch_lightning as pl
+import argparse
 
 
 def main():
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--device",
+                      type=str,
+                      required=True,
+                      choices=["cpu", 'gpu'])
+  args = parser.parse_args()
   featurizer = MolGraphConvFeaturizer()
   tasks, datasets, transformers = dc.molnet.load_zinc15(featurizer=featurizer)
   _, valid_dataset, test_dataset = datasets
@@ -20,14 +27,14 @@ def main():
                    learning_rate=0.001)
 
   gcnmodule = DCLightningModule(model)
-  smiles_datasetmodule = DCLightningDatasetModule(valid_dataset, 100,
+  smiles_datasetmodule = DCLightningDatasetModule(valid_dataset, 1024,
                                                   collate_dataset_wrapper)
 
   trainer = pl.Trainer(
       max_epochs=1,
       profiler="simple",
       devices=1,
-      accelerator="gpu",
+      accelerator=args.device,
   )
 
   trainer.fit(gcnmodule, smiles_datasetmodule)

--- a/examples/benchmark/gcnmodel_benchmark.py
+++ b/examples/benchmark/gcnmodel_benchmark.py
@@ -1,0 +1,37 @@
+import deepchem as dc
+from deepchem.models import GCNModel
+from deepchem.models.lightning.dc_lightning_module import DCLightningModule
+from deepchem.models.lightning.dc_lightning_dataset_module import DCLightningDatasetModule, collate_dataset_wrapper
+from deepchem.feat import MolGraphConvFeaturizer
+import pytorch_lightning as pl
+
+
+def main():
+  featurizer = MolGraphConvFeaturizer()
+  tasks, datasets, transformers = dc.molnet.load_zinc15(featurizer=featurizer)
+  _, valid_dataset, test_dataset = datasets
+
+  n_tasks = len(tasks)
+  model = GCNModel(graph_conv_layers=[1024, 1024, 1024, 512, 512, 512],
+                   mode='regression',
+                   n_tasks=n_tasks,
+                   number_atom_features=30,
+                   batch_size=1024,
+                   learning_rate=0.001)
+
+  gcnmodule = DCLightningModule(model)
+  smiles_datasetmodule = DCLightningDatasetModule(valid_dataset, 100,
+                                                  collate_dataset_wrapper)
+
+  trainer = pl.Trainer(
+      max_epochs=1,
+      profiler="simple",
+      devices=1,
+      accelerator="gpu",
+  )
+
+  trainer.fit(gcnmodule, smiles_datasetmodule)
+
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
Make the loss implementation non-local, if the implementation is local then when launching processes for multiple GPUs code breaks. Python uses pickle in the process of forking processes and the pickle fails with the error `torch multigpu AttributeError: Can't pickle local object`.

Questions:
1. Is there a better way to do this, one possibility is with https://docs.python.org/3/reference/expressions.html#lambda, I will have to test this way more to make things work.
2. This would require making changes to how loss is specified in other methods also. 



## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
