### PR TITLE
Removing mol2vec dependency

### DIFF
--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -24,5 +24,5 @@ dependencies:
     - simdna
     - transformers==4.10.*
     - xgboost
-    - git+https://github.com/samoturk/mol2vec
+    - gensim  # used by mol2vec 
     - tb-nightly # @arunppsg shift to tensorboard stable version once tb 2.9.1 is released


### PR DESCRIPTION
The mol2vec package is used for computing `mol2vec_fingerprints`. The package is available [here](https://github.com/samoturk/mol2vec) and we use only one method from it: `mol2vec_alt_sentence`. I copied the method from mol2vec repo to local. The reason is that the package seems to cause dependency issues when used with python 3.10 ([ref](https://github.com/deepchem/deepchem/runs/8140061861?check_suite_focus=true#step:10:751)).