### PR TITLE
Improving CI

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -12,11 +12,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest]
-        python-version: ['3.8']
+        os: ubuntu-latest
+        python-version: ['3.7', '3.8', '3.9']
         include:
-        - os: ubuntu-latest
-          python-version: '3.9'
+        - os: windows-latest
+          python-version: ['3.8']
     steps:
     - uses: actions/checkout@v3
       # using cached dependencies to speed up workflow

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [windows-latest, ubuntu-latest]
         python-version: ['3.8']
-      include:
+        include:
         - os: ubuntu-latest
           python-version: '3.9'
     steps:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -8,11 +8,15 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        os: [windows-latest, ubuntu-latest]
+        python-version: ['3.8']
+      include:
+        - os: ubuntu-latest
+          python-version: '3.9'
     steps:
     - uses: actions/checkout@v3
       # using cached dependencies to speed up workflow
@@ -43,10 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
-        include:
-          - os: windows-latest
-            python-version: 3.7
+        python-version: ['3.8', '3.9']
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}
@@ -157,7 +158,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9']
+        python-version: ['3.7', '3.9']
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/tensorflow_setup.yml
+++ b/.github/workflows/tensorflow_setup.yml
@@ -44,6 +44,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.9]
+        include:
+          - os: windows-latest
+            python-version: 3.8
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/tensorflow_setup.yml
+++ b/.github/workflows/tensorflow_setup.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/tensorflow_setup.yml
+++ b/.github/workflows/tensorflow_setup.yml
@@ -8,11 +8,15 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: windows-latest
+            python-version: 3.7
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip modules for Linux
@@ -39,10 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
-        include:
-          - os: windows-latest
-            python-version: 3.7
+        python-version: [3.8, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         python-version: [3.7, 3.8, 3.9]
         include:
           - os: windows-latest
-            python-version: 3.7
+            python-version: 3.8
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip modules for Linux
@@ -44,6 +44,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.9]
+        include:
+          - os: windows-latest
+            python-version: 3.7
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ubuntu-latest
+        os: [ubuntu-latest]
         python-version: [3.8, 3.9]
     env:
       OS: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,11 +8,15 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: windows-latest
+            python-version: 3.7
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip modules for Linux
@@ -38,11 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
-        include:
-          - os: windows-latest
-            python-version: 3.7
+        os: ubuntu-latest
+        python-version: [3.8, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/torch_setup.yml
+++ b/.github/workflows/torch_setup.yml
@@ -44,6 +44,9 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: [3.7, 3.9]
+        include:
+          - os: windows-latest
+            python-version: 3.8
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/torch_setup.yml
+++ b/.github/workflows/torch_setup.yml
@@ -43,7 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/torch_setup.yml
+++ b/.github/workflows/torch_setup.yml
@@ -8,11 +8,15 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: windows-latest
+            python-version: 3.7
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip modules for Linux
@@ -39,10 +43,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
-        include:
-          - os: windows-latest
-            python-version: 3.7
+        python-version: [3.8, 3.9]
     env:
       OS: ${{ matrix.os }}
       PYTHON_VERSION: ${{ matrix.python-version }}


### PR DESCRIPTION
Fix #3054 

Summary of changes:
- formatting ci
    - Earlier: Build only on ubuntu OS python 3.7, tests on ubuntu os python version 3.7, 3.8, 3.9
    - Now: Build on ubuntu OS python 3.8, 3.9, windows py 3.8, tests on ubuntu python 3.7, 3.9
- jax ci
    - Earlier: Build on ubuntu-py 3.7, 3.8, 3.9, run test on ubuntu py 3.7, 3.8, 3.9
    - Now: Build on ubuntu-py 3.7, 3.8, 3.8, run test on ubuntu py 3.7, 3.9
- Tensorflow, torch and common unit tests ci
   - Earlier: Build on ubuntu os in python version 3.7, 3.8, 3.9, run test on ubuntu os in python version 3.7, 3.8, 3.9, windows 3.7
   - Now: Build on ubuntu os in python version 3.7, 3.8, 3.9, windows 3.7 run test on ubuntu os in python version 3.7, 3.9