### PR TITLE
Correctly import lightning to avoid import errors

### DIFF
--- a/deepchem/models/lightning/dc_lightning_module.py
+++ b/deepchem/models/lightning/dc_lightning_module.py
@@ -1,9 +1,5 @@
-try:
-  import torch
-  import pytorch_lightning as pl  # noqa
-  PYTORCH_LIGHTNING_IMPORT_FAILED = False
-except ImportError:
-  PYTORCH_LIGHTNING_IMPORT_FAILED = True
+import torch
+import pytorch_lightning as pl  # noqa
 
 
 class DCLightningModule(pl.LightningModule):


### PR DESCRIPTION
## Description

Fix deepchem installation failure, remove try catch block around lightning import which was causing previous crashes.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)


Tested the fix with
```
pip install --pre deepchem
import deepchem as dc
print(dc.__version__)
```
