### PR TITLE
Substract padding from list length when slicing

### DIFF
--- a/deepchem/feat/molecule_featurizers/smiles_to_seq.py
+++ b/deepchem/feat/molecule_featurizers/smiles_to_seq.py
@@ -98,8 +98,7 @@ class SmilesToSeq(MolecularFeaturizer):
 
   def remove_pad(self, characters: List[str]) -> List[str]:
     """Removes PAD_TOKEN from the character list."""
-    characters = characters[self.pad_len:]
-    characters = characters[:-self.pad_len]
+    characters = characters[self.pad_len:len(characters) - self.pad_len]
     chars = list()
 
     for char in characters:


### PR DESCRIPTION
# Pull Request Template

## Description

Avoid issues when pad_len is zero

Fix #3070

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
