### PR TITLE
Fix broken typehint in SparseMatrixOneHotFeaturizer.untransform

### DIFF
--- a/deepchem/feat/molecule_featurizers/sparse_matrix_one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/sparse_matrix_one_hot_featurizer.py
@@ -84,7 +84,7 @@ class SparseMatrixOneHotFeaturizer(Featurizer):
     else:
       raise ValueError("Datapoint is not a string")
 
-  def untransform(self, one_hot_vectors: scipy.sparse) -> str:
+  def untransform(self, one_hot_vectors: scipy.sparse.base.spmatrix) -> str:
     """Convert from one hot representation back to original string
 
     Parameters


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #2894 

Fixes Issue 2894, where the `one_hot_vectors` argument for `SparseMatrixOneHotFeaturizer.untransform` had some odd typing:

![image](https://user-images.githubusercontent.com/24254612/196007720-fa6da338-59fe-4007-983f-0fa356431362.png)

This was caused by the typehint pointing to the module, not to the actual Sparse Matrix class in SciPy. 

Fixed the typehint by changing the reference to Scipy's base class for sparse matrices. Building the docs locally verified this fixes the issue:

![image](https://user-images.githubusercontent.com/24254612/196007705-9501bebb-6ee5-4428-bacf-222374d50a1c.png)

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [X] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
