### PR TITLE
Minor patches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip modules for Linux
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip packages for Windows

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip packages for Linux

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -95,7 +95,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip;
         pip install conda-merge;
-        conda-merge requirements/env_common.yml requirements/env_test.yml > env.yml
+        conda-merge requirements/env_common.yml requirements/env_test.yml requirements/jax/env_jax.cpu.yml > env.yml
     - name: Install all dependencies
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -108,7 +108,7 @@ jobs:
     - name: Install DeepChem
       id: install
       shell: bash -l {0}
-      run: pip install -e '.[jax]'
+      run: pip install -e .
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8']
+        python-version: ['3.9']
     steps:
     - uses: actions/checkout@v3
     - name: Cache pip modules for Linux

--- a/.github/workflows/tensorflow_setup.yml
+++ b/.github/workflows/tensorflow_setup.yml
@@ -102,7 +102,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip;
         pip install conda-merge;
-        conda-merge requirements/env_common.yml requirements/env_test.yml > env.yml
+        conda-merge requirements/env_common.yml requirements/env_test.yml requirements/tensorflow/env_tensorflow.cpu.yml > env.yml
     - name: Install all dependencies
       uses: conda-incubator/setup-miniconda@v2
       with:
@@ -115,7 +115,7 @@ jobs:
     - name: Install DeepChem
       id: install
       shell: bash -l {0}
-      run: pip install -e '.[tensorflow]'
+      run: pip install -e .
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}

--- a/.github/workflows/torch_setup.yml
+++ b/.github/workflows/torch_setup.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Install DeepChem
       id: install
       shell: bash -l {0}
-      run: pip install -e '.[torch]'
+      run: pip install -e .
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -48,11 +48,19 @@ try:
   from deepchem.models.fcnet import MultitaskRegressor, MultitaskClassifier, MultitaskFitTransformRegressor
   from deepchem.models.torch_models import MEGNetModel
   from deepchem.models.torch_models import CNN
-  from deepchem.models.torch_models import DMPNN, DMPNNModel
   from deepchem.models.lightning import DCLightningModule, DCLightningDatasetModule
 except ModuleNotFoundError as e:
   logger.warning(
       f'Skipped loading some PyTorch models, missing a dependency. {e}')
+
+# Pytorch models with torch-geometric dependency
+try:
+  # TODO We should clean up DMPNN and remove torch_geometric dependency during import
+  from deepchem.models.torch_models import DMPNN, DMPNNModel
+except ModuleNotFoundError as e:
+  logger.warning(
+      f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}'
+  )
 
 # Jax models
 try:

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -48,7 +48,6 @@ try:
   from deepchem.models.fcnet import MultitaskRegressor, MultitaskClassifier, MultitaskFitTransformRegressor
   from deepchem.models.torch_models import MEGNetModel
   from deepchem.models.torch_models import CNN
-  from deepchem.models.lightning import DCLightningModule, DCLightningDatasetModule
 except ModuleNotFoundError as e:
   logger.warning(
       f'Skipped loading some PyTorch models, missing a dependency. {e}')
@@ -57,9 +56,17 @@ except ModuleNotFoundError as e:
 try:
   # TODO We should clean up DMPNN and remove torch_geometric dependency during import
   from deepchem.models.torch_models import DMPNN, DMPNNModel
-except ModuleNotFoundError as e:
+except ImportError as e:
   logger.warning(
       f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}'
+  )
+
+# Pytorch-lightning modules import
+try:
+  from deepchem.models.lightning import DCLightningModule, DCLightningDatasetModule
+except ModuleNotFoundError as e:
+  logger.warning(
+      f'Skipped loading modules with pytorch-lightning dependency, missing a dependency. {e}'
   )
 
 # Jax models

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -16,4 +16,10 @@ from deepchem.models.torch_models.megnet import MEGNetModel
 from deepchem.models.torch_models.normalizing_flows_pytorch import NormalizingFlow
 from deepchem.models.torch_models.layers import CNNModule, CombineMeanStd, WeightedLinearCombo, AtomicConvolution, NeighborList
 from deepchem.models.torch_models.cnn import CNN
-from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel
+
+try:
+  from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel
+except ModuleNotFoundError as e:
+  logger.warning(
+      f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}'
+  )

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,12 +7,12 @@ sphinx>=4.0,<5.0
 sphinx_rtd_theme>=1.0
 tensorflow
 transformers>=4.6.*
-torch
+torch==1.12.1 --extra-index-url https://download.pytorch.org/whl/cpu
 pytorch-lightning==1.6.5
 jax
 dm-haiku
 optax
-rdkit-pypi
-https://data.pyg.org/whl/torch-1.12.0%2Bcpu/torch_sparse-0.6.14-cp38-cp38-linux_x86_64.whl --extra-index-url https://data.pyg.org/whl/torch-1.12.0+cpu.html
-https://data.pyg.org/whl/torch-1.12.0%2Bcpu/torch_scatter-2.0.9-cp38-cp38-linux_x86_64.whl --extra-index-url https://data.pyg.org/whl/torch-1.12.0+cpu.html
+rdkit
+https://data.pyg.org/whl/torch-1.12.0%2Bcpu/torch_sparse-0.6.14-cp39-cp39-linux_x86_64.whl
+https://data.pyg.org/whl/torch-1.12.0%2Bcpu/torch_scatter-2.0.9-cp39-cp39-linux_x86_64.whl
 torch-geometric>=2.0.4

--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - pip:
     - -f https://download.pytorch.org/whl/cpu/torch_stable.html
-    - -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
+    - -f https://data.pyg.org/whl/torch-1.12.0+cpu.html
     - -f https://data.dgl.ai/wheels/repo.html
     - dgl
     - torch==1.12.0+cpu

--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -4,8 +4,7 @@ dependencies:
     - -f https://data.pyg.org/whl/torch-1.11.0+cpu.html
     - -f https://data.dgl.ai/wheels/repo.html
     - dgl
-    - torch==1.11.0+cpu
-    - torchvision==0.12.0+cpu
+    - torch==1.12.0+cpu
     - torch-scatter
     - torch-sparse
     - torch-geometric


### PR DESCRIPTION
This PR fixes:
- docs ci by updating torch-geometric import
- making models requiring torch-geometric import under an separate try-except block, so that torch-geometric import fail does not block import of other models (potential fix for #3098)
- updates torch version to 1.12 (we have it pinned because torch-geometric requires a precise version of pytorch)