### PR TITLE
adding batch size argument to lightning module

### DIFF
--- a/deepchem/models/lightning/dc_lightning_module.py
+++ b/deepchem/models/lightning/dc_lightning_module.py
@@ -72,6 +72,7 @@ class DCLightningModule(pl.LightningModule):
         sync_dist=True,
         reduce_fx="mean",
         prog_bar=True,
+        batch_size=self.dc_model.batch_size,
     )
 
     return loss_outputs


### PR DESCRIPTION
The `training_step` in lightning module can either infer batch size from the dataset directly or requires an explicit batch size argument. Since the `_prepare_batch` of deepchem.models return a tuple of inputs, labels and weights, batch size cannot be inferred from the `batch` argument. Hence, I have added an explicit batch_size argument to `self.log` method.