### PR TITLE
updated mdtraj requirement

### DIFF
--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -4,12 +4,12 @@ channels:
   - defaults
 dependencies:
   - openmm
+  - mdtraj
   - pdbfixer
   - pip
   - pip:
     - numpy
     - rdkit
-    - mdtraj
     - pre-commit
     - biopython
     - dgllife==0.2.8

--- a/requirements/jax/env_jax.cpu.yml
+++ b/requirements/jax/env_jax.cpu.yml
@@ -1,5 +1,7 @@
 dependencies:
   - pip:
-    - jax[cpu]
+    - jax[cpu]<0.3.25
+    # 0.3.25 contains breaking change not compatible with haiku
+    # https://github.com/deepmind/dm-haiku/issues/565
     - dm-haiku
     - optax

--- a/requirements/jax/env_jax.gpu.yml
+++ b/requirements/jax/env_jax.gpu.yml
@@ -1,4 +1,4 @@
 dependencies:
   - pip:
     - -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jax[cuda111]
+    - jax[cuda111]<0.3.25


### PR DESCRIPTION
Moved mdtraj from pip channel to conda channel in requirements file. This might fix mdtraj breakage in windows build.