### PR TITLE
removing tensorflow install in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
     - name: Build DeepChem
       run: |
         python -m pip install --upgrade pip
-        pip install tensorflow'>=2.3,<2.4'
         pip install -e .
     - name: Import checking
       run: python -c "import deepchem"

--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -3,7 +3,7 @@ Imports all submodules
 """
 
 # If you push the tag, please remove `.dev`
-__version__ = '2.7.0'
+__version__ = '2.7.1'
 
 import deepchem.data
 import deepchem.feat


### PR DESCRIPTION
The `pip install tensorflow` in workflow is not required as deepchem core works without tensorflow.