### PR TITLE
Merge dataset when the dimension of y is 1

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -795,6 +795,8 @@ class NumpyDataset(Dataset):
         w = np.ones((y.shape[0], 1), np.float32)
     if not isinstance(w, np.ndarray):
       w = np.array(w)
+    if y.shape == 1:
+      print("true")
     self._X = X
     self._y = y
     self._w = w
@@ -1082,6 +1084,7 @@ class NumpyDataset(Dataset):
     """
     X, y, w, ids = datasets[0].X, datasets[0].y, datasets[0].w, datasets[0].ids
     for dataset in datasets[1:]:
+      print(X.shape, y.shape)
       X = np.concatenate([X, dataset.X], axis=0)
       y = np.concatenate([y, dataset.y], axis=0)
       w = np.concatenate([w, dataset.w], axis=0)
@@ -1089,7 +1092,10 @@ class NumpyDataset(Dataset):
           [ids, dataset.ids],
           axis=0,
       )
-
+    k = y.shape[0]
+    if y.shape==(k,):
+        y=y.reshape(k,1)
+    print(X.shape, y.shape)
     return NumpyDataset(X, y, w, ids, n_tasks=y.shape[1])
 
 

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1084,7 +1084,6 @@ class NumpyDataset(Dataset):
     """
     X, y, w, ids = datasets[0].X, datasets[0].y, datasets[0].w, datasets[0].ids
     for dataset in datasets[1:]:
-      print(X.shape, y.shape)
       X = np.concatenate([X, dataset.X], axis=0)
       y = np.concatenate([y, dataset.y], axis=0)
       w = np.concatenate([w, dataset.w], axis=0)
@@ -1093,9 +1092,8 @@ class NumpyDataset(Dataset):
           axis=0,
       )
     k = y.shape[0]
-    if y.shape==(k,):
-        y=y.reshape(k,1)
-    print(X.shape, y.shape)
+    if y.shape == (k,):
+      y = y.reshape(k, 1)
     return NumpyDataset(X, y, w, ids, n_tasks=y.shape[1])
 
 

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -795,8 +795,6 @@ class NumpyDataset(Dataset):
         w = np.ones((y.shape[0], 1), np.float32)
     if not isinstance(w, np.ndarray):
       w = np.array(w)
-    if y.shape == 1:
-      print("true")
     self._X = X
     self._y = y
     self._w = w

--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1089,9 +1089,9 @@ class NumpyDataset(Dataset):
           [ids, dataset.ids],
           axis=0,
       )
-    k = y.shape[0]
-    if y.shape == (k,):
-      y = y.reshape(k, 1)
+
+    if y.ndim == 1:
+      y = y.reshape(-1, 1)
     return NumpyDataset(X, y, w, ids, n_tasks=y.shape[1])
 
 

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -680,7 +680,13 @@ def test_merge():
     datasets.append(dataseti)
 
   new_data = dc.data.datasets.DiskDataset.merge(datasets)
-
+  x=[1,2, 3]
+  X= np.array(x)
+  y= np.array(x)
+  a = dc.data.NumpyDataset(X, y)
+  b = dc.data.NumpyDataset(X, y)
+  c=dc.data.NumpyDataset.merge([a, b])
+  assert c.y.shape == (6,1) #test to check if merge works when y is one dimensional
   # Check that we have all the data in
   assert new_data.X.shape == (num_datapoints * num_datasets, num_features)
   assert new_data.y.shape == (num_datapoints * num_datasets, num_tasks)

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -680,13 +680,14 @@ def test_merge():
     datasets.append(dataseti)
 
   new_data = dc.data.datasets.DiskDataset.merge(datasets)
-  x=[1,2, 3]
-  X= np.array(x)
-  y= np.array(x)
+  x = [1, 2, 3]
+  X = np.array(x)
+  y = np.array(x)
   a = dc.data.NumpyDataset(X, y)
   b = dc.data.NumpyDataset(X, y)
-  c=dc.data.NumpyDataset.merge([a, b])
-  assert c.y.shape == (6,1) #test to check if merge works when y is one dimensional
+  c = dc.data.NumpyDataset.merge([a, b])
+  assert c.y.shape == (6, 1
+                      )  #test to check if merge works when y is one dimensional
   # Check that we have all the data in
   assert new_data.X.shape == (num_datapoints * num_datasets, num_features)
   assert new_data.y.shape == (num_datapoints * num_datasets, num_tasks)


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #3130 

Dataset merge does not work when the dimension of y is 1. We fix this by checking the dimension and reshaping accordingly. 


## Type of change

Please check the option that is related to your PR.

- [ x] Bug fix (non-breaking change which fixes an issue) 