### PR TITLE
type fixes for pep 484 compliance

### DIFF
--- a/deepchem/data/pytorch_datasets.py
+++ b/deepchem/data/pytorch_datasets.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 
 from deepchem.data.datasets import NumpyDataset, DiskDataset, ImageDataset
+from typing import Optional
 
 
 class _TorchNumpyDataset(torch.utils.data.IterableDataset):  # type: ignore
@@ -10,7 +11,7 @@ class _TorchNumpyDataset(torch.utils.data.IterableDataset):  # type: ignore
                  numpy_dataset: NumpyDataset,
                  epochs: int,
                  deterministic: bool,
-                 batch_size: int = None):
+                 batch_size: Optional[int] = None):
         """
         Parameters
         ----------
@@ -66,7 +67,7 @@ class _TorchDiskDataset(torch.utils.data.IterableDataset):  # type: ignore
                  disk_dataset: DiskDataset,
                  epochs: int,
                  deterministic: bool,
-                 batch_size: int = None):
+                 batch_size: Optional[int] = None):
         """
         Parameters
         ----------
@@ -118,7 +119,7 @@ class _TorchImageDataset(torch.utils.data.IterableDataset):  # type: ignore
                  image_dataset: ImageDataset,
                  epochs: int,
                  deterministic: bool,
-                 batch_size: int = None):
+                 batch_size: Optional[int] = None):
         """
         Parameters
         ----------

--- a/deepchem/feat/complex_featurizers/contact_fingerprints.py
+++ b/deepchem/feat/complex_featurizers/contact_fingerprints.py
@@ -16,7 +16,7 @@ from deepchem.utils.rdkit_utils import MoleculeLoadException
 from deepchem.utils.geometry_utils import compute_pairwise_distances
 from deepchem.utils.geometry_utils import subtract_centroid
 
-from typing import Tuple, Dict, List
+from typing import Optional, Tuple, Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def featurize_contacts_ecfp(
     frag1: Tuple,
     frag2: Tuple,
-    pairwise_distances: np.ndarray = None,
+    pairwise_distances: Optional[np.ndarray] = None,
     cutoff: float = 4.5,
     ecfp_degree: int = 2) -> Tuple[Dict[int, str], Dict[int, str]]:
   """Computes ECFP dicts for pairwise interaction between two molecular fragments.

--- a/deepchem/feat/complex_featurizers/contact_fingerprints.py
+++ b/deepchem/feat/complex_featurizers/contact_fingerprints.py
@@ -16,7 +16,7 @@ from deepchem.utils.rdkit_utils import MoleculeLoadException
 from deepchem.utils.geometry_utils import compute_pairwise_distances
 from deepchem.utils.geometry_utils import subtract_centroid
 
-from typing import Optional, Tuple, Dict, List
+from typing import Optional, Tuple, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +200,7 @@ class ContactCircularVoxelizer(ComplexFeaturizer):
     except MoleculeLoadException:
       logger.warning("This molecule cannot be loaded by Rdkit. Returning None")
       return None
-    pairwise_features: List[np.ndarray] = []
+    pairwise_features = []
     # We compute pairwise contact fingerprints
     centroid = compute_contact_centroid(fragments, cutoff=self.cutoff)
     for (frag1, frag2) in itertools.combinations(fragments, 2):

--- a/deepchem/feat/complex_featurizers/splif_fingerprints.py
+++ b/deepchem/feat/complex_featurizers/splif_fingerprints.py
@@ -16,7 +16,7 @@ from deepchem.utils.voxel_utils import convert_atom_pair_to_voxel
 from deepchem.utils.geometry_utils import compute_pairwise_distances
 from deepchem.utils.geometry_utils import subtract_centroid
 
-from typing import Tuple, Dict, List
+from typing import Optional, Tuple, Dict, List
 
 logger = logging.getLogger(__name__)
 
@@ -207,7 +207,7 @@ class SplifVoxelizer(ComplexFeaturizer):
 
   def __init__(self,
                cutoff: float = 4.5,
-               contact_bins: List = None,
+               contact_bins: Optional[List] = None,
                radius: int = 2,
                size: int = 8,
                box_width: float = 16.0,

--- a/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
@@ -126,7 +126,7 @@ def get_atom_mass(atom: RDKitAtom) -> List[float]:
 
 def atom_features(
     atom: RDKitAtom,
-    functional_groups: List[int] = None,
+    functional_groups: Optional[List[int]] = None,
     only_atom_num: bool = False) -> Sequence[Union[bool, int, float]]:
   """Helper method used to compute atom feature vector.
 

--- a/deepchem/feat/molecule_featurizers/molgan_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/molgan_featurizer.py
@@ -60,8 +60,8 @@ class MolGanFeaturizer(MolecularFeaturizer):
       self,
       max_atom_count: int = 9,
       kekulize: bool = True,
-      bond_labels: List[RDKitBond] = None,
-      atom_labels: List[int] = None,
+      bond_labels: Optional[List[RDKitBond]] = None,
+      atom_labels: Optional[List[int]] = None,
   ):
     """
     Parameters

--- a/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
+++ b/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
@@ -92,7 +92,6 @@ class RDKitDescriptors(MolecularFeaturizer):
     self.ipc_avg: bool = ipc_avg
     self.labels_only = labels_only
     self.reqd_properties = {}
-    self.properties = []
     self.normalized_desc: Dict[str, Callable] = {}
 
     all_descriptors = {name: func for name, func in Descriptors.descList}
@@ -123,7 +122,7 @@ class RDKitDescriptors(MolecularFeaturizer):
 
     self.reqd_properties = dict(sorted(self.reqd_properties.items()))
 
-  def _featurize(self, datapoint: RDKitMol) -> np.ndarray:
+  def _featurize(self, datapoint: RDKitMol, **kwargs) -> np.ndarray:
     """
     Calculate RDKit descriptors.
 
@@ -196,18 +195,16 @@ class RDKitDescriptors(MolecularFeaturizer):
     """
     normalized_desc = {}
     # get sequence of descriptor names and normalization parameters from DescriptorsNormalizationParameters class
-    parameters: Sequence[Union[str, Sequence[Union[str, Sequence[float],
-                                                   float]]]]
     parameters = DNP.desc_norm_params.items()
 
     for desc_name, (distribution_name, params, minV, maxV, avg,
                     std) in parameters:
-      arg: Sequence[float] = params[:-2]
-      loc: float = params[-2]
-      scale: float = params[-1]
+      arg = params[:-2]
+      loc = params[-2]
+      scale = params[-1]
 
       # get required distribution_ from `scipy.stats` module.
-      cont_distribution: rv_continuous = getattr(st, distribution_name)
+      cont_distribution = getattr(st, distribution_name)
 
       # cdf => cumulative density functions
       # make the cdf with the parameters.

--- a/deepchem/models/jax_models/jax_model.py
+++ b/deepchem/models/jax_models/jax_model.py
@@ -12,7 +12,7 @@ from deepchem.utils.evaluate import GeneratorEvaluator
 from deepchem.trans.transformers import Transformer, undo_transforms
 
 from typing import Any, Callable, Iterable, List, Optional, Tuple, Union, Sequence
-from deepchem.utils.typing import LossFn, OneOrMany, ArrayLike
+from deepchem.utils.typing import LossFn, OneOrMany
 
 # JAX depend
 import jax.numpy as jnp
@@ -497,8 +497,7 @@ class JaxModel(Model):
       self,
       X: Sequence,
       masks: int = 50) -> OneOrMany[Tuple[np.ndarray, np.ndarray]]:
-
-    pass
+    raise NotImplementedError('Predicting uncertainity on batch is not supported currently for JAX models')
 
   def predict(
       self,
@@ -537,8 +536,8 @@ class JaxModel(Model):
     return self._global_step
 
   def predict_embedding(self, dataset: Dataset) -> OneOrMany[np.ndarray]:
+    raise NotImplementedError('Predicting embedding is not supported currently for JAX models')
 
-    pass
 
   # def predict_uncertainty(self, dataset: Dataset, masks: int = 50
   #                        ) -> OneOrMany[Tuple[np.ndarray, np.ndarray]]:

--- a/deepchem/models/jax_models/jax_model.py
+++ b/deepchem/models/jax_models/jax_model.py
@@ -100,7 +100,7 @@ class JaxModel(Model):
                output_types: Optional[List[str]] = None,
                batch_size: int = 100,
                learning_rate: float = 0.001,
-               optimizer: Union[optax.GradientTransformation, Optimizer] = None,
+               optimizer: Optional[Union[optax.GradientTransformation, Optimizer]] = None,
                grad_fn: Callable = create_default_gradient_fn,
                update_fn: Callable = create_default_update_fn,
                eval_fn: Callable = create_default_eval_fn,
@@ -213,7 +213,7 @@ class JaxModel(Model):
           dataset: Dataset,
           nb_epochs: int = 10,
           deterministic: bool = False,
-          loss: Union[Loss, LossFn] = None,
+          loss: Optional[Union[Loss, LossFn]] = None,
           callbacks: Union[Callable, List[Callable]] = [],
           all_losses: Optional[List[float]] = None) -> float:
     """Train this model on a dataset.
@@ -267,7 +267,7 @@ class JaxModel(Model):
 
   def fit_generator(self,
                     generator: Iterable[Tuple[Any, Any, Any]],
-                    loss: Union[Loss, LossFn] = None,
+                    loss: Optional[Union[Loss, LossFn]] = None,
                     callbacks: Union[Callable, List[Callable]] = [],
                     all_losses: Optional[List[float]] = None) -> float:
     if not isinstance(callbacks, SequenceCollection):

--- a/deepchem/models/jax_models/pinns_model.py
+++ b/deepchem/models/jax_models/pinns_model.py
@@ -111,7 +111,7 @@ class PINNModel(JaxModel):
                output_types: Optional[List[str]] = None,
                batch_size: int = 100,
                learning_rate: float = 0.001,
-               optimizer: Union[optax.GradientTransformation, Optimizer] = None,
+               optimizer: Optional[Union[optax.GradientTransformation, Optimizer]] = None,
                grad_fn: Callable = create_default_gradient_fn,
                update_fn: Callable = create_default_update_fn,
                eval_fn: Callable = create_default_eval_fn,
@@ -161,7 +161,7 @@ class PINNModel(JaxModel):
 
   def fit_generator(self,
                     generator: Iterable[Tuple[Any, Any, Any]],
-                    loss: Union[Loss, LossFn] = None,
+                    loss: Optional[Union[Loss, LossFn]] = None,
                     callbacks: Union[Callable, List[Callable]] = [],
                     all_losses: Optional[List[float]] = None) -> float:
     if not isinstance(callbacks, SequenceCollection):

--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -2,7 +2,7 @@
 import tensorflow as tf
 import numpy as np
 from collections.abc import Sequence as SequenceCollection
-from typing import Callable, Dict, List, Tuple
+from typing import Optional, Callable, Dict, List, Tuple
 from tensorflow.keras import activations, initializers, backend
 from tensorflow.keras.layers import Dropout, BatchNormalization, Dense, Activation
 
@@ -97,7 +97,7 @@ class GraphConv(tf.keras.layers.Layer):
                out_channel: int,
                min_deg: int = 0,
                max_deg: int = 10,
-               activation_fn: Callable = None,
+               activation_fn: Optional[Callable] = None,
                **kwargs):
     """Initialize a graph convolutional layer.
 

--- a/deepchem/models/molgan.py
+++ b/deepchem/models/molgan.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple, Any
+from typing import Optional, List, Tuple, Any
 
 import tensorflow as tf
 from deepchem.feat.molecule_featurizers.molgan_featurizer import GraphMatrix
@@ -166,7 +166,7 @@ class BasicMolGANModel(WGAN):
 
   def predict_gan_generator(self,
                             batch_size: int = 1,
-                            noise_input: List = None,
+                            noise_input: Optional[List] = None,
                             conditional_inputs: List = [],
                             generator_index: int = 0) -> List[GraphMatrix]:
     """

--- a/deepchem/models/torch_models/dmpnn.py
+++ b/deepchem/models/torch_models/dmpnn.py
@@ -239,7 +239,7 @@ class _MapperDMPNN:
     Method to get b2revb and replace the reverse bond indices with -1 in mapping.
     """
     # mapping from bond index to the index of the reverse bond
-    b2revb: np.ndarray = np.empty(self.num_bonds, dtype=int)
+    b2revb = np.empty(self.num_bonds, dtype=int)
     for i in range(self.num_bonds):
       if i % 2 == 0:
         b2revb[i] = i + 1

--- a/deepchem/models/torch_models/gat.py
+++ b/deepchem/models/torch_models/gat.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 
 from deepchem.models.losses import Loss, L2Loss, SparseSoftmaxCrossEntropy
 from deepchem.models.torch_models.torch_model import TorchModel
+from typing import Optional
 
 
 class GAT(nn.Module):
@@ -54,9 +55,9 @@ class GAT(nn.Module):
 
   def __init__(self,
                n_tasks: int,
-               graph_attention_layers: list = None,
+               graph_attention_layers: Optional[list] = None,
                n_attention_heads: int = 8,
-               agg_modes: list = None,
+               agg_modes: Optional[list] = None,
                activation=F.elu,
                residual: bool = True,
                dropout: float = 0.,
@@ -253,9 +254,9 @@ class GATModel(TorchModel):
 
   def __init__(self,
                n_tasks: int,
-               graph_attention_layers: list = None,
+               graph_attention_layers: Optional[list] = None,
                n_attention_heads: int = 8,
-               agg_modes: list = None,
+               agg_modes: Optional[list] = None,
                activation=F.elu,
                residual: bool = True,
                dropout: float = 0.,

--- a/deepchem/models/torch_models/gcn.py
+++ b/deepchem/models/torch_models/gcn.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 
 from deepchem.models.losses import Loss, L2Loss, SparseSoftmaxCrossEntropy
 from deepchem.models.torch_models.torch_model import TorchModel
+from typing import Optional
 
 
 class GCN(nn.Module):
@@ -69,7 +70,7 @@ class GCN(nn.Module):
 
   def __init__(self,
                n_tasks: int,
-               graph_conv_layers: list = None,
+               graph_conv_layers: Optional[list] = None,
                activation=None,
                residual: bool = True,
                batchnorm: bool = False,
@@ -252,7 +253,7 @@ class GCNModel(TorchModel):
 
   def __init__(self,
                n_tasks: int,
-               graph_conv_layers: list = None,
+               graph_conv_layers: Optional[list] = None,
                activation=None,
                residual: bool = True,
                batchnorm: bool = False,

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -2392,9 +2392,9 @@ class AtomicConvolution(nn.Module):
     """
 
     def __init__(self,
-                 atom_types: Union[ArrayLike, torch.Tensor] = None,
+                 atom_types: Optional[Union[ArrayLike, torch.Tensor]] = None,
                  radial_params: Union[ArrayLike, torch.Tensor] = list(),
-                 box_size: Union[ArrayLike, torch.Tensor] = None,
+                 box_size: Optional[Union[ArrayLike, torch.Tensor]] = None,
                  **kwargs):
         """Initialize this layer.
 

--- a/deepchem/molnet/defaults.py
+++ b/deepchem/molnet/defaults.py
@@ -5,7 +5,7 @@ Featurizers, transformers, and splitters for MolNet.
 import importlib
 import inspect
 import logging
-from typing import Dict, Any
+from typing import Optional, Dict, Any
 
 from deepchem.feat.base_classes import Featurizer
 from deepchem.trans.transformers import Transformer
@@ -14,7 +14,7 @@ from deepchem.splits.splitters import Splitter
 logger = logging.getLogger(__name__)
 
 
-def get_defaults(module_name: str = None) -> Dict[str, Any]:
+def get_defaults(module_name: Optional[str] = None) -> Dict[str, Any]:
   """Get featurizers, transformers, and splitters.
 
   This function returns a dictionary with class names as keys and classes

--- a/deepchem/utils/docking_utils.py
+++ b/deepchem/utils/docking_utils.py
@@ -15,7 +15,7 @@ def write_vina_conf(protein_filename: str,
                     box_dims: np.ndarray,
                     conf_filename: str,
                     num_modes: int = 9,
-                    exhaustiveness: int = None) -> None:
+                    exhaustiveness: Optional[int] = None) -> None:
   """Writes Vina configuration file to disk.
 
   Autodock Vina accepts a configuration file which provides options
@@ -61,7 +61,7 @@ def write_gnina_conf(protein_filename: str,
                      ligand_filename: str,
                      conf_filename: str,
                      num_modes: int = 9,
-                     exhaustiveness: int = None,
+                     exhaustiveness: Optional[int] = None,
                      **kwargs) -> None:
   """Writes GNINA configuration file to disk.
 


### PR DESCRIPTION
Made some type fixes for compliance with pep 484.

PEP 484 prohibits the use of implicit optional. For example, the following piece of code allows assumption of implicit optional: `def foo(a: int = None): ... `. It allows type checkers to assume an optional type of `None` for `a`. To comply with PEP 484, it should be `def foo(a: Optional[int] = None): ...`.

The latest mypy version (0.991, release [blog](https://mypy-lang.blogspot.com/2022/11/mypy-0990-released.html)) had a breaking change which disabled implicit optionals type. Hence, it was not detected earlier by mypy.