### PR TITLE
DeepChem package version update in __init__.py

### DIFF
--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -3,7 +3,7 @@ Imports all submodules
 """
 
 # If you push the tag, please remove `.dev`
-__version__ = '2.7.1'
+__version__ = '2.7.2.dev'
 
 import deepchem.data
 import deepchem.feat

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -25,4 +25,4 @@ dependencies:
     - transformers==4.10.*
     - xgboost
     - gensim  # used by mol2vec 
-    - tb-nightly # @arunppsg shift to tensorboard stable version once tb 2.9.1 is released
+    - tensorboard


### PR DESCRIPTION
In `__init__.py`, after 2.7.1 release was made , the version has to be updated to 2.7.2.dev.