### PR TITLE
Adding Usage Examples to Splitters

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -401,6 +401,18 @@ class RandomGroupSplitter(Splitter):
     to maximize the choice such that frac_train, frac_valid, or frac_test is
     maximized.  It simply permutes the groups themselves. As such, use with
     caution if the number of elements per group varies significantly.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> X=np.arange(12)
+    >>> groups = [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
+    >>> splitter = dc.splits.RandomGroupSplitter(groups=groups)
+    >>> dataset = dc.data.NumpyDataset(X)   # 12 elements
+    >>> train, test = splitter.train_test_split(dataset, frac_train=0.75, seed=0)
+    >>> print (train.ids) #array([6, 7, 8, 9, 10, 11, 3, 4, 5], dtype=object)
+    [6 7 8 9 10 11 3 4 5]
     """
 
     def __init__(self, groups: Sequence):

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -763,7 +763,7 @@ class IndexSplitter(Splitter):
     training, the next `frac_valid` for validation, and the final `frac_test` for
     testing. This class may make sense to use your `Dataset` is already time
     ordered (for example).
-            
+
     Examples
     --------
     >>> n_samples = 100
@@ -827,7 +827,7 @@ class SpecifiedSplitter(Splitter):
     dataset. Note that this is different from `IndexSplitter` which only splits
     based on the existing dataset ordering, while this `SpecifiedSplitter` can
     split on any specified ordering.
-        
+
     Examples
     --------
     >>> n_samples = 10
@@ -838,7 +838,7 @@ class SpecifiedSplitter(Splitter):
     >>> splitter = dc.splits.SpecifiedSplitter(valid_indices=[1,3,5], test_indices=[0,2,7,9])
     >>> dataset = dc.data.NumpyDataset(X, y)
     >>> train_dataset, valid_dataset , test_dataset = splitter.split(dataset)
-    
+
     """
 
     def __init__(self,
@@ -920,7 +920,7 @@ class MolecularWeightSplitter(Splitter):
 
     Examples
     --------
-    
+
     >>> import deepchem as dc
     >>> import numpy as np
     >>> # creation of demo data set with some smiles strings
@@ -932,6 +932,7 @@ class MolecularWeightSplitter(Splitter):
     >>> molecularweightsplitter = dc.splits.MolecularWeightSplitter()
     >>> train, val, test = molecularweightsplitter.split(dataset)
     >>> train
+    array([0, 1, 6, 2, 3])
     
     """
 

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -505,6 +505,20 @@ class RandomStratifiedSplitter(Splitter):
     only whether a label is zero or non-zero. When labels can take on multiple
     non-zero values, it does not try to give each split a proportional fraction
     of the samples with each value.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> from typing import Sequence
+    >>> # creation of demo data set with some smiles strings
+    >>> smiles= ['C', 'CC', 'CCC', 'CCCC', 'CCCCC']
+    >>> Xs = np.zeros(len(smiles))
+    >>> # creation of a deepchem dataset with the smile codes in the ids field
+    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,ids=smiles)
+    >>> randomstratifiedsplitter = dc.splits.RandomStratifiedSplitter()
+    >>> train_dataset, test_dataset = randomstratifiedsplitter.train_test_split(dataset)
+
     """
 
     def split(self,
@@ -766,14 +780,19 @@ class IndexSplitter(Splitter):
 
     Examples
     --------
-    >>> n_samples = 100
-    >>> n_features = 10
-    >>> n_tasks = 10
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> n_samples = 5
+    >>> n_features = 2
     >>> X = np.random.rand(n_samples, n_features)
-    >>> y = np.random.rand(n_samples, n_tasks)
-    >>> splitter = dc.splits.IndexSplitter()
+    >>> y = np.random.rand(n_samples)
+    >>> indexsplitter = dc.splits.IndexSplitter()
     >>> dataset = dc.data.NumpyDataset(X, y)
-    >>> train_dataset, valid_dataset , test_dataset = splitter.split(dataset)
+    >>> train_dataset, test_dataset = indexsplitter.train_test_split(dataset)
+    >>> print(train_dataset.ids)
+    [0 1 2 3]
+    >>> print (test_dataset.ids)
+    [4]
 
     """
 
@@ -830,6 +849,8 @@ class SpecifiedSplitter(Splitter):
 
     Examples
     --------
+    >>> import deepchem as dc
+    >>> import numpy as np
     >>> n_samples = 10
     >>> n_features = 3
     >>> n_tasks = 1
@@ -837,7 +858,13 @@ class SpecifiedSplitter(Splitter):
     >>> y = np.random.rand(n_samples, n_tasks)
     >>> splitter = dc.splits.SpecifiedSplitter(valid_indices=[1,3,5], test_indices=[0,2,7,9])
     >>> dataset = dc.data.NumpyDataset(X, y)
-    >>> train_dataset, valid_dataset , test_dataset = splitter.split(dataset)
+    >>> train_dataset, valid_dataset, test_dataset = splitter.train_valid_test_split(dataset)
+    >>> print(train_dataset.ids)
+    [4 6 8]
+    >>> print(valid_dataset.ids)
+    [1 3 5]
+    >>> print(test_dataset.ids)
+    [0 2 7 9]
 
     """
 
@@ -920,20 +947,20 @@ class MolecularWeightSplitter(Splitter):
 
     Examples
     --------
-
     >>> import deepchem as dc
     >>> import numpy as np
     >>> # creation of demo data set with some smiles strings
-    >>> data_test= ["CC(C)Cl" , "CCC(C)CO" ,  "CCCCCCCO" , "CCCCCCCC(=O)OC" , "c3ccc2nc1ccccc1cc2c3" , "Nc2cccc3nc1ccccc1cc23" , "C1CCCCCC1" ]
-    >>> Xs = np.zeros(len(data_test))
-    >>> Ys = np.ones(len(data_test))
+    >>> smiles= ['C', 'CC', 'CCC', 'CCCC', 'CCCCC']
+    >>> Xs = np.zeros(len(smiles))
     >>> # creation of a deepchem dataset with the smile codes in the ids field
-    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,y=Ys,w=np.zeros(len(data_test)),ids=data_test)
+    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,ids=smiles)
     >>> molecularweightsplitter = dc.splits.MolecularWeightSplitter()
-    >>> train, val, test = molecularweightsplitter.split(dataset)
-    >>> train
-    array([0, 1, 6, 2, 3])
-    
+    >>> train_dataset, test_dataset = molecularweightsplitter.train_test_split(dataset)
+    >>> print(train_dataset.ids)
+    ['C' 'CC' 'CCC' 'CCCC']
+    >>> print(test_dataset.ids)
+    ['CCCCC']
+
     """
 
     def split(
@@ -1007,6 +1034,19 @@ class MaxMinSplitter(Splitter):
     Note
     ----
     This class requires RDKit to be installed.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> # creation of demo data set with some smiles strings
+    >>> smiles= ['C', 'CC', 'CCC', 'CCCC', 'CCCCC']
+    >>> Xs = np.zeros(len(smiles))
+    >>> # creation of a deepchem dataset with the smile codes in the ids field
+    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,ids=smiles)
+    >>> maxminsplitter = dc.splits.MaxMinSplitter()
+    >>> train_dataset, test_dataset = maxminsplitter.train_test_split(dataset)
+
     """
 
     def split(
@@ -1107,6 +1147,23 @@ class ButinaSplitter(Splitter):
     Note
     ----
     This class requires RDKit to be installed.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> # creation of demo data set with some smiles strings
+    >>> smiles= ['C', 'CC', 'CCC', 'CCCC', 'CCCCC']
+    >>> Xs = np.zeros(len(smiles))
+    >>> # creation of a deepchem dataset with the smile codes in the ids field
+    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,ids=smiles)
+    >>> butinasplitter = dc.splits.ButinaSplitter()
+    >>> train_dataset, test_dataset = butinasplitter.train_test_split(dataset)
+    >>> print(train_dataset.ids)
+    ['CCCC' 'CCC' 'CCCCC' 'CC']
+    >>> print(test_dataset.ids)
+    ['C']
+
     """
 
     def __init__(self, cutoff: float = 0.6):
@@ -1259,6 +1316,23 @@ class FingerprintSplitter(Splitter):
     Note
     ----
     This class requires RDKit to be installed.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> # creation of demo data set with some smiles strings
+    >>> smiles= ['C', 'CC', 'CCC', 'CCCC', 'CCCCC']
+    >>> Xs = np.zeros(len(smiles))
+    >>> # creation of a deepchem dataset with the smile codes in the ids field
+    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,ids=smiles)
+    >>> fingerprintsplitter = dc.splits.FingerprintSplitter()
+    >>> train_dataset, test_dataset = fingerprintsplitter.train_test_split(dataset)
+    >>> print(train_dataset.ids)
+    ['C' 'CCCCC' 'CCCC' 'CCC']
+    >>> print(test_dataset.ids)
+    ['CC']
+
     """
 
     def __init__(self):

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -763,6 +763,18 @@ class IndexSplitter(Splitter):
     training, the next `frac_valid` for validation, and the final `frac_test` for
     testing. This class may make sense to use your `Dataset` is already time
     ordered (for example).
+            
+    Examples
+    --------
+    >>> n_samples = 100
+    >>> n_features = 10
+    >>> n_tasks = 10
+    >>> X = np.random.rand(n_samples, n_features)
+    >>> y = np.random.rand(n_samples, n_tasks)
+    >>> splitter = dc.splits.IndexSplitter()
+    >>> dataset = dc.data.NumpyDataset(X, y)
+    >>> train_dataset, valid_dataset , test_dataset = splitter.split(dataset)
+
     """
 
     def split(
@@ -815,6 +827,18 @@ class SpecifiedSplitter(Splitter):
     dataset. Note that this is different from `IndexSplitter` which only splits
     based on the existing dataset ordering, while this `SpecifiedSplitter` can
     split on any specified ordering.
+        
+    Examples
+    --------
+    >>> n_samples = 10
+    >>> n_features = 3
+    >>> n_tasks = 1
+    >>> X = np.random.rand(n_samples, n_features)
+    >>> y = np.random.rand(n_samples, n_tasks)
+    >>> splitter = dc.splits.SpecifiedSplitter(valid_indices=[1,3,5], test_indices=[0,2,7,9])
+    >>> dataset = dc.data.NumpyDataset(X, y)
+    >>> train_dataset, valid_dataset , test_dataset = splitter.split(dataset)
+    
     """
 
     def __init__(self,

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -917,6 +917,22 @@ class MolecularWeightSplitter(Splitter):
     Note
     ----
     This class requires RDKit to be installed.
+
+    Examples
+    --------
+    
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> # creation of demo data set with some smiles strings
+    >>> data_test= ["CC(C)Cl" , "CCC(C)CO" ,  "CCCCCCCO" , "CCCCCCCC(=O)OC" , "c3ccc2nc1ccccc1cc2c3" , "Nc2cccc3nc1ccccc1cc23" , "C1CCCCCC1" ]
+    >>> Xs = np.zeros(len(data_test))
+    >>> Ys = np.ones(len(data_test))
+    >>> # creation of a deepchem dataset with the smile codes in the ids field
+    >>> dataset = dc.data.DiskDataset.from_numpy(X=Xs,y=Ys,w=np.zeros(len(data_test)),ids=data_test)
+    >>> molecularweightsplitter = dc.splits.MolecularWeightSplitter()
+    >>> train, val, test = molecularweightsplitter.split(dataset)
+    >>> train
+    
     """
 
     def split(


### PR DESCRIPTION
# Pull Request Template

## Description

Fix #3230

This PR aims to add example documentation for Splitters.
- [x] RandomSplitter - Already Done
- [x] RandomGroupSplitter
- [x] RandomStratifiedSplitter
- [x] SingletaskStratifiedSplitter - Already Done
- [x] IndexSplitter
- [x] SpecifiedSplitter
- [x] MolecularWeightSplitter
- [x] MaxMinSplitter
- [x] ButinaSplitter
- [x] FingerprintSplitter
- [x] ScaffoldSplitter - Already Done

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
