### PR TITLE
Refactor MLP

### DIFF
--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -663,9 +663,8 @@ def test_MultilayerPerceptron():
     torch.manual_seed(0)
     input_ar = torch.tensor([[1., 2.], [5., 6.]])
     layer = torch_layers.MultilayerPerceptron(d_input=2,
-                                              d_hidden=2,
-                                              n_layers=2,
                                               d_output=2,
+                                              d_hidden=(2, 2),
                                               activation_fn='relu',
                                               dropout=0.0)
     result = layer(input_ar)

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -658,9 +658,10 @@ def test_position_wise_feed_forward():
 
 
 @pytest.mark.torch
-@pytest.mark.parametrize('skip_connection,expected',
-                          [(False, torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])),
-                           (True, torch.tensor([[-0.9612, 2.3846], [-4.1104, 5.7606]]))])
+@pytest.mark.parametrize(
+    'skip_connection,expected',
+    [(False, torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])),
+     (True, torch.tensor([[-0.9612, 2.3846], [-4.1104, 5.7606]]))])
 def test_MultilayerPerceptron(skip_connection, expected):
     """Test invoking MLP."""
     torch.manual_seed(0)

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -660,8 +660,8 @@ def test_position_wise_feed_forward():
 @pytest.mark.torch
 @pytest.mark.parametrize(
     'skip_connection,expected',
-    [(False, torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])),
-     (True, torch.tensor([[-0.9612, 2.3846], [-4.1104, 5.7606]]))])
+    [(False, [[0.2795, 0.4243], [0.2795, 0.4243]]),
+     (True, [[-0.9612, 2.3846], [-4.1104, 5.7606]])])
 def test_MultilayerPerceptron(skip_connection, expected):
     """Test invoking MLP."""
     torch.manual_seed(0)
@@ -673,7 +673,7 @@ def test_MultilayerPerceptron(skip_connection, expected):
                                               dropout=0.0,
                                               skip_connection=skip_connection)
     result = layer(input_ar)
-    output_ar = expected
+    output_ar = torch.tensor(expected)
     assert torch.allclose(result, output_ar, atol=1e-4)
 
 

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -658,7 +658,10 @@ def test_position_wise_feed_forward():
 
 
 @pytest.mark.torch
-def test_MultilayerPerceptron():
+@pytest.mark.parametrize('skip_connection,expected',
+                          [(False, torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])),
+                           (True, torch.tensor([[-0.9612, 2.3846], [-4.1104, 5.7606]]))])
+def test_MultilayerPerceptron(skip_connection, expected):
     """Test invoking MLP."""
     torch.manual_seed(0)
     input_ar = torch.tensor([[1., 2.], [5., 6.]])
@@ -667,11 +670,11 @@ def test_MultilayerPerceptron():
                                               d_hidden=(2, 2),
                                               activation_fn='relu',
                                               dropout=0.0,
-                                              skip_connection=False)
+                                              skip_connection=skip_connection)
     result = layer(input_ar)
-    output_ar = torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])
+    output_ar = expected
     assert torch.allclose(result, output_ar, atol=1e-4)
-    
+
 
 @pytest.mark.torch
 def test_position_wise_feed_forward_dropout_at_input():

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -658,10 +658,9 @@ def test_position_wise_feed_forward():
 
 
 @pytest.mark.torch
-@pytest.mark.parametrize(
-    'skip_connection,expected',
-    [(False, [[0.2795, 0.4243], [0.2795, 0.4243]]),
-     (True, [[-0.9612, 2.3846], [-4.1104, 5.7606]])])
+@pytest.mark.parametrize('skip_connection,expected',
+                         [(False, [[0.2795, 0.4243], [0.2795, 0.4243]]),
+                          (True, [[-0.9612, 2.3846], [-4.1104, 5.7606]])])
 def test_MultilayerPerceptron(skip_connection, expected):
     """Test invoking MLP."""
     torch.manual_seed(0)

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -666,11 +666,11 @@ def test_MultilayerPerceptron():
                                               d_output=2,
                                               d_hidden=(2, 2),
                                               activation_fn='relu',
-                                              dropout=0.0)
+                                              dropout=0.0,
+                                              skip_connection=False)
     result = layer(input_ar)
     output_ar = torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])
     assert torch.allclose(result, output_ar, atol=1e-4)
-
 
 @pytest.mark.torch
 def test_position_wise_feed_forward_dropout_at_input():

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -671,6 +671,7 @@ def test_MultilayerPerceptron():
     result = layer(input_ar)
     output_ar = torch.tensor([[[0.2795, 0.4243], [0.2795, 0.4243]]])
     assert torch.allclose(result, output_ar, atol=1e-4)
+    
 
 @pytest.mark.torch
 def test_position_wise_feed_forward_dropout_at_input():

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -74,7 +74,7 @@ class MultilayerPerceptron(nn.Module):
             return x
 
         if self.n_layers == 1:
-            x = self.input_layer(x)
+            x = nn.Linear(self.d_input, self.d_output)(x)
             x = self.activation_fn(x)
             return x
 

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -30,7 +30,6 @@ class MultilayerPerceptron(nn.Module):
     >>> out = model(x)
     >>> print(out.shape)
     torch.Size([2, 2])
-
     """
 
     def __init__(self,
@@ -65,7 +64,7 @@ class MultilayerPerceptron(nn.Module):
         self.activation_fn = get_activation(activation_fn)
         self.model = nn.Sequential(*self.build_layers())
         self.skip = nn.Linear(d_input, d_output) if skip_connection else None
-        
+
     def build_layers(self):
         layer_list = []
         layer_dim = self.d_input
@@ -88,6 +87,7 @@ class MultilayerPerceptron(nn.Module):
             return x + self.skip(input)
         else:
             return x
+
 
 class CNNModule(nn.Module):
     """A 1, 2, or 3 dimensional convolutional network for either regression or classification.

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -22,7 +22,7 @@ from torch.nn import init as initializers
 
 class MultilayerPerceptron(nn.Module):
     """A simple fully connected feed-forward network, otherwise known as a multilayer perceptron (MLP).
-    
+
     Examples
     --------
     >>> model = MultilayerPerceptron(d_input=10, d_hidden=(2,3), d_output=2, dropout=0.0, activation_fn='relu')

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -86,7 +86,9 @@ class MultilayerPerceptron(nn.Module):
         for layer in self.model:
             x = layer(x)
             if isinstance(layer, nn.Linear):
-                x = self.activation_fn(x)  # Done because activation_fn is torch.nn.functional
+                x = self.activation_fn(
+                    x
+                )  # Done because activation_fn returns a torch.nn.functional
         if self.skip is not None:
             return x + self.skip(input)
         else:
@@ -673,9 +675,9 @@ class MATEncoderLayer(nn.Module):
         self.self_attn = MultiHeadedMATAttention(dist_kernel, lambda_attention,
                                                  lambda_distance, h, sa_hsize,
                                                  sa_dropout_p, output_bias)
-        self.feed_forward = PositionwiseFeedForward(d_input, d_hidden,
-                                                    d_output, activation,
-                                                    n_layers, ff_dropout_p)
+        self.feed_forward = PositionwiseFeedForward(d_input, d_hidden, d_output,
+                                                    activation, n_layers,
+                                                    ff_dropout_p)
         layer = SublayerConnection(size=encoder_hsize,
                                    dropout_p=encoder_dropout_p)
         self.sublayer = nn.ModuleList([layer for _ in range(2)])
@@ -852,8 +854,7 @@ class PositionwiseFeedForward(nn.Module):
 
         self.linears = nn.ModuleList(self.linears)
         dropout_layer = nn.Dropout(dropout_p)
-        self.dropout_p = nn.ModuleList(
-            [dropout_layer for _ in range(n_layers)])
+        self.dropout_p = nn.ModuleList([dropout_layer for _ in range(n_layers)])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Output Computation for the PositionwiseFeedForward layer.
@@ -1140,9 +1141,9 @@ class GraphNetwork(torch.nn.Module):
         edge_features_mean_by_node = scatter_mean(edge_features,
                                                   dst_index,
                                                   dim=0)
-        out = torch.cat((node_features, edge_features_mean_by_node,
-                         global_features[batch]),
-                        dim=1)
+        out = torch.cat(
+            (node_features, edge_features_mean_by_node, global_features[batch]),
+            dim=1)
         for model in self.node_models:
             out = model(out)
         return self.node_dense(out)
@@ -1612,8 +1613,8 @@ class DMPNNEncoderLayer(nn.Module):
         atoms_hidden_states: torch.Tensor
             Tensor containing atom hidden states.
         """
-        messages_to_atoms: torch.Tensor = h_message[
-            atom_to_incoming_bonds].sum(1)  # num_atoms x hidden_size
+        messages_to_atoms: torch.Tensor = h_message[atom_to_incoming_bonds].sum(
+            1)  # num_atoms x hidden_size
         atoms_hidden_states: torch.Tensor = self.W_o(
             torch.cat((atom_features, messages_to_atoms),
                       1))  # num_atoms x hidden_size
@@ -1767,8 +1768,8 @@ class InteratomicL2Distances(nn.Module):
         )
 
     def forward(
-        self, inputs: List[Union[torch.Tensor, List[Union[int, float]]]]
-    ) -> torch.Tensor:
+        self, inputs: List[Union[torch.Tensor,
+                                 List[Union[int, float]]]]) -> torch.Tensor:
         """Invokes this layer.
 
         Parameters
@@ -2035,7 +2036,7 @@ class NeighborList(nn.Module):
 
         # List of length N_atoms, each element of different length uniques_i
         nbrs = self.get_atoms_in_nbrs(coords, cells)
-        padding = torch.full((self.M_nbrs, ), -1)
+        padding = torch.full((self.M_nbrs,), -1)
         padded_nbrs = [
             torch.concat([unique_nbrs, padding], 0) for unique_nbrs in nbrs
         ]
@@ -2051,8 +2052,7 @@ class NeighborList(nn.Module):
         coord_padding = torch.full((self.M_nbrs, self.ndim),
                                    2 * self.stop).to(torch.float)
         padded_nbr_coords = [
-            torch.cat([nbr_coord, coord_padding], 0)
-            for nbr_coord in nbr_coords
+            torch.cat([nbr_coord, coord_padding], 0) for nbr_coord in nbr_coords
         ]
 
         # List of length N_atoms, each of shape (1, ndim)
@@ -2155,8 +2155,8 @@ class NeighborList(nn.Module):
         closest_inds: torch.Tensor
             Of shape (n_cells, M_nbrs)
         """
-        N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells,
-                                          self.ndim, self.M_nbrs)
+        N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells, self.ndim,
+                                          self.M_nbrs)
         # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
         tiled_cells = torch.reshape(torch.tile(cells, (1, N_atoms)),
                                     (N_atoms * n_cells, ndim))
@@ -2693,8 +2693,8 @@ class CombineMeanStd(nn.Module):
 
         mean_parent, std_parent = torch.tensor(inputs[0]), torch.tensor(
             inputs[1])
-        noise_scale = torch.tensor(training
-                                   or not self.training_only).to(torch.float)
+        noise_scale = torch.tensor(training or
+                                   not self.training_only).to(torch.float)
         sample_noise = torch.normal(0.0, self.noise_epsilon, mean_parent.shape)
         return mean_parent + noise_scale * std_parent * sample_noise
 
@@ -2713,9 +2713,9 @@ class GatedRecurrentUnit(nn.Module):
         self.Uz = init(torch.empty(n_hidden, n_hidden))
         self.Ur = init(torch.empty(n_hidden, n_hidden))
         self.Uh = init(torch.empty(n_hidden, n_hidden))
-        self.bz = torch.zeros((n_hidden, ))
-        self.br = torch.zeros((n_hidden, ))
-        self.bh = torch.zeros((n_hidden, ))
+        self.bz = torch.zeros((n_hidden,))
+        self.br = torch.zeros((n_hidden,))
+        self.bh = torch.zeros((n_hidden,))
 
     def forward(self, inputs):
         sigmoid = get_activation('sigmoid')
@@ -2767,8 +2767,8 @@ class WeightedLinearCombo(nn.Module):
         )
 
     def forward(
-        self, inputs: Sequence[Union[ArrayLike, torch.Tensor]]
-    ) -> Optional[torch.Tensor]:
+        self, inputs: Sequence[Union[ArrayLike,
+                                     torch.Tensor]]) -> Optional[torch.Tensor]:
         """
         Parameters
         ----------

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -47,7 +47,7 @@ class MultilayerPerceptron(nn.Module):
             the dimension of the input layer
         d_output: int
             the dimension of the output layer
-        d_hidden: tuples
+        d_hidden: tuple
             the dimensions of the hidden layers
         dropout: float
             the dropout probability

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -75,7 +75,6 @@ class MultilayerPerceptron(nn.Module):
         if self.d_hidden is not None:
             for d in self.d_hidden:
                 layer_list.append(nn.Linear(layer_dim, d))
-                layer_list.append(self.activation_fn())
                 layer_list.append(self.dropout)
                 layer_dim = d
         layer_list.append(nn.Linear(layer_dim, self.d_output))
@@ -86,8 +85,8 @@ class MultilayerPerceptron(nn.Module):
         input = x
         for layer in self.model:
             x = layer(x)
-            # if isinstance(layer, nn.Linear):
-            #     x = self.activation_fn(x)
+            if isinstance(layer, nn.Linear):
+                x = self.activation_fn(x)  # Done because activation_fn is torch.nn.functional
         if self.skip is not None:
             return x + self.skip(input)
         else:

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -669,9 +669,9 @@ class MATEncoderLayer(nn.Module):
         self.self_attn = MultiHeadedMATAttention(dist_kernel, lambda_attention,
                                                  lambda_distance, h, sa_hsize,
                                                  sa_dropout_p, output_bias)
-        self.feed_forward = PositionwiseFeedForward(d_input, d_hidden,
-                                                    d_output, activation,
-                                                    n_layers, ff_dropout_p)
+        self.feed_forward = PositionwiseFeedForward(d_input, d_hidden, d_output,
+                                                    activation, n_layers,
+                                                    ff_dropout_p)
         layer = SublayerConnection(size=encoder_hsize,
                                    dropout_p=encoder_dropout_p)
         self.sublayer = nn.ModuleList([layer for _ in range(2)])
@@ -852,8 +852,7 @@ class PositionwiseFeedForward(nn.Module):
 
         self.linears = nn.ModuleList(self.linears)
         dropout_layer = nn.Dropout(dropout_p)
-        self.dropout_p = nn.ModuleList(
-            [dropout_layer for _ in range(n_layers)])
+        self.dropout_p = nn.ModuleList([dropout_layer for _ in range(n_layers)])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Output Computation for the PositionwiseFeedForward layer.
@@ -1140,9 +1139,9 @@ class GraphNetwork(torch.nn.Module):
         edge_features_mean_by_node = scatter_mean(edge_features,
                                                   dst_index,
                                                   dim=0)
-        out = torch.cat((node_features, edge_features_mean_by_node,
-                         global_features[batch]),
-                        dim=1)
+        out = torch.cat(
+            (node_features, edge_features_mean_by_node, global_features[batch]),
+            dim=1)
         for model in self.node_models:
             out = model(out)
         return self.node_dense(out)
@@ -1612,8 +1611,8 @@ class DMPNNEncoderLayer(nn.Module):
         atoms_hidden_states: torch.Tensor
             Tensor containing atom hidden states.
         """
-        messages_to_atoms: torch.Tensor = h_message[
-            atom_to_incoming_bonds].sum(1)  # num_atoms x hidden_size
+        messages_to_atoms: torch.Tensor = h_message[atom_to_incoming_bonds].sum(
+            1)  # num_atoms x hidden_size
         atoms_hidden_states: torch.Tensor = self.W_o(
             torch.cat((atom_features, messages_to_atoms),
                       1))  # num_atoms x hidden_size
@@ -1767,8 +1766,8 @@ class InteratomicL2Distances(nn.Module):
         )
 
     def forward(
-        self, inputs: List[Union[torch.Tensor, List[Union[int, float]]]]
-    ) -> torch.Tensor:
+        self, inputs: List[Union[torch.Tensor,
+                                 List[Union[int, float]]]]) -> torch.Tensor:
         """Invokes this layer.
 
         Parameters
@@ -2035,7 +2034,7 @@ class NeighborList(nn.Module):
 
         # List of length N_atoms, each element of different length uniques_i
         nbrs = self.get_atoms_in_nbrs(coords, cells)
-        padding = torch.full((self.M_nbrs, ), -1)
+        padding = torch.full((self.M_nbrs,), -1)
         padded_nbrs = [
             torch.concat([unique_nbrs, padding], 0) for unique_nbrs in nbrs
         ]
@@ -2051,8 +2050,7 @@ class NeighborList(nn.Module):
         coord_padding = torch.full((self.M_nbrs, self.ndim),
                                    2 * self.stop).to(torch.float)
         padded_nbr_coords = [
-            torch.cat([nbr_coord, coord_padding], 0)
-            for nbr_coord in nbr_coords
+            torch.cat([nbr_coord, coord_padding], 0) for nbr_coord in nbr_coords
         ]
 
         # List of length N_atoms, each of shape (1, ndim)
@@ -2155,8 +2153,8 @@ class NeighborList(nn.Module):
         closest_inds: torch.Tensor
             Of shape (n_cells, M_nbrs)
         """
-        N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells,
-                                          self.ndim, self.M_nbrs)
+        N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells, self.ndim,
+                                          self.M_nbrs)
         # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
         tiled_cells = torch.reshape(torch.tile(cells, (1, N_atoms)),
                                     (N_atoms * n_cells, ndim))
@@ -2693,8 +2691,8 @@ class CombineMeanStd(nn.Module):
 
         mean_parent, std_parent = torch.tensor(inputs[0]), torch.tensor(
             inputs[1])
-        noise_scale = torch.tensor(training
-                                   or not self.training_only).to(torch.float)
+        noise_scale = torch.tensor(training or
+                                   not self.training_only).to(torch.float)
         sample_noise = torch.normal(0.0, self.noise_epsilon, mean_parent.shape)
         return mean_parent + noise_scale * std_parent * sample_noise
 
@@ -2713,9 +2711,9 @@ class GatedRecurrentUnit(nn.Module):
         self.Uz = init(torch.empty(n_hidden, n_hidden))
         self.Ur = init(torch.empty(n_hidden, n_hidden))
         self.Uh = init(torch.empty(n_hidden, n_hidden))
-        self.bz = torch.zeros((n_hidden, ))
-        self.br = torch.zeros((n_hidden, ))
-        self.bh = torch.zeros((n_hidden, ))
+        self.bz = torch.zeros((n_hidden,))
+        self.br = torch.zeros((n_hidden,))
+        self.bh = torch.zeros((n_hidden,))
 
     def forward(self, inputs):
         sigmoid = get_activation('sigmoid')
@@ -2767,8 +2765,8 @@ class WeightedLinearCombo(nn.Module):
         )
 
     def forward(
-        self, inputs: Sequence[Union[ArrayLike, torch.Tensor]]
-    ) -> Optional[torch.Tensor]:
+        self, inputs: Sequence[Union[ArrayLike,
+                                     torch.Tensor]]) -> Optional[torch.Tensor]:
         """
         Parameters
         ----------

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -65,15 +65,16 @@ class MultilayerPerceptron(nn.Module):
         self.activation_fn = get_activation(activation_fn)
         self.model = nn.Sequential(*self.build_layers())
         self.skip = nn.Linear(d_input, d_output) if skip_connection else None
-
+        
     def build_layers(self):
         layer_list = []
+        layer_dim = self.d_input
         if self.d_hidden is not None:
             for d in self.d_hidden:
-                layer_list.append(nn.Linear(self.d_input, d))
+                layer_list.append(nn.Linear(layer_dim, d))
                 layer_list.append(self.dropout)
-                self.d_input = d
-        layer_list.append(nn.Linear(self.d_input, self.d_output))
+                layer_dim = d
+        layer_list.append(nn.Linear(layer_dim, self.d_output))
         return layer_list
 
     def forward(self, x: Tensor) -> Tensor:


### PR DESCRIPTION
# Pull Request Template

## Description

This PR allows the user to create an MLP with different sized hidden layers using a tuple, which was not previously possible.  It also adds an activation on the final layer which would likely be expected. This change was made in an effort to unify the different feedforward network implementations in deepchem.

This PR also fixes a bug in the case of selecting to use 1 hidden layer. The current implementation produces a layer in the shape of [input_dim,hidden_dim], not the expected [input_dim,output_dim]. 


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
