### PR TITLE
Graphdata.numpy_to_torch()

### DIFF
--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -206,7 +206,20 @@ class GraphData:
         return g
 
     def numpy_to_torch(self):
-        """Convert numpy arrays to torch tensors"""
+        """Convert numpy arrays to torch tensors. This may be useful when you are using PyTorch Geometric with GraphData objects.
+
+        Example
+        -------
+        >>> num_nodes, num_node_features = 5, 32
+        >>> num_edges, num_edge_features = 6, 32
+        >>> node_features = np.random.random_sample((num_nodes, num_node_features))
+        >>> edge_features = np.random.random_sample((num_edges, num_edge_features))
+        >>> edge_index = np.random.randint(0, num_nodes, (2, num_edges))
+        >>> graph_data = GraphData(node_features, edge_index, edge_features)
+        >>> graph_data = graph_data.numpy_to_torch()
+        >>> print(type(graph_data.node_features))
+        <class 'torch.Tensor'>
+        """
         import torch
         self.node_features = torch.from_numpy(self.node_features).float()
         self.edge_index = torch.from_numpy(self.edge_index).long()
@@ -221,6 +234,7 @@ class GraphData:
             value = torch.from_numpy(value)
             self.kwargs[key] = value
             setattr(self, key, value)
+        return self
 
 
 class BatchGraphData(GraphData):

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -14,11 +14,11 @@ class GraphData:
     ----------
     node_features: np.ndarray or torch.Tensor
         Node feature matrix with shape [num_nodes, num_node_features]
-    edge_index: np.ndarray  or torch.Tensor, dtype int
+    edge_index: np.ndarray or torch.Tensor, dtype int
         Graph connectivity in COO format with shape [2, num_edges]
-    edge_features: np.ndarray  or torch.Tensor, optional (default None)
+    edge_features: np.ndarray or torch.Tensor, optional (default None)
         Edge feature matrix with shape [num_edges, num_edge_features]
-    node_pos_features: np.ndarray  or torch.Tensor, optional (default None)
+    node_pos_features: np.ndarray or torch.Tensor, optional (default None)
         Node position matrix with shape [num_nodes, num_dimensions].
     num_nodes: int
         The number of nodes in the graph

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -82,7 +82,7 @@ class GraphData:
             elif edge_index.shape[1] != edge_features.shape[0]:
                 raise ValueError(
                     'The first dimension of edge_features must be the \
-                          same as the second dimension of edge_index.')
+                          same as the second dimension of edge_index.'                                                                      )
 
         if node_pos_features is not None:
             if isinstance(node_pos_features, np.ndarray) is False:
@@ -91,7 +91,7 @@ class GraphData:
             elif node_pos_features.shape[0] != node_features.shape[0]:
                 raise ValueError(
                     'The length of node_pos_features must be the same as the \
-                          length of node_features.')
+                          length of node_features.'                                                   )
 
         self.node_features = node_features
         self.edge_index = edge_index
@@ -223,37 +223,33 @@ class GraphData:
         import copy
 
         import torch
+        graph_copy = copy.deepcopy(self)
 
-        node_features = torch.from_numpy(self.node_features).float()
-        edge_index = torch.from_numpy(self.edge_index).long()
+        graph_copy.node_features = torch.from_numpy(self.node_features).float()
+        graph_copy.edge_index = torch.from_numpy(self.edge_index).long()
         if self.edge_features is not None:
-            edge_features = torch.from_numpy(self.edge_features).float()
+            graph_copy.edge_features = torch.from_numpy(
+                self.edge_features).float()
         else:
-            edge_features = None
+            graph_copy.edge_features = None
         if self.node_pos_features is not None:
-            node_pos_features = torch.from_numpy(self.node_pos_features).float()
+            graph_copy.node_pos_features = torch.from_numpy(
+                self.node_pos_features).float()
         else:
-            node_pos_features = None
+            graph_copy.node_pos_features = None
 
-        kwargs = {}
+        graph_copy.kwargs = {}
         for key, value in self.kwargs.items():
-            value = torch.from_numpy(value)
-            kwargs[key] = value
+            if isinstance(value, np.ndarray):
+                value = torch.from_numpy(value)
+                graph_copy.kwargs[key] = value
+                setattr(graph_copy, key, value)
 
         if isinstance(self, BatchGraphData):
-            bgcopy = copy.deepcopy(self)
-            bgcopy.node_features = node_features
-            bgcopy.edge_index = edge_index
-            bgcopy.edge_features = edge_features
-            bgcopy.node_pos_features = node_pos_features
-
             graph_index = torch.from_numpy(self.graph_index).long()
-            bgcopy.graph_index = graph_index
+            graph_copy.graph_index = graph_index
 
-            return bgcopy
-
-        return GraphData(node_features, edge_index, edge_features,
-                         node_pos_features, **kwargs)
+        return graph_copy
 
 
 class BatchGraphData(GraphData):

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -1,4 +1,5 @@
 from typing import Optional, Sequence
+
 import numpy as np
 
 
@@ -81,7 +82,7 @@ class GraphData:
             elif edge_index.shape[1] != edge_features.shape[0]:
                 raise ValueError(
                     'The first dimension of edge_features must be the \
-                          same as the second dimension of edge_index.')
+                          same as the second dimension of edge_index.'                                                                      )
 
         if node_pos_features is not None:
             if isinstance(node_pos_features, np.ndarray) is False:
@@ -90,7 +91,7 @@ class GraphData:
             elif node_pos_features.shape[0] != node_features.shape[0]:
                 raise ValueError(
                     'The length of node_pos_features must be the same as the \
-                          length of node_features.')
+                          length of node_features.'                                                   )
 
         self.node_features = node_features
         self.edge_index = edge_index
@@ -203,6 +204,23 @@ class GraphData:
             g.add_edges(np.arange(self.num_nodes), np.arange(self.num_nodes))
 
         return g
+
+    def numpy_to_torch(self):
+        """Convert numpy arrays to torch tensors"""
+        import torch
+        self.node_features = torch.from_numpy(self.node_features).float()
+        self.edge_index = torch.from_numpy(self.edge_index).long()
+        if self.edge_features is not None:
+            self.edge_features = torch.from_numpy(self.edge_features).float()
+        if self.node_pos_features is not None:
+            self.node_pos_features = torch.from_numpy(
+                self.node_pos_features).float()
+        if hasattr(self, 'graph_index'):
+            self.graph_index = torch.from_numpy(self.graph_index).long()
+        for key, value in self.kwargs.items():
+            value = torch.from_numpy(value)
+            self.kwargs[key] = value
+            setattr(self, key, value)
 
 
 class BatchGraphData(GraphData):

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -82,7 +82,7 @@ class GraphData:
             elif edge_index.shape[1] != edge_features.shape[0]:
                 raise ValueError(
                     'The first dimension of edge_features must be the \
-                          same as the second dimension of edge_index.'                                                                      )
+                          same as the second dimension of edge_index.')
 
         if node_pos_features is not None:
             if isinstance(node_pos_features, np.ndarray) is False:
@@ -91,7 +91,7 @@ class GraphData:
             elif node_pos_features.shape[0] != node_features.shape[0]:
                 raise ValueError(
                     'The length of node_pos_features must be the same as the \
-                          length of node_features.'                                                   )
+                          length of node_features.')
 
         self.node_features = node_features
         self.edge_index = edge_index

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -11,13 +11,13 @@ class GraphData:
 
     Attributes
     ----------
-    node_features: np.ndarray or torch.Tensor
+    node_features: np.ndarray
         Node feature matrix with shape [num_nodes, num_node_features]
-    edge_index: np.ndarray or torch.Tensor, dtype int
+    edge_index: np.ndarray, dtype int
         Graph connectivity in COO format with shape [2, num_edges]
-    edge_features: np.ndarray or torch.Tensor, optional (default None)
+    edge_features: np.ndarray, optional (default None)
         Edge feature matrix with shape [num_edges, num_edge_features]
-    node_pos_features: np.ndarray or torch.Tensor, optional (default None)
+    node_pos_features: np.ndarray, optional (default None)
         Node position matrix with shape [num_nodes, num_dimensions].
     num_nodes: int
         The number of nodes in the graph
@@ -245,10 +245,6 @@ class GraphData:
                 graph_copy.kwargs[key] = value
                 setattr(graph_copy, key, value)
 
-        if isinstance(self, BatchGraphData):
-            graph_index = torch.from_numpy(self.graph_index).long()
-            graph_copy.graph_index = graph_index
-
         return graph_copy
 
 
@@ -321,14 +317,11 @@ class BatchGraphData(GraphData):
             batch_node_pos_features = None
 
         # create new edge index
-        # number of nodes in each graph
         num_nodes_list = [graph.num_nodes for graph in graph_list]
-        # cumulative number of nodes for each graph
-        cum_num_nodes_list = np.cumsum([0] + num_nodes_list)[:-1]
-        # columns are the edge index, values are the node index
         batch_edge_index = np.hstack([
-            graph.edge_index + cum_num_nodes
-            for cum_num_nodes, graph in zip(cum_num_nodes_list, graph_list)
+            graph.edge_index + prev_num_node
+            for prev_num_node, graph in zip([0] +
+                                            num_nodes_list[:-1], graph_list)
         ])
 
         # graph_index indicates which nodes belong to which graph
@@ -343,3 +336,12 @@ class BatchGraphData(GraphData):
             edge_features=batch_edge_features,
             node_pos_features=batch_node_pos_features,
         )
+
+    def numpy_to_torch(self):
+        import torch
+        graph_copy = super().numpy_to_torch()
+
+        graph_index = torch.from_numpy(self.graph_index).long()
+        graph_copy.graph_index = graph_index
+
+        return graph_copy

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -82,7 +82,7 @@ class GraphData:
             elif edge_index.shape[1] != edge_features.shape[0]:
                 raise ValueError(
                     'The first dimension of edge_features must be the \
-                          same as the second dimension of edge_index.'                                                                      )
+                          same as the second dimension of edge_index.')
 
         if node_pos_features is not None:
             if isinstance(node_pos_features, np.ndarray) is False:
@@ -91,7 +91,7 @@ class GraphData:
             elif node_pos_features.shape[0] != node_features.shape[0]:
                 raise ValueError(
                     'The length of node_pos_features must be the same as the \
-                          length of node_features.'                                                   )
+                          length of node_features.')
 
         self.node_features = node_features
         self.edge_index = edge_index
@@ -321,11 +321,14 @@ class BatchGraphData(GraphData):
             batch_node_pos_features = None
 
         # create new edge index
+        # number of nodes in each graph
         num_nodes_list = [graph.num_nodes for graph in graph_list]
+        # cumulative number of nodes for each graph
+        cum_num_nodes_list = np.cumsum([0] + num_nodes_list)[:-1]
+        # columns are the edge index, values are the node index
         batch_edge_index = np.hstack([
-            graph.edge_index + prev_num_node
-            for prev_num_node, graph in zip([0] +
-                                            num_nodes_list[:-1], graph_list)
+            graph.edge_index + cum_num_nodes
+            for cum_num_nodes, graph in zip(cum_num_nodes_list, graph_list)
         ])
 
         # graph_index indicates which nodes belong to which graph

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -12,13 +12,13 @@ class GraphData:
 
     Attributes
     ----------
-    node_features: np.ndarray
+    node_features: np.ndarray or torch.Tensor
         Node feature matrix with shape [num_nodes, num_node_features]
-    edge_index: np.ndarray, dtype int
+    edge_index: np.ndarray  or torch.Tensor, dtype int
         Graph connectivity in COO format with shape [2, num_edges]
-    edge_features: np.ndarray, optional (default None)
+    edge_features: np.ndarray  or torch.Tensor, optional (default None)
         Edge feature matrix with shape [num_edges, num_edge_features]
-    node_pos_features: np.ndarray, optional (default None)
+    node_pos_features: np.ndarray  or torch.Tensor, optional (default None)
         Node position matrix with shape [num_nodes, num_dimensions].
     num_nodes: int
         The number of nodes in the graph

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -338,6 +338,26 @@ class BatchGraphData(GraphData):
         )
 
     def numpy_to_torch(self):
+        """
+        Convert numpy arrays to torch tensors for BatchGraphData. BatchGraphData is very similar to GraphData, but it combines all graphs into a single graph object and it has an additional attribute `graph_index` which indicates which nodes belong to which graph.
+
+        Example
+        -------
+        >>> num_nodes, num_node_features = 5, 32
+        >>> num_edges, num_edge_features = 6, 32
+        >>> node_features = np.random.random_sample((num_nodes, num_node_features))
+        >>> edge_features = np.random.random_sample((num_edges, num_edge_features))
+        >>> edge_index = np.random.randint(0, num_nodes, (2, num_edges))
+        >>> graph_data = GraphData(node_features, edge_index, edge_features)
+        >>> node_features2 = np.random.random_sample((num_nodes, num_node_features))
+        >>> edge_features2 = np.random.random_sample((num_edges, num_edge_features))
+        >>> edge_index2 = np.random.randint(0, num_nodes, (2, num_edges))
+        >>> graph_data2 = GraphData(node_features2, edge_index2, edge_features2)
+        >>> batch_graph_data = BatchGraphData([graph_data, graph_data2])
+        >>> batch_graph_data = batch_graph_data.numpy_to_torch()
+        >>> print(type(batch_graph_data.node_features))
+        <class 'torch.Tensor'>
+        """
         import torch
         graph_copy = super().numpy_to_torch()
 

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -1,7 +1,6 @@
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence
 
 import numpy as np
-import torch
 
 
 class GraphData:
@@ -42,12 +41,10 @@ class GraphData:
     """
 
     def __init__(self,
-                 node_features: Union[np.ndarray, torch.Tensor],
-                 edge_index: Union[np.ndarray, torch.Tensor],
-                 edge_features: Optional[Union[np.ndarray,
-                                               torch.Tensor]] = None,
-                 node_pos_features: Optional[Union[np.ndarray,
-                                                   torch.Tensor]] = None,
+                 node_features: np.ndarray,
+                 edge_index: np.ndarray,
+                 edge_features: Optional[np.ndarray] = None,
+                 node_pos_features: Optional[np.ndarray] = None,
                  **kwargs):
         """
         Parameters
@@ -64,30 +61,23 @@ class GraphData:
             Additional attributes and their values
         """
         # validate params
-        if isinstance(node_features, (np.ndarray, torch.Tensor)) is False:
-            raise ValueError(
-                'node_features must be np.ndarray or torch.tensor.')
+        if isinstance(node_features, np.ndarray) is False:
+            raise ValueError('node_features must be np.ndarray.')
 
-        if isinstance(edge_index, (np.ndarray, torch.Tensor)) is False:
-            raise ValueError('edge_index must be np.ndarray or torch.tensor.')
-        elif isinstance(edge_index,
-                        np.ndarray) and edge_index.dtype != np.integer:
-            raise ValueError('edge_index must be of dtype integer.')
-        elif isinstance(
-                edge_index,
-                torch.Tensor) and edge_index.is_floating_point() is True:
-            raise ValueError('edge_index must be of dtype integer.')
-
+        if isinstance(edge_index, np.ndarray) is False:
+            raise ValueError('edge_index must be np.ndarray.')
+        elif issubclass(edge_index.dtype.type, np.integer) is False:
+            raise ValueError('edge_index.dtype must contains integers.')
         elif edge_index.shape[0] != 2:
             raise ValueError('The shape of edge_index is [2, num_edges].')
 
-        # np.max() method works only for a non-empty array, so size of the array should be non-zero. Convert edge index to numpy array if it is a torch tensor.
-        elif (edge_index.size != 0) and (np.max(np.array(edge_index)) >=
+        # np.max() method works only for a non-empty array, so size of the array should be non-zero
+        elif (edge_index.size != 0) and (np.max(edge_index) >=
                                          len(node_features)):
             raise ValueError('edge_index contains the invalid node number.')
 
         if edge_features is not None:
-            if isinstance(edge_features, (np.ndarray, torch.Tensor)) is False:
+            if isinstance(edge_features, np.ndarray) is False:
                 raise ValueError('edge_features must be np.ndarray or None.')
             elif edge_index.shape[1] != edge_features.shape[0]:
                 raise ValueError(
@@ -95,11 +85,9 @@ class GraphData:
                           same as the second dimension of edge_index.')
 
         if node_pos_features is not None:
-            if isinstance(node_pos_features,
-                          (np.ndarray, torch.Tensor)) is False:
+            if isinstance(node_pos_features, np.ndarray) is False:
                 raise ValueError(
-                    'node_pos_features must be np.ndarray, torch.tensor or None.'
-                )
+                    'node_pos_features must be np.ndarray or None.')
             elif node_pos_features.shape[0] != node_features.shape[0]:
                 raise ValueError(
                     'The length of node_pos_features must be the same as the \
@@ -233,6 +221,8 @@ class GraphData:
         <class 'torch.Tensor'>
         """
         import copy
+
+        import torch
 
         node_features = torch.from_numpy(self.node_features).float()
         edge_index = torch.from_numpy(self.edge_index).long()

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -77,7 +77,7 @@ class TestGraph(unittest.TestCase):
                 [0, 1, 2, 2, 3, 4],
                 [1, 2, 0, 3, 4, 0],
                 [2, 2, 1, 4, 0, 3],
-            ], )
+            ],)
             _ = GraphData(
                 node_features=node_features,
                 edge_index=invalid_edge_index_shape,
@@ -111,7 +111,7 @@ class TestGraph(unittest.TestCase):
         assert batch.num_node_features == num_node_features
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
-        assert batch.graph_index.shape == (sum(num_nodes_list), )
+        assert batch.graph_index.shape == (sum(num_nodes_list),)
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -163,7 +163,27 @@ class TestGraph(unittest.TestCase):
         assert graph.node_pos_features is None
         assert isinstance(graph.z, torch.Tensor)
 
-        batched_graph = BatchGraphData([graph_np, graph_np])
+    @pytest.mark.torch
+    def test_batchgraphdata_numpy_to_torch(self):
+        import torch
+        num_nodes_list, num_edge_list = [3, 4, 5], [2, 4, 5]
+        num_node_features, num_edge_features = 32, 32
+        edge_index_list = [
+            np.array([[0, 1], [1, 2]]),
+            np.array([[0, 1, 2, 3], [1, 2, 0, 2]]),
+            np.array([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]]),
+        ]
+
+        graph_list = [
+            GraphData(node_features=np.random.random_sample(
+                (num_nodes_list[i], num_node_features)),
+                      edge_index=edge_index_list[i],
+                      edge_features=np.random.random_sample(
+                          (num_edge_list[i], num_edge_features)),
+                      node_pos_features=None) for i in range(len(num_edge_list))
+        ]
+        batched_graph = BatchGraphData(graph_list)
+
         batched_graph = batched_graph.numpy_to_torch()
 
         assert isinstance(batched_graph, BatchGraphData)
@@ -171,4 +191,3 @@ class TestGraph(unittest.TestCase):
         assert isinstance(batched_graph.edge_index, torch.Tensor)
         assert isinstance(batched_graph.edge_features, torch.Tensor)
         assert batched_graph.node_pos_features is None
-        # batched graph does not take kwargs like 'z'

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -2,7 +2,6 @@ import unittest
 
 import numpy as np
 import pytest
-import torch
 
 from deepchem.feat.graph_data import BatchGraphData, GraphData
 
@@ -78,7 +77,7 @@ class TestGraph(unittest.TestCase):
                 [0, 1, 2, 2, 3, 4],
                 [1, 2, 0, 3, 4, 0],
                 [2, 2, 1, 4, 0, 3],
-            ],)
+            ], )
             _ = GraphData(
                 node_features=node_features,
                 edge_index=invalid_edge_index_shape,
@@ -112,7 +111,7 @@ class TestGraph(unittest.TestCase):
         assert batch.num_node_features == num_node_features
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
-        assert batch.graph_index.shape == (sum(num_nodes_list),)
+        assert batch.graph_index.shape == (sum(num_nodes_list), )
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):
@@ -138,6 +137,7 @@ class TestGraph(unittest.TestCase):
         """
         Test for converting GraphData numpy arrays to torch tensors
         """
+        import torch
         num_nodes, num_node_features = 5, 32
         num_edges, num_edge_features = 6, 32
         node_features = np.random.random_sample((num_nodes, num_node_features))
@@ -155,10 +155,19 @@ class TestGraph(unittest.TestCase):
                           edge_features=edge_features,
                           node_pos_features=node_pos_features,
                           z=z)
-        graph.numpy_to_torch()
+        graph = graph.numpy_to_torch()
 
         assert isinstance(graph.node_features, torch.Tensor)
         assert isinstance(graph.edge_index, torch.Tensor)
         assert isinstance(graph.edge_features, torch.Tensor)
         assert graph.node_pos_features is None
         assert isinstance(graph.z, torch.Tensor)
+
+        batched_graph = BatchGraphData([graph, graph])
+        batched_graph = batched_graph.numpy_to_torch()
+
+        assert isinstance(batched_graph.node_features, torch.Tensor)
+        assert isinstance(batched_graph.edge_index, torch.Tensor)
+        assert isinstance(batched_graph.edge_features, torch.Tensor)
+        assert batched_graph.node_pos_features is None
+        # batched graph does not take kwargs like 'z'

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -112,6 +112,8 @@ class TestGraph(unittest.TestCase):
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
         assert batch.graph_index.shape == (sum(num_nodes_list), )
+        assert batch.edge_index.max() == sum(num_edge_list)
+        assert batch.edge_index.shape == (2, sum(num_edge_list))
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -77,7 +77,7 @@ class TestGraph(unittest.TestCase):
                 [0, 1, 2, 2, 3, 4],
                 [1, 2, 0, 3, 4, 0],
                 [2, 2, 1, 4, 0, 3],
-            ],)
+            ], )
             _ = GraphData(
                 node_features=node_features,
                 edge_index=invalid_edge_index_shape,
@@ -111,7 +111,7 @@ class TestGraph(unittest.TestCase):
         assert batch.num_node_features == num_node_features
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
-        assert batch.graph_index.shape == (sum(num_nodes_list),)
+        assert batch.graph_index.shape == (sum(num_nodes_list), )
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):
@@ -150,12 +150,12 @@ class TestGraph(unittest.TestCase):
         # z is kwargs
         z = np.random.random(5)
 
-        graph = GraphData(node_features=node_features,
-                          edge_index=edge_index,
-                          edge_features=edge_features,
-                          node_pos_features=node_pos_features,
-                          z=z)
-        graph = graph.numpy_to_torch()
+        graph_np = GraphData(node_features=node_features,
+                             edge_index=edge_index,
+                             edge_features=edge_features,
+                             node_pos_features=node_pos_features,
+                             z=z)
+        graph = graph_np.numpy_to_torch()
 
         assert isinstance(graph.node_features, torch.Tensor)
         assert isinstance(graph.edge_index, torch.Tensor)
@@ -163,7 +163,7 @@ class TestGraph(unittest.TestCase):
         assert graph.node_pos_features is None
         assert isinstance(graph.z, torch.Tensor)
 
-        batched_graph = BatchGraphData([graph, graph])
+        batched_graph = BatchGraphData([graph_np, graph_np])
         batched_graph = batched_graph.numpy_to_torch()
 
         assert isinstance(batched_graph, BatchGraphData)

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -172,6 +172,3 @@ class TestGraph(unittest.TestCase):
         assert isinstance(batched_graph.edge_features, torch.Tensor)
         assert batched_graph.node_pos_features is None
         # batched graph does not take kwargs like 'z'
-
-test = TestGraph()
-test.test_graphdata_numpy_to_torch()

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -78,7 +78,7 @@ class TestGraph(unittest.TestCase):
                 [0, 1, 2, 2, 3, 4],
                 [1, 2, 0, 3, 4, 0],
                 [2, 2, 1, 4, 0, 3],
-            ], )
+            ],)
             _ = GraphData(
                 node_features=node_features,
                 edge_index=invalid_edge_index_shape,
@@ -112,7 +112,7 @@ class TestGraph(unittest.TestCase):
         assert batch.num_node_features == num_node_features
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
-        assert batch.graph_index.shape == (sum(num_nodes_list), )
+        assert batch.graph_index.shape == (sum(num_nodes_list),)
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -112,8 +112,6 @@ class TestGraph(unittest.TestCase):
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
         assert batch.graph_index.shape == (sum(num_nodes_list), )
-        assert batch.edge_index.max() == sum(num_edge_list)
-        assert batch.edge_index.shape == (2, sum(num_edge_list))
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -166,8 +166,12 @@ class TestGraph(unittest.TestCase):
         batched_graph = BatchGraphData([graph, graph])
         batched_graph = batched_graph.numpy_to_torch()
 
+        assert isinstance(batched_graph, BatchGraphData)
         assert isinstance(batched_graph.node_features, torch.Tensor)
         assert isinstance(batched_graph.edge_index, torch.Tensor)
         assert isinstance(batched_graph.edge_features, torch.Tensor)
         assert batched_graph.node_pos_features is None
         # batched graph does not take kwargs like 'z'
+
+test = TestGraph()
+test.test_graphdata_numpy_to_torch()

--- a/deepchem/feat/tests/test_graph_data.py
+++ b/deepchem/feat/tests/test_graph_data.py
@@ -1,7 +1,10 @@
 import unittest
-import pytest
+
 import numpy as np
-from deepchem.feat.graph_data import GraphData, BatchGraphData
+import pytest
+import torch
+
+from deepchem.feat.graph_data import BatchGraphData, GraphData
 
 
 class TestGraph(unittest.TestCase):
@@ -75,7 +78,7 @@ class TestGraph(unittest.TestCase):
                 [0, 1, 2, 2, 3, 4],
                 [1, 2, 0, 3, 4, 0],
                 [2, 2, 1, 4, 0, 3],
-            ],)
+            ], )
             _ = GraphData(
                 node_features=node_features,
                 edge_index=invalid_edge_index_shape,
@@ -109,7 +112,7 @@ class TestGraph(unittest.TestCase):
         assert batch.num_node_features == num_node_features
         assert batch.num_edges == sum(num_edge_list)
         assert batch.num_edge_features == num_edge_features
-        assert batch.graph_index.shape == (sum(num_nodes_list),)
+        assert batch.graph_index.shape == (sum(num_nodes_list), )
 
     @pytest.mark.torch
     def test_graph_data_single_atom_mol(self):
@@ -129,3 +132,33 @@ class TestGraph(unittest.TestCase):
         assert str(
             graph
         ) == 'GraphData(node_features=[1, 32], edge_index=[2, 0], edge_features=None)'
+
+    @pytest.mark.torch
+    def test_graphdata_numpy_to_torch(self):
+        """
+        Test for converting GraphData numpy arrays to torch tensors
+        """
+        num_nodes, num_node_features = 5, 32
+        num_edges, num_edge_features = 6, 32
+        node_features = np.random.random_sample((num_nodes, num_node_features))
+        edge_features = np.random.random_sample((num_edges, num_edge_features))
+        edge_index = np.array([
+            [0, 1, 2, 2, 3, 4],
+            [1, 2, 0, 3, 4, 0],
+        ])
+        node_pos_features = None
+        # z is kwargs
+        z = np.random.random(5)
+
+        graph = GraphData(node_features=node_features,
+                          edge_index=edge_index,
+                          edge_features=edge_features,
+                          node_pos_features=node_pos_features,
+                          z=z)
+        graph.numpy_to_torch()
+
+        assert isinstance(graph.node_features, torch.Tensor)
+        assert isinstance(graph.edge_index, torch.Tensor)
+        assert isinstance(graph.edge_features, torch.Tensor)
+        assert graph.node_pos_features is None
+        assert isinstance(graph.z, torch.Tensor)


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds a method GraphData.numpy_to_torch(). This converts the GraphData's values from numpy to torch tensors, which is useful when using deepchem and pytorch geometric at the same time. 


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
