### PR TITLE
removed embedding output type arg in grover

### DIFF
--- a/deepchem/models/torch_models/grover_layers.py
+++ b/deepchem/models/torch_models/grover_layers.py
@@ -16,7 +16,7 @@ from deepchem.models.torch_models.layers import SublayerConnection, Positionwise
 class GroverEmbedding(nn.Module):
     """GroverEmbedding layer.
 
-    This layer is a simple wrapper over GroverTransEncoder layer for retrieving the embeddings from the GroverTransEncoder corresponding to the `embedding_output_type` chosen by the user.
+    This layer is a simple wrapper over GroverTransEncoder layer for retrieving the embeddings from the GroverTransEncoder layer.
 
     Parameters
     ----------
@@ -716,14 +716,6 @@ class GroverTransEncoder(nn.Module):
         the number of mt block.
     num_head: int
         the number of attention AttentionHead.
-    embedding_output_type: str
-        enable the output aggregation after message passing.
-                                            atom_messages:      True                      False
-        - "none": no aggregation         output size:     (num_atoms, hidden_size)    (num_bonds, hidden_size)
-        -"atom":  aggregating to atom  output size:     (num_atoms, hidden_size)    (num_atoms, hidden_size)
-        -"bond": aggragating to bond.   output size:     (num_bonds, hidden_size)    (num_bonds, hidden_size)
-        -"both": aggregating to atom&bond. output size:  (num_atoms, hidden_size)    (num_bonds, hidden_size)
-                                                        (num_bonds, hidden_size)    (num_atoms, hidden_size)
     bias: bool
         enable bias term in all linear layers.
     res_connection: bool

--- a/deepchem/models/torch_models/tests/test_grover.py
+++ b/deepchem/models/torch_models/tests/test_grover.py
@@ -5,7 +5,7 @@ except ModuleNotFoundError:
 
 
 def testGroverEmbedding():
-    from deepchem.models.torch_models.grover import GroverEmbedding
+    from deepchem.models.torch_models.grover_layers import GroverEmbedding
     hidden_size = 8
     f_atoms = torch.randn(4, 151)
     f_bonds = torch.randn(5, 165)
@@ -19,8 +19,7 @@ def testGroverEmbedding():
     node_fdim, edge_fdim = f_atoms.shape[1], f_bonds.shape[1]
     layer = GroverEmbedding(edge_fdim=edge_fdim,
                             node_fdim=node_fdim,
-                            hidden_size=8,
-                            embedding_output_type='both')
+                            hidden_size=8)
     output = layer([f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope, a2a])
     assert output['atom_from_atom'].shape == (n_atoms, hidden_size)
     assert output['bond_from_atom'].shape == (n_bonds, hidden_size)

--- a/deepchem/models/torch_models/tests/test_grover_layers.py
+++ b/deepchem/models/torch_models/tests/test_grover_layers.py
@@ -22,8 +22,7 @@ def testGroverEmbedding():
     node_fdim, edge_fdim = f_atoms.shape[1], f_bonds.shape[1]
     layer = GroverEmbedding(hidden_size=hidden_size,
                             edge_fdim=edge_fdim,
-                            node_fdim=node_fdim,
-                            embedding_output_type='both')
+                            node_fdim=node_fdim)
     output = layer([f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope, a2a])
     assert output['atom_from_atom'].shape == (n_atoms, hidden_size)
     assert output['bond_from_atom'].shape == (n_bonds, hidden_size)
@@ -207,8 +206,7 @@ def testGroverTransEncoder():
     node_fdim, edge_fdim = f_atoms.shape[1], f_bonds.shape[1]
     layer = GroverTransEncoder(hidden_size=hidden_size,
                                edge_fdim=edge_fdim,
-                               node_fdim=node_fdim,
-                               embedding_output_type='both')
+                               node_fdim=node_fdim)
     output = layer([f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope, a2a])
     assert output[0][0].shape == (n_atoms, hidden_size)
     assert output[0][1].shape == (n_bonds, hidden_size)


### PR DESCRIPTION
# Pull Request Template

## Description

I am removing the `embedding_output_type` argument from grover as it is not needed and used.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
