### PR TITLE
align torch device in MI Loss

### DIFF
--- a/deepchem/models/losses.py
+++ b/deepchem/models/losses.py
@@ -521,8 +521,9 @@ class GlobalMutualInformationLoss(Loss):
         import torch
 
         def loss(global_enc, global_enc2):
+            device = global_enc.device
             num_graphs = global_enc.shape[0]
-            pos_mask = torch.eye(num_graphs)
+            pos_mask = torch.eye(num_graphs).to(device)
             neg_mask = 1 - pos_mask
 
             res = torch.mm(global_enc, global_enc2.t())
@@ -599,11 +600,12 @@ class LocalMutualInformationLoss(Loss):
         import torch
 
         def loss(local_enc, global_enc, batch_graph_index):
+            device = local_enc.device
             num_graphs = global_enc.shape[0]
             num_nodes = local_enc.shape[0]
 
-            pos_mask = torch.zeros((num_nodes, num_graphs))
-            neg_mask = torch.ones((num_nodes, num_graphs))
+            pos_mask = torch.zeros((num_nodes, num_graphs)).to(device)
+            neg_mask = torch.ones((num_nodes, num_graphs)).to(device)
             for nodeidx, graphidx in enumerate(batch_graph_index):
                 pos_mask[nodeidx][graphidx] = 1.
                 neg_mask[nodeidx][graphidx] = 0.


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a device mismatch for torchmodels and modulartorchmodels that use Global and Local Information Losses by sending all torch tensors to the same device.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
