### PR TITLE
pin torch-sparse to 0.6.16

### DIFF
--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -6,6 +6,6 @@ dependencies:
     - dgl
     - torch==1.12.0+cpu
     - torch-scatter==2.1.0
-    - torch-sparse
+    - torch-sparse==0.6.16
     - torch-geometric
     - pytorch-lightning==1.6.5

--- a/requirements/torch/env_torch.gpu.yml
+++ b/requirements/torch/env_torch.gpu.yml
@@ -7,6 +7,6 @@ dependencies:
     - torch==1.11.0+cu113
     - torchvision==0.12.0+cu113
     - torch-scatter==2.1.0
-    - torch-sparse
+    - torch-sparse==0.6.16
     - torch-geometric
     - pytorch-lightning==1.6.5

--- a/requirements/torch/env_torch.mac.cpu.yml
+++ b/requirements/torch/env_torch.mac.cpu.yml
@@ -6,6 +6,6 @@ dependencies:
     - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
     - dgl
     - torch-scatter==2.1.0
-    - torch-sparse
+    - torch-sparse==0.6.16
     - torch-geometric
     - pytorch-lightning==1.6.5


### PR DESCRIPTION
# Pull Request Template

## Description

The release of torch-sparse 0.6.17 seems to have broken our install. This PR pins torch-sparse to 0.6.16 as a temporary fix.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
