### PR TITLE
Surpress assignment errors in graph_data

### DIFF
--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -230,17 +230,17 @@ class GraphData:
         import torch
         graph_copy = copy.deepcopy(self)
 
-        graph_copy.node_features = torch.from_numpy(
+        graph_copy.node_features = torch.from_numpy(  # type: ignore
             self.node_features).float().to(device)
-        graph_copy.edge_index = torch.from_numpy(
+        graph_copy.edge_index = torch.from_numpy(  # type: ignore
             self.edge_index).long().to(device)
         if self.edge_features is not None:
-            graph_copy.edge_features = torch.from_numpy(
+            graph_copy.edge_features = torch.from_numpy(  # type: ignore
                 self.edge_features).float().to(device)
         else:
             graph_copy.edge_features = None
         if self.node_pos_features is not None:
-            graph_copy.node_pos_features = torch.from_numpy(
+            graph_copy.node_pos_features = torch.from_numpy(  # type: ignore
                 self.node_pos_features).float().to(device)
         else:
             graph_copy.node_pos_features = None
@@ -376,7 +376,8 @@ class BatchGraphData(GraphData):
         import torch
         graph_copy = super().numpy_to_torch(device)
 
-        graph_index = torch.from_numpy(self.graph_index).long().to(device)
+        graph_index = torch.from_numpy(self.graph_index).long().to(  # type: ignore
+            device)
         graph_copy.graph_index = graph_index
 
         return graph_copy

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -376,8 +376,9 @@ class BatchGraphData(GraphData):
         import torch
         graph_copy = super().numpy_to_torch(device)
 
-        graph_index = torch.from_numpy(self.graph_index).long().to(  # type: ignore
-            device)
+        graph_index = torch.from_numpy(
+            self.graph_index).long().to(  # type: ignore
+                device)
         graph_copy.graph_index = graph_index
 
         return graph_copy


### PR DESCRIPTION
# Pull Request Template

## Description

A recent PR allows graph_data attribute types to change from np to torch. Mypy throws an error because the argument types are defined as np arrays only. This PR surpresses the errors.

An alternative would be to allow torch tensors as an input type, however this would not match the convention of accepting only numpy arrays into featurizers, as deepchem datasets operate exclusively with numpy arrays to remain framework agnostic.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
