### PR TITLE
removed torch-scatter and torch-sparse from dependency

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -11,7 +11,7 @@ except ModuleNotFoundError:
     raise ImportError('These classes require PyTorch to be installed.')
 
 try:
-    from torch_scatter import scatter_mean
+    from torch_geometric.utils import scatter
 except ModuleNotFoundError:
     pass
 
@@ -1138,9 +1138,10 @@ class GraphNetwork(torch.nn.Module):
         # Compute mean edge features for each node by dst_index (each node
         # receives information from edges which have that node as its destination,
         # hence the computation uses dst_index to aggregate information)
-        edge_features_mean_by_node = scatter_mean(edge_features,
-                                                  dst_index,
-                                                  dim=0)
+        edge_features_mean_by_node = scatter(src=edge_features,
+                                             index=dst_index,
+                                             dim=0,
+                                             reduce='mean')
         out = torch.cat(
             (node_features, edge_features_mean_by_node, global_features[batch]),
             dim=1)
@@ -1151,8 +1152,14 @@ class GraphNetwork(torch.nn.Module):
     def _update_global_features(self, node_features, edge_features,
                                 global_features, node_batch_map,
                                 edge_batch_map):
-        edge_features_mean = scatter_mean(edge_features, edge_batch_map, dim=0)
-        node_features_mean = scatter_mean(node_features, node_batch_map, dim=0)
+        edge_features_mean = scatter(src=edge_features,
+                                     index=edge_batch_map,
+                                     dim=0,
+                                     reduce='mean')
+        node_features_mean = scatter(src=node_features,
+                                     index=node_batch_map,
+                                     dim=0,
+                                     reduce='mean')
         out = torch.cat(
             (edge_features_mean, node_features_mean, global_features), dim=1)
         for model in self.global_models:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,6 +13,4 @@ jax
 dm-haiku
 optax
 rdkit
-# https://data.pyg.org/whl/torch-1.13.0%2Bcpu/torch_sparse-0.6.16%2Bpt113cpu-cp38-cp38-linux_x86_64.whl
-# https://data.pyg.org/whl/torch-1.13.0%2Bcpu/torch_scatter-2.1.1%2Bpt113cpu-cp38-cp38-linux_x86_64.whl
 torch_geometric

--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -5,7 +5,5 @@ dependencies:
     - -f https://data.dgl.ai/wheels/repo.html
     - dgl
     - torch==1.12.0+cpu
-    - torch-scatter==2.1.0
-    - torch-sparse==0.6.16
     - torch-geometric
     - pytorch-lightning==1.6.5

--- a/requirements/torch/env_torch.gpu.yml
+++ b/requirements/torch/env_torch.gpu.yml
@@ -5,8 +5,5 @@ dependencies:
     - -f https://data.dgl.ai/wheels/repo.html
     - dgl-cu111
     - torch==1.11.0+cu113
-    - torchvision==0.12.0+cu113
-    - torch-scatter==2.1.0
-    - torch-sparse==0.6.16
     - torch-geometric
     - pytorch-lightning==1.6.5

--- a/requirements/torch/env_torch.mac.cpu.yml
+++ b/requirements/torch/env_torch.mac.cpu.yml
@@ -5,7 +5,5 @@ dependencies:
   - pip:
     - -f https://data.pyg.org/whl/torch-1.10.0+cpu.html
     - dgl
-    - torch-scatter==2.1.0
-    - torch-sparse==0.6.16
     - torch-geometric
     - pytorch-lightning==1.6.5


### PR DESCRIPTION
# Pull Request Template

## Description

Related to #3317 

The latest pytorch-geometric release does not require torch-scatter and torch-sparse. Hence, these two modules are removed from requirements file.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
