### PR TITLE
add max size feature to grover vocabulary

### DIFF
--- a/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
@@ -28,6 +28,12 @@ def testGroverAtomVocabularyBuilder():
     assert loaded_vocab.atom_to_vocab(mol, atom) == 'C_C-SINGLE1'
     assert loaded_vocab.encode(mol, mol.GetAtomWithIdx(0)) == 2
 
+    # test with max size
+    vocab = GroverAtomVocabularyBuilder(max_size=3)
+    vocab.build(dataset)
+    assert vocab.size == 3
+    assert vocab.size == len(vocab.itos)
+
 
 def testGroverBondVocabularyBuilder():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder
@@ -59,6 +65,12 @@ def testGroverBondVocabularyBuilder():
         mol, bond
     ) == '(SINGLE-STEREONONE-NONE)_C-(DOUBLE-STEREONONE-NONE)1_C-(SINGLE-STEREONONE-NONE)1'
     assert loaded_vocab.encode(mol, bond) == 2
+
+    # test with max size
+    vocab = GroverBondVocabularyBuilder(max_size=3)
+    vocab.build(dataset)
+    assert vocab.size == 3
+    assert vocab.size == len(vocab.itos)
 
 
 def testGroverAtomVocabTokenizer():


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a new `max_size` parameter to grover vocabulary which can be used for setting the size of vocabulary.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
