### PR TITLE
removed macos installation steps in ci worfklow

### DIFF
--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -62,28 +62,11 @@ jobs:
       run: |
         git fetch origin master
         echo "COMMIT_RANGE=origin/master..." >> $GITHUB_ENV
-    - name: Cache pip packages for Linux
-      if: runner.os == 'Linux'
+    - name: Cache pip packages
       uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/jax/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Cache pip packages for MacOS
-      if: runner.os == 'macOS'
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-pip-${{ hashFiles('requirements/jax/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-    - name: Cache pip packages for Windows
-      if: runner.os == 'Windows'
-      uses: actions/cache@v3
-      with:
-        path: ~\AppData\Local\pip\Cache
-        key: ${{ matrix.os }}-pip-${{ hashFiles('requirements/jax/**') }}
         restore-keys: |
           ${{ runner.os }}-pip-
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/mini_build.yml
+++ b/.github/workflows/mini_build.yml
@@ -81,14 +81,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/**') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Cache pip packages for MacOS
-      if: runner.os == 'macOS'
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-pip-${{ hashFiles('requirements/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Cache pip packages for Windows
       if: runner.os == 'Windows'
       uses: actions/cache@v3
@@ -101,9 +93,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install prerequisites for XGBoost and LightGBM (MacOS)
-      if: startsWith(runner.os, 'macOS')
-      run: brew update && brew install libomp
     - name: Create env.yml
       shell: bash
       run: |
@@ -112,8 +101,6 @@ jobs:
         cd requirements
         if [ "$(uname)" == 'Linux' ]; then
           conda-merge env_common.yml env_test.yml env_ubuntu.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml jax/env_jax.cpu.yml > env.yml
-        elif [  "$(uname)" == 'Darwin' ]; then
-          conda-merge env_common.yml env_test.yml env_mac.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.mac.cpu.yml jax/env_jax.cpu.yml > env.yml
         elif [[  "$(uname)" == "MINGW64_NT"* ]]; then
           conda-merge env_common.yml env_test.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml > env.yml
         fi;

--- a/.github/workflows/tensorflow_setup.yml
+++ b/.github/workflows/tensorflow_setup.yml
@@ -77,14 +77,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/tensorflow/**') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Cache pip packages for MacOS
-      if: runner.os == 'macOS'
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-pip-${{ hashFiles('requirements/tensorflow/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Cache pip packages for Windows
       if: runner.os == 'Windows'
       uses: actions/cache@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,14 +77,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/**.yml') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Cache pip packages for MacOS
-      if: runner.os == 'macOS'
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-pip-${{ hashFiles('requirements/**.yml') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Cache pip packages for Windows
       if: runner.os == 'Windows'
       uses: actions/cache@v3
@@ -106,8 +98,6 @@ jobs:
         cd requirements
         if [ "$(uname)" == 'Linux' ]; then
           conda-merge env_common.yml env_test.yml env_ubuntu.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml jax/env_jax.cpu.yml env_py310_no_support.yml >  env.yml
-        elif [  "$(uname)" == 'Darwin' ]; then
-          conda-merge env_common.yml env_test.yml env_mac.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.mac.cpu.yml jax/env_jax.cpu.yml env_py310_no_support.yml > env.yml
         elif [[  "$(uname)" == "MINGW64_NT"* ]]; then
           conda-merge env_common.yml env_test.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml > env.yml
         fi;
@@ -123,8 +113,6 @@ jobs:
         cd requirements
         if [ "$(uname)" == 'Linux' ]; then
           conda-merge env_common.yml env_test.yml env_ubuntu.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml jax/env_jax.cpu.yml > env.yml
-        elif [  "$(uname)" == 'Darwin' ]; then
-          conda-merge env_common.yml env_test.yml env_mac.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.mac.cpu.yml jax/env_jax.cpu.yml > env.yml
         elif [[  "$(uname)" == "MINGW64_NT"* ]]; then
           conda-merge env_common.yml env_test.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml > env.yml
         fi;

--- a/.github/workflows/torch_setup.yml
+++ b/.github/workflows/torch_setup.yml
@@ -77,14 +77,6 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/torch/**') }}
         restore-keys: |
           ${{ runner.os }}-pip-
-    - name: Cache pip packages for MacOS
-      if: runner.os == 'macOS'
-      uses: actions/cache@v3
-      with:
-        path: ~/Library/Caches/pip
-        key: ${{ matrix.os }}-pip-${{ hashFiles('requirements/torch/**') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
     - name: Cache pip packages for Windows
       if: runner.os == 'Windows'
       uses: actions/cache@v3


### PR DESCRIPTION
## Description

DeepChem's workflow does not run tests on macos. I am removing the steps which cache package for macOS as they are dead code.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings