### PR TITLE
Add tutorial rendering orders as CSVs

### DIFF
--- a/examples/tutorials/README.md
+++ b/examples/tutorials/README.md
@@ -30,73 +30,37 @@ practitioners. By enabling the growth of open source tools for drug discovery,
 you can help democratize these skills and open up drug discovery to more
 competition. Increased competition can help drive down the cost of medicine.
 
-The tutorial is organized as follows:
 
-### Introduction to DeepChem
-The following tutorials covers the core features of DeepChem. Covering these
-tutorials will help you in getting started with DeepChem for machine learning. The later
-tutorials discuss about using DeepChem for specific applications.
 
-* [1 The Basic Tools of the Deep Life Sciences](The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb)
-* [2 Working With Datasets](Working_With_Datasets.ipynb)
-* [3 An Introduction to MoleculeNet](An_Introduction_To_MoleculeNet.ipynb)
-* [4 Molecular Fingerprints](Molecular_Fingerprints.ipynb)
-* [5 Creating Models with Tensorflow and Pytorch](Creating_Models_with_TensorFlow_and_PyTorch.ipynb)
-* [6 Introduction to Graph Convolutions](Introduction_to_Graph_Convolutions.ipynb)
-* [7 Going Deeper on Molecular Featurizations](Going_Deeper_on_Molecular_Featurizations.ipynb)
-* [8 Working With Splitters](Working_With_Splitters.ipynb)
-* [9 Advanced Model Training](Advanced_Model_Training.ipynb)
-* [10 Creating a high fidelity model from experimental data](Creating_a_high_fidelity_model_from_experimental_data.ipynb)
-* [11 Putting Multitask Learning to Work](Putting_Multitask_Learning_to_Work.ipynb)
-* [12 Modeling Protein Ligand Interactions](Modeling_Protein_Ligand_Interactions.ipynb)
-* [13 Modeling Protein Ligand Interactions with Atomic Convolutions](Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb)
-* [14 Conditional Generative Adversarial Networks](Conditional_Generative_Adversarial_Networks.ipynb)
-* [15 Training a Generative Adversarial Network on MNIST](Training_a_Generative_Adversarial_Network_on_MNIST.ipynb)
-* [16 Distributed Multi-GPU Training of DeepChem Models with LitMatter](https://github.com/ncfrey/litmatter/blob/main/LitDeepChem.ipynb)
-* [17 Advanced model training using Hyperopt](Advanced_model_training_using_hyperopt.ipynb)
-* [18 Introduction to Gaussian Processes](Introduction_to_Gaussian_Processes.ipynb)
-* [19 Pytorch-Lightning Integration for DeepChem Models](PytorchLightning_Integration.ipynb)
 
-### Molecular Machine Learning
-* [1 Molecular Fingerprints](Molecular_Fingerprints.ipynb)
-* [2 Going Deeper on Molecular Featurizations](Going_Deeper_on_Molecular_Featurizations.ipynb)
-* [3 Learning Unsupervised Embeddings for Molecules](Learning_Unsupervised_Embeddings_for_Molecules.ipynb)
-* [4 Synthetic Feasibility Scoring](Synthetic_Feasibility_Scoring.ipynb)
-* [5 Atomic Contributions for Molecules](Atomic_Contributions_for_Molecules.ipynb)
-* [6 Interactive Model Evaluation with Trident Chemwidgets](Interactive_Model_Evaluation_with_Trident_Chemwidgets.ipynb)
-* [7 Transfer Learning with ChemBERTa Transformers](Transfer_Learning_With_ChemBERTa_Transformers.ipynb)
-* [8 Training a Normalizing Flow on QM9](Training_a_Normalizing_Flow_on_QM9.ipynb)
-* [9 Large Scale Chemical Screens](Large_Scale_Chemical_Screens.ipynb)
-* [10 Introduction to Molecular Attention Transformer](Introduction_to_Molecular_Attention_Transformer.ipynb)
-* [11 Generating Molecules with MolGAN](Generating_molecules_with_MolGAN.ipynb)
-* [12 Introduction to GROVER](Introduction_to_GROVER.ipynb)
+The tutorial is organized as follows. Each section is linked to a CSV file containing the order in which the tutorials
+should be followed. 
 
-### Modeling Proteins
-* [1 Protein Deep Learning](Protein_Deep_Learning.ipynb)
+The rendered tutorials are available to read at the [Deepchem Website](https://deepchem.io/tutorials)
 
-### Protein Ligand Modeling
-* [1 Modeling Protein Ligand Interactions](Modeling_Protein_Ligand_Interactions.ipynb)
-* [2 Modeling Protein Ligand Interactions with Atomic Convolutions](Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb)
+**We highly recommend you to visit the Deepchem website to read the tutorials.**
 
-### Quantum Chemistry
-* [1 Exploring Quantum Chemistry with GDB1k](Exploring_Quantum_Chemistry_with_GDB1k.ipynb)
-* [2 Finding ground state energy of molecules with DeepQMC](DeepQMC_tutorial.ipynb)
+## Introduction to DeepChem - [Introduction to Deepchem](./website-render-order/1-introduction-to-deepchem.csv)
 
-### Bioinformatics
-* [1 Introduction to BioInformatics](Introduction_to_Bioinformatics.ipynb)
-* [2 Multisequence Alignments](Multisequence_Alignments.ipynb)
-* [3 Scanpy](Scanpy.ipynb)
-* [4 Deep probabilistic analysis of omics data](Deep_probabilistic_analysis_of_single-cell_omics_data.ipynb)
+These tutorials covers the core features of DeepChem. Covering these
+tutorials will help you in getting started with DeepChem for machine learning. 
 
-### Material Science
-* [1 Introduction to Material Science](Introduction_To_Material_Science.ipynb)
 
-### Machine Learning Methods
-* [1 Using Reinforcement Learning to Play Pong](Using_Reinforcement_Learning_to_Play_Pong.ipynb)
-* [2 Introduction to Model Interpretability](Introduction_to_Model_Interpretability.ipynb)
-* [3 Uncertainty in Deep Learning](Uncertainty_In_Deep_Learning.ipynb)
 
-### Deep Differential Equations
-* [1 Physics Informed Neural Networks (Burgers Equation)](Physics_Informed_Neural_Networks.ipynb) 
-* [2 Introducing_JaxModel_and_PINNModel](Introducing_JaxModel_and_PINNModel.ipynb)
-* [3 About_nODE_Using_Torchdiffeq_in_Deepchem](About_nODE_Using_Torchdiffeq_in_Deepchem.ipynb)
+The following tutorials discuss about using DeepChem for specific applications.
+
+## Molecular Machine Learning - [Molecular Machine Learning](./website-render-order/2-molecular-machine-learning.csv)
+
+## Modeling Proteins - [Modeling Proteins](./website-render-order/3-modeling-proteins.csv)
+
+## Protein Ligand Modeling - [Protein Ligand Modeling](./website-render-order/4-protein-ligand-modeling.csv)
+
+## Quantum Chemistry - [Quantum Chemistry](./website-render-order/5-quantum-chemistry.csv)
+
+## Bioinformatics - [Bioinformatics](./website-render-order/6-bioinformatics.csv)
+
+## Material Science - [Material Science](./website-render-order/7-material-science.csv)
+
+## Machine Learning Methods - [Machine Learning Methods](./website-render-order/8-machine-learning-methods.csv)
+
+## Deep Differential Equations - [Deep Differential Equations](./website-render-order/9-deep-differential-equations.csv)

--- a/examples/tutorials/website-render-order/1-introduction-to-deepchem.csv
+++ b/examples/tutorials/website-render-order/1-introduction-to-deepchem.csv
@@ -1,0 +1,20 @@
+Title,File Name
+The Basic Tools of the Deep Life Sciences,The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+Working With Datasets,Working_With_Datasets.ipynb
+An Introduction to MoleculeNet,An_Introduction_To_MoleculeNet.ipynb
+Molecular Fingerprints,Molecular_Fingerprints.ipynb
+Creating Models with Tensorflow and Pytorch,Creating_Models_with_TensorFlow_and_PyTorch.ipynb
+Introduction to Graph Convolutions,Introduction_to_Graph_Convolutions.ipynb
+Going Deeper on Molecular Featurizations,Going_Deeper_on_Molecular_Featurizations.ipynb
+Working With Splitters,Working_With_Splitters.ipynb
+Advanced Model Training,Advanced_Model_Training.ipynb
+Creating a high fidelity model from experimental data,Creating_a_high_fidelity_model_from_experimental_data.ipynb
+Putting Multitask Learning to Work,Putting_Multitask_Learning_to_Work.ipynb
+Modeling Protein Ligand Interactions,Modeling_Protein_Ligand_Interactions.ipynb
+Modeling Protein Ligand Interactions with Atomic Convolutions,Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb
+Conditional Generative Adversarial Networks,Conditional_Generative_Adversarial_Networks.ipynb
+Training a Generative Adversarial Network on MNIST,Training_a_Generative_Adversarial_Network_on_MNIST.ipynb
+Distributed Multi-GPU Training of DeepChem Models with LitMatter,https://github.com/ncfrey/litmatter/blob/main/LitDeepChem.ipynb
+Advanced model training using Hyperopt,Advanced_model_training_using_hyperopt.ipynb
+Introduction to Gaussian Processes,Introduction_to_Gaussian_Processes.ipynb
+Pytorch-Lightning Integration for DeepChem Models,PytorchLightning_Integration.ipynb

--- a/examples/tutorials/website-render-order/2-molecular-machine-learning.csv
+++ b/examples/tutorials/website-render-order/2-molecular-machine-learning.csv
@@ -1,0 +1,13 @@
+Title,File Name
+Molecular Fingerprints,Molecular_Fingerprints.ipynb
+Going Deeper on Molecular Featurizations,Going_Deeper_on_Molecular_Featurizations.ipynb
+Learning Unsupervised Embeddings for Molecules,Learning_Unsupervised_Embeddings_for_Molecules.ipynb
+Synthetic Feasibility Scoring,Synthetic_Feasibility_Scoring.ipynb
+Atomic Contributions for Molecules,Atomic_Contributions_for_Molecules.ipynb
+Interactive Model Evaluation with Trident Chemwidgets,Interactive_Model_Evaluation_with_Trident_Chemwidgets.ipynb
+Transfer Learning with ChemBERTa Transformers,Transfer_Learning_With_ChemBERTa_Transformers.ipynb
+Training a Normalizing Flow on QM9,Training_a_Normalizing_Flow_on_QM9.ipynb
+Large Scale Chemical Screens,Large_Scale_Chemical_Screens.ipynb
+Introduction to Molecular Attention Transformer,Introduction_to_Molecular_Attention_Transformer.ipynb
+Generating Molecules with MolGAN,Generating_molecules_with_MolGAN.ipynb
+Introduction to GROVER,Introduction_to_GROVER.ipynb

--- a/examples/tutorials/website-render-order/3-modeling-proteins.csv
+++ b/examples/tutorials/website-render-order/3-modeling-proteins.csv
@@ -1,0 +1,2 @@
+Title,File Name
+Protein Deep Learning,Protein_Deep_Learning.ipynb

--- a/examples/tutorials/website-render-order/4-protein-ligand-modeling.csv
+++ b/examples/tutorials/website-render-order/4-protein-ligand-modeling.csv
@@ -1,0 +1,3 @@
+Title,File Name
+Modeling Protein Ligand Interactions,Modeling_Protein_Ligand_Interactions.ipynb
+Modeling Protein Ligand Interactions with Atomic Convolutions,Modeling_Protein_Ligand_Interactions_With_Atomic_Convolutions.ipynb

--- a/examples/tutorials/website-render-order/5-quantum-chemistry.csv
+++ b/examples/tutorials/website-render-order/5-quantum-chemistry.csv
@@ -1,0 +1,3 @@
+Title,File Name
+Exploring Quantum Chemistry with GDB1k,Exploring_Quantum_Chemistry_with_GDB1k.ipynb
+Finding ground state energy of molecules with DeepQMC,DeepQMC_tutorial.ipynb

--- a/examples/tutorials/website-render-order/6-bioinformatics.csv
+++ b/examples/tutorials/website-render-order/6-bioinformatics.csv
@@ -1,0 +1,5 @@
+Title,File Name
+Introduction to BioInformatics,Introduction_to_Bioinformatics.ipynb
+Multisequence Alignments,Multisequence_Alignments.ipynb
+Scanpy,Scanpy.ipynb
+Deep probabilistic analysis of omics data,Deep_probabilistic_analysis_of_single-cell_omics_data.ipynb

--- a/examples/tutorials/website-render-order/7-material-science.csv
+++ b/examples/tutorials/website-render-order/7-material-science.csv
@@ -1,0 +1,2 @@
+Title,File Name
+Introduction to Material Science,Introduction_To_Material_Science.ipynb

--- a/examples/tutorials/website-render-order/8-machine-learning-methods.csv
+++ b/examples/tutorials/website-render-order/8-machine-learning-methods.csv
@@ -1,0 +1,4 @@
+Title,File Name
+Using Reinforcement Learning to Play Pong,Using_Reinforcement_Learning_to_Play_Pong.ipynb
+Introduction to Model Interpretability,Introduction_to_Model_Interpretability.ipynb
+Uncertainty in Deep Learning,Uncertainty_In_Deep_Learning.ipynb

--- a/examples/tutorials/website-render-order/9-deep-differential-equations.csv
+++ b/examples/tutorials/website-render-order/9-deep-differential-equations.csv
@@ -1,0 +1,4 @@
+Title,File Name
+Physics Informed Neural Networks Burgers Equation,Physics_Informed_Neural_Networks.ipynb 
+Introducing_JaxModel_and_PINNModel,Introducing_JaxModel_and_PINNModel.ipynb
+About_nODE_Using_Torchdiffeq_in_Deepchem,About_nODE_Using_Torchdiffeq_in_Deepchem.ipynb


### PR DESCRIPTION
## Description

Added a csv file containing the order of the tutorials to be rendered on the deepchem website.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
