### PR TITLE
Added support for Multitask regression task in HuggingFace models 

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -134,7 +134,7 @@ class HuggingFaceModel(TorchModel):
             self.data_collator = DataCollatorForLanguageModeling(
                 tokenizer=tokenizer)
         else:
-            self.data_collator = None
+            self.data_collator = None  # type: ignore
         # Ignoring type. For TorchModel, loss is a required argument but HuggingFace computes
         # loss during the forward iteration, removing the need for a loss function.
         super(HuggingFaceModel, self).__init__(

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -46,7 +46,11 @@ class HuggingFaceModel(TorchModel):
     models: transformers.modeling_utils.PreTrainedModel
         The HuggingFace model to wrap.
     task: str
-        Pretraining or finetuning task
+        The task defines the type of learning task in the model. The supported tasks are
+         - `mlm` - masked language modeling commonly used in pretraining
+         - `mtr` - multitask regression - a task used for both pretraining base models and finetuning
+         - `regression` - use it for regression tasks, like property prediction
+         - `classification` - use it for classification tasks
     tokenizer: transformers.tokenization_utils.PreTrainedTokenizer
         Tokenizer
 
@@ -92,14 +96,14 @@ class HuggingFaceModel(TorchModel):
     >>> from transformers.models.roberta import RobertaForMaskedLM, RobertaModel, RobertaConfig
     >>> config = RobertaConfig(vocab_size=tokenizer.vocab_size)
     >>> model = RobertaForMaskedLM(config)
-    >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='pretraining', model_dir='model-dir')
+    >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='mlm', model_dir='model-dir')
     >>> training_loss = hf_model.fit(dataset, nb_epoch=1)
 
     >>> # finetuning a regression model
     >>> from transformers.models.roberta import RobertaForSequenceClassification
     >>> config = RobertaConfig(vocab_size=tokenizer.vocab_size, problem_type='regression', num_labels=1)
     >>> model = RobertaForSequenceClassification(config)
-    >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='finetuning', model_dir='model-dir')
+    >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='regression', model_dir='model-dir')
     >>> hf_model.load_from_pretrained()
     >>> training_loss = hf_model.fit(dataset, nb_epoch=1)
     >>> prediction = hf_model.predict(dataset)  # prediction
@@ -114,7 +118,7 @@ class HuggingFaceModel(TorchModel):
     >>> from transformers import RobertaForSequenceClassification
     >>> config = RobertaConfig(vocab_size=tokenizer.vocab_size)
     >>> model = RobertaForSequenceClassification(config)
-    >>> hf_model = HuggingFaceModel(model=model, task='finetuning', tokenizer=tokenizer)
+    >>> hf_model = HuggingFaceModel(model=model, task='classification', tokenizer=tokenizer)
     >>> training_loss = hf_model.fit(dataset, nb_epoch=1)
     >>> predictions = hf_model.predict(dataset)
     >>> eval_result = hf_model.evaluate(dataset, metrics=dc.metrics.Metric(dc.metrics.f1_score))
@@ -126,9 +130,11 @@ class HuggingFaceModel(TorchModel):
             **kwargs):
         self.task = task
         self.tokenizer = tokenizer
-        if self.task == 'pretraining':
+        if self.task == 'mlm':
             self.data_collator = DataCollatorForLanguageModeling(
                 tokenizer=tokenizer)
+        else:
+            self.data_collator = None
         # Ignoring type. For TorchModel, loss is a required argument but HuggingFace computes
         # loss during the forward iteration, removing the need for a loss function.
         super(HuggingFaceModel, self).__init__(
@@ -161,13 +167,13 @@ class HuggingFaceModel(TorchModel):
         >>> from transformers.models.roberta import RobertaForMaskedLM, RobertaModel, RobertaConfig
         >>> config = RobertaConfig(vocab_size=tokenizer.vocab_size)
         >>> model = RobertaForMaskedLM(config)
-        >>> pretrain_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='pretraining', model_dir='model-dir')
+        >>> pretrain_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='mlm', model_dir='model-dir')
         >>> pretrain_model.save_checkpoint()
 
         >>> from transformers import RobertaForSequenceClassification
         >>> config = RobertaConfig(vocab_size=tokenizer.vocab_size)
         >>> model = RobertaForSequenceClassification(config)
-        >>> finetune_model = HuggingFaceModel(model=model, task='finetuning', tokenizer=tokenizer, model_dir='model-dir')
+        >>> finetune_model = HuggingFaceModel(model=model, task='classification', tokenizer=tokenizer, model_dir='model-dir')
 
         >>> finetune_model.load_from_pretrained()
         """
@@ -189,24 +195,21 @@ class HuggingFaceModel(TorchModel):
                                            strict=False)
 
     def _prepare_batch(self, batch: Tuple[Any, Any, Any]):
-        if self.task == 'pretraining':
-            smiles_batch, _, w = batch
-            tokens = self.tokenizer(smiles_batch[0].tolist(),
-                                    padding=True,
-                                    return_tensors="pt")
+        smiles_batch, y, w = batch
+        tokens = self.tokenizer(smiles_batch[0].tolist(),
+                                padding=True,
+                                return_tensors="pt")
+
+        if self.task == 'mlm':
             inputs, labels = self.data_collator.torch_mask_tokens(
                 tokens['input_ids'])
             inputs = {'input_ids': inputs, 'labels': labels}
             return inputs, None, w
-        elif self.task == 'finetuning':
-            smiles_batch, y, w = batch
-            tokens = self.tokenizer(smiles_batch[0].tolist(),
-                                    padding=True,
-                                    return_tensors="pt")
+        elif self.task in ['regression', 'classification', 'mtr']:
             if y is not None:
                 # y is None during predict
                 y = torch.from_numpy(y[0])
-                if self.model.config.problem_type == 'regression':
+                if self.task == 'regression' or self.task == 'mtr':
                     y = y.float()
 
             inputs = {**tokens, 'labels': y}

--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -66,9 +66,7 @@ def test_pretraining(hf_tokenizer, smiles_dataset):
     config = RobertaConfig(vocab_size=hf_tokenizer.vocab_size)
     model = RobertaForMaskedLM(config)
 
-    hf_model = HuggingFaceModel(model=model,
-                                tokenizer=hf_tokenizer,
-                                task='pretraining')
+    hf_model = HuggingFaceModel(model=model, tokenizer=hf_tokenizer, task='mlm')
     loss = hf_model.fit(smiles_dataset, nb_epoch=1)
 
     assert loss
@@ -85,7 +83,7 @@ def test_hf_model_regression(hf_tokenizer, smiles_dataset):
     model = RobertaForSequenceClassification(config)
     hf_model = HuggingFaceModel(model=model,
                                 tokenizer=hf_tokenizer,
-                                task='finetuning')
+                                task='regression')
     hf_model.fit(smiles_dataset, nb_epoch=1)
     result = hf_model.predict(smiles_dataset)
     assert result.all()
@@ -107,7 +105,7 @@ def test_hf_model_classification(hf_tokenizer, smiles_dataset):
     config = RobertaConfig(vocab_size=hf_tokenizer.vocab_size)
     model = RobertaForSequenceClassification(config)
     hf_model = HuggingFaceModel(model=model,
-                                task='finetuning',
+                                task='classification',
                                 tokenizer=hf_tokenizer)
 
     hf_model.fit(dataset, nb_epoch=1)
@@ -128,7 +126,7 @@ def test_load_from_pretrained(tmpdir, hf_tokenizer):
     model = RobertaForMaskedLM(config)
     pretrained_model = HuggingFaceModel(model=model,
                                         tokenizer=hf_tokenizer,
-                                        task='pretraining',
+                                        task='mlm',
                                         model_dir=tmpdir)
     pretrained_model.save_checkpoint()
 
@@ -139,7 +137,7 @@ def test_load_from_pretrained(tmpdir, hf_tokenizer):
     model = RobertaForSequenceClassification(config)
     finetune_model = HuggingFaceModel(model=model,
                                       tokenizer=hf_tokenizer,
-                                      task='finetuning',
+                                      task='regression',
                                       model_dir=tmpdir)
 
     # Load pretrained model
@@ -170,7 +168,7 @@ def test_model_save_reload(tmpdir, hf_tokenizer):
     model = RobertaForSequenceClassification(config)
     hf_model = HuggingFaceModel(model=model,
                                 tokenizer=hf_tokenizer,
-                                task='finetuning',
+                                task='classification',
                                 model_dir=tmpdir)
     hf_model._ensure_built()
     hf_model.save_checkpoint()
@@ -178,7 +176,7 @@ def test_model_save_reload(tmpdir, hf_tokenizer):
     model = RobertaForSequenceClassification(config)
     hf_model2 = HuggingFaceModel(model=model,
                                  tokenizer=hf_tokenizer,
-                                 task='finetuning',
+                                 task='classification',
                                  model_dir=tmpdir)
 
     hf_model2.restore()


### PR DESCRIPTION
## Description

I have updated `HuggingFaceModel` class to allow for different type of tasks.

Earlier, task can only be `finetuning` or `pretraining`. If the task was `pretraining`, then the default 
pretraining mode assumed is masked language modeling and data was prepared accordingly. The problem with this approach was other pretraining task like multitask regression uses different data batching process (the batching does not involve masking as required for mlm) and hence, there was no way to generate data for tasks like `mtr`.

The PR broadens the scope of task by including various types of task like `mlm` for masked language modeling, `mtr` for multitask regression, `regression` and `classification` for simple regression and classification tasks. Task of type `finetuning` is removed since finetuning itself involves multiple subtasks like regression, classification, mtr. Instead, users can directly specify the task.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings