### PR TITLE
Fixing load from pretrained for huggingFace Models

### DIFF
--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -192,3 +192,22 @@ def test_model_save_reload(tmpdir, hf_tokenizer):
 
     # all keys should match
     assert all(matches)
+
+
+@pytest.mark.torch
+def test_load_from_hf_checkpoint():
+    from transformers.models.t5 import T5Config, T5Model
+    config = T5Config()
+    model = T5Model(config)
+    hf_model = HuggingFaceModel(model=model, tokenizer=None, task='regression')
+    old_state_dict = hf_model.model.state_dict()
+    hf_model_checkpoint = 't5-small'
+    hf_model.load_from_pretrained(hf_model_checkpoint, from_hf_checkpoint=True)
+    new_state_dict = hf_model.model.state_dict()
+    not_matches = [
+        not torch.allclose(old_state_dict[key], new_state_dict[key])
+        for key in old_state_dict.keys()
+    ]
+
+    # keys should not match
+    assert all(not_matches)


### PR DESCRIPTION
`HuggingFaceModel.load_from_pretrained` does not handle loading from pretrained well for loading models from 
hugging face checkpoint. The earlier implementation by me was not clear. This PR improves it and adds a test for 
checking loading of pretrained model from huggingface model checkpoint.

 ## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
