### PR TITLE
Allow loading only specific tasks in zinc15 dataset

### DIFF
--- a/deepchem/molnet/load_function/zinc15_datasets.py
+++ b/deepchem/molnet/load_function/zinc15_datasets.py
@@ -61,6 +61,7 @@ def load_zinc15(
     save_dir: Optional[str] = None,
     dataset_size: str = '250K',
     dataset_dimension: str = '2D',
+    tasks: List[str] = ZINC15_TASKS,
     **kwargs
 ) -> Tuple[List[str], Tuple[Dataset, ...], List[dc.trans.Transformer]]:
     """Load zinc15.
@@ -111,6 +112,9 @@ def load_zinc15(
         Size of dataset to download. '250K', '1M', '10M', and '270M' are supported.
     format : str (default '2D')
         Format of data to download. 2D SMILES strings or 3D SDF files.
+    tasks: List[str], (optional) default: `['molwt', 'logp', 'reactive']`
+        Specify the set of tasks to load. If no task is specified, then it loads
+    the default set of tasks which are molwt, logp, reactive.
 
     Returns
     -------
@@ -134,10 +138,12 @@ def load_zinc15(
     ----------
     .. [1] Sterling and Irwin. J. Chem. Inf. Model, 2015 http://pubs.acs.org/doi/abs/10.1021/acs.jcim.5b00559.
     """
+    for task in tasks:
+        assert task in ZINC15_TASKS, f'Invalid task name {task}. Task should be one of logp, mwt, reactive'
     loader = _Zinc15Loader(featurizer,
                            splitter,
                            transformers,
-                           ZINC15_TASKS,
+                           tasks,
                            data_dir,
                            save_dir,
                            dataset_size=dataset_size,


### PR DESCRIPTION
## Description

I had an use case where I need to load only a specific set of tasks from the zinc15 dataset. By default, 
`load_zinc15` loads all tasks (molwt, logp, reactive) but I want to use only logp for experiments. To allow for 
loading specific set of subtasks, I added an optional argument `tasks` which by default loads all tasks but when 
a subtask is specified, it loads only the specific subtask.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
