### PR TITLE
Adding evaluate method for MLM models

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -201,8 +201,10 @@ class HuggingFaceModel(TorchModel):
     def _prepare_batch(self, batch: Tuple[Any, Any, Any]):
         smiles_batch, y, w = batch
         tokens = self.tokenizer(smiles_batch[0].tolist(),
-                                padding=True,
-                                return_tensors="pt")
+                                return_tensors="pt",
+                                padding='max_length',
+                                max_length=100,
+                                truncation=True)
 
         if self.task == 'mlm':
             inputs, labels = self.data_collator.torch_mask_tokens(

--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -48,8 +48,11 @@ def test_pretraining(hf_tokenizer, smiles_regression_dataset):
 
     hf_model = HuggingFaceModel(model=model, tokenizer=hf_tokenizer, task='mlm')
     loss = hf_model.fit(smiles_regression_dataset, nb_epoch=1)
-
     assert loss
+
+    metrics = [dc.metrics.Metric(dc.metrics.accuracy_score)]
+    scores = hf_model.evaluate(smiles_regression_dataset, metrics=metrics)
+    assert scores['accuracy_score'] >= 0.0
 
 
 @pytest.mark.torch


### PR DESCRIPTION

## Description

In the current setup, evaluate does not work for masked langauge models since the input to mlm models are masked tokens which are generated on the fly and hence the labels are not known beforehand. An evaluate method in mlm will be useful for validating different mlm models. I have addressed this issue in the pull request by overriding the default `evaluate` method for masked langauge models and added tests for it.

Other changes: setting `max_length` as 100 (a hyperparameter) during tokenization of smiles strings to use in 
huggingface models and enabling padding and truncation. If the max_length variable is not set, input tokens can 
be of various length.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
