### PR TITLE
Adding gpu training support for chemberta and grover

### DIFF
--- a/deepchem/models/torch_models/grover.py
+++ b/deepchem/models/torch_models/grover.py
@@ -548,15 +548,20 @@ class GroverModel(ModularTorchModel):
             batchgraph)
 
         atom_vocab_label = torch.Tensor(
-            self.atom_vocab_random_mask(self.atom_vocab, smiles_batch)).long()
+            self.atom_vocab_random_mask(self.atom_vocab,
+                                        smiles_batch)).long().to(self.device)
         bond_vocab_label = torch.Tensor(
-            self.bond_vocab_random_mask(self.bond_vocab, smiles_batch)).long()
+            self.bond_vocab_random_mask(self.bond_vocab,
+                                        smiles_batch)).long().to(self.device)
         labels = {
             "av_task": atom_vocab_label,
             "bv_task": bond_vocab_label,
-            "fg_task": torch.Tensor(fgroup_label)
+            "fg_task": torch.Tensor(fgroup_label).to(self.device)
         }
-        inputs = (f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope, a2a)
+        inputs = (f_atoms.to(self.device), f_bonds.to(self.device),
+                  a2b.to(self.device), b2a.to(self.device),
+                  b2revb.to(self.device), a_scope.to(self.device),
+                  b_scope.to(self.device), a2a.to(self.device))
         return inputs, labels, w
 
     def _prepare_batch_for_finetuning(self, batch: Tuple[Any, Any, Any]):
@@ -583,13 +588,16 @@ class GroverModel(ModularTorchModel):
         X, y, w = batch
         batchgraph = BatchGraphData(X[0])
         if y is not None:
-            labels = torch.FloatTensor(y[0])
+            labels = torch.FloatTensor(y[0]).to(self.device)
         else:
             labels = None
         f_atoms, f_bonds, a2b, b2a, b2revb, a2a, a_scope, b_scope, _, additional_features = extract_grover_attributes(
             batchgraph)
-        inputs = (f_atoms, f_bonds, a2b, b2a, b2revb, a_scope, b_scope,
-                  a2a), additional_features
+        inputs = (f_atoms.to(self.device), f_bonds.to(self.device),
+                  a2b.to(self.device), b2a.to(self.device),
+                  b2revb.to(self.device), a_scope.to(self.device),
+                  b_scope.to(self.device),
+                  a2a.to(self.device)), additional_features.to(self.device)
         return inputs, labels, w
 
     def _pretraining_loss(self,

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -223,14 +223,20 @@ class HuggingFaceModel(TorchModel):
         if self.task == 'mlm':
             inputs, labels = self.data_collator.torch_mask_tokens(
                 tokens['input_ids'])
-            inputs = {'input_ids': inputs, 'labels': labels}
+            inputs = {
+                'input_ids': inputs.to(self.device),
+                'labels': labels.to(self.device)
+            }
             return inputs, None, w
         elif self.task in ['regression', 'classification', 'mtr']:
             if y is not None:
                 # y is None during predict
                 y = torch.from_numpy(y[0])
                 if self.task == 'regression' or self.task == 'mtr':
-                    y = y.float()
+                    y = y.float().to(self.device)
+
+            for key, value in tokens.items():
+                tokens[key] = value.to(self.device)
 
             inputs = {**tokens, 'labels': y}
             return inputs, y, w

--- a/deepchem/models/torch_models/tests/test_grover.py
+++ b/deepchem/models/torch_models/tests/test_grover.py
@@ -166,7 +166,8 @@ def test_grover_pretraining_task_overfit(tmpdir):
                         features_dim=2048,
                         hidden_size=128,
                         functional_group_size=85,
-                        task='pretraining')
+                        task='pretraining',
+                        device=torch.device('cpu'))
 
     # since pretraining is a self-supervision task where labels are generated during
     # preparing batch, we mock _prepare_batch_for_pretraining to set all labels to 0.
@@ -240,7 +241,8 @@ def test_grover_model_overfit_finetune(tmpdir):
                         functional_group_size=85,
                         mode='regression',
                         task='finetuning',
-                        model_dir='gm_ft')
+                        model_dir='gm_ft',
+                        device=torch.device('cpu'))
 
     loss = model.fit(graph_data, nb_epoch=200)
     scores = model.evaluate(
@@ -275,11 +277,11 @@ def test_grover_model_save_restore(tmpdir, task):
         'task': task
     }
 
-    old_model = GroverModel(**model_config)
+    old_model = GroverModel(**model_config, device=torch.device('cpu'))
     old_model._ensure_built()
     old_model.save_checkpoint()
 
-    new_model = GroverModel(**model_config)
+    new_model = GroverModel(**model_config, device=torch.device('cpu'))
     new_model._ensure_built()
     # checking weights don't match before restore
     old_state = old_model.model.state_dict()
@@ -323,14 +325,14 @@ def test_load_from_pretrained_embeddings(tmpdir):
     }
     model_config['task'] = 'pretraining'
 
-    pretrain_model = GroverModel(**model_config)
+    pretrain_model = GroverModel(**model_config, device=torch.device('cpu'))
     pretrain_model._ensure_built()
     pretrain_model.save_checkpoint()
 
     model_config['task'] = 'finetuning'
     model_config['model_dir'] = os.path.join(tmpdir, 'finetune_model')
 
-    finetune_model = GroverModel(**model_config)
+    finetune_model = GroverModel(**model_config, device=torch.device('cpu'))
     finetune_model._ensure_built()
 
     pm_e_sdict = pretrain_model.model.embedding.state_dict()

--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -46,7 +46,10 @@ def test_pretraining(hf_tokenizer, smiles_regression_dataset):
     config = RobertaConfig(vocab_size=hf_tokenizer.vocab_size)
     model = RobertaForMaskedLM(config)
 
-    hf_model = HuggingFaceModel(model=model, tokenizer=hf_tokenizer, task='mlm')
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=hf_tokenizer,
+                                task='mlm',
+                                device=torch.device('cpu'))
     loss = hf_model.fit(smiles_regression_dataset, nb_epoch=1)
 
     assert loss
@@ -63,7 +66,8 @@ def test_hf_model_regression(hf_tokenizer, smiles_regression_dataset):
     model = RobertaForSequenceClassification(config)
     hf_model = HuggingFaceModel(model=model,
                                 tokenizer=hf_tokenizer,
-                                task='regression')
+                                task='regression',
+                                device=torch.device('cpu'))
     hf_model.fit(smiles_regression_dataset, nb_epoch=1)
     result = hf_model.predict(smiles_regression_dataset)
 
@@ -87,7 +91,8 @@ def test_hf_model_classification(hf_tokenizer, smiles_regression_dataset):
     model = RobertaForSequenceClassification(config)
     hf_model = HuggingFaceModel(model=model,
                                 task='classification',
-                                tokenizer=hf_tokenizer)
+                                tokenizer=hf_tokenizer,
+                                device=torch.device('cpu'))
 
     hf_model.fit(dataset, nb_epoch=1)
     result = hf_model.predict(dataset)
@@ -108,7 +113,8 @@ def test_load_from_pretrained(tmpdir, hf_tokenizer):
     pretrained_model = HuggingFaceModel(model=model,
                                         tokenizer=hf_tokenizer,
                                         task='mlm',
-                                        model_dir=tmpdir)
+                                        model_dir=tmpdir,
+                                        device=torch.device('cpu'))
     pretrained_model.save_checkpoint()
 
     # Create finetuning model
@@ -119,7 +125,8 @@ def test_load_from_pretrained(tmpdir, hf_tokenizer):
     finetune_model = HuggingFaceModel(model=model,
                                       tokenizer=hf_tokenizer,
                                       task='regression',
-                                      model_dir=tmpdir)
+                                      model_dir=tmpdir,
+                                      device=torch.device('cpu'))
 
     # Load pretrained model
     finetune_model.load_from_pretrained()
@@ -150,7 +157,8 @@ def test_model_save_reload(tmpdir, hf_tokenizer):
     hf_model = HuggingFaceModel(model=model,
                                 tokenizer=hf_tokenizer,
                                 task='classification',
-                                model_dir=tmpdir)
+                                model_dir=tmpdir,
+                                device=torch.device('cpu'))
     hf_model._ensure_built()
     hf_model.save_checkpoint()
 
@@ -158,8 +166,8 @@ def test_model_save_reload(tmpdir, hf_tokenizer):
     hf_model2 = HuggingFaceModel(model=model,
                                  tokenizer=hf_tokenizer,
                                  task='classification',
-                                 model_dir=tmpdir)
-
+                                 model_dir=tmpdir,
+                                 device=torch.device('cpu'))
     hf_model2.restore()
 
     old_state = hf_model.model.state_dict()
@@ -178,7 +186,10 @@ def test_load_from_hf_checkpoint():
     from transformers.models.t5 import T5Config, T5Model
     config = T5Config()
     model = T5Model(config)
-    hf_model = HuggingFaceModel(model=model, tokenizer=None, task=None)
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=None,
+                                task=None,
+                                device=torch.device('cpu'))
     old_state_dict = hf_model.model.state_dict()
     hf_model_checkpoint = 't5-small'
     hf_model.load_from_pretrained(hf_model_checkpoint, from_hf_checkpoint=True)

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -194,6 +194,8 @@ class TorchModel(Model):
         if device is None:
             if torch.cuda.is_available():
                 device = torch.device('cuda')
+            elif torch.backends.mps.is_available():
+                device = torch.device('mps')
             else:
                 device = torch.device('cpu')
         self.device = device


### PR DESCRIPTION
## Description

To train models on gpu, we need to move the tensors to the gpu device.
In the earlier implementation, this piece was missing (credits to myself).
I have added the missing piece here - moving of tensors to gpu for training models on gpu.

Along with this, I have added support mps backend for training on apple m1 gpu.

Corresponding changes have been made to tests to pin the device as cpu during testing.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
