### PR TITLE
Fix grover vocabulary builder

### DIFF
--- a/deepchem/feat/vocabulary_builders/grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/grover_vocab.py
@@ -1,4 +1,5 @@
 import json
+import numpy as np
 from typing import Dict, Optional
 from collections import Counter
 from rdkit import Chem
@@ -76,7 +77,12 @@ class GroverAtomVocabularyBuilder(VocabularyBuilder):
         """
         counter: Dict[str, int] = Counter()
         for x, _, _, _ in dataset.itersamples():
-            smiles = x[0]
+            if isinstance(x, str):
+                smiles = x
+            elif isinstance(x, np.ndarray):
+                x = x.squeeze()
+                assert x.ndim == 0, 'expected x attribute of dataset to be a 1-D array of SMILES strings'
+                smiles = x.item()
             mol = Chem.MolFromSmiles(smiles)
             for atom in mol.GetAtoms():
                 v = self.atom_to_vocab(mol, atom)
@@ -266,7 +272,10 @@ class GroverBondVocabularyBuilder(VocabularyBuilder):
         """
         counter: Dict[str, int] = Counter()
         for x, _, _, _ in dataset.itersamples():
-            smiles = x[0]
+            if isinstance(x, str):
+                smiles = x
+            elif isinstance(x, np.ndarray):
+                smiles = x.squeeze().item()
             mol = Chem.MolFromSmiles(smiles)
             for bond in mol.GetBonds():
                 v = self.bond_to_vocab(mol, bond)

--- a/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
@@ -6,19 +6,20 @@ import deepchem as dc
 def testGroverAtomVocabularyBuilder():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverAtomVocabularyBuilder
     file = tempfile.NamedTemporaryFile()
-    dataset = dc.data.NumpyDataset(X=[['CC(=O)C', 'CCC']])
+    dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverAtomVocabularyBuilder()
     vocab.build(dataset)
     assert vocab.stoi == {
         '<pad>': 0,
         '<other>': 1,
         'C_C-SINGLE1': 2,
-        'C_C-SINGLE2_O-DOUBLE1': 3,
-        'O_C-DOUBLE1': 4
+        'C_C-SINGLE2': 3,
+        'C_C-SINGLE2_O-DOUBLE1': 4,
+        'O_C-DOUBLE1': 5
     }
     assert vocab.itos == [
-        '<pad>', '<other>', 'C_C-SINGLE1', 'C_C-SINGLE2_O-DOUBLE1',
-        'O_C-DOUBLE1'
+        '<pad>', '<other>', 'C_C-SINGLE1', 'C_C-SINGLE2',
+        'C_C-SINGLE2_O-DOUBLE1', 'O_C-DOUBLE1'
     ]
     vocab.save(file.name)
 
@@ -38,7 +39,7 @@ def testGroverAtomVocabularyBuilder():
 def testGroverBondVocabularyBuilder():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder
     file = tempfile.NamedTemporaryFile()
-    dataset = dc.data.NumpyDataset(X=[['CC(=O)C', 'CCC']])
+    dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverBondVocabularyBuilder()
     vocab.build(dataset)
     assert vocab.stoi == {
@@ -48,12 +49,15 @@ def testGroverBondVocabularyBuilder():
             1,
         '(SINGLE-STEREONONE-NONE)_C-(DOUBLE-STEREONONE-NONE)1_C-(SINGLE-STEREONONE-NONE)1':
             2,
+        '(SINGLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)1':
+            3,
         '(DOUBLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)2':
-            3
+            4,
     }
     assert vocab.itos == [
         '<pad>', '<other>',
         '(SINGLE-STEREONONE-NONE)_C-(DOUBLE-STEREONONE-NONE)1_C-(SINGLE-STEREONONE-NONE)1',
+        '(SINGLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)1',
         '(DOUBLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)2'
     ]
     vocab.save(file.name)
@@ -76,7 +80,7 @@ def testGroverBondVocabularyBuilder():
 def testGroverAtomVocabTokenizer():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverAtomVocabularyBuilder, GroverAtomVocabTokenizer
     file = tempfile.NamedTemporaryFile()
-    dataset = dc.data.NumpyDataset(X=[['CC(=O)C', 'CCC']])
+    dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverAtomVocabularyBuilder()
     vocab.build(dataset)
     vocab.save(file.name)  # build and save the vocabulary
@@ -91,7 +95,7 @@ def testGroverAtomVocabTokenizer():
 def testGroverBondVocabTokenizer():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder, GroverBondVocabTokenizer
     file = tempfile.NamedTemporaryFile()
-    dataset = dc.data.NumpyDataset(X=[['CC(=O)C', 'CCC']])
+    dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverBondVocabularyBuilder()
     vocab.build(dataset)
     vocab.save(file.name)  # build and save the vocabulary


### PR DESCRIPTION
## Description

Fix #3449

Earlier, grover vocabulary builder used only one smiles string when a list of smiles string where passed as x 
attribute.

Now, it raises an error when a list of smiles string is passed.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
