### PR TITLE
Fix in RDKitDescriptors

### DIFF
--- a/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
+++ b/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
@@ -142,7 +142,7 @@ class RDKitDescriptors(MolecularFeaturizer):
             The length is `len(self.descriptors)`.
 
         """
-        features: List[Union[int, float]] = []
+        features = []
         for desc_name, function in self.reqd_properties.items():
             if desc_name == 'Ipc' and self.ipc_avg:
                 feature = function(datapoint, avg=True)
@@ -155,10 +155,10 @@ class RDKitDescriptors(MolecularFeaturizer):
 
             features.append(feature)
 
-        features = np.asarray(features)
+        np_features = np.asarray(features)
         if self.labels_only:
-            np.putmask(features, features != 0, 1)
-        return features
+            np.putmask(np_features, np_features != 0, 1)
+        return np_features
 
     def _make_normalised_func_dict(self):
         """

--- a/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
+++ b/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
@@ -155,9 +155,10 @@ class RDKitDescriptors(MolecularFeaturizer):
 
             features.append(feature)
 
+        features = np.asarray(features)
         if self.labels_only:
-            features[features != 0] = 1
-        return np.asarray(features)
+            np.putmask(features, features != 0, 1)
+        return features
 
     def _make_normalised_func_dict(self):
         """

--- a/deepchem/feat/tests/test_rdkit_descriptors.py
+++ b/deepchem/feat/tests/test_rdkit_descriptors.py
@@ -106,5 +106,14 @@ class TestRDKitDescriptors(unittest.TestCase):
                                       labels_only=True)
         features = featurizer.featurize(smiles)[0]
         assert len(features) == len(grover_props)
-        assert sum(features) == 4  # expected number of functional groups in CCC
-        assert (np.where(features == 1)[0] == (1, 10, 11, 23)).all()
+        assert sum(
+            features) == 3  # expected number of functional groups in CCC(=O)
+        assert (np.where(features == 1)[0] == (10, 11, 23)).all()
+
+    def test_with_labels_only(self):
+        descriptors = ['fr_Al_COO', 'fr_Al_OH', 'fr_allylic_oxid']
+        smiles = 'CC(C)=CCCC(C)=CC(=O)'
+        featurizer = RDKitDescriptors(descriptors=descriptors, labels_only=True)
+        features = featurizer.featurize(smiles)[0]
+        assert len(features) == len(descriptors)
+        assert (features == [0, 0, 1]).all()


### PR DESCRIPTION
## Description

Fix #3483

Update program logic in setting labels only attribute in `RDKitDescriptors`. Earlier, it was `features[features 
!= 0] = 1`. Here, `features` is a list and `features != 0` computed whether `features` is 0 or not. This is 
incorrect as we have to compare elements of `features` with 0 and not the list itself. The update uses 
`np.putmask` to mask elements and replace others with 1.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
