### PR TITLE
Fix typo in pytest markers of infomax

### DIFF
--- a/deepchem/models/tests/test_gnn3d.py
+++ b/deepchem/models/tests/test_gnn3d.py
@@ -59,7 +59,7 @@ def get_regression_dataset():
     return dataset, metric
 
 
-@pytest.mark.pytorch
+@pytest.mark.torch
 def test_net3d():
     import numpy as np
 
@@ -86,7 +86,7 @@ def compare_weights(key, model1, model2):
                  model2.components[key].weight)).item()
 
 
-@pytest.mark.pytorch
+@pytest.mark.torch
 def test_InfoMax3DModular():
     from deepchem.models.torch_models.gnn3d import InfoMax3DModular
 
@@ -103,7 +103,7 @@ def test_InfoMax3DModular():
     assert loss1 > loss2
 
 
-@pytest.mark.pytorch
+@pytest.mark.torch
 def test_InfoMax3DModular_save_reload():
     from deepchem.models.torch_models.gnn3d import InfoMax3DModular
 


### PR DESCRIPTION
## Description

Fixes typo in pytest marker for infomax tests - `pytorch` -> `torch`. The change will allow test for gnn3d models 
to run in torch CI.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
