### PR TITLE
Adding weighted_skip parameter to MutilayerPerceptron layer

### DIFF
--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -664,7 +664,7 @@ def test_position_wise_feed_forward():
                           (True, False, [[-0.9612, 2.3846], [-4.1104, 5.7606]]),
                           (False, True, [[0.2795, 0.4243], [0.2795, 0.4243]]),
                           (True, True, [[-0.9612, 2.3846], [-4.1104, 5.7606]])])
-def test_MultilayerPerceptron(skip_connection, batch_norm, expected):
+def test_multilayer_perceptron(skip_connection, batch_norm, expected):
     """Test invoking MLP."""
     torch.manual_seed(0)
     input_ar = torch.tensor([[1., 2.], [5., 6.]])
@@ -681,7 +681,7 @@ def test_MultilayerPerceptron(skip_connection, batch_norm, expected):
 
 
 @pytest.mark.torch
-def test_MultilayerPerceptron_overfit():
+def test_multilayer_perceptron_overfit():
     import torch
     import deepchem.models.torch_models.layers as torch_layers
     from deepchem.data import NumpyDataset
@@ -704,7 +704,7 @@ def test_MultilayerPerceptron_overfit():
 
 
 @pytest.mark.torch
-def test_weighted_skip_MultilayerPerceptron():
+def test_weighted_skip_multilayer_perceptron():
     "Test for weighted skip connection from the input to the output"
     seed = 123
     torch.manual_seed(seed)

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -704,6 +704,30 @@ def test_MultilayerPerceptron_overfit():
 
 
 @pytest.mark.torch
+def test_weighted_skip_MultilayerPerceptron():
+    "Test for weighted skip connection from the input to the output"
+    seed = 123
+    torch.backends.cudnn.deterministic = True
+    torch.backends.cudnn.benchmark = False
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    dim = 1
+    features = torch.Tensor([[0.8343], [1.2713], [1.2713], [1.2713], [1.2713]])
+    layer = dc.models.torch_models.layers.MultilayerPerceptron(
+        d_input=dim,
+        d_hidden=(dim,),
+        d_output=dim,
+        activation_fn='silu',
+        weighted_skip=False)
+    output = layer(features)
+    output = output.detach().numpy()
+    result = np.array([[1.1032], [1.5598], [1.5598], [1.5598], [1.5598]])
+    assert np.allclose(output, result, atol=1e-04)
+    assert output.shape == (5, 1)
+
+
+@pytest.mark.torch
 def test_position_wise_feed_forward_dropout_at_input():
     """Test invoking PositionwiseFeedForward."""
     torch.manual_seed(0)

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -707,11 +707,7 @@ def test_MultilayerPerceptron_overfit():
 def test_weighted_skip_MultilayerPerceptron():
     "Test for weighted skip connection from the input to the output"
     seed = 123
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
     torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-
     dim = 1
     features = torch.Tensor([[0.8343], [1.2713], [1.2713], [1.2713], [1.2713]])
     layer = dc.models.torch_models.layers.MultilayerPerceptron(
@@ -719,6 +715,7 @@ def test_weighted_skip_MultilayerPerceptron():
         d_hidden=(dim,),
         d_output=dim,
         activation_fn='silu',
+        skip_connection=True,
         weighted_skip=False)
     output = layer(features)
     output = output.detach().numpy()

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -104,10 +104,11 @@ class MultilayerPerceptron(nn.Module):
                 x = self.activation_fn(
                     x
                 )  # Done because activation_fn returns a torch.nn.functional
-        if not self.weighted_skip:
-            return x + input
-        elif self.skip is not None:
-            return x + self.skip(input)
+        if self.skip is not None:
+            if not self.weighted_skip:
+                return x + input
+            else:
+                return x + self.skip(input)
         else:
             return x
 

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -40,7 +40,8 @@ class MultilayerPerceptron(nn.Module):
                  batch_norm: bool = False,
                  batch_norm_momentum: float = 0.1,
                  activation_fn: Union[Callable, str] = 'relu',
-                 skip_connection: bool = False):
+                 skip_connection: bool = False,
+                 weighted_skip: bool = True):
         """Initialize the model.
 
         Parameters
@@ -61,6 +62,8 @@ class MultilayerPerceptron(nn.Module):
             the activation function to use in the hidden layers
         skip_connection: bool
             whether to add a skip connection from the input to the output
+        weighted_skip: bool
+            whether to add a weighted skip connection from the input to the output
         """
         super(MultilayerPerceptron, self).__init__()
         self.d_input = d_input
@@ -72,6 +75,7 @@ class MultilayerPerceptron(nn.Module):
         self.activation_fn = get_activation(activation_fn)
         self.model = nn.Sequential(*self.build_layers())
         self.skip = nn.Linear(d_input, d_output) if skip_connection else None
+        self.weighted_skip = weighted_skip
 
     def build_layers(self):
         """
@@ -100,7 +104,9 @@ class MultilayerPerceptron(nn.Module):
                 x = self.activation_fn(
                     x
                 )  # Done because activation_fn returns a torch.nn.functional
-        if self.skip is not None:
+        if not self.weighted_skip:
+            return x + input
+        elif self.skip is not None:
             return x + self.skip(input)
         else:
             return x


### PR DESCRIPTION
## Description

By Adding weighted_skip parameter to MutilayerPerceptron layer, it can be used for skip connection as well. Hence, it can be used in place of ResidualBlock for Global and Local Message Passing in MXMNet Model.

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
