### PR TITLE
Grover finetuning fix on mps/cuda devices

### DIFF
--- a/deepchem/models/torch_models/grover.py
+++ b/deepchem/models/torch_models/grover.py
@@ -221,9 +221,6 @@ class GroverFinetune(nn.Module):
                                                  atom_scope)
 
         if additional_features[0] is not None:
-            additional_features = torch.from_numpy(
-                np.stack(additional_features)).float()
-            additional_features.to(output["atom_from_bond"])
             if len(additional_features.shape) == 1:
                 additional_features = additional_features.view(
                     1, additional_features.shape[0])


### PR DESCRIPTION
## Description

Fixes #3506 

In this line,
https://github.com/deepchem/deepchem/blob/6ce8cd62d9a1a6a9e59fc6cd3d4d6c84e3046135/deepchem/models/torch_models/grover.py?plain=1#L224-L225

we need not use `torch.from_numpy` since `additional_features` is already a torch.Tensor (made here:
https://github.com/deepchem/deepchem/blob/6ce8cd62d9a1a6a9e59fc6cd3d4d6c84e3046135/deepchem/utils/grover.py?plain=1#L192



Also the next line,
https://github.com/deepchem/deepchem/blob/6ce8cd62d9a1a6a9e59fc6cd3d4d6c84e3046135/deepchem/models/torch_models/grover.py?plain=1#L226

is not needed since it is moved to device here:
https://github.com/deepchem/deepchem/blob/6ce8cd62d9a1a6a9e59fc6cd3d4d6c84e3046135/deepchem/models/torch_models/grover.py?plain=1#L597

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
