### PR TITLE
Variable name change in infograph

### DIFF
--- a/deepchem/models/torch_models/infograph.py
+++ b/deepchem/models/torch_models/infograph.py
@@ -303,10 +303,10 @@ class InfoGraphModel(ModularTorchModel):
 
     Parameters
     ----------
-    num_features: int
-        Number of node features for each input
-    edge_features: int
-        Number of edge features for each input
+    node_fdim: int
+        Number of node features in input graph data
+    edge_fdim: int
+        Number of edge features in input graph data
     embedding_dim: int
         Dimension of the embedding
     num_gc_layers: int
@@ -345,8 +345,8 @@ class InfoGraphModel(ModularTorchModel):
     """
 
     def __init__(self,
-                 num_features,
-                 embedding_dim,
+                 node_fdim,
+                 edge_fdim,
                  num_gc_layers=5,
                  prior=True,
                  gamma=.1,
@@ -357,8 +357,9 @@ class InfoGraphModel(ModularTorchModel):
                  **kwargs):
         if task == 'regression':
             assert n_tasks, 'Number of prediction tasks required for building regression model'
-        self.num_features = num_features
-        self.embedding_dim = embedding_dim * num_gc_layers
+        # TODO Replace num_features with node_fdim in other instances for better readability
+        self.num_features = node_fdim
+        self.embedding_dim = edge_fdim * num_gc_layers
         self.num_gc_layers = num_gc_layers
         self.gamma = gamma
         self.prior = prior

--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -93,9 +93,11 @@ def load_bace_classification(
     save_dir: Optional[str] = None,
     **kwargs
 ) -> Tuple[List[str], Tuple[Dataset, ...], List[dc.trans.Transformer]]:
-    """ Load BACE dataset, classification labels
+    """Load BACE dataset with classification labels.
 
-    BACE dataset with classification labels ("class").
+    BACE dataset with classification labels ("class"). The BACE dataset
+    contains 1513 compounds and the dataset is a binary classification
+    dataset with labels 0 or 1.
 
     Parameters
     ----------


### PR DESCRIPTION
## Description

The user arg `embedding_dim` was misleading as it meant dimension of embedding but expected input as number of 
edge features. I have updated it to `edge_fdim` to make it a more meaningful name.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
