### PR TITLE
Added additional user argument to load subset of tasks in tox21 dataset

### DIFF
--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -34,6 +34,7 @@ def load_tox21(
     reload: bool = True,
     data_dir: Optional[str] = None,
     save_dir: Optional[str] = None,
+    tasks: List[str] = TOX21_TASKS,
     **kwargs
 ) -> Tuple[List[str], Tuple[Dataset, ...], List[dc.trans.Transformer]]:
     """Load Tox21 dataset
@@ -75,11 +76,15 @@ def load_tox21(
         a directory to save the raw data in
     save_dir: str
         a directory to save the dataset in
+    tasks: List[str], (optional)
+        Specify the set of tasks to load. If no task is specified, then it loads
+    the default set of tasks which are NR-AR, NR-AR-LBD, NR-AhR, NR-Aromatase, NR-ER,
+    NR-ER-LBD, NR-PPAR-gamma, SR-ARE, SR-ATAD5, SR-HSE, SR-MMP, SR-p53.
 
     References
     ----------
     .. [1] Tox21 Challenge. https://tripod.nih.gov/tox21/challenge/
     """
-    loader = _Tox21Loader(featurizer, splitter, transformers, TOX21_TASKS,
-                          data_dir, save_dir, **kwargs)
+    loader = _Tox21Loader(featurizer, splitter, transformers, tasks, data_dir,
+                          save_dir, **kwargs)
     return loader.load_dataset('tox21', reload)


### PR DESCRIPTION
## Description

I have added an argument `tasks` to allow users to load only a subset of tasks when loading `tox21` dataset.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
