### PR TITLE
Skip scaffold generation on invalid molecules

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1508,9 +1508,13 @@ class ScaffoldSplitter(Splitter):
     .. [1] Bemis, Guy W., and Mark A. Murcko. "The properties of known drugs.
         1. Molecular frameworks." Journal of medicinal chemistry 39.15 (1996): 2887-2893.
 
-    Note
-    ----
-    This class requires RDKit to be installed.
+    Notes
+    -----
+    - This class requires RDKit to be installed.
+
+    - When a SMILES representation of a molecule is invalid, the splitter skips processing
+    the datapoint i.e it will not include the molecule in any splits.
+
     """
 
     def split(

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -2,17 +2,16 @@
 Contains an abstract base class that supports chemically aware data splits.
 """
 import inspect
+import itertools
+import logging
 import os
 import random
 import tempfile
-import itertools
-import logging
-from typing import Any, Dict, List, Iterator, Optional, Sequence, Tuple
-
-import numpy as np
-import pandas as pd
+from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 import deepchem as dc
+import numpy as np
+import pandas as pd
 from deepchem.data import Dataset, DiskDataset
 from deepchem.utils import get_print_threshold
 
@@ -1274,7 +1273,8 @@ class ButinaSplitter(Splitter):
         return train_inds, valid_inds, test_inds
 
 
-def _generate_scaffold(smiles: str, include_chirality: bool = False) -> str:
+def _generate_scaffold(smiles: str,
+                       include_chirality: bool = False) -> Union[str, None]:
     """Compute the Bemis-Murcko scaffold for a SMILES string.
 
     Bemis-Murcko scaffolds are described in DOI: 10.1021/jm9602928.
@@ -1309,6 +1309,12 @@ def _generate_scaffold(smiles: str, include_chirality: bool = False) -> str:
         raise ImportError("This function requires RDKit to be installed.")
 
     mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        logger.info(
+            'Not generating scaffold for smiles %s - invalid smiles string' %
+            smiles)
+        return None
+
     scaffold = MurckoScaffoldSmiles(mol=mol, includeChirality=include_chirality)
     return scaffold
 
@@ -1588,10 +1594,11 @@ class ScaffoldSplitter(Splitter):
             if ind % log_every_n == 0:
                 logger.info("Generating scaffold %d/%d" % (ind, data_len))
             scaffold = _generate_scaffold(smiles)
-            if scaffold not in scaffolds:
-                scaffolds[scaffold] = [ind]
-            else:
-                scaffolds[scaffold].append(ind)
+            if scaffold is not None:
+                if scaffold not in scaffolds:
+                    scaffolds[scaffold] = [ind]
+                else:
+                    scaffolds[scaffold].append(ind)
 
         # Sort from largest to smallest scaffold sets
         scaffolds = {key: sorted(value) for key, value in scaffolds.items()}

--- a/deepchem/splits/tests/test_scaffold_splitter.py
+++ b/deepchem/splits/tests/test_scaffold_splitter.py
@@ -23,3 +23,14 @@ class TestScaffoldSplitter(unittest.TestCase):
         # has to be smaller or equal than number of total molecules
         scaffolds_separate_cnt = len(scaffolds_separate)
         self.assertTrue(scaffolds_separate_cnt <= train_dataset.X.shape[0])
+
+    def test_generate_scaffold(self):
+        from deepchem.splits.splitters import _generate_scaffold
+        valid_smiles = r's1cc(nc1\[N]=C(\N)N)C'
+        scaffold = _generate_scaffold(valid_smiles)
+        self.assertTrue(scaffold == 'c1cscn1')
+
+        # Invalid because valence for atom 5 N is greater than permitted (4)
+        invalid_smiles = r's1cc(nc1\[NH]=C(\N)N)C'
+        scaffold = _generate_scaffold(invalid_smiles)
+        self.assertIsNone(scaffold)


### PR DESCRIPTION
## Description

Fix #3512

Add a conditional check to skip scaffold split on invalid molecules.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this 
project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
