### PR TITLE
chemberta set problem type in config

### DIFF
--- a/deepchem/models/torch_models/chemberta.py
+++ b/deepchem/models/torch_models/chemberta.py
@@ -100,6 +100,10 @@ class Chemberta(HuggingFaceModel):
             chemberta_config.num_labels = n_tasks
             model = RobertaForSequenceClassification(chemberta_config)
         elif task == 'classification':
+            if n_tasks == 1:
+                chemberta_config.problem_type = 'single_label_classification'
+            else:
+                chemberta_config.problem_type = 'multi_label_classification'
             model = RobertaForSequenceClassification(chemberta_config)
         else:
             raise ValueError('invalid task specification')

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -234,7 +234,8 @@ class HuggingFaceModel(TorchModel):
                 y = torch.from_numpy(y[0])
                 if self.task == 'regression' or self.task == 'mtr':
                     y = y.float().to(self.device)
-
+                elif self.task == 'classification':
+                    y = y.long().to(self.device)
             for key, value in tokens.items():
                 tokens[key] = value.to(self.device)
 


### PR DESCRIPTION
## Description

Set `problem_type` during chemberta model intialisation for classification model.
When this attribute is not set, transformers library assign problem type by inspecting `labels`, which I can turn out to be wrong in some cases. For example, when I was trying out single label classification, the assigned problem type was different across different runs of the instance.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
