### PR TITLE
Atomic Convolution Module with Pytorch

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -17,7 +17,7 @@ from deepchem.models.torch_models.pagtn import Pagtn, PagtnModel
 from deepchem.models.torch_models.mat import MAT, MATModel
 from deepchem.models.torch_models.megnet import MEGNetModel
 from deepchem.models.torch_models.normalizing_flows_pytorch import NormalizingFlow
-from deepchem.models.torch_models.layers import MultilayerPerceptron, CNNModule, CombineMeanStd, WeightedLinearCombo, AtomicConvolution, NeighborList, SetGather, EdgeNetwork, WeaveLayer, WeaveGather, MolGANConvolutionLayer, MolGANAggregationLayer, MolGANMultiConvolutionLayer, MolGANEncoderLayer, VariationalRandomizer, EncoderRNN, DecoderRNN
+from deepchem.models.torch_models.layers import MultilayerPerceptron, CNNModule, CombineMeanStd, WeightedLinearCombo, AtomicConvolution, NeighborList, SetGather, EdgeNetwork, WeaveLayer, WeaveGather, MolGANConvolutionLayer, MolGANAggregationLayer, MolGANMultiConvolutionLayer, MolGANEncoderLayer, VariationalRandomizer, EncoderRNN, DecoderRNN, AtomicConv
 from deepchem.models.torch_models.cnn import CNN
 from deepchem.models.torch_models.weavemodel_pytorch import Weave, WeaveModel
 from deepchem.models.torch_models.attention import ScaledDotProductAttention, SelfAttention

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -1,6 +1,7 @@
 import math
 from math import pi as PI
 import numpy as np
+import itertools
 import sympy as sym
 from typing import Any, Tuple, Optional, Sequence, List, Union, Callable, Dict, TypedDict
 from collections.abc import Sequence as SequenceCollection
@@ -2661,6 +2662,243 @@ class AtomicConvolution(nn.Module):
         FC = self.radial_cutoff(R, rc)
 
         return torch.mul(K, FC)
+
+
+class AtomicConv(nn.Module):
+    """
+    Implements an Atomic Convolution Model.
+
+    The atomic convolutional networks function as a variant of
+    graph convolutions. The difference is that the "graph" here is
+    the nearest neighbors graph in 3D space [1]. The AtomicConvModule
+    leverages these connections in 3D space to train models that
+    learn to predict energetic states starting from the spatial
+    geometry of the model.
+
+    References
+    ----------
+    .. [1] Gomes, Joseph, et al. "Atomic convolutional networks for predicting protein-ligand binding affinity." arXiv preprint arXiv:1703.10603 (2017).
+
+    Examples
+    --------
+    >>> n_tasks = 1
+    >>> frag1_num_atoms = 70
+    >>> frag2_num_atoms = 634
+    >>> complex_num_atoms = 701
+    >>> max_num_neighbors = 12
+    >>> batch_size = 24
+    >>> atom_types = [
+            6, 7., 8., 9., 11., 12., 15., 16., 17., 20., 25., 30., 35., 53.,
+            -1.
+        ]
+    >>> radial = [[
+            1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0, 7.5,
+            8.0, 8.5, 9.0, 9.5, 10.0, 10.5, 11.0, 11.5, 12.0
+        ], [0.0, 4.0, 8.0], [0.4]]
+    >>> layer_sizes = [32, 32, 16]
+    >>> acnn_model = AtomicConv(n_tasks=n_tasks,
+        frag1_num_atoms=frag1_num_atoms,
+        frag2_num_atoms=frag2_num_atoms,
+        complex_num_atoms=complex_num_atoms,
+        max_num_neighbors=max_num_neighbors,
+        batch_size=batch_size,
+        atom_types=atom_types,
+        radial=radial,
+        layer_sizes=layer_sizes)
+    """
+
+    def __init__(self,
+                 n_tasks: int,
+                 frag1_num_atoms: int = 70,
+                 frag2_num_atoms: int = 634,
+                 complex_num_atoms: int = 701,
+                 max_num_neighbors: int = 12,
+                 batch_size: int = 24,
+                 atom_types: Sequence[float] = [
+                     6, 7., 8., 9., 11., 12., 15., 16., 17., 20., 25., 30., 35.,
+                     53., -1.
+                 ],
+                 radial: Sequence[Sequence[float]] = [[
+                     1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5.0, 5.5, 6.0, 6.5, 7.0,
+                     7.5, 8.0, 8.5, 9.0, 9.5, 10.0, 10.5, 11.0, 11.5, 12.0
+                 ], [0.0, 4.0, 8.0], [0.4]],
+                 layer_sizes=[100],
+                 weight_init_stddevs: OneOrMany[float] = 0.02,
+                 bias_init_consts: OneOrMany[float] = 1.0,
+                 dropouts: OneOrMany[float] = 0.5,
+                 activation_fns: OneOrMany[ActivationFn] = ['relu'],
+                 init: str = 'trunc_normal_',
+                 **kwargs) -> None:
+        """
+        Parameters
+        ----------
+        n_tasks: int
+            number of tasks
+        frag1_num_atoms: int
+            Number of atoms in first fragment
+        frag2_num_atoms: int
+            Number of atoms in sec
+        max_num_neighbors: int
+            Maximum number of neighbors possible for an atom. Recall neighbors
+            are spatial neighbors.
+        atom_types: list
+            List of atoms recognized by model. Atoms are indicated by their
+            nuclear numbers.
+        radial: list
+            Radial parameters used in the atomic convolution transformation.
+        layer_sizes: list
+            the size of each dense layer in the network.  The length of
+            this list determines the number of layers.
+        weight_init_stddevs: list or float
+            the standard deviation of the distribution to use for weight
+            initialization of each layer.  The length of this list should
+            equal len(layer_sizes).  Alternatively, this may be a single
+            value instead of a list, where the same value is used
+            for every layer.
+        bias_init_consts: list or float
+            the value to initialize the biases in each layer.  The
+            length of this list should equal len(layer_sizes).
+            Alternatively, this may be a single value instead of a list, where the same value is used for every layer.
+        dropouts: list or float
+            the dropout probability to use for each layer.  The length of this list should equal len(layer_sizes).
+            Alternatively, this may be a single value instead of a list, where the same value is used for every layer.
+        activation_fns: list or object
+            the Tensorflow activation function to apply to each layer.  The length of this list should equal
+            len(layer_sizes).  Alternatively, this may be a single value instead of a list, where the
+            same value is used for every layer.
+        """
+        super(AtomicConv, self).__init__()
+        self.complex_num_atoms = complex_num_atoms
+        self.frag1_num_atoms = frag1_num_atoms
+        self.frag2_num_atoms = frag2_num_atoms
+        self.max_num_neighbors = max_num_neighbors
+        self.batch_size = batch_size
+        self.atom_types = atom_types
+        self.init = init
+        self.n_tasks = n_tasks
+
+        rp = [x for x in itertools.product(*radial)]
+
+        frag1_X = np.random.rand(self.batch_size, self.frag1_num_atoms,
+                                 3).astype(np.float32)
+        frag1_nbrs = np.random.randint(frag1_num_atoms,
+                                       size=(batch_size, frag1_num_atoms,
+                                             max_num_neighbors))
+        frag1_nbrs_z = np.random.randint(1,
+                                         10,
+                                         size=(batch_size, frag1_num_atoms,
+                                               max_num_neighbors))
+        frag1_z = torch.tensor((frag1_num_atoms,))
+
+        frag2_X = np.random.rand(self.batch_size, self.frag2_num_atoms,
+                                 3).astype(np.float32)
+        frag2_nbrs = np.random.randint(frag2_num_atoms,
+                                       size=(batch_size, frag2_num_atoms,
+                                             max_num_neighbors))
+        frag2_nbrs_z = np.random.randint(1,
+                                         10,
+                                         size=(batch_size, frag2_num_atoms,
+                                               max_num_neighbors))
+        frag2_z = torch.tensor((frag2_num_atoms,))
+
+        complex_X = np.random.rand(self.batch_size, self.complex_num_atoms,
+                                   3).astype(np.float32)
+        complex_nbrs = np.random.randint(complex_num_atoms,
+                                         size=(batch_size, complex_num_atoms,
+                                               max_num_neighbors))
+        complex_nbrs_z = np.random.randint(1,
+                                           10,
+                                           size=(batch_size, complex_num_atoms,
+                                                 max_num_neighbors))
+        complex_z = torch.tensor((complex_num_atoms,))
+
+        flattener = nn.Flatten()
+        self._frag1_conv = AtomicConvolution(
+            atom_types=self.atom_types, radial_params=rp,
+            box_size=None)([frag1_X, frag1_nbrs, frag1_nbrs_z])
+        flattened1 = nn.Flatten()(self._frag1_conv)
+
+        self._frag2_conv = AtomicConvolution(
+            atom_types=self.atom_types, radial_params=rp,
+            box_size=None)([frag2_X, frag2_nbrs, frag2_nbrs_z])
+        flattened2 = flattener(self._frag2_conv)
+
+        self._complex_conv = AtomicConvolution(
+            atom_types=self.atom_types, radial_params=rp,
+            box_size=None)([complex_X, complex_nbrs, complex_nbrs_z])
+        flattened3 = flattener(self._complex_conv)
+
+        concat = torch.cat((flattened1, flattened2, flattened3), dim=1)
+
+        n_layers = len(layer_sizes)
+        if not isinstance(weight_init_stddevs, SequenceCollection):
+            weight_init_stddevs = [weight_init_stddevs] * n_layers
+        if not isinstance(bias_init_consts, SequenceCollection):
+            bias_init_consts = [bias_init_consts] * n_layers
+        if not isinstance(dropouts, SequenceCollection):
+            dropouts = [dropouts] * n_layers
+        if not isinstance(activation_fns, SequenceCollection):
+            activation_fns = [activation_fns] * n_layers
+
+        self.activation_fns = [get_activation(f) for f in activation_fns]
+        self.dropouts = dropouts
+
+        self.prev_layer = concat
+        prev_size = concat.size(1)
+        next_activation = None
+
+        # Define the layers
+        self.layers = nn.ModuleList()
+        for size, weight_stddev, bias_const, dropout, activation_fn in zip(
+                layer_sizes, weight_init_stddevs, bias_init_consts, dropouts,
+                activation_fns):
+            layer = self.prev_layer
+            if next_activation is not None:
+                layer = next_activation(layer)
+            linear = nn.Linear(prev_size, size)
+            nn.init.trunc_normal_(linear.weight, std=weight_stddev)
+            nn.init.constant_(linear.bias, bias_const)
+            self.layers.append(linear)
+
+            prev_size = size
+            next_activation = activation_fn
+
+        # Create the final layers
+        self.neural_fingerprint = self.prev_layer
+        self.output = nn.Sequential(nn.Linear(prev_size, n_tasks),
+                                    nn.Linear(n_tasks, 1))
+
+    def forward(self, inputs: OneOrMany[torch.Tensor]):
+        """
+        Parameters
+        ----------
+        x: torch.Tensor
+            Input Tensor
+        Returns
+        -------
+        torch.Tensor
+            Output for each label.
+        """
+
+        x = self.prev_layer[0]
+        x = torch.reshape(x, (-1,))
+
+        for layer, activation_fn, dropout in zip(self.layers,
+                                                 self.activation_fns,
+                                                 self.dropouts):
+            x = layer(x)
+
+            if dropout > 0:
+                x = F.dropout(x, dropout)
+
+            if activation_fn is not None:
+                x = activation_fn(x)
+
+        outputs = []
+        output = self.output(x)
+        outputs = [output]
+
+        return outputs
 
 
 class CombineMeanStd(nn.Module):

--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -1,0 +1,33 @@
+import pytest
+
+try:
+    import torch
+    has_torch = True
+except ModuleNotFoundError:
+    has_torch = False
+    pass
+
+
+@pytest.mark.torch
+def test_atomic_convolution_module():
+    from deepchem.models.torch_models.layers import AtomicConvolutionModule
+    f1_num_atoms = 100  # maximum number of atoms to consider in the ligand
+    f2_num_atoms = 1000  # maximum number of atoms to consider in the protein
+    max_num_neighbors = 12  # maximum number of spatial neighbors for an atom
+
+    acm = AtomicConvolutionModule(
+        n_tasks=1,
+        frag1_num_atoms=f1_num_atoms,
+        frag2_num_atoms=f2_num_atoms,
+        complex_num_atoms=f1_num_atoms + f2_num_atoms,
+        max_num_neighbors=max_num_neighbors,
+        batch_size=12,
+        layer_sizes=[32, 32, 16],
+    )
+
+    frag1_size = (acm._frag1_conv.size()[1]) * (acm._frag1_conv.size()[2])
+    frag2_size = (acm._frag2_conv.size()[1]) * (acm._frag2_conv.size()[2])
+    complex_size = (acm._complex_conv.size()[1]) * (acm._complex_conv.size()[2])
+
+    assert acm.prev_layer.size() == torch.Size(
+        [acm.batch_size, frag1_size + frag2_size + complex_size])

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -67,6 +67,9 @@ Keras Layers
 .. autoclass:: deepchem.models.layers.AtomicConvolution
   :members:
 
+.. autoclass:: deepchem.models.layers.AtomicConv
+  :members:
+
 .. autoclass:: deepchem.models.layers.AlphaShareLayer
   :members:
 


### PR DESCRIPTION
## Description

This is the first split (1/2) of atomic convolution porting from tensorflow to pytorch.

Fix on of https://github.com/deepchem/deepchem/issues/2863 models

There is an implementation of Atomic Convolutions in Tensorflow but this PR aims to port it to Pytorch. Since the Atomic Convolution layers already exists in pytorch, the pathway would be to include AtomicConvolutionModule at layer.py and the model itself as a python file.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
