### PR TITLE
Utility to build grover vocab from csv

### DIFF
--- a/deepchem/feat/vocabulary_builders/grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/grover_vocab.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import numpy as np
+import pandas as pd
 from typing import Dict, Optional
 from collections import Counter
 from rdkit import Chem
@@ -96,6 +97,49 @@ class GroverAtomVocabularyBuilder(VocabularyBuilder):
             for atom in mol.GetAtoms():
                 v = self.atom_to_vocab(mol, atom)
                 counter[v] += 1
+        logger.info('Completed enumeration of atom contextual properties.')
+        # sort first by frequency, then alphabetically
+        words_and_frequencies = sorted(counter.items(), key=lambda tup: tup[0])
+        words_and_frequencies.sort(key=lambda tup: tup[1], reverse=True)
+        for word, freq in words_and_frequencies:
+            if len(self.itos) == self.size:
+                break
+            self.itos.append(word)
+        if self.size is None:
+            self.size = len(self.itos)
+        self.stoi = self._make_reverse_mapping(self.itos)
+        logger.info('Completed building of atom vocabulary')
+
+    def build_from_csv(self,
+                       csv_path: str,
+                       smiles_field: str,
+                       log_every_n: int = 1000) -> None:
+        """Builds vocabulary from csv file
+
+        Parameters
+        ----------
+        csv_path: str
+            Path to csv file containing smiles string
+        smiles_field: str
+            Name of column containing smiles string
+        log_every_n: int, default 1000
+            Logs vocabulary building progress every `log_every_n` steps.
+        """
+        counter: Dict[str, int] = Counter()
+        logger.info('Starting to build atom vocabulary')
+        chunksize = 8196
+        for i, df in enumerate(pd.read_csv(csv_path, chunksize=chunksize)):
+            for index, row in df.iterrows():
+                if (i * chunksize + index) % log_every_n == 0:
+                    logger.info(
+                        'Computing contextual property of atoms in molecule %i'
+                        % i)
+                smiles = row[smiles_field]
+                mol = Chem.MolFromSmiles(smiles)
+                for atom in mol.GetAtoms():
+                    v = self.atom_to_vocab(mol, atom)
+                    counter[v] += 1
+
         logger.info('Completed enumeration of atom contextual properties.')
         # sort first by frequency, then alphabetically
         words_and_frequencies = sorted(counter.items(), key=lambda tup: tup[0])
@@ -297,6 +341,53 @@ class GroverBondVocabularyBuilder(VocabularyBuilder):
                 v = self.bond_to_vocab(mol, bond)
                 counter[v] += 1
         logger.info('Completed enumeration of bond contextual properties.')
+
+        # sort first by frequency, then alphabetically
+        words_and_frequencies = sorted(counter.items(), key=lambda tup: tup[0])
+        words_and_frequencies.sort(key=lambda tup: tup[1], reverse=True)
+        for word, freq in words_and_frequencies:
+            if len(self.itos) == self.size:
+                break
+            self.itos.append(word)
+        if self.size is None:
+            self.size = len(self.itos)
+        self.stoi = self._make_reverse_mapping(self.itos)
+        logger.info('Completed building of bond vocabulary')
+
+    def build_from_csv(self,
+                       csv_path: str,
+                       smiles_field: str,
+                       log_every_n: int = 1000) -> None:
+        """Builds vocabulary
+
+        Parameters
+        ----------
+        csv_path: str
+            Path to csv file containing smiles string
+        smiles_field: str
+            Name of column containing smiles string
+        log_every_n: int, default 1000
+            Logs vocabulary building progress every `log_every_n` steps.
+        """
+        counter: Dict[str, int] = Counter()
+        logger.info('Starting to build bond vocabulary')
+        chunksize = 8196
+        for i, df in enumerate(pd.read_csv(csv_path, chunksize=chunksize)):
+            row_count = i * chunksize
+            for index, row in df.iterrows():
+                if (row_count + i) % log_every_n == 0:
+                    logger.info(
+                        'Computing contextual property of bonds in molecule %i'
+                        % i)
+
+                smiles = row[smiles_field]
+
+                mol = Chem.MolFromSmiles(smiles)
+                for bond in mol.GetBonds():
+                    v = self.bond_to_vocab(mol, bond)
+                    counter[v] += 1
+
+            logger.info('Completed enumeration of bond contextual properties.')
 
         # sort first by frequency, then alphabetically
         words_and_frequencies = sorted(counter.items(), key=lambda tup: tup[0])

--- a/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
@@ -1,4 +1,6 @@
 import tempfile
+import os
+import pandas as pd
 from rdkit import Chem
 import deepchem as dc
 
@@ -34,6 +36,30 @@ def testGroverAtomVocabularyBuilder():
     vocab.build(dataset)
     assert vocab.size == 3
     assert vocab.size == len(vocab.itos)
+
+
+def test_grover_atom_vocabulary_build_from_csv(tmpdir):
+    # test build from csv
+    from deepchem.feat.vocabulary_builders.grover_vocab import GroverAtomVocabularyBuilder
+    atom_vocab = GroverAtomVocabularyBuilder()
+    X = ['CC(=O)C', 'CCC']
+    df = pd.DataFrame({'X': X})
+    csv_path = os.path.join(tmpdir, 'temp.csv')
+    df.to_csv(csv_path)
+
+    atom_vocab.build_from_csv(csv_path, smiles_field='X')
+    assert atom_vocab.stoi == {
+        '<pad>': 0,
+        '<other>': 1,
+        'C_C-SINGLE1': 2,
+        'C_C-SINGLE2': 3,
+        'C_C-SINGLE2_O-DOUBLE1': 4,
+        'O_C-DOUBLE1': 5
+    }
+    assert atom_vocab.itos == [
+        '<pad>', '<other>', 'C_C-SINGLE1', 'C_C-SINGLE2',
+        'C_C-SINGLE2_O-DOUBLE1', 'O_C-DOUBLE1'
+    ]
 
 
 def testGroverBondVocabularyBuilder():
@@ -75,6 +101,36 @@ def testGroverBondVocabularyBuilder():
     vocab.build(dataset)
     assert vocab.size == 3
     assert vocab.size == len(vocab.itos)
+
+
+def test_grover_bond_vocabulary_build_from_csv(tmpdir):
+    from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder
+    bond_vocab = GroverBondVocabularyBuilder()
+    X = ['CC(=O)C', 'CCC']
+    df = pd.DataFrame({'X': X})
+    csv_path = os.path.join(tmpdir, 'temp.csv')
+    df.to_csv(csv_path)
+
+    bond_vocab.build_from_csv(csv_path, smiles_field='X')
+
+    assert bond_vocab.stoi == {
+        '<pad>':
+            0,
+        '<other>':
+            1,
+        '(SINGLE-STEREONONE-NONE)_C-(DOUBLE-STEREONONE-NONE)1_C-(SINGLE-STEREONONE-NONE)1':
+            2,
+        '(SINGLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)1':
+            3,
+        '(DOUBLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)2':
+            4,
+    }
+    assert bond_vocab.itos == [
+        '<pad>', '<other>',
+        '(SINGLE-STEREONONE-NONE)_C-(DOUBLE-STEREONONE-NONE)1_C-(SINGLE-STEREONONE-NONE)1',
+        '(SINGLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)1',
+        '(DOUBLE-STEREONONE-NONE)_C-(SINGLE-STEREONONE-NONE)2'
+    ]
 
 
 def testGroverAtomVocabTokenizer():


### PR DESCRIPTION
## Description

I added a new feature to build vocabulary for grover directly from csv files.
This approach will be faster when working on large datasets (in existing approach, vocab can only be built from DiskDataset)

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
