### PR TITLE
Atomic Contributions bug fix

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -908,7 +908,11 @@ class SDFLoader(DataLoader):
         features = [
             elt for (is_valid, elt) in zip(valid_inds, features) if is_valid
         ]
-        return np.array(features), valid_inds
+        try:
+            return np.array(features), valid_inds
+        except ValueError as e:
+            logger.warning("Exception message: {}".format(e))
+            return np.asarray(features, dtype=object), valid_inds
 
 
 class FASTALoader(DataLoader):


### PR DESCRIPTION
## Description

Fix: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. When calculating atomic contributions as shown in tutorial: Atomic_Contributions_for_Molecules.ipynb. This error was shown when running the tutorial on both 2.7.1 and 2.7.2.dev. Requires `dtype=object` when creating the array when using `per_atom_fragmentation = True`. Tutorial completes successfully after fix.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
