### PR TITLE
Fix PR for acnn test

### DIFF
--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -10,12 +10,12 @@ except ModuleNotFoundError:
 
 @pytest.mark.torch
 def test_atomic_convolution_module():
-    from deepchem.models.torch_models.layers import AtomicConvolutionModule
+    from deepchem.models.torch_models.layers import AtomicConv
     f1_num_atoms = 100  # maximum number of atoms to consider in the ligand
     f2_num_atoms = 1000  # maximum number of atoms to consider in the protein
     max_num_neighbors = 12  # maximum number of spatial neighbors for an atom
 
-    acm = AtomicConvolutionModule(
+    acm = AtomicConv(
         n_tasks=1,
         frag1_num_atoms=f1_num_atoms,
         frag2_num_atoms=f2_num_atoms,


### PR DESCRIPTION
## Description

Fix failing torch test: 

`FAILED deepchem/models/torch_models/tests/test_acnn.py::test_atomic_convolution_module - ImportError: cannot import name 'AtomicConvolutionModule' from 'deepchem.models.torch_models.layers' (/home/runner/work/deepchem/deepchem/deepchem/models/torch_models/layers.py)`


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
