### PR TITLE
Added output_types in grover

### DIFF
--- a/deepchem/models/torch_models/grover.py
+++ b/deepchem/models/torch_models/grover.py
@@ -337,12 +337,12 @@ class GroverModel(ModularTorchModel):
     def __init__(self,
                  node_fdim: int,
                  edge_fdim: int,
-                 atom_vocab: GroverAtomVocabularyBuilder,
-                 bond_vocab: GroverBondVocabularyBuilder,
                  hidden_size: int,
                  self_attention=False,
                  features_only=False,
-                 functional_group_size: int = 85,
+                 atom_vocab: Optional[GroverAtomVocabularyBuilder] = None,
+                 bond_vocab: Optional[GroverBondVocabularyBuilder] = None,
+                 functional_group_size: Optional[int] = 85,
                  features_dim=128,
                  dropout=0.2,
                  activation='relu',
@@ -360,8 +360,14 @@ class GroverModel(ModularTorchModel):
         self.edge_fdim = edge_fdim
         self.atom_vocab = atom_vocab
         self.bond_vocab = bond_vocab
-        self.atom_vocab_size = atom_vocab.size
-        self.bond_vocab_size = bond_vocab.size
+        if isinstance(atom_vocab, GroverAtomVocabularyBuilder):
+            self.atom_vocab_size = atom_vocab.size
+        else:
+            self.atom_vocab_size = None
+        if isinstance(bond_vocab, GroverBondVocabularyBuilder):
+            self.bond_vocab_size = bond_vocab.size
+        else:
+            self.bond_vocab_size = None
         self.task = task
         self.model_dir = model_dir
         self.hidden_size = hidden_size

--- a/deepchem/models/torch_models/grover.py
+++ b/deepchem/models/torch_models/grover.py
@@ -558,11 +558,13 @@ class GroverModel(ModularTorchModel):
         )
 
         atom_vocab_label = torch.Tensor(
-            self.atom_vocab_random_mask(self.atom_vocab,
-                                        smiles_batch)).long().to(self.device)
+            self.atom_vocab_random_mask(
+                self.atom_vocab,  # type: ignore
+                smiles_batch)).long().to(self.device)
         bond_vocab_label = torch.Tensor(
-            self.bond_vocab_random_mask(self.bond_vocab,
-                                        smiles_batch)).long().to(self.device)
+            self.bond_vocab_random_mask(
+                self.bond_vocab,  # type: ignore
+                smiles_batch)).long().to(self.device)
         labels = {
             "av_task": atom_vocab_label,
             "bv_task": bond_vocab_label,

--- a/deepchem/models/torch_models/grover.py
+++ b/deepchem/models/torch_models/grover.py
@@ -383,9 +383,16 @@ class GroverModel(ModularTorchModel):
         self.n_classes = n_classes
         self.components = self.build_components()
         self.model = self.build_model()
+        if self.mode == 'regression':
+            output_types = ['prediction']
+        elif self.mode == 'classification':
+            output_types = ['prediction', 'loss']
+        else:
+            output_types = None
         super().__init__(self.model,
                          self.components,
                          model_dir=self.model_dir,
+                         output_types=output_types,
                          **kwargs)
         # FIXME In the above step, we initialize modular torch model but
         # something is missing here. The attribute loss from TorchModel gets assigned `loss_func`


### PR DESCRIPTION
## Description

Summary of changes:
- added output types - torch-models requires output typy - I missed adding it earlier and I have added it now. Output types helps in distinguishing different outputs from a model, like probability values and logits.
- add optional params - vocabulary is not required for finetuning applications, hence those parameters are made os optional in GroverModel.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
