### PR TITLE
Fix Atomic Convolution Model (ACNN) tests in Pytorch and Tensorflow

### DIFF
--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -210,7 +210,7 @@ class ComplexFeaturizer(Featurizer):
         for idx in failures:
             features[idx] = dummy_array
 
-        return np.asarray(features)
+        return np.asarray(features, dtype=object)
 
     def _featurize(self, datapoint: Optional[Tuple[str, str]] = None, **kwargs):
         """

--- a/deepchem/models/tests/test_atomic_conv.py
+++ b/deepchem/models/tests/test_atomic_conv.py
@@ -78,7 +78,7 @@ def test_atomic_conv():
     features.append(
         (frag1_coords, frag1_nbr_list, frag1_z, frag2_coords, frag2_nbr_list,
          frag2_z, system_coords, system_nbr_list, system_z))
-    features = np.asarray(features)
+    features = np.asarray(features, dtype=object)
     labels = np.random.rand(batch_size)
     train = NumpyDataset(features, labels)
     atomic_convnet.fit(train, nb_epoch=150)
@@ -119,7 +119,7 @@ def test_atomic_conv_variable():
     features.append(
         (frag1_coords, frag1_nbr_list, frag1_z, frag2_coords, frag2_nbr_list,
          frag2_z, system_coords, system_nbr_list, system_z))
-    features = np.asarray(features)
+    features = np.asarray(features, dtype=object)
     labels = np.zeros(batch_size)
     train = NumpyDataset(features, labels)
     atomic_convnet.fit(train, nb_epoch=1)

--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -101,10 +101,9 @@ def test_atomic_convolution_model():
     features = np.asarray(features, dtype=object)
     labels = np.random.rand(batch_size)
     train = NumpyDataset(features, labels)
-    atomic_convnet.fit(train, nb_epoch=150)
+    atomic_convnet.fit(train, nb_epoch=200)
     preds = atomic_convnet.predict(train)
-    assert preds.shape == (1, 1)
-    assert np.count_nonzero(preds) > 0
+    assert np.allclose(labels, preds, atol=0.01)
 
 
 @pytest.mark.slow

--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 from deepchem.data import NumpyDataset
-from flaky import flaky
 
 try:
     import torch
@@ -54,7 +53,6 @@ def test_atomic_conv_initialize_params():
     assert len(acm.atom_types) == 15
 
 
-@flaky
 @pytest.mark.slow
 @pytest.mark.torch
 def test_atomic_convolution_model():
@@ -104,7 +102,9 @@ def test_atomic_convolution_model():
     labels = np.random.rand(batch_size)
     train = NumpyDataset(features, labels)
     atomic_convnet.fit(train, nb_epoch=150)
-    assert np.allclose(labels, atomic_convnet.predict(train), atol=0.01)
+    preds = atomic_convnet.predict(train)
+    assert preds.shape == (1, 1)
+    assert np.count_nonzero(preds) > 0
 
 
 @pytest.mark.slow

--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from deepchem.data import NumpyDataset
+from flaky import flaky
 
 try:
     import torch
@@ -53,6 +54,7 @@ def test_atomic_conv_initialize_params():
     assert len(acm.atom_types) == 15
 
 
+@flaky
 @pytest.mark.slow
 @pytest.mark.torch
 def test_atomic_convolution_model():
@@ -98,6 +100,7 @@ def test_atomic_convolution_model():
     features.append(
         (frag1_coords, frag1_nbr_list, frag1_z, frag2_coords, frag2_nbr_list,
          frag2_z, system_coords, system_nbr_list, system_z))
+    features = np.asarray(features, dtype=object)
     labels = np.random.rand(batch_size)
     train = NumpyDataset(features, labels)
     atomic_convnet.fit(train, nb_epoch=150)
@@ -138,7 +141,7 @@ def test_atomic_convolution_model_variable():
     features.append(
         (frag1_coords, frag1_nbr_list, frag1_z, frag2_coords, frag2_nbr_list,
          frag2_z, system_coords, system_nbr_list, system_z))
-    features = np.asarray(features)
+    features = np.asarray(features, dtype=object)
     labels = np.zeros(batch_size)
     train = NumpyDataset(features, labels)
     atomic_convnet.fit(train, nb_epoch=1)


### PR DESCRIPTION
## Description

An error message appeared when running ACNN tensorflow and pytorch tests locally:
`ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 2 dimensions. The detected shape was (1, 9) + inhomogeneous part.`

This PR aims to solve this issue and update feat when using `featurize` with `dtype=object`


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
