### PR TITLE
fix: update scipy spmatrix usage to avoid depreciation warning

### DIFF
--- a/deepchem/feat/molecule_featurizers/sparse_matrix_one_hot_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/sparse_matrix_one_hot_featurizer.py
@@ -87,7 +87,7 @@ class SparseMatrixOneHotFeaturizer(Featurizer):
         else:
             raise ValueError("Datapoint is not a string")
 
-    def untransform(self, one_hot_vectors: scipy.sparse.base.spmatrix) -> str:
+    def untransform(self, one_hot_vectors: scipy.sparse.spmatrix) -> str:
         """Convert from one hot representation back to original string
 
         Parameters


### PR DESCRIPTION
## Description

Fix #(issue)

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Updates usage of scipy.sparse.base.spmatrix to scipy.sparse.spmatrix in sparse_matrix_one_hot_featurizer.py to fix a depreciation warning.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
