### PR TITLE
Discrepancy in DTNNGather class of layers.py.

### DIFF
--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -3294,7 +3294,7 @@ class DTNNGather(tf.keras.layers.Layer):
             Number of features for each atom
         n_outputs: int, optional
             Number of features for each molecule(output)
-        layer_sizes: list of int, optional(default=[1000])
+        layer_sizes: list of int, optional(default=[100])
             Structure of hidden layer(s)
         init: str, optional
             Weight initialization for filters.


### PR DESCRIPTION
The default value for layer_sizes is [1000] in the parameter description, while in the method signature, it is [100].This inconsistency could potentially confuse users who rely on the documentation to understand the default behavior of the DTNNGather class.

## Description

Fix #3854 

Please include a summary of the change and which issue is fixed.
The default value for layer_sizes is [1000] in the parameter description, while in the method signature, it is [100].This inconsistency could potentially confuse users who rely on the documentation to understand the default behavior of the DTNNGather class.To resolve this discrepancy, we need to ensure that both the parameter description and the method signature reflect the same default value for layer_sizes.

List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
