### PR TITLE
Added blank space before and after the bullet points.

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -472,6 +472,7 @@ class MultiHeadedMATAttention(nn.Module):
                  dropout_p: float = 0.0,
                  output_bias: bool = True):
         """Initialize a multi-headed attention layer.
+        
         Parameters
         ----------
         dist_kernel: str
@@ -489,6 +490,7 @@ class MultiHeadedMATAttention(nn.Module):
         output_bias: bool
             If True, dense layers will use bias vectors.
         """
+        
         super().__init__()
         if dist_kernel == "softmax":
             self.dist_kernel = lambda x: torch.softmax(-x, dim=-1)


### PR DESCRIPTION
Bullet points are not properly rendered in the documentation .I have added blank space to make it correct

## Description

Fix #3857 

Please include a summary of the change and which issue is fixed.
Bullet points are not properly rendered in the documentation.

List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
