### PR TITLE
Remove invalid line in hf_models.py

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -330,8 +330,6 @@ class HuggingFaceModel(TorchModel):
             optimizer.zero_grad()
             outputs = self.model(**inputs)
 
-            if self._loss_outputs is not None:
-                outputs = [outputs[i] for i in self._loss_outputs]
             batch_loss = outputs.get("loss")
             batch_loss.backward()
             optimizer.step()


### PR DESCRIPTION
## Description

HuggingFace models always returns a output of type `dict` containing the model
loss, logits and other values. Accessing the model output via index (as in the above deleted
line is invalid `outputs[i]`) is invalid.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
