### PR TITLE
Avoiding errors on dataset.y when task is not specified in CSVLoader

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2581,7 +2581,7 @@ class DiskDataset(Dataset):
     @property
     def y(self) -> np.ndarray:
         """Get the y vector for this dataset as a single numpy array."""
-        if len(self) == 0:
+        if len(self) == 0 or len(self.get_task_names()) == 0:
             return np.array([])
         ys = []
         one_dimensional = False

--- a/deepchem/data/tests/test_csv_loader.py
+++ b/deepchem/data/tests/test_csv_loader.py
@@ -16,3 +16,17 @@ def test_load_singleton_csv():
     X = loader.create_dataset(fin.name)
     assert len(X) == 1
     os.remove(fin.name)
+
+
+def test_empty_task_dataset_y():
+    fin = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    fin.write("smiles\nC\nCCCC")
+    fin.close()
+    featurizer = dc.feat.SNAPFeaturizer()
+    loader = dc.data.CSVLoader(tasks=[],
+                               feature_field="smiles",
+                               featurizer=featurizer,
+                               id_field="smiles")
+    X = loader.create_dataset(fin.name)
+    assert X.y == []
+    os.remove(fin.name)

--- a/deepchem/data/tests/test_csv_loader.py
+++ b/deepchem/data/tests/test_csv_loader.py
@@ -19,6 +19,7 @@ def test_load_singleton_csv():
 
 
 def test_empty_task_dataset_y():
+    """Test that dataset.y doesn't throw an error when there are no tasks specified in CSVLoader"""
     fin = tempfile.NamedTemporaryFile(mode='w', delete=False)
     fin.write("smiles\nC\nCCCC")
     fin.close()


### PR DESCRIPTION
## Description

Fixes #3464, except that some tests broke when I tried to make `dataset.y` return `None` on empty task list, so I have it just return an empty array. I've also added a test to check for the exact case described in the issue. Hope that is sufficient. 

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
