### PR TITLE
vocab path wrong

### DIFF
--- a/deepchem/feat/smiles_tokenizer.py
+++ b/deepchem/feat/smiles_tokenizer.py
@@ -30,7 +30,7 @@ VOCAB_FILES_NAMES = {"vocab_file": "vocab.txt"}
 
 def get_default_tokenizer():
     default_vocab_path = (pkg_resources.resource_filename(
-        "deepchem", "feat/tests/vocab.txt"))
+        "deepchem", "feat/tests/data/vocab.txt"))
     return SmilesTokenizer(default_vocab_path)
 
 


### PR DESCRIPTION
## Description

Smiles tokenizer vocab.txt path wrong 

<!-- Please include a summary of the change and which issue is fixed.
one line change to path 

## Type of change

Please check the option that is related to your PR.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

