### PR TITLE
 implementation of the build_model function 

### DIFF
--- a/deepchem/models/torch_models/modular.py
+++ b/deepchem/models/torch_models/modular.py
@@ -92,7 +92,11 @@ class ModularTorchModel(TorchModel):
 
     def build_model(self) -> nn.Module:
         """Builds the final model from the components."""
-        raise NotImplementedError("Subclass must define the components")
+        layers = []
+        for layer in self.components.values():
+            layers.append(layer)
+        
+        return nn.Sequential(*layers)
 
     def build_components(self) -> dict:
         """Creates the components dictionary, with the keys being the names of the


### PR DESCRIPTION
… model from the components

## Description

Fix #1

In following the example of how to use ModularTorchModel in the implementation of 
```python
modular_model.load_from_pretrained(pretrain_modular_model, components=['linear']) 
```
there was a failure of the load_from_pretrained function because this use build_model function that builds the model from the entered components and the same was not defined.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
