### PR TITLE
bump up deepchem version to 2.8.0

### DIFF
--- a/.github/workflows/mini_build.yml
+++ b/.github/workflows/mini_build.yml
@@ -224,7 +224,7 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ github.sha }}
         restore-keys: ${{ runner.os }}-buildx-
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKER_HUB_USERNAME }}
         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}

--- a/.github/workflows/mini_build.yml
+++ b/.github/workflows/mini_build.yml
@@ -206,6 +206,13 @@ jobs:
     needs: [core-build, pypi-build]
     runs-on: ubuntu-latest
     steps:
+    - name: Maximize build space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo rm -rf /usr/local/lib/android
     - uses: actions/checkout@v4
     - name: Set up Docker Buildx
       id: buildx

--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -3,7 +3,7 @@ Imports all submodules
 """
 
 # If you push the tag, please remove `.dev`
-__version__ = '2.7.2.dev'
+__version__ = '2.8.0'
 
 import deepchem.data
 import deepchem.feat

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ sphinx==7.2.6
 sphinx_rtd_theme>=1.0
 tensorflow<2.16
 transformers>=4.34.1
-torch==2.1.0 --extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
 lightning
 jax
 dm-haiku

--- a/docs/source/get_started/examples.rst
+++ b/docs/source/get_started/examples.rst
@@ -33,8 +33,9 @@ Before jumping in to examples, we'll import our libraries and ensure our doctest
 
     # Run before every test for reproducibility
     def seed_all():
-        np.random.seed(123)
-        tf.random.set_seed(123)
+        np.random.seed(456)
+        tf.random.set_seed(456)
+        random.seed(456)
 
 
 Delaney (ESOL)
@@ -160,6 +161,7 @@ GraphConvModel
 
 .. doctest:: chembl
 
+    >>> seed_all()
     >>> # Load ChEMBL dataset
     >>> chembl_tasks, datasets, transformers = dc.molnet.load_chembl(
     ...    shard_size=2000, featurizer="GraphConv", set="5thresh", split="random")

--- a/docs/source/get_started/examples.rst
+++ b/docs/source/get_started/examples.rst
@@ -30,6 +30,7 @@ Before jumping in to examples, we'll import our libraries and ensure our doctest
     import numpy as np
     import tensorflow as tf
     import deepchem as dc
+    import random
 
     # Run before every test for reproducibility
     def seed_all():

--- a/docs/source/get_started/requirements.rst
+++ b/docs/source/get_started/requirements.rst
@@ -99,7 +99,7 @@ DeepChem has a number of "soft" requirements.
 |                                |               |                                                   |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
-| `PyTorch Geometric`_           | latest (with   | :code:`dc.feat.graph_data`                        |
+| `PyTorch Geometric`_           | latest (with  | :code:`dc.feat.graph_data`                        |
 |                                | PyTorch 2.2.1)| :code:`dc.models.torch_models`                    |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+

--- a/docs/source/get_started/requirements.rst
+++ b/docs/source/get_started/requirements.rst
@@ -95,12 +95,12 @@ DeepChem has a number of "soft" requirements.
 |                                |               |                                                   |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
-| `PyTorch`_                     | 2.1.0         | :code:`dc.models.torch_models`                    |
+| `PyTorch`_                     | 2.2.1         | :code:`dc.models.torch_models`                    |
 |                                |               |                                                   |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
-| `PyTorch Geometric`_           | 2.1.x (with   | :code:`dc.feat.graph_data`                        |
-|                                | PyTorch 2.1.0)| :code:`dc.models.torch_models`                    |
+| `PyTorch Geometric`_           | latest (with   | :code:`dc.feat.graph_data`                        |
+|                                | PyTorch 2.2.1)| :code:`dc.models.torch_models`                    |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
 | `RDKit`_                       | latest        | Many modules                                      |
@@ -111,7 +111,11 @@ DeepChem has a number of "soft" requirements.
 |                                |               | :code:`dc.molnet.dnasim`                          |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
-| `Tensorflow Probability`_      | 0.11.x        | :code:`dc.rl`                                     |
+| `TensorFlow`_                  | 2.15          | :code:`dc.models`                                 |
+|                                |               | `deepchem>=2.4.0` depends on TensorFlow v2(2.3.x) |
+|                                |               | `deepchem<2.4.0` depends on TensorFlow v1(>=1.14) |
++--------------------------------+---------------+---------------------------------------------------+
+| `Tensorflow Probability`_      | 0.23.x        | :code:`dc.rl`                                     |
 |                                |               |                                                   |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
@@ -130,10 +134,6 @@ DeepChem has a number of "soft" requirements.
 | `pySCF`_                       | latest        | :code:`dc.models.torch_models.ferminet`           |
 |                                |               |                                                   |
 |                                |               |                                                   |
-+--------------------------------+---------------+---------------------------------------------------+
-| `TensorFlow`_                  | latest        | :code:`dc.models`                                 |
-|                                |               | `deepchem>=2.4.0` depends on TensorFlow v2(2.3.x) |
-|                                |               | `deepchem<2.4.0` depends on TensorFlow v1(>=1.14) |
 +--------------------------------+---------------+---------------------------------------------------+
 | `pysam`_                       | latest        | :code:`dc.feat.bio_seq_featurizer`                |
 |                                |               | :code:`dc.models.data_loader`                     |

--- a/requirements/env_dqc.yml
+++ b/requirements/env_dqc.yml
@@ -9,7 +9,7 @@ dependencies:
    - scipy
    - h5py
    - -f https://download.pytorch.org/whl/cpu/torch_stable.html
-   - torch==2.1.0+cpu
+   - torch==2.2.1+cpu
    - torch-geometric
    - git+https://github.com/diffqc/dqc.git
    - xitorch

--- a/requirements/torch/env_torch.mac.cpu.yml
+++ b/requirements/torch/env_torch.mac.cpu.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - pytorch==2.2.1
   - pip:
-    - -f https://data.pyg.org/whl/torch-2.1.0+cpu.html
+    - -f https://data.pyg.org/whl/torch-2.2.1+cpu.html
     - dgl
     - torch-geometric
     - lightning


### PR DESCRIPTION
## Description

Fix #(issue)

- Bump up deepchem to version 2.8.0 for release
- Fix docker out of storage error
- Release notes: In progress at [Link](https://docs.google.com/document/u/7/d/1K-m07rDUtcgbOfO42PT0Xy5we9i4K5Q1SgIIUSgnXoE/edit)
- fixed some inconsistencies in docs and env files
- Fixed seeding of doctest (should prevent failed doctests now)


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
