### PR TITLE
fix#3746 fit_generator() not accepting variables as generators

### DIFF
--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -401,18 +401,21 @@ class TorchModel(Model):
             optimizer = self._pytorch_optimizer
             lr_schedule = self._lr_schedule
         else:
-            var_key = tuple(variables)
-            if var_key in self._optimizer_for_vars:
-                optimizer, lr_schedule = self._optimizer_for_vars[var_key]
+            variables_tuple = tuple(variables)
+            if variables_tuple in self._optimizer_for_vars:
+                optimizer, lr_schedule = self._optimizer_for_vars[
+                    variables_tuple]
             else:
-                optimizer = self.optimizer._create_pytorch_optimizer(variables)
+                optimizer = self.optimizer._create_pytorch_optimizer(
+                    variables_tuple)
                 if isinstance(self.optimizer.learning_rate,
                               LearningRateSchedule):
                     lr_schedule = self.optimizer.learning_rate._create_pytorch_schedule(
                         optimizer)
                 else:
                     lr_schedule = None
-                self._optimizer_for_vars[var_key] = (optimizer, lr_schedule)
+                self._optimizer_for_vars[variables_tuple] = (optimizer,
+                                                             lr_schedule)
         time1 = time.time()
 
         # Main training loop.


### PR DESCRIPTION
## Description

Fix #3746

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
