### PR TITLE
Update Advanced_Model_Training.ipynb

### DIFF
--- a/examples/tutorials/Advanced_Model_Training.ipynb
+++ b/examples/tutorials/Advanced_Model_Training.ipynb
@@ -65,7 +65,7 @@
    "source": [
     "import deepchem as dc\n",
     "\n",
-    "tasks, datasets, transformers = dc.molnet.load_hiv(featurizer='ECFP', split='scaffold')\n",
+    "tasks, datasets, transformers = dc.molnet.load_hiv(featurizer='ECFP', splitter='scaffold')\n",
     "train_dataset, valid_dataset, test_dataset = datasets"
    ]
   },


### PR DESCRIPTION
split is deprecated, changed to splitter

## Description

Fix #(issue)

when I ran the tutorial I got the following warning: WARNING:deepchem.molnet.load_function.molnet_loader:'split' is deprecated.  Use 'splitter' instead.

minor change to correct deprecated tutorial parameter to use correct "splitter" parameter. 

For more information, see the parameter list under the molnet HIV dataset: https://deepchem.readthedocs.io/en/latest/api_reference/moleculenet.html


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ x] Run `mypy -p deepchem` and check no errors
  - [x ] Run `flake8 <modified file> --count` and check no errors
  - [ x] Run `python -m doctest <modified file>` and check no errors
- [x ] I have performed a self-review of my own code
- [n/a ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] New unit tests pass locally with my changes
- [x ] I have checked my code and corrected any misspellings
