### PR TITLE
Pass loss in model training callbacks

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -472,7 +472,13 @@ class KerasModel(Model):
             if checkpoint_interval > 0 and current_step % checkpoint_interval == checkpoint_interval - 1:
                 manager.save()
             for c in callbacks:
-                c(self, current_step)
+                try:
+                    # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
+                    # variable arguments.
+                    c(self, current_step, {'iteration_loss': batch_loss})
+                except TypeError:
+                    # DeepChem <= 2.8.0, the callback should have this signature.
+                    c(self, current_step)
             if self.tensorboard and should_log:
                 self._log_scalar_to_tensorboard('loss', batch_loss,
                                                 current_step)

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -395,8 +395,8 @@ class KerasModel(Model):
             for each batch.  If None (the default), the model's standard loss function
             is used.
         callbacks: function or list of functions
-            one or more functions of the form f(model, step) that will be invoked after
-            every step.  This can be used to perform validation, logging, etc.
+            one or more functions of the form f(model, step, **kwargs) that will be invoked
+            after every step.  This can be used to perform validation, logging, etc.
         all_losses: Optional[List[float]], optional (default None)
             If specified, all logged losses are appended into this list. Note that
             you can call `fit()` repeatedly with the same list and losses will
@@ -475,7 +475,7 @@ class KerasModel(Model):
                 try:
                     # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
                     # variable arguments.
-                    c(self, current_step, {'iteration_loss': batch_loss})
+                    c(self, current_step, iteration_loss=batch_loss)
                 except TypeError:
                     # DeepChem <= 2.8.0, the callback should have this signature.
                     c(self, current_step)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -358,7 +358,7 @@ class HuggingFaceModel(TorchModel):
             if checkpoint_interval > 0 and current_step % checkpoint_interval == checkpoint_interval - 1:
                 self.save_checkpoint(max_checkpoints_to_keep)
             for c in callbacks:
-                c(self, current_step)
+                c(self, batch_loss, current_step)
             if self.tensorboard and should_log:
                 self._log_scalar_to_tensorboard('loss', batch_loss,
                                                 current_step)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -358,7 +358,13 @@ class HuggingFaceModel(TorchModel):
             if checkpoint_interval > 0 and current_step % checkpoint_interval == checkpoint_interval - 1:
                 self.save_checkpoint(max_checkpoints_to_keep)
             for c in callbacks:
-                c(self, batch_loss, current_step)
+                try:
+                    # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
+                    # variable arguments.
+                    c(self, current_step, {'iteration_loss': batch_loss})
+                except TypeError:
+                    # DeepChem <= 2.8.0, the callback should have this signature.
+                    c(self, current_step)
             if self.tensorboard and should_log:
                 self._log_scalar_to_tensorboard('loss', batch_loss,
                                                 current_step)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -277,8 +277,8 @@ class HuggingFaceModel(TorchModel):
             for each batch.  If None (the default), the model's standard loss function
             is used.
         callbacks: function or list of functions
-            one or more functions of the form f(model, step) that will be invoked after
-            every step.  This can be used to perform validation, logging, etc.
+            one or more functions of the form f(model, step, **kwargs) that will be invoked
+            after every step.  This can be used to perform validation, logging, etc.
         all_losses: Optional[List[float]], optional (default None)
             If specified, all logged losses are appended into this list. Note that
             you can call `fit()` repeatedly with the same list and losses will
@@ -361,7 +361,7 @@ class HuggingFaceModel(TorchModel):
                 try:
                     # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
                     # variable arguments.
-                    c(self, current_step, {'iteration_loss': batch_loss})
+                    c(self, current_step, iteration_loss=batch_loss)
                 except TypeError:
                     # DeepChem <= 2.8.0, the callback should have this signature.
                     c(self, current_step)

--- a/deepchem/models/torch_models/modular.py
+++ b/deepchem/models/torch_models/modular.py
@@ -252,7 +252,13 @@ class ModularTorchModel(TorchModel):
             if checkpoint_interval > 0 and current_step % checkpoint_interval == checkpoint_interval - 1:
                 self.save_checkpoint(max_checkpoints_to_keep)
             for c in callbacks:
-                c(self, current_step)
+                try:
+                    # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
+                    # variable arguments.
+                    c(self, current_step, {'iteration_loss': batch_loss})
+                except TypeError:
+                    # DeepChem <= 2.8.0, the callback should have this signature.
+                    c(self, current_step)
             if self.tensorboard and should_log:
                 self._log_scalar_to_tensorboard('loss', batch_loss,
                                                 current_step)

--- a/deepchem/models/torch_models/modular.py
+++ b/deepchem/models/torch_models/modular.py
@@ -171,8 +171,8 @@ class ModularTorchModel(TorchModel):
             for each batch.  If None (the default), the model's standard loss function
             is used.
         callbacks: function or list of functions
-            one or more functions of the form f(model, step) that will be invoked after
-            every step.  This can be used to perform validation, logging, etc.
+            one or more functions of the form f(model, step, **kwargs) that will be invoked
+            after every step.  This can be used to perform validation, logging, etc.
         all_losses: Optional[List[float]], optional (default None)
             If specified, all logged losses are appended into this list. Note that
             you can call `fit()` repeatedly with the same list and losses will
@@ -255,7 +255,7 @@ class ModularTorchModel(TorchModel):
                 try:
                     # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
                     # variable arguments.
-                    c(self, current_step, {'iteration_loss': batch_loss})
+                    c(self, current_step, iteration_loss=batch_loss)
                 except TypeError:
                     # DeepChem <= 2.8.0, the callback should have this signature.
                     c(self, current_step)

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -465,7 +465,7 @@ class TorchModel(Model):
             if checkpoint_interval > 0 and current_step % checkpoint_interval == checkpoint_interval - 1:
                 self.save_checkpoint(max_checkpoints_to_keep)
             for c in callbacks:
-                c(self, current_step)
+                c(self, batch_loss, current_step)
             if self.tensorboard and should_log:
                 self._log_scalar_to_tensorboard('loss', batch_loss,
                                                 current_step)

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -324,7 +324,7 @@ class TorchModel(Model):
             for each batch.  If None (the default), the model's standard loss function
             is used.
         callbacks: function or list of functions
-            one or more functions of the form f(model, step) that will be invoked after
+            one or more functions of the form f(model, step, **kwargs) that will be invoked after
             every step.  This can be used to perform validation, logging, etc.
         all_losses: Optional[List[float]], optional (default None)
             If specified, all logged losses are appended into this list. Note that
@@ -468,7 +468,7 @@ class TorchModel(Model):
                 try:
                     # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
                     # variable arguments.
-                    c(self, current_step, {'iteration_loss': batch_loss})
+                    c(self, current_step, iteration_loss=batch_loss)
                 except TypeError:
                     # DeepChem <= 2.8.0, the callback should have this signature.
                     c(self, current_step)

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -465,7 +465,13 @@ class TorchModel(Model):
             if checkpoint_interval > 0 and current_step % checkpoint_interval == checkpoint_interval - 1:
                 self.save_checkpoint(max_checkpoints_to_keep)
             for c in callbacks:
-                c(self, batch_loss, current_step)
+                try:
+                    # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
+                    # variable arguments.
+                    c(self, current_step, {'iteration_loss': batch_loss})
+                except TypeError:
+                    # DeepChem <= 2.8.0, the callback should have this signature.
+                    c(self, current_step)
             if self.tensorboard and should_log:
                 self._log_scalar_to_tensorboard('loss', batch_loss,
                                                 current_step)


### PR DESCRIPTION
## Description

I have updated callback to accept more metrics, like loss in this PR. This is a breaking change.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
