### PR TITLE
Made changes to image transformer. 

### DIFF
--- a/deepchem/trans/tests/test_image_transform.py
+++ b/deepchem/trans/tests/test_image_transform.py
@@ -42,7 +42,7 @@ def test_y_image_transform():
 
     dataset = dc.data.ImageDataset(X, y, w, ids)
     img_transformer = dc.trans.ImageTransformer(size=new_size,
-                                                transform_x=False,
+                                                transform_X=False,
                                                 transform_y=True)
     dataset = dataset.transform(img_transformer)
 
@@ -67,7 +67,7 @@ def test_xy_image_transform():
 
     dataset = dc.data.ImageDataset(X, y, w, ids)
     img_transformer = dc.trans.ImageTransformer(size=new_size,
-                                                transform_x=True,
+                                                transform_X=True,
                                                 transform_y=True)
     dataset = dataset.transform(img_transformer)
 
@@ -91,7 +91,7 @@ def test_image_transform_array():
     ids = np.random.randn(n_samples, 1)
 
     img_transform = dc.trans.ImageTransformer(size=new_size,
-                                              transform_x=True,
+                                              transform_X=True,
                                               transform_y=True)
     data = img_transform.transform_array(X, y, w, ids)
 

--- a/deepchem/trans/tests/test_image_transform.py
+++ b/deepchem/trans/tests/test_image_transform.py
@@ -21,7 +21,7 @@ def test_x_image_transform():
                                                 transform_y=False)
     dataset = dataset.transform(img_transformer)
 
-    assert dataset.X.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.X.shape == (n_samples, new_size[1], new_size[0], channels)
     assert dataset.y.shape == (n_samples, 1)
     assert dataset.w.shape == (n_samples, 1)
     assert dataset.ids.shape == (n_samples, 1)
@@ -47,7 +47,7 @@ def test_y_image_transform():
     dataset = dataset.transform(img_transformer)
 
     assert dataset.X.shape == (n_samples, width, height, channels)
-    assert dataset.y.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.y.shape == (n_samples, new_size[1], new_size[0], channels)
     assert dataset.w.shape == (n_samples, 1)
     assert dataset.ids.shape == (n_samples, 1)
 
@@ -71,8 +71,8 @@ def test_xy_image_transform():
                                                 transform_y=True)
     dataset = dataset.transform(img_transformer)
 
-    assert dataset.X.shape == (n_samples, new_size[0], new_size[1], channels)
-    assert dataset.y.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.X.shape == (n_samples, new_size[1], new_size[0], channels)
+    assert dataset.y.shape == (n_samples, new_size[1], new_size[0], channels)
     assert dataset.w.shape == (n_samples, 1)
     assert dataset.ids.shape == (n_samples, 1)
 
@@ -95,7 +95,7 @@ def test_image_transform_array():
                                               transform_y=True)
     data = img_transform.transform_array(X, y, w, ids)
 
-    assert data[0].shape == (n_samples, new_size[0], new_size[1], channels)
-    assert data[1].shape == (n_samples, new_size[0], new_size[1], channels)
+    assert data[0].shape == (n_samples, new_size[1], new_size[0], channels)
+    assert data[1].shape == (n_samples, new_size[1], new_size[0], channels)
     assert data[2].shape == (n_samples, 1)
     assert data[3].shape == (n_samples, 1)

--- a/deepchem/trans/tests/test_image_transform.py
+++ b/deepchem/trans/tests/test_image_transform.py
@@ -1,0 +1,101 @@
+import numpy as np
+import deepchem as dc
+
+
+def test_x_image_transform():
+    """Test ImageTransformer on only X array"""
+    n_samples = 10
+    width = 35
+    height = 67
+    channels = 4
+    new_size = (10, 15)
+
+    X = np.random.randn(n_samples, width, height, channels)
+    y = np.random.randn(n_samples, 1)
+    w = np.random.randn(n_samples, 1)
+    ids = np.random.randn(n_samples, 1)
+
+    dataset = dc.data.ImageDataset(X, y, w, ids)
+    img_transformer = dc.trans.ImageTransformer(size=new_size,
+                                                transform_X=True,
+                                                transform_y=False)
+    dataset = dataset.transform(img_transformer)
+
+    assert dataset.X.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.y.shape == (n_samples, 1)
+    assert dataset.w.shape == (n_samples, 1)
+    assert dataset.ids.shape == (n_samples, 1)
+
+
+def test_y_image_transform():
+    """Test ImageTransformer on only y array"""
+    n_samples = 10
+    width = 35
+    height = 67
+    channels = 4
+    new_size = (10, 15)
+
+    X = np.random.randn(n_samples, width, height, channels)
+    y = np.random.randn(n_samples, width, height, channels)
+    w = np.random.randn(n_samples, 1)
+    ids = np.random.randn(n_samples, 1)
+
+    dataset = dc.data.ImageDataset(X, y, w, ids)
+    img_transformer = dc.trans.ImageTransformer(size=new_size,
+                                                transform_x=False,
+                                                transform_y=True)
+    dataset = dataset.transform(img_transformer)
+
+    assert dataset.X.shape == (n_samples, width, height, channels)
+    assert dataset.y.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.w.shape == (n_samples, 1)
+    assert dataset.ids.shape == (n_samples, 1)
+
+
+def test_xy_image_transform():
+    """Test ImageTransformer on both X and y arrays"""
+    n_samples = 10
+    width = 35
+    height = 67
+    channels = 4
+    new_size = (10, 15)
+
+    X = np.random.randn(n_samples, width, height, channels)
+    y = np.random.randn(n_samples, width, height, channels)
+    w = np.random.randn(n_samples, 1)
+    ids = np.random.randn(n_samples, 1)
+
+    dataset = dc.data.ImageDataset(X, y, w, ids)
+    img_transformer = dc.trans.ImageTransformer(size=new_size,
+                                                transform_x=True,
+                                                transform_y=True)
+    dataset = dataset.transform(img_transformer)
+
+    assert dataset.X.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.y.shape == (n_samples, new_size[0], new_size[1], channels)
+    assert dataset.w.shape == (n_samples, 1)
+    assert dataset.ids.shape == (n_samples, 1)
+
+
+def test_image_transform_array():
+    """Test ImageTransformer on random array"""
+    n_samples = 10
+    width = 35
+    height = 67
+    channels = 4
+    new_size = (10, 15)
+
+    X = np.random.randn(n_samples, width, height, channels)
+    y = np.random.randn(n_samples, width, height, channels)
+    w = np.random.randn(n_samples, 1)
+    ids = np.random.randn(n_samples, 1)
+
+    img_transform = dc.trans.ImageTransformer(size=new_size,
+                                              transform_x=True,
+                                              transform_y=True)
+    data = img_transform.transform_array(X, y, w, ids)
+
+    assert data[0].shape == (n_samples, new_size[0], new_size[1], channels)
+    assert data[1].shape == (n_samples, new_size[0], new_size[1], channels)
+    assert data[2].shape == (n_samples, 1)
+    assert data[3].shape == (n_samples, 1)

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -1980,16 +1980,16 @@ class ImageTransformer(Transformer):
         >>> X = np.random.rand(10, 256, 256, 3)
         >>> y = np.random.rand(10, 256, 256, 3)
 
-        Let's now make a ImageDataset using the ImageLoader
-        >>> loader = dc.data.ImageLoader(tasks=['image-resizing'])
-        >>> dataset = loader.create_dataset(inputs=(X, y), in_memory=False)
+        Let's now make a ImageDataset
+        >>> dataset = dc.data.ImageDataset(X, y)
 
         And let's apply our transformer with a size of (128, 128, 3).
         >>> img_transform = dc.trans.ImageTransformer(size=(128, 128), transform_X=True, transform_y=True)
         >>> resized_dataset = dataset.transform(img_transform)
 
         We can see that our dataset has been resized.
-        >>> resized_dataset.get_shape()
+        >>> resized_X = resized_dataset.X
+        >>> resized_X.shape
         (10, 128, 128, 3)
 
         We can also see that the masks have been resized.

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -1943,25 +1943,36 @@ class DAGTransformer(Transformer):
 
 
 class ImageTransformer(Transformer):
-    """Convert an image into width, height, channel
+    """
+    Transforms images to a specified size.
 
     Note
     ----
     This class require Pillow to be installed.
     """
 
-    def __init__(self, size: Tuple[int, int]):
+    def __init__(self,
+                 size: Tuple[int, int],
+                 transform_X: bool = True,
+                 transform_y: bool = False):
         """Initializes ImageTransformer.
 
         Parameters
         ----------
         size: Tuple[int, int]
             The image size, a tuple of (width, height).
+        transform_X: bool, optional (default True)
+            Whether to transform X
+        transform_y: bool, optional (default False)
+            Whether to transform y
         """
         self.size = size
-        super(ImageTransformer, self).__init__(transform_X=True)
+        super(ImageTransformer, self).__init__(transform_X=transform_X,
+                                               transform_y=transform_y)
 
-    def transform_array(self, X, y, w):
+    def transform_array(
+        self, X: np.ndarray, y: np.ndarray, w: np.ndarray, ids: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Transform the data in a set of (X, y, w, ids) arrays.
 
         Parameters
@@ -1990,9 +2001,28 @@ class ImageTransformer(Transformer):
             from PIL import Image
         except ModuleNotFoundError:
             raise ImportError("This function requires Pillow to be installed.")
-        images = [scipy.ndimage.imread(x, mode='RGB') for x in X]
-        images = [Image.fromarray(x).resize(self.size) for x in images]
-        return np.array(images), y, w
+
+        if self.transform_X:
+            assert len(
+                X.shape
+            ) >= 3, "X must be an array of images with shape (n_samples, width, height) or (n_samples, width, height, channels)."
+            x = [
+                np.array(
+                    Image.fromarray(
+                        (img * 255).astype(np.uint8)).resize(self.size)) / 255
+                for img in X
+            ]
+        if self.transform_y:
+            assert len(
+                y.shape
+            ) >= 3, "y must be an array of images with shape (n_samples, width, height) or (n_samples, width, height, channels)."
+            y = [
+                np.array(
+                    Image.fromarray(
+                        (img * 255).astype(np.uint8)).resize(self.size)) / 255
+                for img in y
+            ]
+        return (np.array(x), np.array(y), w, ids)
 
 
 # class ANITransformer(Transformer):

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -2006,6 +2006,7 @@ class ImageTransformer(Transformer):
             assert len(
                 X.shape
             ) >= 3, "X must be an array of images with shape (n_samples, width, height) or (n_samples, width, height, channels)."
+            # PIL only accepts uint8 data type as inputs, so we multiply then divide by 255 to minimize information loss while resizing.
             x = [
                 np.array(
                     Image.fromarray(

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -1943,8 +1943,12 @@ class DAGTransformer(Transformer):
 
 
 class ImageTransformer(Transformer):
-    """
-    Transforms images to a specified size.
+    """Transforms images to a specified width and/or height.
+
+    Images of shape (n_samples, width, height) and (n_samples, width, height, channels) are supported.
+
+    Images of shape (n_samples, width, height, channels) can be resized to
+    (n_samples, new_width, new_height, channels).
 
     Note
     ----
@@ -1955,7 +1959,8 @@ class ImageTransformer(Transformer):
                  size: Tuple[int, int],
                  transform_X: bool = True,
                  transform_y: bool = False):
-        """Initializes ImageTransformer.
+        """
+        Initializes ImageTransformer.
 
         Parameters
         ----------
@@ -1965,6 +1970,30 @@ class ImageTransformer(Transformer):
             Whether to transform X
         transform_y: bool, optional (default False)
             Whether to transform y
+
+        Examples
+        --------
+        Let's transform a small dataset of images and their masks.
+
+        >>> import deepchem as dc
+        >>> import numpy as np
+        >>> X = np.random.rand(10, 256, 256, 3)
+        >>> y = np.random.rand(10, 256, 256, 3)
+
+        Let's now make a ImageDataset using the ImageLoader
+        >>> loader = dc.data.ImageLoader(tasks=['image-resizing'])
+        >>> dataset = loader.create_dataset(inputs=(X, y), in_memory=False)
+
+        And let's apply our transformer with a size of (128, 128, 3).
+        >>> img_transform = dc.trans.ImageTransformer(size=(128, 128), transform_X=True, transform_y=True)
+        >>> resized_dataset = dataset.transform(img_transform)
+
+        We can see that our dataset has been resized.
+        >>> resized_dataset.get_shape()
+        (10, 128, 128, 3)
+
+        We can also see that the masks have been resized.
+        If you want to transform only X, you can set `transform_y` to `False`, and vice versa.
         """
         self.size = size
         super(ImageTransformer, self).__init__(transform_X=transform_X,

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -2036,25 +2036,25 @@ class ImageTransformer(Transformer):
                 X.shape
             ) >= 3, "X must be an array of images with shape (n_samples, width, height) or (n_samples, width, height, channels)."
             # PIL only accepts uint8 data type as inputs, so we multiply then divide by 255 to minimize information loss while resizing.
-            x = [
+            x = np.array([
                 np.array(
                     Image.fromarray(
                         (img * 255).astype(np.uint8)).resize(self.size)) / 255
                 for img in X
-            ]
+            ])
         else:  # if not transforming X, return the original X
-            x = X
+            x = np.array(X)
         if self.transform_y:
             assert len(
                 y.shape
             ) >= 3, "y must be an array of images with shape (n_samples, width, height) or (n_samples, width, height, channels)."
-            y = [
+            y = np.array([
                 np.array(
                     Image.fromarray(
                         (img * 255).astype(np.uint8)).resize(self.size)) / 255
                 for img in y
-            ]
-        return (np.array(x), np.array(y), w, ids)
+            ])
+        return (x, y, w, ids)
 
 
 # class ANITransformer(Transformer):

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -2013,6 +2013,8 @@ class ImageTransformer(Transformer):
                         (img * 255).astype(np.uint8)).resize(self.size)) / 255
                 for img in X
             ]
+        else:  # if not transforming X, return the original X
+            x = X
         if self.transform_y:
             assert len(
                 y.shape


### PR DESCRIPTION
## Description

Current Image Transform uses a scipy method that has been dropped and is no longer functional. 
I've added the ImageTransformer method to allow Resizing of images within ImageDatasets (or NumpyDatasets). 
Both input data (X) and labels (y) can be transformed.
Uses only Pillow. 

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
