### PR TITLE
making the tensorflow dependancy less than 2.16.1

### DIFF
--- a/requirements/tensorflow/env_tensorflow.cpu.yml
+++ b/requirements/tensorflow/env_tensorflow.cpu.yml
@@ -1,5 +1,5 @@
 dependencies:
   - pip:
-    - tensorflow<2.16
+    - tensorflow<2.16.1
     - tensorflow_probability<0.24
     - tensorflow_addons


### PR DESCRIPTION
## Description

Testing changing the min tensorflow version to check CI pipeline !


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)