### PR TITLE
Added learning rate schedulers with warmups

### DIFF
--- a/deepchem/models/optimizers.py
+++ b/deepchem/models/optimizers.py
@@ -551,7 +551,18 @@ class ExponentialDecay(LearningRateSchedule):
 
 
 class LambdaLRWithWarmup(LearningRateSchedule):
-    """A learning rate scheduler supporting warmup."""
+    """A learning rate scheduler supporting warmup followed by cool down.
+
+    Example
+    -------
+    >>> import deepchem.models.optimizers as optimizers
+    >>> opt = optimizers.Adam(learning_rate=5e-5)
+    >>> lr_schedule = optimizers.LambdaLRWithWarmup(initial_rate=5e-5,
+    ...     num_training_steps=100, num_warmup_steps=10)
+    >>> params = [torch.nn.Parameter(torch.Tensor([1.0]))]
+    >>> optimizer = opt._create_pytorch_optimizer(params)
+    >>> scheduler = lr_schedule._create_pytorch_schedule(optimizer)
+    """
 
     def __init__(self,
                  initial_rate: float,
@@ -581,6 +592,17 @@ class LambdaLRWithWarmup(LearningRateSchedule):
         self.warmup_type = warmup_type
 
     def _create_pytorch_schedule(self, optimizer):
+        """Creates a PyTorch learning rate scheduler for the given optimizer.
+
+        When the warmup type is linear, the method _linear_schedule_with_warmup
+        is used to create a learning rate schedule such that the learning
+        rate increases linearly from 0 to initial_rate and
+        then cools down to 0 linearly.
+
+        When the warmup type is constant, the method _constant_schedule_with_warmup
+        is used to create a learning rate schedule such that the learning
+        rate linearly increases form 0 to initial_rate and then stays constant.
+        """
 
         def _linear_schedule_with_warmup(current_step: int, *,
                                          num_warmup_steps: int,

--- a/deepchem/models/optimizers.py
+++ b/deepchem/models/optimizers.py
@@ -551,19 +551,37 @@ class ExponentialDecay(LearningRateSchedule):
 
 
 class LambdaLRWithWarmup(LearningRateSchedule):
+    """A learning rate scheduler supporting warmup."""
 
     def __init__(self,
                  initial_rate: float,
                  num_warmup_steps: int,
-                 num_training_steps: int = 1,
+                 num_training_steps: Optional[int] = None,
                  warmup_type: str = 'linear'):
-        assert warmup_type == 'linear', f'Warmup type {warmup_type} is not supported.'
+        """
+        Parameters
+        ----------
+        initial_rate: float
+            Initial learning rate
+        num_warmup_steps: int
+            Number of warmup steps
+        num_training_steps: int
+            Number of training steps - required for linear schedule.
+        warmup_type: str, optional. default: linear
+            When `linear`, creates a learning rate schedule that decreases linearly from
+                the initial lr in the optimizer to 0.
+            When `constant`, creates a constant learning rate preceded by a warmup period
+                during which the learning rate increases linearly between 0 and the initial
+                lr set in the optimizer.
+        """
+        assert warmup_type == 'linear' or 'constant', f'Warmup type {warmup_type} is not supported.'
         self.initial_rate = initial_rate
         self.num_warmup_steps = num_warmup_steps
         self.num_training_steps = num_training_steps
         self.warmup_type = warmup_type
 
     def _create_pytorch_schedule(self, optimizer):
+
         def _linear_schedule_with_warmup(current_step: int, *,
                                          num_warmup_steps: int,
                                          num_training_steps: int):
@@ -574,10 +592,19 @@ class LambdaLRWithWarmup(LearningRateSchedule):
                 float(num_training_steps - current_step) /
                 float(max(1, num_training_steps - num_warmup_steps)))
 
+        def _constant_schedule_with_warmup(current_step: int, *,
+                                           num_warmup_steps: int):
+            if current_step < num_warmup_steps:
+                return float(current_step) / float(max(1.0, num_warmup_steps))
+            return 1.0
+
         if self.warmup_type == 'linear':
-            f = partial(_linear_schedule_with_warmup, 
-                num_warmup_steps=self.num_warmup_steps,
-                num_training_steps=self.num_training_steps)
+            f = partial(_linear_schedule_with_warmup,
+                        num_warmup_steps=self.num_warmup_steps,
+                        num_training_steps=self.num_training_steps)
+        elif self.warmup_type == 'constant':
+            f = partial(_constant_schedule_with_warmup,
+                        num_warmup_steps=self.num_warmup_steps)
 
         import torch
         return torch.optim.lr_scheduler.LambdaLR(optimizer, f)

--- a/deepchem/models/tests/test_optimizers.py
+++ b/deepchem/models/tests/test_optimizers.py
@@ -184,6 +184,16 @@ class TestOptimizers(unittest.TestCase):
         torchopt = opt._create_pytorch_optimizer(params)
         _ = rate._create_pytorch_schedule(torchopt)
 
+    @pytest.mark.torch
+    def test_lambda_lr_with_warmup(self):
+        opt = optimizers.Adam(learning_rate=5e-5)
+        lr_schedule = optimizers.LambdaLRWithWarmup(initial_rate=5e-5,
+                                            num_training_steps=100_000 * 10,
+                                            num_warmup_steps=10_000)
+        params = [torch.nn.Parameter(torch.Tensor([1.0]))]
+        torchopt = opt._create_pytorch_optimizer(params)
+        _ = lr_schedule._create_pytorch_schedule(torchopt)
+
     @pytest.mark.jax
     def test_exponential_decay_jax(self):
         """Test creating an optimizer with an exponentially decaying learning rate."""

--- a/deepchem/models/tests/test_optimizers.py
+++ b/deepchem/models/tests/test_optimizers.py
@@ -188,8 +188,9 @@ class TestOptimizers(unittest.TestCase):
     def test_lambda_lr_with_warmup(self):
         opt = optimizers.Adam(learning_rate=5e-5)
         lr_schedule = optimizers.LambdaLRWithWarmup(initial_rate=5e-5,
-                                            num_training_steps=100_000 * 10,
-                                            num_warmup_steps=10_000)
+                                                    num_training_steps=100_000 *
+                                                    10,
+                                                    num_warmup_steps=10_000)
         params = [torch.nn.Parameter(torch.Tensor([1.0]))]
         torchopt = opt._create_pytorch_optimizer(params)
         _ = lr_schedule._create_pytorch_schedule(torchopt)

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -162,6 +162,8 @@ Optimizers
 .. autoclass:: deepchem.models.optimizers.LinearCosineDecay
   :members:
 
+.. autoclass:: deepchem.models.optimizers.LambdaLRWithWarmup
+  :members:
 
 Keras Models
 ============


### PR DESCRIPTION
## Description

I have added learning rate schedulers with warmup in this pull request.
Currently, two warmup schedules are supported:
- linear schedule where the learning rate increases from 0 to `lr` during the warmup period and then
decreases to 0 linearly after the warmup period.
- constant schedule where the learning rate increases from 0 to `lr` during the warmup period and then 
remains constant for rest of the training.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
