### PR TITLE
small fix to get more info from pysam pileups

### DIFF
--- a/deepchem/feat/bio_seq_featurizer.py
+++ b/deepchem/feat/bio_seq_featurizer.py
@@ -204,12 +204,14 @@ class BAMFeaturizer(Featurizer):
                         start=record.reference_start,
                         end=record.reference_end):
                     pileup_info = {
+                        "name": 
+                            pileupcolumn.reference_name,
                         "pos":
                             pileupcolumn.reference_pos,
                         "depth":
                             pileupcolumn.nsegments,
                         "reads": [
-                            pileupread.alignment.query_sequence
+                            [pileupread.alignment.query_sequence, pileupread.query_position, pileupread.is_del, pileupread.is_refskip, pileupread.indel]
                             for pileupread in pileupcolumn.pileups
                         ]
                     }

--- a/deepchem/feat/bio_seq_featurizer.py
+++ b/deepchem/feat/bio_seq_featurizer.py
@@ -204,16 +204,17 @@ class BAMFeaturizer(Featurizer):
                         start=record.reference_start,
                         end=record.reference_end):
                     pileup_info = {
-                        "name": 
+                        "name":
                             pileupcolumn.reference_name,
                         "pos":
                             pileupcolumn.reference_pos,
                         "depth":
                             pileupcolumn.nsegments,
-                        "reads": [
-                            [pileupread.alignment.query_sequence, pileupread.query_position, pileupread.is_del, pileupread.is_refskip, pileupread.indel]
-                            for pileupread in pileupcolumn.pileups
-                        ]
+                        "reads": [[
+                            pileupread.alignment.query_sequence,
+                            pileupread.query_position, pileupread.is_del,
+                            pileupread.is_refskip, pileupread.indel
+                        ] for pileupread in pileupcolumn.pileups]
                     }
                     pileup_columns.append(pileup_info)
                 feature_vector.append(pileup_columns)


### PR DESCRIPTION
## Description

Gets reference name and additional information about each pileupread in pileupcolumns

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
