### PR TITLE
Added SMILES tokenization section to tutorial

### DIFF
--- a/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
+++ b/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -31,10 +31,23 @@
     "id": "D43MbibL_EK0",
     "outputId": "e7b205ae-9962-4089-d49a-6d0ebe4c8430"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2.6.0.dev'"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "!pip install --pre deepchem\n",
+    "!pip install -qq --pre deepchem\n",
     "import deepchem\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
     "deepchem.__version__"
    ]
   },
@@ -56,7 +69,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "colab": {},
     "colab_type": "code",
@@ -70,6 +83,15 @@
       "[[0. 0. 0. ... 0. 0. 0.]\n",
       " [0. 0. 0. ... 0. 0. 0.]\n",
       " [0. 0. 0. ... 0. 0. 0.]]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[09:05:59] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[09:05:59] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[09:05:59] DEPRECATION WARNING: please use MorganGenerator\n"
      ]
     }
    ],
@@ -118,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -133,23 +155,34 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MaxEStateIndex 2.125\n",
-      "MinEStateIndex 1.25\n",
       "MaxAbsEStateIndex 2.125\n",
+      "MaxEStateIndex 2.125\n",
       "MinAbsEStateIndex 1.25\n",
+      "MinEStateIndex 1.25\n",
       "qed 0.3854706587740357\n",
+      "SPS 6.0\n",
       "MolWt 44.097\n",
       "HeavyAtomMolWt 36.033\n",
       "ExactMolWt 44.062600255999996\n",
-      "NumValenceElectrons 20.0\n",
-      "NumRadicalElectrons 0.0\n"
+      "NumValenceElectrons 20.0\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[09:07:17] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[09:07:17] DEPRECATION WARNING: please use MorganGenerator\n",
+      "[09:07:17] DEPRECATION WARNING: please use MorganGenerator\n"
      ]
     }
    ],
    "source": [
+    "from rdkit.Chem.Descriptors import descList\n",
     "rdkit_featurizer = dc.feat.RDKitDescriptors()\n",
     "features = rdkit_featurizer(['CCC'])[0]\n",
-    "for feature, descriptor in zip(features[:10], rdkit_featurizer.descriptors):\n",
+    "descriptors = [i[0] for i in descList]\n",
+    "for feature, descriptor in zip(features[:10], descriptors):\n",
     "    print(descriptor, feature)"
    ]
   },
@@ -162,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -177,7 +210,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The number of descriptors present is:  200\n"
+      "The number of descriptors present is:  210\n"
      ]
     }
    ],
@@ -217,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -253,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -278,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -374,14 +407,6 @@
       "    0.          0.          0.          0.          0.\n",
       "    0.          0.          0.          0.          0.        ]]]\n"
      ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/peastman/workspace/deepchem/deepchem/feat/molecule_featurizers/coulomb_matrices.py:141: RuntimeWarning: divide by zero encountered in true_divide\n",
-      "  m = np.outer(z, z) / d\n"
-     ]
     }
    ],
    "source": [
@@ -426,7 +451,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/",
@@ -456,6 +481,404 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### SMILES Tokenization and Numericalization\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So far, we have looked at featurization techniques that translate the implicit structural and physical information in SMILES data into more explicit features that help our models learn and make predictions. In this section, we will preprocess SMILES strings into a format that can be fed to sequence models, such as 1D convolutional neural networks and transformers, and enables these models to learn their own representations of molecular properties.\n",
+    "\n",
+    "To prepare SMILES strings for a sequence model, we break them down into lists of substrings (called tokens) and turn them into lists of integer values (numericalization). Sequence models use those integer values as indices of an embedding matrix, which contains a vector of floating-point numbers for each token in the vocabulary. These embedding vectors are updated during model training. This process allows the sequence model to learn its own representations of the molecular properties implicit in the training data.\n",
+    "\n",
+    "We will use DeepChem's `BasicSmilesTokenizer` and the Tox21 dataset from MoleculeNet to demonstrate the process of tokenizing SMILES."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<DiskDataset X.shape: (6264,), y.shape: (6264, 12), w.shape: (6264, 12), task_names: ['NR-AR' 'NR-AR-LBD' 'NR-AhR' ... 'SR-HSE' 'SR-MMP' 'SR-p53']>\n"
+     ]
+    }
+   ],
+   "source": [
+    "tasks, datasets, transformers = dc.molnet.load_tox21(featurizer=\"Raw\")\n",
+    "train_dataset, valid_dataset, test_dataset = datasets\n",
+    "print(train_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We loaded the datasets with `featurizer=\"Raw\"`. Now we obtain the SMILES from their `ids` attributes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['CC(O)(P(=O)(O)O)P(=O)(O)O' 'CC(C)(C)OOC(C)(C)CCC(C)(C)OOC(C)(C)C'\n",
+      " 'OC[C@H](O)[C@@H](O)[C@H](O)CO'\n",
+      " 'CCCCCCCC(=O)[O-].CCCCCCCC(=O)[O-].[Zn+2]' 'CC(C)COC(=O)C(C)C']\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_smiles = train_dataset.ids\n",
+    "valid_smiles = valid_dataset.ids\n",
+    "test_smiles = test_dataset.ids\n",
+    "print(train_smiles[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next we define our tokenizer and `map` it onto all our data to convert the SMILES strings into lists of tokens. The `BasicSmilesTokenizer` breaks down SMILES roughly at atom level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['C', 'C', '(', 'O', ')', '(', 'P', '(', '=', 'O', ')', '(', 'O', ')', 'O', ')', 'P', '(', '=', 'O', ')', '(', 'O', ')', 'O']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "6264"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tokenizer = dc.feat.smiles_tokenizer.BasicSmilesTokenizer()\n",
+    "\n",
+    "train_tok = list(map(tokenizer.tokenize, train_smiles))\n",
+    "valid_tok = list(map(tokenizer.tokenize, valid_smiles))\n",
+    "test_tok = list(map(tokenizer.tokenize, test_smiles))\n",
+    "print(train_tok[0])\n",
+    "len(train_tok)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have tokenized versions of all SMILES strings in our dataset. To convert those into lists of integer values we first need to create a list of all possible tokens in our dataset. That list is called the vocabulary. We also add the empty string `\"\"` to our vocabulary in order to correctly handle trailing zeros when decoding zero-padded numericalized SMILES."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['', '#', '(', ')', '-', '.', '/', '1', '2', '3', '4', '5'] ... ['[n+]', '[n-]', '[nH+]', '[nH]', '[o+]', '[s+]', '[se]', '\\\\', 'c', 'n', 'o', 's']\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "128"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flatten = lambda l: [item for items in l for item in items]\n",
+    "\n",
+    "all_toks = flatten(train_tok) + flatten(valid_tok) + flatten(test_tok)\n",
+    "vocab = sorted(set(all_toks + [\"\"]))\n",
+    "print(vocab[:12], \"...\", vocab[-12:])\n",
+    "len(vocab)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To numericalize tokenized SMILES strings we create a `str2int` dictionary which assigns a number to each token in the dictionary. We also create the reverse `int2str` dictionary and define the corresponding `encode` and `decode` functions. Finally we `map` the `encode` function on the tokenized data to obtain numericalized SMILES data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "str2int: {'': 0, '#': 1, '(': 2, ')': 3, '-': 4} ...\n",
+      "int2str: {0: '', 1: '#', 2: '(', 3: ')', 4: '-'} ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "str2int = {s:i for i, s in enumerate(vocab)}\n",
+    "int2str = {i:s for i, s in enumerate(vocab)}\n",
+    "print(f\"str2int: {dict(list(str2int.items())[:5])} ...\")\n",
+    "print(f\"int2str: {dict(list(int2str.items())[:5])} ...\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CC(O)(P(=O)(O)O)P(=O)(O)O\n",
+      "[19, 19, 2, 24, 3, 2, 25, 2, 16, 24, 3, 2, 24, 3, 24, 3, 25, 2, 16, 24, 3, 2, 24, 3, 24]\n",
+      "CC(O)(P(=O)(O)O)P(=O)(O)O\n"
+     ]
+    }
+   ],
+   "source": [
+    "encode = lambda s: [str2int[tok] for tok in s]\n",
+    "decode = lambda i: [int2str[num] for num in i]\n",
+    "print(train_smiles[0])\n",
+    "print(encode(train_tok[0]))\n",
+    "print(\"\".join(decode(encode(train_tok[0]))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[19, 19, 2, 24, 3, 2, 25, 2, 16, 24, 3, 2, 24, 3, 24, 3, 25, 2, 16, 24, 3, 2, 24, 3, 24]\n"
+     ]
+    }
+   ],
+   "source": [
+    "train_num = list(map(encode, train_tok))\n",
+    "valid_num = list(map(encode, valid_tok))\n",
+    "test_num = list(map(encode, test_tok))\n",
+    "print(train_num[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Lastly, we would like to combine all molecules in a dataset in an `np.array` so they can be served to a model in batches. To achieve that, all sequences have to be of the same length. As in the CoulombMatrix section, we achieve that by appending zeros up to a fixed value."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "240"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "max_len = max(map(len, train_num + valid_num + test_num))\n",
+    "max_len"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The longest sequence across all Tox21 datasets has length `240`, so we use that as our fixed length. We create a `zero_pad` function,  `map` it to all numericalized SMILES, and turn them into `np.array`s."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([[19, 19,  2, ...,  0,  0,  0],\n",
+       "       [19, 19,  2, ...,  0,  0,  0],\n",
+       "       [24, 19, 42, ...,  0,  0,  0],\n",
+       "       ...,\n",
+       "       [24, 16, 19, ...,  0,  0,  0],\n",
+       "       [19, 19,  2, ...,  0,  0,  0],\n",
+       "       [19, 19,  2, ...,  0,  0,  0]])"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zero_pad = lambda x: x + [0] * (max_len - len(x))\n",
+    "\n",
+    "train_numpad = np.array(list(map(zero_pad, train_num)))\n",
+    "valid_numpad = np.array(list(map(zero_pad, valid_num)))\n",
+    "test_numpad = np.array(list(map(zero_pad, test_num)))\n",
+    "train_numpad"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can check that the zero-padded data still converts back to the correct SMILES string using the `decode` function on a random datapoint."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Cc1cc(C(C)(C)c2ccc(O)c(C)c2)ccc1O\n",
+      "Cc1cc(C(C)(C)c2ccc(O)c(C)c2)ccc1O\n"
+     ]
+    }
+   ],
+   "source": [
+    "idx = np.random.randint(0, train_numpad.shape[0], 1).item()\n",
+    "print(train_smiles[idx])\n",
+    "print(\"\".join(decode(train_numpad[idx])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The padded data passes the test. It is now in the correct format to be used for training of a sequence model, but it doesn't yet interface nicely with DeepChem's training framework. To change that, we define a `tokenize_smiles` function that combines all the steps spelled out above to process a single datapoint. Additionally, we define a `SmilesFeaturizer` that uses our custom `tokenize_smiles` function in its `_featurize` method and instanciate it as `smiles_featurizer` passing it our `vocab` and `max_len`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenize_smiles(x, vocab, max_len):\n",
+    "    tokenizer = dc.feat.smiles_tokenizer.BasicSmilesTokenizer()\n",
+    "    str2int = {s:i for i, s in enumerate(vocab)}\n",
+    "    encode = lambda s: [str2int[tok] for tok in s]\n",
+    "    zero_pad = lambda x: x + [0] * (max_len - len(x))\n",
+    "    x = tokenizer.tokenize(x)\n",
+    "    x = encode(x)\n",
+    "    x = zero_pad(x)\n",
+    "    return np.array(x)\n",
+    "\n",
+    "class SmilesFeaturizer(dc.feat.Featurizer):\n",
+    "    def __init__(self, feat_func, vocab, max_len):\n",
+    "        self.feat_func = feat_func\n",
+    "        self.vocab = vocab\n",
+    "        self.max_len = max_len\n",
+    "        \n",
+    "    def _featurize(self, x):\n",
+    "        return self.feat_func(x, self.vocab, self.max_len)\n",
+    "    \n",
+    "smiles_featurizer = SmilesFeaturizer(tokenize_smiles, vocab, max_len)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we use the `smiles_featurizer` to create new Tox21 datasets that contain tokenized and numericalized SMILES in their `X` attribute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[09:24:48] WARNING: not removing hydrogen atom without neighbors\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[19 19  2 ...  0  0  0]\n",
+      " [19 19  2 ...  0  0  0]\n",
+      " [24 19 42 ...  0  0  0]\n",
+      " ...\n",
+      " [24 16 19 ...  0  0  0]\n",
+      " [19 19  2 ...  0  0  0]\n",
+      " [19 19  2 ...  0  0  0]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "tasks, datasets, transformers = dc.molnet.load_tox21(featurizer=smiles_featurizer)\n",
+    "print(datasets[0].X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The datasets are now ready to be used with your custom DeepChem sequence model. Don't forget to wrap your model into the appropriate DeepChem model class."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "wssi6cBmh12z"
@@ -472,33 +895,33 @@
     "The DeepChem [Gitter](https://gitter.im/deepchem/Lobby) hosts a number of scientists, developers, and enthusiasts interested in deep learning for the life sciences. Join the conversation!"
    ]
   },
-   {
-      "cell_type": "markdown",
-      "source": [
-        "## Citing This Tutorial\n",
-        "If you found this tutorial useful please consider citing it using the provided BibTeX. "
-      ],
-      "metadata": {
-        "id": "pOBd6-YdQSvF"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "@manual{Intro7, \n",
-        " title={Going Deeper on Molecular Featurizations}, \n",
-        " organization={DeepChem},\n",
-        " author={Ramsundar, Bharath}, \n",
-        " howpublished = {\\url{https://github.com/deepchem/deepchem/blob/master/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb}}, \n",
-        " year={2021}, \n",
-        "} "
-      ],
-      "metadata": {
-        "id": "KZUk_9yIYw0c"
-      },
-      "execution_count": null,
-      "outputs": []
-    }
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pOBd6-YdQSvF"
+   },
+   "source": [
+    "## Citing This Tutorial\n",
+    "If you found this tutorial useful please consider citing it using the provided BibTeX. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "KZUk_9yIYw0c"
+   },
+   "outputs": [],
+   "source": [
+    "@manual{Intro7, \n",
+    " title={Going Deeper on Molecular Featurizations}, \n",
+    " organization={DeepChem},\n",
+    " author={Ramsundar, Bharath}, \n",
+    " howpublished = {\\url{https://github.com/deepchem/deepchem/blob/master/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb}}, \n",
+    " year={2021}, \n",
+    "} "
+   ]
+  }
  ],
  "metadata": {
   "colab": {
@@ -506,7 +929,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -520,7 +943,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

Not a fix! I added a new section "SMILES Tokenization and Numericalization" to the "Going Deeper on Molecular Featurizations" tutorial. 

The new section contains a step-by-step guide on the pre-processing of SMILES data for sequence models. It also demonstrates how these steps can be combined in a custom `Featurizer` class that can be used with `dc.molnet`'s load functions to load tokenized and numericalized SMILES data.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project (https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors n/a
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
