### PR TITLE
fix to get accurate pileups with pysam

### DIFF
--- a/deepchem/data/tests/test_deepvariant_featurizer.py
+++ b/deepchem/data/tests/test_deepvariant_featurizer.py
@@ -20,10 +20,12 @@ class TestRealignerFeaturizer(unittest.TestCase):
         candidate_windows = self.featurizer._featurize(datapoint)
 
         # Assert the number of reads
-        self.assertEqual(len(candidate_windows), 14)
-        self.assertEqual(candidate_windows[13],
-                         ('chr2', 193, 197, 18, 21,
-                          ['GTAAATTGATTTGAATTTTATTTCTTGGTAATGAGG']))
+        self.assertEqual(len(candidate_windows), 15)
+        self.assertEqual(candidate_windows[13][0],'chr2')
+        self.assertEqual(candidate_windows[13][1],136)
+        self.assertEqual(candidate_windows[13][2],137)
+        self.assertEqual(candidate_windows[13][3],102)
+        self.assertEqual(candidate_windows[13][4],21)
 
 
 if __name__ == "__main__":

--- a/deepchem/data/tests/test_deepvariant_featurizer.py
+++ b/deepchem/data/tests/test_deepvariant_featurizer.py
@@ -21,11 +21,11 @@ class TestRealignerFeaturizer(unittest.TestCase):
 
         # Assert the number of reads
         self.assertEqual(len(candidate_windows), 15)
-        self.assertEqual(candidate_windows[13][0],'chr2')
-        self.assertEqual(candidate_windows[13][1],136)
-        self.assertEqual(candidate_windows[13][2],137)
-        self.assertEqual(candidate_windows[13][3],102)
-        self.assertEqual(candidate_windows[13][4],21)
+        self.assertEqual(candidate_windows[13][0], 'chr2')
+        self.assertEqual(candidate_windows[13][1], 136)
+        self.assertEqual(candidate_windows[13][2], 137)
+        self.assertEqual(candidate_windows[13][3], 102)
+        self.assertEqual(candidate_windows[13][4], 21)
 
 
 if __name__ == "__main__":

--- a/deepchem/feat/bio_seq_featurizer.py
+++ b/deepchem/feat/bio_seq_featurizer.py
@@ -200,10 +200,7 @@ class BAMFeaturizer(Featurizer):
 
             if (self.get_pileup):
                 pileup_columns = []
-                for pileupcolumn in datapoint.pileup(
-                        reference=record.reference_name,
-                        start=record.reference_start,
-                        end=record.reference_end):
+                for pileupcolumn in datapoint.pileup():
                     pileup_info = {
                         "name":
                             pileupcolumn.reference_name,


### PR DESCRIPTION
## Description

Fix to get pileups over all BAM reads, not just specific ones


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
