### PR TITLE
Added attribute descriptors to RDKitDescriptors

### DIFF
--- a/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
+++ b/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
@@ -96,9 +96,8 @@ class RDKitDescriptors(MolecularFeaturizer):
         self.reqd_properties = {}
         self.normalized_desc: Dict[str, Callable] = {}
 
-        self.descriptors = all_descriptors = {
-            name: func for name, func in Descriptors.descList
-        }
+        all_descriptors = {name: func for name, func in Descriptors.descList}
+        self.descriptors = all_descriptors
 
         if not descriptors:
             # user has not specified a descriptor list

--- a/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
+++ b/deepchem/feat/molecule_featurizers/rdkit_descriptors.py
@@ -96,7 +96,9 @@ class RDKitDescriptors(MolecularFeaturizer):
         self.reqd_properties = {}
         self.normalized_desc: Dict[str, Callable] = {}
 
-        all_descriptors = {name: func for name, func in Descriptors.descList}
+        self.descriptors = all_descriptors = {
+            name: func for name, func in Descriptors.descList
+        }
 
         if not descriptors:
             # user has not specified a descriptor list


### PR DESCRIPTION
## Description

Fix #3396

I added the `self.descriptors` attribute back into the `RDKitDescriptors` class as was requested in issue [#3396](https://github.com/deepchem/deepchem/issues/3396).

Previously:
```python
all_descriptors = {name: func for name, func in Descriptors.descList}
```

Now:
```python
self.descriptors = all_descriptors = {name: func for name, func in Descriptors.descList}
```

Note that I did run `mypy -p deepchem` on my local build which found 40 errors in 15 files that don't seem related to my fix, so I went ahead regardless.
 
## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
