### PR TITLE
Fixed antibody model reload test

### DIFF
--- a/deepchem/models/torch_models/tests/test_antibody_modeling.py
+++ b/deepchem/models/torch_models/tests/test_antibody_modeling.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:
 
 @pytest.fixture
 def igbert_tokenizer():
-    from tokenizers import AutoTokenizer
+    from transformers import AutoTokenizer
     tokenizer = AutoTokenizer.from_pretrained('Exscientia/IgBert')
     return tokenizer
 
@@ -18,7 +18,7 @@ def igbert_tokenizer():
 @pytest.mark.torch
 def test_init(igbert_tokenizer):
     from deepchem.models.torch_models.antibody_modeling import DeepAbLLM
-    from deepchem.models.torch_models.hf_model import HuggingFaceModel
+    from deepchem.models.torch_models.hf_models import HuggingFaceModel
     anti_model = DeepAbLLM(task='mlm', model_path='Exscientia/IgBert')
     assert isinstance(anti_model, HuggingFaceModel)
     assert anti_model.tokenizer == igbert_tokenizer
@@ -82,7 +82,7 @@ def test_save_reload(tmpdir):
     anti_model._ensure_built()
     anti_model.save_checkpoint()
 
-    anti_model2 = DeepAbLLM(task='classification',
+    anti_model2 = DeepAbLLM(task='mlm',
                             model_path=model_path,
                             n_tasks=1,
                             model_dir=tmpdir)


### PR DESCRIPTION
## Description

Fix #(issue)

Issue was that the task used to reload the model was different. Initial model has task=mlm, while 2nd model has task=classification. 


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
