### PR TITLE
Add layers and docs for SE(3) Transformer implemention

### DIFF
--- a/deepchem/models/torch_models/tests/test_se3_transformer.py
+++ b/deepchem/models/torch_models/tests/test_se3_transformer.py
@@ -1,0 +1,139 @@
+import pytest
+import numpy as np
+
+try:
+    import torch
+    has_torch = True
+except ModuleNotFoundError:
+    has_torch = False
+
+
+def rotation_matrix(axis, angle):
+    """Generate a 3D rotation matrix."""
+    axis = axis / np.linalg.norm(axis)
+    a = np.cos(angle / 2.0)
+    b, c, d = -axis * np.sin(angle / 2.0)
+    return np.array([[
+        a * a + b * b - c * c - d * d, 2 * (b * c - a * d), 2 * (b * d + a * c)
+    ], [
+        2 * (b * c + a * d), a * a + c * c - b * b - d * d, 2 * (c * d - a * b)
+    ], [
+        2 * (b * d - a * c), 2 * (c * d + a * b), a * a + d * d - b * b - c * c
+    ]])
+
+
+@pytest.mark.torch
+def test_equivariant_linear_module():
+    """Test the EquivariantLinear layer transformations."""
+    if not has_torch:
+        pytest.skip("PyTorch is not installed.")
+
+    from deepchem.models.torch_models.layers import EquivariantLinear
+
+    B, N, D = 1, 16, 64
+    layer = EquivariantLinear(D, D * 2).double()
+    x = torch.randn(B, N, D, dtype=torch.float64)
+    out = layer(x)
+    assert out.shape == (B, N, D * 2)
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize("batch_size, num_nodes, input_dim, output_dim", [
+    (1, 16, 64, 128),
+    (4, 32, 128, 64),
+    (2, 1, 32, 16),
+    (0, 10, 64, 128),
+])
+def test_equivariant_linear_module_initialization(batch_size, num_nodes,
+                                                  input_dim, output_dim):
+    """Test the EquivariantLinear layer initialization."""
+    if not has_torch:
+        pytest.skip("PyTorch is not installed.")
+
+    from deepchem.models.torch_models.layers import EquivariantLinear
+
+    layer = EquivariantLinear(input_dim, output_dim).double()
+    x = torch.randn(batch_size, num_nodes, input_dim, dtype=torch.float64)
+    out = layer(x)
+
+    assert out.shape == (batch_size, num_nodes, output_dim)
+
+    assert torch.isfinite(out).all()
+
+    if batch_size > 0:
+        out.sum().backward()
+        assert layer.weight.grad is not None
+
+
+@pytest.mark.torch
+def test_se3_attention_module():
+    """Test the SE(3) Attention mechanism."""
+    if not has_torch:
+        pytest.skip("PyTorch is not installed.")
+
+    from deepchem.models.torch_models.layers import SE3Attention
+
+    B, N, D = 1, 16, 64
+    x = torch.randn(B, N, D, dtype=torch.float64)
+    coords = torch.randn(B, N, 3, dtype=torch.float64)
+    layer = SE3Attention(embed_dim=D, num_heads=4).double()
+    out_x, out_coords = layer(x, coords)
+    assert out_x.shape == x.shape
+    assert out_coords.shape == coords.shape
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize("batch_size, num_nodes, feature_dim", [
+    (1, 16, 64),
+    (4, 32, 128),
+    (2, 1, 32),
+])
+def test_se3_attention_module_initialization(batch_size, num_nodes,
+                                             feature_dim):
+    """Test the SE(3) Attention mechanism initilization."""
+    if not has_torch:
+        pytest.skip("PyTorch is not installed.")
+
+    from deepchem.models.torch_models.layers import SE3Attention
+
+    x = torch.randn(batch_size, num_nodes, feature_dim, dtype=torch.float64)
+    coords = torch.randn(batch_size, num_nodes, 3, dtype=torch.float64)
+    layer = SE3Attention(embed_dim=feature_dim, num_heads=4).double()
+    out_x, out_coords = layer(x, coords)
+
+    assert out_x.shape == x.shape
+    assert out_coords.shape == coords.shape
+
+    assert torch.isfinite(out_x).all()
+    assert torch.isfinite(out_coords).all()
+
+    if batch_size > 0:
+        out_x.sum().backward()
+        assert layer.query.weight.grad is not None
+
+
+@pytest.mark.torch
+def test_se3_attention_equivariance():
+    """Test SE(3) Attention for equivariance."""
+    if not has_torch:
+        pytest.skip("PyTorch is not installed.")
+
+    from deepchem.models.torch_models.layers import SE3Attention
+
+    B, N, D = 1, 16, 64
+    x = torch.randn(B, N, D, dtype=torch.float64)
+    coords = torch.randn(B, N, 3, dtype=torch.float64)
+    layer = SE3Attention(embed_dim=D, num_heads=4).double()
+
+    axis = np.array([0, 1, 0])
+    angle = np.pi / 4
+    rot_matrix = torch.tensor(rotation_matrix(axis, angle), dtype=torch.float64)
+    rotated_coords = coords @ rot_matrix.T
+
+    out_x_original, out_coords_original = layer(x, coords)
+    out_x_rotated, out_coords_rotated = layer(x, rotated_coords)
+
+    recovered_coords = out_coords_rotated @ rot_matrix
+    assert torch.allclose(out_coords_original, recovered_coords, atol=1e-2)
+
+    assert torch.allclose(out_x_original, out_x_rotated, atol=1e-2)

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -358,6 +358,12 @@ The following layers are used for implementing GROVER model as described in the 
 .. autoclass:: deepchem.models.torch_models.grover.GroverFinetune
   :members:
 
+.. autoclass:: deepchem.models.torch_models.grover.EquivariantLinear
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.grover.SphericalHarmonics
+  :members:
+
 Attention Layers
 ^^^^^^^^^^^^^^^^
 
@@ -366,6 +372,9 @@ Attention Layers
 
 .. autoclass:: deepchem.models.torch_models.attention.SelfAttention
   :members:
+
+.. autoclass:: deepchem.models.torch_models.attention.SE3Attention
+  :members:  
 
 Readout Layers
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
Fix #2680 

Layers and docs for a pytorch implementation of SE(3) Transformer model were added. This is one of the there equivariant models in Deepchem's whishlist.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
