### PR TITLE
swapping torch code for tutorial

### DIFF
--- a/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
+++ b/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
@@ -121,7 +121,8 @@
    ],
    "source": [
     "n_tasks = len(tasks)\n",
-    "model = dc.models.GraphConvModel(n_tasks, mode='classification')\n",
+    "num_features = train_dataset.X[0].get_atom_features().shape[1]\n",
+    "model = dc.models.torch_models.GraphConvModel(n_tasks, mode='classification',number_input_features=[num_features,64])\n",
     "model.fit(train_dataset, nb_epoch=50)"
    ]
   },


### PR DESCRIPTION
## Description

Fix #(issue)

Running the third cell in the issue gives the error ValueError: Unrecognized keyword arguments passed to BatchNormalization: {'fused': False} and if if do batch_normalize = False it throws the error 
ImportError: keras.optimizers.legacy is not supported in Keras 3. When using tf.keras, to continue using a tf.keras.optimizers.legacy optimizer, you can install the tf_keras package (Keras 2) and set the environment variable TF_USE_LEGACY_KERAS=True to configure TensorFlow to use tf_keras when accessing tf.keras.
.


## Type of change

(Fixed the tutorial)

## Checklist
Since only 1 line of code was changed no specific checing is required in the tutorial. The tutorial upto that cell works perfectly fine after this change. 