### PR TITLE
Removes "module." prefix from the state_dict keys of models trained using DDP

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -231,6 +231,17 @@ class HuggingFaceModel(TorchModel):
                 # Delete keys of output projection layer (last layer) as the number of
                 # tasks (projections) in pretrain model and the current model
                 # might vary.
+
+                # When using Distributed Data Parallel (DDP) for training models, PyTorch automatically
+                # wraps model parameters in a module. prefix. This can cause issues when loading or
+                # saving model states because the key names in state_dict differ from their original
+                # single-GPU counterparts. To address this, model_state_dict is updated by removing
+                # the "module." prefix when saving or loading models.
+
+                data['model_state_dict'] = {
+                    key.replace("module.", ""): value
+                    for key, value in data['model_state_dict'].items()
+                }
                 keys = data['model_state_dict'].keys()
                 if 'classifier.out_proj.weight' in keys:
                     del data['model_state_dict']['classifier.out_proj.weight']


### PR DESCRIPTION
## Description
When using Distributed Data Parallel (DDP) for training models, PyTorch automatically wraps model parameters in a module. prefix. This can cause issues when loading or saving model states because the key names in state_dict differ from their original single-GPU counterparts. Model_state_dict is updated by removing the "module." prefix when saving or loading models to address this.

Fix #(issue)

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
