### PR TITLE
Add SE3TransformerFeaturizer for graph data

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -47,6 +47,7 @@ from deepchem.feat.molecule_featurizers import GroverFeaturizer
 from deepchem.feat.molecule_featurizers import SNAPFeaturizer
 from deepchem.feat.molecule_featurizers import RDKitConformerFeaturizer
 from deepchem.feat.molecule_featurizers import MXMNetFeaturizer
+from deepchem.feat.molecule_featurizers import SE3TransformerFeaturizer
 
 # complex featurizers
 from deepchem.feat.complex_featurizers import RdkitGridFeaturizer

--- a/deepchem/feat/molecule_featurizers/__init__.py
+++ b/deepchem/feat/molecule_featurizers/__init__.py
@@ -24,3 +24,4 @@ from deepchem.feat.molecule_featurizers.grover_featurizer import GroverFeaturize
 from deepchem.feat.molecule_featurizers.snap_featurizer import SNAPFeaturizer
 from deepchem.feat.molecule_featurizers.conformer_featurizer import RDKitConformerFeaturizer
 from deepchem.feat.molecule_featurizers.mxmnet_featurizer import MXMNetFeaturizer
+from deepchem.feat.molecule_featurizers.se3_transformer_featurizer import SE3TransformerFeaturizer

--- a/deepchem/feat/molecule_featurizers/se3_transformer_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/se3_transformer_featurizer.py
@@ -1,0 +1,240 @@
+"""
+Featurizer for SE(3)-equivariant Graph Neural Networks.
+"""
+
+import numpy as np
+from deepchem.feat.graph_data import GraphData
+from deepchem.feat import MolecularFeaturizer
+from rdkit import Chem
+from rdkit.Chem import AllChem
+import logging
+from typing import List, Tuple
+from deepchem.utils.typing import RDKitMol, ArrayLike
+
+logger = logging.getLogger(__name__)
+
+
+class SE3TransformerFeaturizer(MolecularFeaturizer):
+    """Featurizer for SE(3)-equivariant Graph Neural Networks.
+
+    This featurizer constructs graph representations of molecular structures,
+    capturing atomic features, pairwise distances, and spatial positions. These
+    features are tailored for use in SE(3)-equivariant models with QM9 dataset
+    as described in [1]_.
+
+    Features include:
+    - **Node features**: Atomic one-hot encodings and additional descriptors.
+    - **Edge features**: Vector displacements between atom pairs.
+    - **Edge weights**: Discretized pairwise distances in one-hot encoding.
+    - **Atomic coordinates**: 3D positions of atoms.
+
+    Examples
+    --------
+    >>> from rdkit import Chem
+    >>> import deepchem as dc
+    >>> mol = Chem.MolFromSmiles('CCO')
+    >>> featurizer = dc.feat.SE3TransformerFeaturizer(fully_connected=True, embeded=True)
+    >>> features = featurizer.featurize([mol])[0]
+    >>> type(features[0])
+    <class 'deepchem.feat.graph_data.GraphData'>
+    >>> features[0].node_features.shape  # (N, F)
+    (3, 6)
+
+    Notes
+    -----
+    This class requires RDKit to be installed.
+
+    References
+    ----------
+    .. [1] Fuchs, F. B., et al. "SE(3)-Transformers: 3D Roto-Translation Equivariant
+           Attention Networks." arXiv preprint arXiv:2006.10503 (2020).
+    """
+
+    def __init__(self,
+                 fully_connected: bool = False,
+                 weight_bins: list = None,
+                 embeded: bool = False):
+        """
+        Parameters
+        ----------
+        fully_connected : bool, optional (default False)
+            If True, generates fully connected graphs with distance-based edges.
+        weight_bins : list of float, optional (default [1.0, 2.0, 3.0, 4.0])
+            Bin boundaries for discretizing edge weights.
+        embeded : bool, optional (default False)
+            Whether to embed 3D coordinates using RDKit's ETKDG method.
+        """
+        self.fully_connected = fully_connected
+        self.embeded = embeded
+        self.weight_bins = weight_bins if weight_bins is not None else [
+            1.0, 2.0, 3.0, 4.0
+        ]
+
+    def _featurize(self, datapoint: RDKitMol,
+                   **kwargs) -> np.ndarray[GraphData]:
+        """Featurizes molecules into GraphData objects.
+
+        Parameters
+        ----------
+        datapoint : rdkit.Chem.rdchem.Mol
+            RDKit Mol object.
+
+        Returns
+        -------
+        np.ndarray of GraphData
+            List of GraphData objects for the molecule.
+        """
+        graph_data_l = []
+
+        if self.embeded:
+            datapoint = Chem.AddHs(datapoint)
+            AllChem.EmbedMolecule(datapoint, AllChem.ETKDG())
+            datapoint = Chem.RemoveHs(datapoint)
+
+        node_features, positions = self._get_node_features(datapoint)
+
+        if self.fully_connected:
+            src, dst, edge_features, edge_weights = self._get_fully_connected_edges(
+                positions)
+        else:
+            src, dst, edge_features, edge_weights = self._get_bonded_edges(
+                datapoint, positions)
+
+        edge_weights = self._discretize_and_one_hot(edge_weights)
+
+        graph_data = GraphData(node_features=node_features,
+                               edge_index=np.array([src, dst]),
+                               edge_features=edge_features,
+                               edge_weights=edge_weights,
+                               positions=positions)
+        graph_data_l.append(graph_data)
+
+        return graph_data_l
+
+    def _get_node_features(self, mol: RDKitMol) -> Tuple[ArrayLike, ArrayLike]:
+        """Generates node features and positions.
+
+        Parameters
+        ----------
+        mol : rdkit.Chem.rdchem.Mol
+            RDKit Mol object.
+
+        Returns
+        -------
+        tuple
+            A tuple of node features (np.ndarray) and positions (np.ndarray).
+        """
+        atom_features, positions = [], []
+
+        for atom in mol.GetAtoms():
+            atomic_number = atom.GetAtomicNum()
+            one_hot = self._one_hot(atomic_number,
+                                    [1, 6, 7, 8, 9])  # H, C, N, O, F
+            additional_features = [atomic_number]
+            atom_features.append(one_hot + additional_features)
+            pos = mol.GetConformer().GetAtomPosition(atom.GetIdx())
+            positions.append([pos.x, pos.y, pos.z])
+
+        positions = np.array(positions, dtype=np.float32)
+        atom_features = np.array(atom_features, dtype=np.float32)
+        return atom_features, positions
+
+    def _get_bonded_edges(
+        self, mol: RDKitMol, positions: np.ndarray
+    ) -> Tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
+        """Generates edges based on bonds.
+
+        Parameters
+        ----------
+        mol : rdkit.Chem.rdchem.Mol
+            RDKit Mol object.
+        positions : np.ndarray
+            Atomic positions.
+
+        Returns
+        -------
+        tuple
+            A tuple of source indices, destination indices, edge features, and edge weights.
+        """
+        src, dst, edge_features, edge_weights = [], [], [], []
+
+        for bond in mol.GetBonds():
+            i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+            src += [i, j]
+            dst += [j, i]
+
+            dist = positions[j] - positions[i]
+            edge_features.append(dist)
+            edge_features.append(-dist)
+            edge_weights.append([np.linalg.norm(dist)])
+            edge_weights.append([np.linalg.norm(dist)])
+
+        return np.array(src), np.array(dst), np.array(edge_features), np.array(
+            edge_weights)
+
+    def _get_fully_connected_edges(
+        self, positions: np.ndarray
+    ) -> Tuple[ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
+        """Generates fully connected edges.
+
+        Parameters
+        ----------
+        positions : np.ndarray
+            Atomic positions.
+
+        Returns
+        -------
+        tuple
+            A tuple of source indices, destination indices, edge features, and edge weights.
+        """
+        num_atoms = len(positions)
+        src, dst, edge_features, edge_weights = [], [], [], []
+
+        for i in range(num_atoms):
+            for j in range(num_atoms):
+                if i != j:
+                    src.append(i)
+                    dst.append(j)
+                    dist = positions[j] - positions[i]
+                    edge_features.append(dist)
+                    edge_weights.append([np.linalg.norm(dist)])
+
+        return np.array(src), np.array(dst), np.array(edge_features), np.array(
+            edge_weights)
+
+    def _discretize_and_one_hot(self, edge_weights: ArrayLike) -> np.ndarray:
+        """Discretizes edge weights into bins and converts to one-hot encoding.
+
+        Parameters
+        ----------
+        edge_weights : np.ndarray
+            Continuous edge weights to be discretized.
+
+        Returns
+        -------
+        np.ndarray
+            One-hot encoded edge weights.
+        """
+        edge_weights = np.array(edge_weights).flatten()
+        digitized = np.digitize(edge_weights, self.weight_bins, right=False)
+        num_bins = len(self.weight_bins) + 1
+        one_hot_weights = np.zeros((len(digitized), num_bins))
+        one_hot_weights[np.arange(len(digitized)), digitized] = 1
+        return one_hot_weights
+
+    def _one_hot(self, value: int, allowable_set: List) -> np.ndarray[int]:
+        """Generates a one-hot encoding for a value.
+
+        Parameters
+        ----------
+        value : int
+            Value to encode.
+        allowable_set : List
+            List of allowable values.
+
+        Returns
+        -------
+        np.ndarray
+            One-hot encoded vector.
+        """
+        return [1 if value == x else 0 for x in allowable_set]

--- a/deepchem/feat/tests/test_se3_transformer_featurizer.py
+++ b/deepchem/feat/tests/test_se3_transformer_featurizer.py
@@ -1,0 +1,96 @@
+import unittest
+from rdkit import Chem
+from deepchem.feat import SE3TransformerFeaturizer
+from deepchem.feat.graph_data import GraphData
+import numpy as np
+
+
+class TestSE3TransformerFeaturizer(unittest.TestCase):
+    """
+    Tests for SE3TransformerFeaturizer.
+    """
+
+    def setUp(self):
+        """
+        Set up tests with a simple molecule.
+        """
+        smiles = 'CCO'
+        self.mol = Chem.MolFromSmiles(smiles)
+
+    def test_bonded_graph_featurization(self):
+        """
+        Test featurization with bonded edges.
+        """
+        featurizer = SE3TransformerFeaturizer(fully_connected=False,
+                                              embeded=True)
+        graphs = featurizer.featurize([self.mol])
+
+        assert len(graphs) == 1
+        graph = graphs[0]
+
+        assert isinstance(graph[0], GraphData)
+
+        assert graph[0].node_features.shape[0] == self.mol.GetNumAtoms()
+        assert graph[0].positions.shape[0] == self.mol.GetNumAtoms()
+        assert graph[0].edge_index.shape[1] > 0
+
+    def test_fully_connected_graph_featurization(self):
+        """
+        Test featurization with fully connected edges.
+        """
+        featurizer = SE3TransformerFeaturizer(fully_connected=True,
+                                              embeded=True)
+        graphs = featurizer.featurize([self.mol])
+        assert len(graphs) == 1
+
+        graph = graphs[0]
+        assert isinstance(graph[0], GraphData)
+
+        num_atoms = self.mol.GetNumAtoms()
+
+        expected_edges = num_atoms * (num_atoms - 1)  # Fully connected graph
+        assert graph[0].edge_index.shape[1] == expected_edges
+
+    def test_embedded_coordinates(self):
+        """
+        Test featurization with embedded 3D coordinates.
+        """
+        featurizer = SE3TransformerFeaturizer(embeded=True)
+        graphs = featurizer.featurize([self.mol])
+        assert len(graphs) == 1
+
+        graph = graphs[0]
+        assert isinstance(graph[0], GraphData)
+        # 3D positions
+        assert graph[0].positions.shape[1] == 3
+
+    def test_edge_weight_discretization(self):
+        """
+        Test discretization of edge weights.
+        """
+        featurizer = SE3TransformerFeaturizer(weight_bins=[1.0, 2.0, 3.0],
+                                              embeded=True)
+
+        graphs = featurizer.featurize([self.mol])
+        assert len(graphs) == 1
+        graph = graphs[0]
+        assert isinstance(graph[0], GraphData)
+
+        one_hot_weights = graph[0].edge_weights
+        assert one_hot_weights.shape[1] == len(
+            featurizer.weight_bins) + 1  # Bin count + 1
+        assert np.all(np.sum(one_hot_weights, axis=1) == 1)
+
+    def test_multiple_molecules(self):
+        """
+        Test featurization of multiple molecules.
+        """
+        smiles_list = ['CCO', 'CCC']
+        mols = [Chem.MolFromSmiles(smiles) for smiles in smiles_list]
+        featurizer = SE3TransformerFeaturizer(fully_connected=False,
+                                              embeded=True)
+        graphs = featurizer.featurize(mols)
+        assert len(graphs) == len(smiles_list)
+
+        for graph, mol in zip(graphs, mols):
+            assert graph[0].node_features.shape[0] == mol.GetNumAtoms()

--- a/docs/source/api_reference/featurizers.rst
+++ b/docs/source/api_reference/featurizers.rst
@@ -74,6 +74,13 @@ MolGraphConvFeaturizer
   :members:
   :inherited-members:
 
+SE3TransformerFeaturizer
+**********************
+
+.. autoclass:: deepchem.feat.SE3TransformerFeaturizer
+  :members:
+  :inherited-members:
+
 PagtnMolGraphFeaturizer
 ***********************
 
@@ -288,6 +295,8 @@ AtomicConvFeaturizer
 .. autoclass:: deepchem.feat.AtomicConvFeaturizer
   :members:
   :inherited-members:
+
+
 
 
 Inorganic Crystal Featurizers


### PR DESCRIPTION
## Description

Featurizer of molecular data to `GraphData` including atom features, pairwise distance and 3D coordinates for SE3Transformer.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
