### PR TITLE
Added SphericalHarmonics and irreps, and fixed wigner_D doctest in `equivariance_utils.py`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo docker image prune --all --force
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
     - name: Cache pip modules for Linux
       if: runner.os == 'Linux'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,8 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo docker image prune --all --force
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
     - name: Cache pip packages for Linux
       uses: actions/cache@v4

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -24,6 +24,8 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo docker image prune --all --force
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0

--- a/.github/workflows/hf_setup.yml
+++ b/.github/workflows/hf_setup.yml
@@ -59,6 +59,8 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo docker image prune --all --force
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -111,7 +113,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip;
         pip install conda-merge;
-        conda-merge requirements/env_common.yml requirements/torch/env_torch.cpu.yml requirements/env_test.yml > env.yml
+        if [ "$(uname)" == 'Linux' ]; then
+          conda-merge requirements/env_common.yml requirements/torch/env_torch.cpu.yml requirements/env_test.yml > env.yml
+        elif [[  "$(uname)" == "MINGW64_NT"* ]]; then
+          conda-merge requirements/env_common.yml requirements/torch/env_torch.win.cpu.yml requirements/env_test.yml > env.yml
+        fi
     - name: Create env.yml for python 3.8
       shell: bash
       # A special case of environment creation for python 3.8 which includes an older version of matminer 

--- a/.github/workflows/jax_setup.yml
+++ b/.github/workflows/jax_setup.yml
@@ -52,6 +52,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0

--- a/.github/workflows/mini_build.yml
+++ b/.github/workflows/mini_build.yml
@@ -63,6 +63,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -213,6 +214,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
     - name: Set up Docker Buildx
       id: buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
     - name: Cache pip modules for Linux
       uses: actions/cache@v4
@@ -60,6 +61,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
     - name: Get the tag version
       id: get_tag_version

--- a/.github/workflows/tensorflow_setup.yml
+++ b/.github/workflows/tensorflow_setup.yml
@@ -59,6 +59,7 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
         sudo rm -rf /opt/ghc
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        sudo docker image prune --all --force
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
     - name: Cache pip modules for Linux
       uses: actions/cache@v4
@@ -120,6 +122,8 @@ jobs:
         pip install conda-merge;
         cd requirements
         if [ "$(uname)" == 'Linux' ]; then
+          sudo apt-get update
+          sudo apt-get install -y libatlas-base-dev libblas-dev liblapack-dev libhdf5-dev
           conda-merge env_common.yml env_test.yml env_ubuntu_3_11.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.cpu.yml jax/env_jax.cpu.yml >  env.yml
         elif [  "$(uname)" == 'Darwin' ]; then
           conda-merge env_common.yml env_test.yml env_mac_3_11.yml tensorflow/env_tensorflow.cpu.yml torch/env_torch.mac.cpu.yml jax/env_jax.cpu.yml > env.yml

--- a/.github/workflows/torch_setup.yml
+++ b/.github/workflows/torch_setup.yml
@@ -59,6 +59,8 @@ jobs:
         sudo rm -rf "/usr/local/share/boost"
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         sudo rm -rf /usr/local/lib/android
+        sudo docker image prune --all --force
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
@@ -111,7 +113,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip;
         pip install conda-merge;
-        conda-merge requirements/env_common.yml requirements/torch/env_torch.cpu.yml requirements/env_test.yml > env.yml
+        if [ "$(uname)" == 'Linux' ]; then
+          conda-merge requirements/env_common.yml requirements/torch/env_torch.cpu.yml requirements/env_test.yml > env.yml
+        elif [[  "$(uname)" == "MINGW64_NT"* ]]; then
+          conda-merge requirements/env_common.yml requirements/torch/env_torch.win.cpu.yml requirements/env_test.yml > env.yml
+        fi
     - name: Create env.yml for python 3.8
       shell: bash
       # A special case of environment creation for python 3.8 which includes an older version of matminer 

--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -1544,3 +1544,35 @@ def test_torch_graph_gather():
         np.load("deepchem/models/tests/assets/graphgatherlayer_result.npy"),
         atol=1e-4)
     assert result.shape == (batch_size, 2 * n_features)
+
+
+@pytest.mark.torch
+def test_torch_cosine_dist():
+    """Test invoking cosine_dist."""
+
+    x = torch.ones((5, 4), dtype=torch.float32)
+    y_same = torch.ones((5, 4), dtype=torch.float32)
+    # x and y are the same tensor (equivalent at every element)
+    # the pairwise inner product of the rows in x and y will always be 1
+    # the output tensor will be of shape (5,5)
+    cos_sim_same = torch_layers.cosine_dist(x, y_same)
+    diff = cos_sim_same - torch.ones((5, 5), dtype=torch.float32)
+    assert torch.abs(torch.sum(diff)) < 1e-5  # True
+
+    identity_tensor = torch.eye(
+        16, dtype=torch.float32)  # identity matrix of shape (16,16)
+    x1 = identity_tensor[0:8, :]  # first half of the identity matrix
+    x2 = identity_tensor[8:16, :]  # second half of the identity matrix
+    # each row in x1 is orthogonal to each row in x2
+    # the pairwise inner product of the rows in x1 and x2 will always be 0
+    # the output tensor will be of shape (8,8)
+    cos_sim_orth = torch_layers.cosine_dist(x1, x2)
+    assert torch.abs(torch.sum(cos_sim_orth)) < 1e-5  # True
+    assert all([cos_sim_orth.shape[dim] == 8 for dim in range(2)])  # True
+
+    x3 = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32)
+    x4 = torch.tensor([[2.0, 1.0], [0.0, -1.0]], dtype=torch.float32)
+    pre_calculated_value = torch.tensor([[0.79999995, -0.8944272],
+                                         [0.8944272, -0.8]])
+    result = torch_layers.cosine_dist(x3, x4)
+    assert torch.allclose(result, pre_calculated_value, atol=1e-4)

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -34,6 +34,8 @@ from deepchem.models.torch_models.flows import Flow, Affine, MaskedAffineFlow, A
 from deepchem.models.torch_models.unet import UNet, UNetModel
 from deepchem.models.torch_models.graphconvmodel import _GraphConvTorchModel, GraphConvModel
 from deepchem.models.torch_models.smiles2vec import Smiles2Vec, Smiles2VecModel
+from deepchem.models.torch_models.robust_multitask import RobustMultitask
+from deepchem.models.torch_models.hf_models import HuggingFaceModel
 from deepchem.models.torch_models.inceptionv3 import InceptionV3Model, InceptionA, InceptionB, InceptionC, InceptionD, InceptionE, InceptionAux, BasicConv2d
 from deepchem.models.torch_models.robust_multitask import RobustMultitask, RobustMultitaskClassifier, RobustMultitaskRegressor
 from deepchem.models.torch_models.IRV import IRVLayer, MultitaskIRVClassifier

--- a/deepchem/models/torch_models/tests/test_antibody_modeling.py
+++ b/deepchem/models/torch_models/tests/test_antibody_modeling.py
@@ -10,7 +10,7 @@ except ModuleNotFoundError:
 
 @pytest.fixture
 def igbert_tokenizer():
-    from tokenizers import AutoTokenizer
+    from transformers import AutoTokenizer
     tokenizer = AutoTokenizer.from_pretrained('Exscientia/IgBert')
     return tokenizer
 
@@ -18,7 +18,7 @@ def igbert_tokenizer():
 @pytest.mark.hf
 def test_init(igbert_tokenizer):
     from deepchem.models.torch_models.antibody_modeling import DeepAbLLM
-    from deepchem.models.torch_models.hf_model import HuggingFaceModel
+    from deepchem.models.torch_models.hf_models import HuggingFaceModel
     anti_model = DeepAbLLM(task='mlm', model_path='Exscientia/IgBert')
     assert isinstance(anti_model, HuggingFaceModel)
     assert anti_model.tokenizer == igbert_tokenizer
@@ -67,9 +67,8 @@ def test_initialize_new_config():
         n_tasks=1,
         config=config,
     )
-
-    assert model.model.config['num_attention_heads'] == 8
-    assert model.model.config['num_hidden_layers'] == 6
+    assert model.model.config.num_attention_heads == 8
+    assert model.model.config.num_hidden_layers == 6
 
 
 @pytest.mark.hf

--- a/deepchem/models/torch_models/tests/test_progressive_multitask.py
+++ b/deepchem/models/torch_models/tests/test_progressive_multitask.py
@@ -1,14 +1,13 @@
 import numpy as np
 import deepchem as dc
 import tempfile
-from deepchem.models.torch_models import ProgressiveMultitaskRegressor, ProgressiveMultitaskClassifier
 import pytest
 import os
 
 try:
     import torch
     import torch.nn as nn
-
+    from deepchem.models.torch_models import ProgressiveMultitaskRegressor, ProgressiveMultitaskClassifier
     has_torch = True
 except ModuleNotFoundError:
     has_torch = False

--- a/deepchem/utils/__init__.py
+++ b/deepchem/utils/__init__.py
@@ -163,6 +163,8 @@ try:
     from deepchem.utils.safeops_utils import occnumber
     from deepchem.utils.safeops_utils import get_floor_and_ceil
     from deepchem.utils.safeops_utils import safe_cdist
+
+    from deepchem.utils.optimizer_utils import LambOptimizer
 except ModuleNotFoundError as e:
     logger.warning(
         f'Skipped loading some Pytorch utilities, missing a dependency. {e}')

--- a/deepchem/utils/equivariance_utils.py
+++ b/deepchem/utils/equivariance_utils.py
@@ -132,6 +132,11 @@ class SphericalHarmonics:
     A class for computing real tesseral spherical harmonics, including
     the Condon-Shortley phase.
 
+    This implementation is inspired by the SE(3)-Transformer library by Fabian Fuchs,
+    which provides efficient computation of spherical harmonics and related transformations.
+    For more details, see the SE(3)-Transformer repository:
+    https://github.com/FabianFuchsML/se3-transformer-public
+
     Methods
     -------
     get_element(l, m, theta, phi)
@@ -236,6 +241,11 @@ def irr_repr(order: int,
 
     This function computes the Wigner D-matrix for the given order and angles (alpha, beta, gamma).
     It is compatible with composition and spherical harmonics computations.
+
+    The output is a 2D tensor of shape `(2*order + 1, 2*order + 1)` where each element represents
+    the transformation coefficients of the Wigner D-matrix. The values correspond to the rotational
+    components for the given order and Euler angles. If `dtype` is specified, the tensor is converted
+    to the desired data type; otherwise, it defaults to the computation’s precision (e.g., `float32` or `float64`).
 
     Parameters
     ----------

--- a/deepchem/utils/test/test_equivariance_utils.py
+++ b/deepchem/utils/test/test_equivariance_utils.py
@@ -203,7 +203,7 @@ class TestEquivarianceUtils(unittest.TestCase):
                                                                         col2])
                     self.assertAlmostEqual(dot_product.item(), 0.0, places=5)
 
-    @unittest.skipIf(not torch, "torch is not available")
+    @unittest.skipIf(not has_torch, "torch is not available")
     def test_semifactorial(self) -> None:
         # Test base cases
         self.assertEqual(equivariance_utils.semifactorial(0), 1.0)
@@ -214,7 +214,7 @@ class TestEquivarianceUtils(unittest.TestCase):
         self.assertEqual(equivariance_utils.semifactorial(6),
                          48.0)  # 6!! = 6 * 4 * 2
 
-    @unittest.skipIf(not torch, "torch is not available")
+    @unittest.skipIf(not has_torch, "torch is not available")
     def test_pochhammer_base_case(self) -> None:
         # Test k=0 (should return 1.0)
         self.assertEqual(equivariance_utils.pochhammer(3, 0), 1.0)
@@ -224,7 +224,7 @@ class TestEquivarianceUtils(unittest.TestCase):
         self.assertEqual(equivariance_utils.pochhammer(5, 2),
                          30.0)  # (5)_2 = 5 * 6
 
-    @unittest.skipIf(not torch, "torch is not available")
+    @unittest.skipIf(not has_torch, "torch is not available")
     def test_lpmv(self) -> None:
         x = torch.tensor([0.5])
         # Test P_2^1(x)
@@ -242,7 +242,7 @@ class TestEquivarianceUtils(unittest.TestCase):
         expected = torch.tensor([3 * (1 - 0.5**2)])
         self.assertTrue(torch.allclose(result, expected, atol=1e-4))
 
-    @unittest.skipIf(not torch, "torch is not available")
+    @unittest.skipIf(not has_torch, "torch is not available")
     def test_spherical_harmonics(self) -> None:
         theta = torch.tensor([0.0, math.pi / 2])
         phi = torch.tensor([0.0, math.pi])
@@ -264,8 +264,7 @@ class TestEquivarianceUtils(unittest.TestCase):
                                  [0.0000, -0.0000, 0.4886]])
         self.assertTrue(torch.allclose(result, expected, atol=1e-4))
 
-    unittest.skipIf(not has_torch, "torch is not available")
-
+    @unittest.skipIf(not has_torch, "torch is not available")
     def test_irr_repr(self) -> None:
         # Test irreducible representation of SO3.
         order = 1

--- a/deepchem/utils/test/test_equivariance_utils.py
+++ b/deepchem/utils/test/test_equivariance_utils.py
@@ -1,4 +1,5 @@
 import unittest
+import math
 try:
     import torch
     has_torch = True
@@ -201,3 +202,85 @@ class TestEquivarianceUtils(unittest.TestCase):
                     dot_product = torch.dot(D_matrix[:, col1], D_matrix[:,
                                                                         col2])
                     self.assertAlmostEqual(dot_product.item(), 0.0, places=5)
+
+    @unittest.skipIf(not torch, "torch is not available")
+    def test_semifactorial(self) -> None:
+        # Test base cases
+        self.assertEqual(equivariance_utils.semifactorial(0), 1.0)
+        self.assertEqual(equivariance_utils.semifactorial(1), 1.0)
+
+        self.assertEqual(equivariance_utils.semifactorial(5),
+                         15.0)  # 5!! = 5 * 3 * 1
+        self.assertEqual(equivariance_utils.semifactorial(6),
+                         48.0)  # 6!! = 6 * 4 * 2
+
+    @unittest.skipIf(not torch, "torch is not available")
+    def test_pochhammer_base_case(self) -> None:
+        # Test k=0 (should return 1.0)
+        self.assertEqual(equivariance_utils.pochhammer(3, 0), 1.0)
+
+        self.assertEqual(equivariance_utils.pochhammer(3, 4),
+                         360.0)  # (3)_4 = 3 * 4 * 5 * 6
+        self.assertEqual(equivariance_utils.pochhammer(5, 2),
+                         30.0)  # (5)_2 = 5 * 6
+
+    @unittest.skipIf(not torch, "torch is not available")
+    def test_lpmv(self) -> None:
+        x = torch.tensor([0.5])
+        # Test P_2^1(x)
+        result = equivariance_utils.lpmv(2, 1, x)
+        expected = torch.tensor([-1.2990])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-4))
+
+        # Test P_1^1(x)
+        result = equivariance_utils.lpmv(1, 1, x)
+        expected = torch.tensor([-math.sqrt(1 - 0.5**2)])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-4))
+
+        # Test P_2^2(x)
+        result = equivariance_utils.lpmv(2, 2, x)
+        expected = torch.tensor([3 * (1 - 0.5**2)])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-4))
+
+    @unittest.skipIf(not torch, "torch is not available")
+    def test_spherical_harmonics(self) -> None:
+        theta = torch.tensor([0.0, math.pi / 2])
+        phi = torch.tensor([0.0, math.pi])
+        sh = equivariance_utils.SphericalHarmonics()
+
+        # Test Y_1^0(theta, phi)
+        result = sh.get_element(1, 0, theta, phi)
+        expected = torch.tensor([0.4886, -0.0000])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-4))
+
+        # Test Y_1^1(theta, phi)
+        result = sh.get_element(1, 1, theta, phi)
+        expected = torch.tensor([-0.0000, 0.4886])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-5))
+
+        # Get all spherical harmonics
+        result = sh.get(1, theta, phi)
+        expected = torch.tensor([[-0.0000, 0.4886, -0.0000],
+                                 [0.0000, -0.0000, 0.4886]])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-4))
+
+    unittest.skipIf(not has_torch, "torch is not available")
+
+    def test_irr_repr(self) -> None:
+        # Test irreducible representation of SO3.
+        order = 1
+        alpha = torch.tensor(0.1)
+        beta = torch.tensor(0.2)
+        gamma = torch.tensor(0.3)
+
+        # Edge case: order = 0.
+        order_zero = 0
+        result_zero = equivariance_utils.irr_repr(order_zero, alpha, beta,
+                                                  gamma)
+        self.assertTrue(torch.allclose(result_zero, torch.tensor([[1.0]])))
+
+        result = equivariance_utils.irr_repr(order, alpha, beta, gamma)
+        expected = torch.tensor([[0.9216, 0.0587, 0.3836],
+                                 [0.0198, 0.9801, -0.1977],
+                                 [-0.3875, 0.1898, 0.9021]])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-4))

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -293,6 +293,8 @@ Torch Layers
 .. autoclass:: deepchem.models.torch_models.flows.ConstScaleLayer
   :members:
 
+.. autofunction:: deepchem.models.torch_models.layers.cosine_dist
+
 Flow Layers
 ^^^^^^^^^^^
 
@@ -363,7 +365,7 @@ The following layers are used for implementing GROVER model as described in the 
 
 .. autoclass:: deepchem.models.torch_models.grover.SphericalHarmonics
   :members:
-
+ 
 Attention Layers
 ^^^^^^^^^^^^^^^^
 

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -813,6 +813,14 @@ for additional information regarding equivariance and Deepchem's support for equ
 
 .. autofunction:: deepchem.utils.equivariance_utils.wigner_D
 
+.. autofunction:: deepchem.utils.equivariance_utils.semifactorial
+
+.. autofunction:: deepchem.utils.equivariance_utils.pochhammer
+
+.. autofunction:: deepchem.utils.equivariance_utils.lpmv
+
+.. autofunction:: deepchem.utils.equivariance_utils.SphericalHarmonics
+
 Miscellaneous Utilities
 -----------------------
 

--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -77,6 +77,39 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Installing tf_keras ensures the availability of legacy optimizers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install tf_keras"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The os module is imported to access and modify environment variables in Python, allowing the configuration of TensorFlow to use tf_keras for legacy optimizer support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['TF_USE_LEGACY_KERAS'] = 'True'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "Jk47QTZ95zF-"
    },

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -8,13 +8,13 @@ dependencies:
   - pdbfixer
   - pip
   - pip:
-    - numpy==1.26.4
+    - numpy<1.26
     - rdkit==2023.09.5
     - pre-commit
     - biopython
     - dgllife
     - lightgbm
-    - git+https://github.com/hackingmaterials/matminer.git
+    - matminer
     - mordred
     - networkx
     - pillow

--- a/requirements/env_dqc.yml
+++ b/requirements/env_dqc.yml
@@ -16,5 +16,4 @@ dependencies:
    - pytest
    - PyYAML
    - yamlloader
-   - --prefer-binary
    - pyscf[all]

--- a/requirements/env_test.yml
+++ b/requirements/env_test.yml
@@ -8,3 +8,4 @@ dependencies:
     - types-pkg_resources==0.1.0
     - types-setuptools
     - yapf==0.32.0
+    - python-Levenshtein

--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -2,8 +2,6 @@ dependencies:
   - pip:
     - -f https://download.pytorch.org/whl/cpu/torch_stable.html
     - -f https://data.dgl.ai/wheels/torch-2.2/repo.html
-    # The above line is commented out due to a bug in the DGL wheel repository.
-    # It contains wheels for the GPU version that are not compatible with the CPU version.
     - torchdata<0.8.0
     - dgl
     - torch==2.2.1+cpu

--- a/requirements/torch/env_torch.win.cpu.yml
+++ b/requirements/torch/env_torch.win.cpu.yml
@@ -2,8 +2,7 @@ dependencies:
   - pip:
     - -f https://download.pytorch.org/whl/cpu/torch_stable.html
     # - -f https://data.dgl.ai/wheels/repo.html
-    # The above line is commented out due to a bug in the DGL wheel repository.
-    # It contains wheels for the GPU version that are not compatible with the CPU version.
+    # DGL is no longer supported on windows
     - torchdata<0.8.0
     - dgl<2.2.1
     - torch==2.2.1+cpu

--- a/scripts/install_deepchem_conda.sh
+++ b/scripts/install_deepchem_conda.sh
@@ -41,6 +41,8 @@ else
         fi
     elif [ "$(uname)" = 'Linux' ]; then
         if [ "$1" = "3.11" ]; then
+            sudo apt update
+            sudo apt install -y libatlas-base-dev libblas-dev liblapack-dev libhdf5-dev
             conda-merge $dir/env_common.yml $dir/env_test.yml $dir/env_ubuntu_3_11.yml $dir/tensorflow/env_tensorflow.cpu.yml $dir/torch/env_torch.cpu.yml $dir/jax/env_jax.cpu.yml > $PWD/env.yml
         else
             conda-merge $dir/env_common.yml $dir/env_test.yml $dir/env_ubuntu.yml $dir/tensorflow/env_tensorflow.cpu.yml $dir/torch/env_torch.cpu.yml $dir/jax/env_jax.cpu.yml > $PWD/env.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     serial
     dqc: marks tests for deepchem-dqc only (deselect with '-m "not dqc"')
+    hf: marks tests for deepchem-hf only (deselect with '-m "not hf"')
 [mypy]
 ignore_missing_imports = True
 


### PR DESCRIPTION
## Description

I have implemented code to compute associated Legendre functions, tesseral spherical harmonics, and the irreducible representation of SO(3) (Wigner D-matrix), along with supporting utilities like the semifactorial and Pochhammer symbol. Docs and tests were added, and I fixed a failing `wigner_D` CI failure.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x]  New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
