### PR TITLE
Dag layer typing fix

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -6896,7 +6896,7 @@ class DAGLayer(nn.Module):
                  activation: str = 'relu',
                  dropout: Optional[float] = None,
                  batch_size: int = 64,
-                 device: str = 'cpu',
+                 device: Optional[torch.device] = torch.device('cpu'),
                  **kwargs: Any) -> None:
         """
         Parameters
@@ -6934,7 +6934,7 @@ class DAGLayer(nn.Module):
         self.n_graph_feat: int = n_graph_feat
         self.n_outputs: int = n_graph_feat
         self.n_atom_feat: int = n_atom_feat
-        self.device: str = device
+        self.device: Optional[torch.device] = device
         self.W_layers: nn.ParameterList = nn.ParameterList()
         self.b_layers: nn.ParameterList = nn.ParameterList()
         self.dropouts: List[Optional[nn.Dropout]] = []
@@ -7107,7 +7107,7 @@ class DAGGather(nn.Module):
                  init: str = 'glorot_uniform',
                  activation: str = 'relu',
                  dropout: Optional[float] = None,
-                 device: str = 'cpu',
+                 device: Optional[torch.device] = torch.device('cpu'),
                  **kwargs: Any) -> None:
         """
         Parameters
@@ -7140,7 +7140,7 @@ class DAGGather(nn.Module):
         self.activation: str = activation
         self.dropout: Optional[float] = dropout
         self.activation_fn: Callable[..., torch.Tensor] = getattr(F, activation)
-        self.device: str = device
+        self.device: Optional[torch.device] = device
         self.W_layers: nn.ParameterList = nn.ParameterList()
         self.b_layers: nn.ParameterList = nn.ParameterList()
         self.dropouts: List[Optional[nn.Dropout]] = []
@@ -7216,7 +7216,8 @@ class DAGGather(nn.Module):
                                          device=self.device)
 
         graph_features = torch.zeros(
-            int(membership.max().item()) + 1, int(atom_features.shape[1]))
+            int(membership.max().item()) + 1,
+            int(atom_features.shape[1])).to(self.device)
 
         graph_features = graph_features.scatter_add_(
             0,


### PR DESCRIPTION
## Description

fixes typing anotation for `dag layers` and `dag gather` class. Fixes Code formatting issue of this [PR](https://github.com/deepchem/deepchem/pull/4260).


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
