### PR TITLE
Add equivariance utils functions to compute weight basis for SE(3)-Transformer model

### DIFF
--- a/deepchem/utils/equivariance_utils.py
+++ b/deepchem/utils/equivariance_utils.py
@@ -1,6 +1,7 @@
 import math
 from typing import Optional
 import torch
+import numpy as np
 
 
 def semifactorial(x: int) -> float:
@@ -125,6 +126,7 @@ class SphericalHarmonics:
     which provides efficient computation of spherical harmonics and related transformations.
     For more details, see the SE(3)-Transformer repository:
     https://github.com/FabianFuchsML/se3-transformer-public
+
     Methods
     -------
     get_element(l, m, theta, phi)
@@ -214,9 +216,9 @@ class SphericalHarmonics:
 
 
 def irr_repr(order: int,
-             alpha: torch.Tensor,
-             beta: torch.Tensor,
-             gamma: torch.Tensor,
+             alpha: float,
+             beta: float,
+             gamma: float,
              dtype: Optional[torch.dtype] = None) -> torch.Tensor:
     """
     Compute the irreducible representation of the special orthogonal group SO(3).
@@ -248,7 +250,8 @@ def irr_repr(order: int,
             [ 0.0198,  0.9801, -0.1977],
             [-0.3875,  0.1898,  0.9021]])
     """
-    result = wigner_D(order, alpha, beta, gamma)[0]
+    result = wigner_D(order, torch.tensor(alpha), torch.tensor(beta),
+                      torch.tensor(gamma))[0]
     return result.clone().detach() if dtype is None else result.clone().detach(
     ).to(dtype)
 
@@ -351,6 +354,322 @@ def su2_generators(k: int) -> torch.Tensor:
     generators = torch.stack([x_generator, z_generator, y_generator], dim=0)
 
     return generators
+
+
+def get_matrix_kernel(A: torch.Tensor, eps: float = 1e-10) -> torch.Tensor:
+    """
+    Compute an orthonormal basis of the kernel (x_1, x_2, ...).
+
+    This function calculates the null space (kernel) of the given matrix A, such that:
+        A x_i = 0
+        scalar_product(x_i, x_j) = delta_ij
+
+    Parameters
+    ----------
+    A : torch.Tensor
+        The input matrix.
+    eps : float, optional
+        Tolerance for singular values considered as zero (default is 1e-10).
+
+    Returns
+    -------
+    torch.Tensor
+        A matrix where each row is a basis vector of the kernel of A.
+
+    Examples
+    --------
+    >>> from deepchem.utils.equivariance_utils import get_matrix_kernel
+    >>> A = torch.tensor([[1.0, 2.0, 3.0],
+    ...                   [2.0, 4.0, 6.0],
+    ...                   [3.0, 6.0, 9.0]])
+    >>> get_matrix_kernel(A)
+    tensor([[ 0.0000, -0.8321,  0.5547],
+            [ 0.9636, -0.1482, -0.2224]])
+    """
+    _, s, v = torch.svd(A)
+
+    kernel = v.t()[s < eps]
+    return kernel
+
+
+def basis_transformation_Q_J(J: int,
+                             order_in: int,
+                             order_out: int,
+                             eps: float = 1e-10,
+                             num_samples: int = 5,
+                             random_angle_higher: float = 6.2,
+                             random_angle_lower: float = 0.2) -> torch.Tensor:
+    """
+    Compute one part of the Q^-1 matrix for the article.
+
+    This function computes the spherical harmonics projection matrix for the
+    Sylvester equation in the subspace J needed in for the weight basis in SE(3)-Transformer model.
+
+    References:
+    -----------
+    - SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+    Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+    NeurIPS 2020, https://arxiv.org/abs/2006.10503
+
+    Parameters
+    ----------
+    J : int
+        Order of the spherical harmonics.
+    order_in : int
+        Order of the input representation.
+    order_out : int
+        Order of the output representation.
+    version : int, optional
+        Version of the computation (default is 3).
+    eps : float, optional
+        Tolerance for singular values considered as zero (default is 1e-10).
+    num_samples : int, optional
+        Number of samples to generate for random angles (default is 5).
+    random_angle_higher : float, optional
+        Upper limit for generating random angles (default is 6.2).
+    random_angle_lower : float, optional
+        Lower limit for generating random angles (default is 0.2).
+
+    Returns
+    -------
+    torch.Tensor
+        A tensor of shape [(m_out * m_in), m], where m = 2 * J + 1.
+
+    Examples
+    --------
+    >>> from deepchem.utils.equivariance_utils import basis_transformation_Q_J
+    >>> basis_transformation_Q_J(1, 1, 1).shape
+    torch.Size([9, 3])
+    """
+
+    def _R_tensor(a: float, b: float, c: float) -> torch.Tensor:
+        """
+        Compute the Kronecker product of irreducible representations.
+
+        This function calculates the Kronecker product of two irreducible
+        representations (input and output orders) for a given set of rotation angles.
+
+        Parameters
+        ----------
+        a : float
+            Rotation angle around the x-axis.
+        b : float
+            Rotation angle around the y-axis.
+        c : float
+            Rotation angle around the z-axis.
+
+        Returns
+        -------
+        torch.Tensor
+            The Kronecker product of the irreducible representations of the
+            given rotation angles.
+
+        Examples
+        --------
+        >>> _R_tensor(1.0, 2.0, 3.0).shape
+        torch.Size([...])
+        return kron(irr_repr(order_out, a, b, c), irr_repr(order_in, a, b, c))
+        """
+        return kron(irr_repr(order_out, a, b, c), irr_repr(order_in, a, b, c))
+
+    def _sylvester_submatrix(J: int, a: float, b: float,
+                             c: float) -> torch.Tensor:
+        """
+        Generate the Kronecker product matrix for solving the Sylvester equation in subspace J.
+
+        This function constructs a Kronecker product matrix that helps solve
+        the Sylvester equation for the given subspace J. The equation ensures
+        the transformation is valid within the subspace.
+
+        Parameters
+        ----------
+        J : int
+            Order of the spherical harmonics.
+        a : float
+            Rotation angle around the x-axis.
+        b : float
+            Rotation angle around the y-axis.
+        c : float
+            Rotation angle around the z-axis.
+
+        Returns
+        -------
+        torch.Tensor
+            A rank-deficient matrix for use in solving the Sylvester equation.
+
+        Examples
+        --------
+        >>> _sylvester_submatrix(1, 1.0, 2.0, 3.0).shape
+        torch.Size([...])
+        """
+        R_tensor = _R_tensor(a, b, c)
+        R_irrep_J = irr_repr(J, a, b, c)
+        return kron(R_tensor, torch.eye(R_irrep_J.size(0))) - \
+                   kron(torch.eye(R_tensor.size(0)), R_irrep_J.t())
+
+    random_angles = np.random.uniform(random_angle_lower,
+                                      random_angle_higher,
+                                      size=(num_samples, 3))
+
+    null_space = get_matrix_kernel(
+        torch.cat(
+            [_sylvester_submatrix(J, a, b, c) for a, b, c in random_angles],
+            dim=0), eps)
+
+    Q_J = null_space[0]
+    Q_J = Q_J.view((2 * order_out + 1) * (2 * order_in + 1), 2 * J + 1)
+
+    return Q_J
+
+
+def get_spherical_from_cartesian(cartesian: torch.Tensor,
+                                 divide_radius_by: float = 1.0) -> torch.Tensor:
+    """
+    Convert Cartesian coordinates to spherical coordinates.
+
+    Parameters
+    ----------
+    cartesian : torch.Tensor
+        Cartesian coordinates tensor of shape [..., 3].
+    divide_radius_by : float, optional
+        Factor by which to divide the radius (default is 1.0).
+
+    Returns
+    -------
+    torch.Tensor
+        Spherical coordinates tensor of shape [..., 3] with [radius, azimuth (phi), elevation (theta)].
+
+    Examples
+    --------
+    >>> from deepchem.utils.equivariance_utils import get_spherical_from_cartesian
+    >>> cartesian = torch.tensor([[1.0, 1.0, 1.0]])
+    >>> get_spherical_from_cartesian(cartesian)
+    tensor([[1.7321, 0.7854, 0.9553]])
+
+    >>> cartesian = torch.tensor([[0.0, 0.0, 1.0]])  # Point on Z-axis
+    >>> get_spherical_from_cartesian(cartesian)
+    tensor([[1.0000, 0.0000, 1.5708]])
+
+    >>> cartesian = torch.tensor([[0.0, 0.0, -1.0]])  # Point on negative Z-axis
+    >>> get_spherical_from_cartesian(cartesian)
+    tensor([[1.0000, 3.1416, 1.5708]])
+    """
+    spherical = torch.zeros_like(cartesian)
+
+    ind_radius = 0
+    ind_alpha = 1
+    ind_beta = 2
+
+    cartesian_x = 2
+    cartesian_y = 0
+    cartesian_z = 1
+
+    r_xy = cartesian[..., cartesian_x]**2 + cartesian[..., cartesian_y]**2
+
+    spherical[..., ind_beta] = torch.atan2(torch.sqrt(r_xy),
+                                           cartesian[..., cartesian_z])
+    spherical[..., ind_alpha] = torch.atan2(cartesian[..., cartesian_y],
+                                            cartesian[..., cartesian_x])
+
+    if divide_radius_by == 1.0:
+        spherical[..., ind_radius] = torch.sqrt(r_xy +
+                                                cartesian[..., cartesian_z]**2)
+    else:
+        spherical[..., ind_radius] = torch.sqrt(
+            r_xy + cartesian[..., cartesian_z]**2) / divide_radius_by
+
+    return spherical
+
+
+def kron(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """
+    Computes the Kronecker product of two tensors needed to comput Q_J matrix.
+
+    References:
+    -----------
+    - SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+    Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+    NeurIPS 2020, https://arxiv.org/abs/2006.10503
+
+    Parameters
+    ----------
+    a : torch.Tensor
+        First input tensor of shape [*, m, n].
+    b : torch.Tensor
+        Second input tensor of shape [*, p, q].
+
+    Returns
+    -------
+    torch.Tensor
+        The Kronecker product of `a` and `b`.
+
+    Examples
+    --------
+    >>> from deepchem.utils.equivariance_utils import kron
+    >>> A = torch.tensor([[1, 2], [3, 4]])
+    >>> B = torch.tensor([[0, 5], [6, 7]])
+    >>> kron(A, B)
+    tensor([[ 0,  5,  0, 10],
+            [ 6,  7, 12, 14],
+            [ 0, 15,  0, 20],
+            [18, 21, 24, 28]])
+    """
+    if a.ndimension() == 2 and b.ndimension() == 2:
+        return torch.einsum("ij,kl->ikjl", (a, b)).reshape(
+            a.size(0) * b.size(0),
+            a.size(1) * b.size(1))
+
+    siz1 = torch.Size(torch.tensor(a.shape[-2:]) * torch.tensor(b.shape[-2:]))
+    res = a.unsqueeze(-1).unsqueeze(-3) * b.unsqueeze(-2).unsqueeze(-4)
+    siz0 = res.shape[:-4]
+    return res.reshape(siz0 + siz1)
+
+
+def precompute_sh(r_ij: torch.Tensor, max_J: int) -> dict:
+    """
+    Precompute spherical harmonics up to a given order used in the forward pass of
+    SE(3)-Transformer model.
+
+    References:
+    -----------
+    - SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+    Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+    NeurIPS 2020, https://arxiv.org/abs/2006.10503
+
+    Parameters
+    ----------
+    r_ij : torch.Tensor
+        Relative positions tensor.
+    max_J : int
+        Maximum order of the spherical harmonics.
+
+    Returns
+    -------
+    dict
+        A dictionary where each key corresponds to an order J and the value is a tensor
+        of shape [B, N, K, 2J+1].
+
+    Examples
+    --------
+    >>> from deepchem.utils.equivariance_utils import precompute_sh
+    >>> r_ij = torch.tensor([[1.0, 0.5, 1.0]])  # Example spherical coordinates (radius, phi, theta)
+    >>> precompute_sh(r_ij, max_J=2)
+    {0: tensor([[0.2821]]), 1: tensor([[-0.1971, -0.2640, -0.3608]]), 2: tensor([[ 0.3255,  0.2381, -0.0392,  0.4359,  0.2090]])}
+    """
+    i_alpha = 1
+    i_beta = 2
+
+    Y_Js = {}
+    sh = SphericalHarmonics()
+
+    for J in range(max_J + 1):
+        Y_Js[J] = sh.get(J,
+                         theta=math.pi - r_ij[..., i_beta],
+                         phi=r_ij[..., i_alpha],
+                         refresh=False)
+
+    sh.clear()
+    return Y_Js
 
 
 def change_basis_real_to_complex(

--- a/deepchem/utils/test/test_equivariance_utils.py
+++ b/deepchem/utils/test/test_equivariance_utils.py
@@ -268,9 +268,9 @@ class TestEquivarianceUtils(unittest.TestCase):
     def test_irr_repr(self) -> None:
         # Test irreducible representation of SO3.
         order = 1
-        alpha = torch.tensor(0.1)
-        beta = torch.tensor(0.2)
-        gamma = torch.tensor(0.3)
+        alpha = 0.1
+        beta = 0.2
+        gamma = 0.3
 
         # Edge case: order = 0.
         order_zero = 0
@@ -283,3 +283,150 @@ class TestEquivarianceUtils(unittest.TestCase):
                                  [0.0198, 0.9801, -0.1977],
                                  [-0.3875, 0.1898, 0.9021]])
         self.assertTrue(torch.allclose(result, expected, atol=1e-4))
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_get_matrix_kernel(self):
+        # Test for computing the kernel of a matrix
+        A = torch.tensor([[1.0, 2.0, 3.0], [2.0, 4.0, 6.0], [3.0, 6.0, 9.0]])
+        kernel = equivariance_utils.get_matrix_kernel(A)
+        for vector in kernel:
+            result = torch.matmul(A, vector)
+            self.assertTrue(
+                torch.allclose(result, torch.zeros_like(result), atol=1e-5))
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_basis_transformation_Q_J_output_shape(self):
+        J, order_in, order_out = 1, 1, 1
+        result = equivariance_utils.basis_transformation_Q_J(
+            J, order_in, order_out)
+        expected_shape = ((2 * order_out + 1) * (2 * order_in + 1), 2 * J + 1)
+        self.assertEqual(result.shape, expected_shape)
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_basis_transformation_Q_J_nonzero_output(self):
+        J, order_in, order_out = 1, 1, 1
+        result = equivariance_utils.basis_transformation_Q_J(
+            J, order_in, order_out)
+        self.assertTrue(torch.any(result != 0),
+                        "Output tensor should not be all zeros")
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_kron(self):
+        # Test Kronecker product
+        A = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+        B = torch.tensor([[0.0, 5.0], [6.0, 7.0]])
+        result = equivariance_utils.kron(A, B)
+        expected = torch.tensor([[0.0, 5.0, 0.0, 10.0], [6.0, 7.0, 12.0, 14.0],
+                                 [0.0, 15.0, 0.0, 20.0],
+                                 [18.0, 21.0, 24.0, 28.0]])
+        self.assertTrue(torch.allclose(result, expected, atol=1e-5))
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_spherical_from_cartesian(self):
+        cartesian = torch.tensor([[1.0, 1.0, 1.0]])  # [y, z, x]
+        result = equivariance_utils.get_spherical_from_cartesian(cartesian)
+
+        expected_radius = math.sqrt(1**2 + 1**2 + 1**2)
+        expected_phi = math.pi / 4
+        expected_theta = math.atan2(math.sqrt(1**2 + 1**2), 1)
+
+        self.assertAlmostEqual(result[0, 0].item(), expected_radius, places=6)
+        self.assertAlmostEqual(result[0, 1].item(), expected_phi, places=6)
+        self.assertAlmostEqual(result[0, 2].item(), expected_theta, places=6)
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_spherical_from_cartesian_zero_vector(self):
+        cartesian = torch.tensor([[0.0, 0.0, 0.0]])
+        result = equivariance_utils.get_spherical_from_cartesian(cartesian)
+
+        self.assertAlmostEqual(result[0, 0].item(), 0.0,
+                               places=6)  # Radius should be 0
+        self.assertAlmostEqual(result[0, 1].item(), 0.0,
+                               places=6)  # Azimuth phi should be 0
+        self.assertAlmostEqual(result[0, 2].item(), 0.0,
+                               places=6)  # Elevation theta should be 0
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_spherical_from_cartesian_negative(self):
+        cartesian = torch.tensor([[-1.0, -1.0, -1.0]])
+        result = equivariance_utils.get_spherical_from_cartesian(cartesian)
+        expected_radius = math.sqrt(1**2 + 1**2 + 1**1)
+        expected_phi = -3 * math.pi / 4
+        expected_theta = math.atan2(math.sqrt(1**2 + 1**2), -1)
+
+        self.assertAlmostEqual(result[0, 0].item(), expected_radius, places=6)
+        self.assertAlmostEqual(result[0, 1].item(), expected_phi, places=6)
+        self.assertAlmostEqual(result[0, 2].item(), expected_theta, places=6)
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_spherical_from_cartesian_divide_radius_arg(self):
+        cartesian = torch.tensor([[3.0, 4.0, 5.0]])
+        result = equivariance_utils.get_spherical_from_cartesian(
+            cartesian, divide_radius_by=2.0)
+        expected_radius = math.sqrt(3**2 + 4**2 + 5**2) / 2
+
+        self.assertAlmostEqual(result[0, 0].item(), expected_radius, places=6)
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_spherical_from_cartesian_angle_boundaries(self):
+        """Ensures φ is in [-π, π] and θ is in [0, π]"""
+        cartesian = torch.tensor([[2.0, -2.0, 2.0]])
+        result = equivariance_utils.get_spherical_from_cartesian(cartesian)
+
+        phi = result[0, 1].item()
+        theta = result[0, 2].item()
+
+        self.assertTrue(-math.pi <= phi <= math.pi,
+                        msg=f"Azimuth φ out of bounds: {phi}")
+        self.assertTrue(0 <= theta <= math.pi,
+                        msg=f"Elevation θ out of bounds: {theta}")
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_spherical_from_cartesian_high_dimensional_tensor(self):
+        cartesian = torch.tensor([[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]],
+                                  [[0.0, 0.0, 1.0], [-1.0, -1.0, -1.0]]])
+        result = equivariance_utils.get_spherical_from_cartesian(cartesian)
+
+        self.assertEqual(result.shape, (2, 2, 3))
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_precompute_sh(self):
+        """Test spherical harmonics computation for a simple input."""
+        r_ij = torch.tensor([[1.0, 0.5, 1.0]])  # [radius, phi, theta]
+        max_J = 2
+        result = equivariance_utils.precompute_sh(r_ij, max_J)
+
+        self.assertEqual(len(result), max_J + 1)
+        for J in range(max_J + 1):
+            self.assertTrue(isinstance(result[J], torch.Tensor))
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_precompute_sh_zero_order(self):
+        """Test when max_J = 0, only J=0 should be present."""
+        r_ij = torch.tensor([[1.0, 1.0, 1.0]])
+        result = equivariance_utils.precompute_sh(r_ij, max_J=0)
+
+        self.assertEqual(len(result), 1)  # Only J=0 should be present
+        self.assertIn(0, result)  # J=0 key should exist
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_precompute_sh_multiple_inputs(self):
+        """Test batch inputs to check if function handles multiple r_ij vectors."""
+        r_ij = torch.tensor([[1.0, 0.5, 1.0], [2.0, 1.0, 0.5]])
+        max_J = 3
+        result = equivariance_utils.precompute_sh(r_ij, max_J)
+
+        self.assertEqual(len(result), max_J + 1)
+        for J in range(max_J + 1):
+            self.assertEqual(result[J].shape[0], r_ij.shape[0])
+
+    @unittest.skipIf(not has_torch, "torch is not available")
+    def test_precompute_sh_output_shape(self):
+        """Test if each J value has shape [B, N, K, 2J+1]."""
+        r_ij = torch.tensor([[1.0, 0.5, 1.0], [2.0, 1.0, 0.5]])
+        max_J = 2
+        result = equivariance_utils.precompute_sh(r_ij, max_J)
+
+        for J in range(max_J + 1):
+            expected_last_dim = 2 * J + 1
+            self.assertEqual(result[J].shape[-1], expected_last_dim)

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -821,6 +821,16 @@ for additional information regarding equivariance and Deepchem's support for equ
 
 .. autofunction:: deepchem.utils.equivariance_utils.SphericalHarmonics
 
+.. autofunction:: deepchem.utils.equivariance_utils.get_matrix_kernel
+
+.. autofunction:: deepchem.utils.equivariance_utils.basis_transformation_Q_J
+
+.. autofunction:: deepchem.utils.equivariance_utils.get_spherical_from_cartesian
+
+.. autofunction:: deepchem.utils.equivariance_utils.kron
+
+.. autofunction:: deepchem.utils.equivariance_utils.precompute_sh
+
 Miscellaneous Utilities
 -----------------------
 


### PR DESCRIPTION
## Description

This PR introduces `get_matrix_kernel`, to calculate an orthonormal basis for the kernel of an input matrix, used for solving Sylvester equations in SE(3)-Transformers. Additionally, `basis_transformation_Q_J` is implemented to compute a spherical harmonics projection matrix required for weight basis transformations and `precompute_sh`needed in SE(3)-Transformer model. 

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
