### PR TITLE
Add Fiber layer for SE(3)-Transformer model

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -18,7 +18,7 @@ from deepchem.models.torch_models.pagtn import Pagtn, PagtnModel
 from deepchem.models.torch_models.mat import MAT, MATModel
 from deepchem.models.torch_models.megnet import MEGNetModel
 from deepchem.models.torch_models.normalizing_flows_pytorch import NormalizingFlow
-from deepchem.models.torch_models.layers import MultilayerPerceptron, CNNModule, CombineMeanStd, WeightedLinearCombo, AtomicConvolution, NeighborList, SetGather, EdgeNetwork, WeaveLayer, WeaveGather, MolGANConvolutionLayer, MolGANAggregationLayer, MolGANMultiConvolutionLayer, MolGANEncoderLayer, VariationalRandomizer, EncoderRNN, DecoderRNN, AtomicConv, GraphConv, GraphPool, GraphGather, DAGGather, DAGLayer
+from deepchem.models.torch_models.layers import MultilayerPerceptron, CNNModule, CombineMeanStd, WeightedLinearCombo, AtomicConvolution, NeighborList, SetGather, EdgeNetwork, WeaveLayer, WeaveGather, MolGANConvolutionLayer, MolGANAggregationLayer, MolGANMultiConvolutionLayer, MolGANEncoderLayer, VariationalRandomizer, EncoderRNN, DecoderRNN, AtomicConv, GraphConv, GraphPool, GraphGather, DAGGather, DAGLayer, Fiber
 from deepchem.models.torch_models.cnn import CNN
 from deepchem.models.torch_models.scscore import ScScore, ScScoreModel
 from deepchem.models.torch_models.weavemodel_pytorch import Weave, WeaveModel

--- a/deepchem/models/torch_models/tests/test_se3_transformer.py
+++ b/deepchem/models/torch_models/tests/test_se3_transformer.py
@@ -137,3 +137,52 @@ def test_se3_attention_equivariance():
     assert torch.allclose(out_coords_original, recovered_coords, atol=1e-2)
 
     assert torch.allclose(out_x_original, out_x_rotated, atol=1e-2)
+
+
+def test_fiber_initialization_from_degrees_channels():
+    """Test Fiber initialization with num_degrees and num_channels."""
+    from deepchem.models.torch_models.layers import Fiber
+    fiber = Fiber(num_degrees=3, num_channels=16)
+    expected_structure = [(16, 0), (16, 1), (16, 2)]
+    assert fiber.structure == expected_structure
+    assert fiber.n_features == np.sum(
+        [i[0] * (2 * i[1] + 1) for i in expected_structure])
+
+
+def test__fiber_initialization_from_dictionary():
+    """Test Fiber initialization with a dictionary input."""
+    from deepchem.models.torch_models.layers import Fiber
+    fiber = Fiber(dictionary={0: 16, 1: 8, 2: 4})
+    expected_structure = [(16, 0), (8, 1), (4, 2)]
+    assert fiber.structure == expected_structure
+
+
+def test_combine_fiber():
+    """Test Fiber.combine() for correct summation of multiplicities."""
+    from deepchem.models.torch_models.layers import Fiber
+    fiber1 = Fiber(dictionary={0: 16, 1: 8})
+    fiber2 = Fiber(dictionary={1: 8, 2: 4})
+    combined = Fiber.combine(fiber1, fiber2)
+    expected_structure = [(16, 0), (16, 1), (4, 2)]
+    assert combined.structure == expected_structure
+
+
+def test_combine_max_fiber():
+    """Test Fiber.combine_max() for correct max operation on multiplicities."""
+    from deepchem.models.torch_models.layers import Fiber
+    fiber1 = Fiber(dictionary={0: 16, 1: 8})
+    fiber2 = Fiber(dictionary={1: 12, 2: 4})
+    combined_max = Fiber.combine_max(fiber1, fiber2)
+    expected_structure = [(16, 0), (12, 1), (4, 2)]
+    assert combined_max.structure == expected_structure
+
+
+def test_feature_indices_fiber():
+    """Test that feature indices are calculated correctly."""
+    from deepchem.models.torch_models.layers import Fiber
+    fiber = Fiber(dictionary={0: 2, 1: 2})
+    expected_indices = {
+        0: (0, 0 + 2 * (2 * 0 + 1)),
+        1: (2, 2 + 2 * (2 * 1 + 1))
+    }
+    assert fiber.feature_indices == expected_indices

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -371,7 +371,10 @@ The following layers are used for implementing GROVER model as described in the 
 
 .. autoclass:: deepchem.models.torch_models.grover.SphericalHarmonics
   :members:
- 
+
+.. autoclass:: deepchem.models.torch_models.grover.Fiber
+  :members:
+
 Attention Layers
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description

Fiber layer used in SE(3)-Transformers to handle atom feature spaces across different degrees and layers in the model.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
