### PR TITLE
Changing information in one of the tutorials notebooks from 'tensorflow-keras' to 'pytorch' (documentation)

### DIFF
--- a/examples/tutorials/Protein_Deep_Learning.ipynb
+++ b/examples/tutorials/Protein_Deep_Learning.ipynb
@@ -1253,7 +1253,7 @@
    "id": "c83cac17-74ba-4af8-a2e1-d5091f8a1f88",
    "metadata": {},
    "source": [
-    "Here we create a neuronal network using tensorflow-keras and using a loss function of \"MAE\" to evaluate the regression result."
+    "Here we create a neuronal network using pytorch and using a loss function of \"MAE\" to evaluate the regression result."
    ]
   },
   {


### PR DESCRIPTION
Incorrect information fixed. Changed 'Here we create a neuronal network using tensorflow-keras' to 'Here we create a neuronal network using pytorch'

## Description

Fix #4280 

As deepchem and its tutorials has shifted from tensorflow to pytorch, the infromation in the tutorials must be accurate regarding the use of pytorch while creating the neural network

![image](https://github.com/user-attachments/assets/33686e87-a4fb-4588-88af-b24f2734822c)
to
![image](https://github.com/user-attachments/assets/f1b40711-6d1d-456a-8ccf-13c573b590cc)



## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
