### PR TITLE
Add RadialFunc and PairwiseConv layers for SE3-Transformer model

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -7302,3 +7302,276 @@ def cosine_dist(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
 
     cosine_similarity = torch.matmul(x_norm, y_norm.transpose(-1, -2))
     return cosine_similarity
+
+
+class BN(nn.Module):
+    """
+    SE(3)-equivariant layer normalization.
+    
+    Layer Normalization is applied to SE(3)-equivariant atomic features. Unlike batch normalization, 
+    which normalizes across the batch dimension, `LayerNorm` normalizes each feature channel independently.  
+    This makes it suitable for graph-based and transformer architectures where batch statistics are not stable.
+
+    Layer normalization ensures that each feature maintains zero mean and unit variance, improving  
+    training stability and preserving SE(3) equivariance, since normalization is applied per feature  
+    rather than per batch.
+
+    Example
+    -------
+    >>> import torch
+    >>> from deepchem.models.torch_models.layers import BN
+    >>> batch_size, num_channels = 10, 30
+    >>> layer = BN(num_channels)
+    >>> x = torch.randn(batch_size, num_channels)
+    >>> output = layer(x)
+    >>> output.shape
+    torch.Size([10, 30])
+    
+    References
+    ----------
+    .. [1] Ba, Jimmy Lei, Jamie Ryan Kiros, and Geoffrey E. Hinton. "Layer normalization."
+           arXiv preprint arXiv:1607.06450 (2016).
+    .. [2] SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+           Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+           NeurIPS 2020, https://arxiv.org/abs/2006.10503
+
+    """
+
+    def __init__(self, num_channels: int, **kwargs: Any) -> None:
+        """
+        Parameters
+        ----------
+        num_channels : int
+            Number of output channels for normalization.
+        """
+        super().__init__(**kwargs)
+        self.bn = nn.LayerNorm(num_channels)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Apply Layer Normalization.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (..., num_channels)
+        
+        Returns
+        -------
+        torch.Tensor
+            Normalized tensor with the same shape as input.
+        """
+        return self.bn(x)
+
+
+class RadialFunc(nn.Module):
+    """
+    Defines the radial profile used in SE(3)-equivariant kernels.
+
+    The radial function serves as a filter that modulates the interaction  
+    strength between features based on their relative distance. It transforms  
+    edge features while preserving the angular components, ensuring  
+    SE(3) equivariance.
+
+    The function is implemented using a fully connected network (MLP) with multiple linear layers,  
+    which allows the model to learn flexible representations of distance-based interactions.  
+    ReLU activations introduce non-linearity, enabling the network to capture complex relationships.
+    To improve training stability and feature scaling, BN layer is applied after
+    intermediate transformations. The final output is then projected into the spherical harmonics basis,
+    ensuring that the learned transformations remain SE(3)-equivariant and can be effectively combined  
+    with angular basis functions for SE(3)-equivariant message passing.
+
+    Example
+    -------
+    >>> import torch
+    >>> from deepchem.models.torch_models.layers import RadialFunc
+    >>> num_freq, in_dim, out_dim, edge_dim = 5, 10, 15, 3
+    >>> layer = RadialFunc(num_freq, in_dim, out_dim, edge_dim)
+    >>> x = torch.randn(8, edge_dim + 1)
+    >>> output = layer(x)
+    >>> output.shape
+    torch.Size([8, 15, 1, 10, 1, 5])
+
+    References
+    ----------
+    .. [1] SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+           Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+           NeurIPS 2020, https://arxiv.org/abs/2006.10503
+    """
+
+    def __init__(self,
+                 num_freq: int,
+                 in_dim: int,
+                 out_dim: int,
+                 edge_dim: int = 0) -> None:
+        """
+        Parameters
+        ----------
+        num_freq : int
+            Number of frequency components.
+        in_dim : int
+            Input feature dimension.
+        out_dim : int
+            Output feature dimension.
+        edge_dim : int, optional
+            Number of edge dimensions (default is 0).
+        """
+        super().__init__()
+        self.num_freq = num_freq
+        self.in_dim = in_dim
+        self.mid_dim = 32
+        self.out_dim = out_dim
+        self.edge_dim = edge_dim
+
+        self.net = nn.Sequential(
+            nn.Linear(self.edge_dim + 1, self.mid_dim), BN(self.mid_dim),
+            nn.ReLU(), nn.Linear(self.mid_dim, self.mid_dim), BN(self.mid_dim),
+            nn.ReLU(), nn.Linear(self.mid_dim,
+                                 self.num_freq * in_dim * out_dim))
+
+        nn.init.kaiming_uniform_(self.net[0].weight)
+        nn.init.kaiming_uniform_(self.net[3].weight)
+        nn.init.kaiming_uniform_(self.net[6].weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the RadialFunc layer.
+        
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (..., edge_dim + 1)
+        
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape (-1, out_dim, 1, in_dim, 1, num_freq)
+        """
+        x = x.cuda() if torch.cuda.is_available() else x.cpu()
+        y = self.net(x)
+        return y.view(-1, self.out_dim, 1, self.in_dim, 1, self.num_freq)
+
+
+class PairwiseConv(nn.Module):
+    """
+    SE(3)-equivariant convolution between two single-type features.
+
+    This layer implements a learnable convolution operation** that preserves SE(3) equivariance
+    by operating on pairwise interactions using a basis defined by spherical harmonics.
+    Instead of standard convolution (which is translation-invariant), this operation ensures
+    equivariance to rotations and translations in 3D space.
+
+    The convolution is defined using SE(3)-equivariant kernels, where the coefficients
+    are learned via `RadialFunc`. The kernel operates on pairwise feature interactions,
+    ensuring that feature transformations respect the underlying geometric symmetries
+    of the data.
+
+    This is achieved by decomposing interactions into radial and angular components:
+    - The radial component (distance-dependent) is learned via `RadialFunc`, capturing
+      how feature strength varies with distance.
+    - The angular component (orientation-dependent) is handled via a spherical harmonics basis,
+      ensuring that rotations affect the output in a structured manner.
+
+    Example
+    -------
+    >>> from rdkit import Chem
+    >>> import dgl
+    >>> import deepchem as dc
+    >>> from deepchem.models.torch_models.layers import PairwiseConv
+    >>> from deepchem.utils.equivariance_utils import get_spherical_from_cartesian, precompute_sh, basis_transformation_Q_J
+    >>> mol = Chem.MolFromSmiles('CCO')
+    >>> featurizer = dc.feat.EquivariantGraphFeaturizer(fully_connected=True, embeded=True)
+    >>> features = featurizer.featurize([mol])[0]
+    >>> G = dgl.graph((features.edge_index[0], features.edge_index[1]))
+    >>> G.ndata['f'] = torch.tensor(features.node_features, dtype=torch.float32).unsqueeze(-1) 
+    >>> G.ndata['x'] = torch.tensor(features.positions, dtype=torch.float32)
+    >>> G.edata['d'] = torch.tensor(features.edge_features, dtype=torch.float32)
+    >>> G.edata['w'] = torch.tensor(features.edge_weights, dtype=torch.float32)
+    >>> max_degree = 3
+    >>> distances = G.edata['d']
+    >>> r_ij = get_spherical_from_cartesian(distances)
+    >>> Y = precompute_sh(r_ij, 2*max_degree)
+    >>> basis = {}
+    >>> # Compute SE(3) basis for different (d_in, d_out) degrees
+    >>> for d_in in range(max_degree + 1):
+    ...     for d_out in range(max_degree + 1):
+    ...         K_Js = []
+    ...         for J in range(abs(d_in - d_out), d_in + d_out + 1):
+    ...             # Get spherical harmonic projection matrices
+    ...             Q_J = basis_transformation_Q_J(J, d_in, d_out)
+    ...             Q_J = Q_J.float().T
+    ...             # Create kernel from spherical harmonics
+    ...             K_J = torch.matmul(Y[J], Q_J)
+    ...             K_Js.append(K_J)    
+    ...         # Reshape so can take linear combinations with a dot product
+    ...         size = (-1, 1, 2 * d_out + 1, 1, 2 * d_in + 1, 2 * min(d_in, d_out) + 1)
+    ...         basis[f"{d_in},{d_out}"] = torch.stack(K_Js, -1).view(*size)
+    >>> # Compute radial distances
+    >>> r = torch.sqrt(torch.sum(distances**2, -1, keepdim=True))
+    >>> # Add edge features
+    >>> if "w" in G.edata.keys():
+    ...     w = G.edata["w"]
+    ...     feat = torch.cat([w, r], -1)
+    ... else:
+    ...     feat = torch.cat([r], -1)
+    >>> pairwise_conv = PairwiseConv(degree_in=0, nc_in=32, degree_out=0, nc_out=128, edge_dim=5)
+    >>> output = pairwise_conv(feat, basis)
+    >>> output.shape
+    torch.Size([6, 128, 32])
+
+    References
+    ----------
+    .. [1] SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+           Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+           NeurIPS 2020, https://arxiv.org/abs/2006.10503
+    """
+
+    def __init__(self,
+                 degree_in: int,
+                 nc_in: int,
+                 degree_out: int,
+                 nc_out: int,
+                 edge_dim: int = 0) -> None:
+        """
+        Parameters
+        ----------
+        degree_in : int
+            Degree of the input feature.
+        nc_in : int
+            Number of channels in the input feature.
+        degree_out : int
+            Degree of the output feature.
+        nc_out : int
+            Number of channels in the output feature.
+        edge_dim : int, optional
+            Number of edge dimensions, default is 0.
+        """
+        super().__init__()
+        self.degree_in = degree_in
+        self.degree_out = degree_out
+        self.nc_in = nc_in
+        self.nc_out = nc_out
+        self.num_freq = 2 * min(degree_in, degree_out) + 1
+        self.d_out = 2 * degree_out + 1
+        self.edge_dim = edge_dim
+        self.rp = RadialFunc(self.num_freq, nc_in, nc_out, self.edge_dim)
+
+    def forward(self, feat: torch.Tensor, basis: dict) -> torch.Tensor:
+        """
+        Forward pass of the PairwiseConv layer.
+
+        Parameters
+        ----------
+        feat : torch.Tensor
+            Input tensor of shape (..., edge_dim + 1).
+        basis : dict
+            Dictionary containing basis functions with keys formatted as 'degree_in, degree_out'.
+
+        Returns
+        -------
+        torch.Tensor
+            Convolved tensor of shape (batch_size, d_out * nc_out, -1).
+        """
+        R = self.rp(feat)
+        kernel = torch.sum(R * basis[f'{self.degree_in},{self.degree_out}'], -1)
+        return kernel.view(kernel.shape[0], self.d_out * self.nc_out, -1)

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -7456,7 +7456,7 @@ class PairwiseConv(nn.Module):
     """
     SE(3)-equivariant convolution between two single-type features.
 
-    This layer implements a learnable convolution operation** that preserves SE(3) equivariance
+    This layer implements a learnable convolution operation that preserves SE(3) equivariance
     by operating on pairwise interactions using a basis defined by spherical harmonics.
     Instead of standard convolution (which is translation-invariant), this operation ensures
     equivariance to rotations and translations in 3D space.

--- a/deepchem/models/torch_models/tests/test_se3_transformer.py
+++ b/deepchem/models/torch_models/tests/test_se3_transformer.py
@@ -10,6 +10,7 @@ except ModuleNotFoundError:
     pass
 
 
+@pytest.mark.torch
 def test_bn_layer():
     from deepchem.models.torch_models.layers import BN
     batch_size, num_channels = 10, 30
@@ -23,6 +24,7 @@ def test_bn_layer():
                           atol=1e-5)
 
 
+@pytest.mark.torch
 @pytest.mark.parametrize("num_freq, in_dim, out_dim, edge_dim", [(5, 10, 15, 3),
                                                                  (2, 8, 16, 2)])
 def test_radial_func(num_freq, in_dim, out_dim, edge_dim):
@@ -34,6 +36,7 @@ def test_radial_func(num_freq, in_dim, out_dim, edge_dim):
     assert output.shape == (8, out_dim, 1, in_dim, 1, num_freq)
 
 
+@pytest.mark.torch
 def rotation_matrix(axis, angle):
     """Generate a 3D rotation matrix."""
     axis = axis / np.linalg.norm(axis)
@@ -48,12 +51,14 @@ def rotation_matrix(axis, angle):
     ]])
 
 
+@pytest.mark.torch
 def apply_rotation(x, axis, angle):
     """Apply a 3D rotation to the positions."""
     R = rotation_matrix(axis, angle)
     return torch.tensor(np.dot(x.numpy(), R), dtype=torch.float32)
 
 
+@pytest.mark.torch
 def get_equivariant_basis(G, max_degree):
     """Compute SE(3) equivariant basis for molecular graph G."""
     from deepchem.utils.equivariance_utils import get_spherical_from_cartesian, precompute_sh, basis_transformation_Q_J
@@ -77,6 +82,7 @@ def get_equivariant_basis(G, max_degree):
     return basis
 
 
+@pytest.mark.torch
 @pytest.mark.parametrize("max_degree, nc_in, nc_out, edge_dim",
                          [(3, 32, 128, 5)])
 def test_pairwiseconv_equivariance(max_degree, nc_in, nc_out, edge_dim):

--- a/deepchem/models/torch_models/tests/test_se3_transformer.py
+++ b/deepchem/models/torch_models/tests/test_se3_transformer.py
@@ -1,11 +1,37 @@
 import pytest
 import numpy as np
+import deepchem as dc
 
 try:
     import torch
     has_torch = True
 except ModuleNotFoundError:
     has_torch = False
+    pass
+
+
+def test_bn_layer():
+    from deepchem.models.torch_models.layers import BN
+    batch_size, num_channels = 10, 30
+    layer = BN(num_channels)
+    x = torch.randn(batch_size, num_channels)
+    output = layer(x)
+
+    assert output.shape == x.shape
+    assert torch.allclose(output.mean(dim=-1),
+                          torch.zeros(batch_size),
+                          atol=1e-5)
+
+
+@pytest.mark.parametrize("num_freq, in_dim, out_dim, edge_dim", [(5, 10, 15, 3),
+                                                                 (2, 8, 16, 2)])
+def test_radial_func(num_freq, in_dim, out_dim, edge_dim):
+    from deepchem.models.torch_models.layers import RadialFunc
+    layer = RadialFunc(num_freq, in_dim, out_dim, edge_dim)
+    x = torch.randn(8, edge_dim + 1)
+    output = layer(x)
+
+    assert output.shape == (8, out_dim, 1, in_dim, 1, num_freq)
 
 
 def rotation_matrix(axis, angle):
@@ -20,6 +46,86 @@ def rotation_matrix(axis, angle):
     ], [
         2 * (b * d - a * c), 2 * (c * d + a * b), a * a + d * d - b * b - c * c
     ]])
+
+
+def apply_rotation(x, axis, angle):
+    """Apply a 3D rotation to the positions."""
+    R = rotation_matrix(axis, angle)
+    return torch.tensor(np.dot(x.numpy(), R), dtype=torch.float32)
+
+
+def get_equivariant_basis(G, max_degree):
+    """Compute SE(3) equivariant basis for molecular graph G."""
+    from deepchem.utils.equivariance_utils import get_spherical_from_cartesian, precompute_sh, basis_transformation_Q_J
+    distances = G.edata['d']
+    r_ij = get_spherical_from_cartesian(distances)
+    Y = precompute_sh(r_ij, 2 * max_degree)
+
+    basis = {}
+
+    for d_in in range(max_degree + 1):
+        for d_out in range(max_degree + 1):
+            K_Js = []
+            for J in range(abs(d_in - d_out), d_in + d_out + 1):
+                Q_J = basis_transformation_Q_J(J, d_in, d_out).float().T
+                K_J = torch.matmul(Y[J], Q_J)
+                K_Js.append(K_J)
+            size = (-1, 1, 2 * d_out + 1, 1, 2 * d_in + 1,
+                    2 * min(d_in, d_out) + 1)
+            basis[f"{d_in},{d_out}"] = torch.stack(K_Js, -1).view(*size)
+
+    return basis
+
+
+@pytest.mark.parametrize("max_degree, nc_in, nc_out, edge_dim",
+                         [(3, 32, 128, 5)])
+def test_pairwiseconv_equivariance(max_degree, nc_in, nc_out, edge_dim):
+    """Test SE(3) equivariance of PairwiseConv using a real molecular graph (CCO)."""
+    from rdkit import Chem
+    import dgl
+    from deepchem.models.torch_models.layers import PairwiseConv
+    mol = Chem.MolFromSmiles("CCO")
+    featurizer = dc.feat.EquivariantGraphFeaturizer(fully_connected=True,
+                                                    embeded=True)
+    features = featurizer.featurize([mol])[0]
+    G = dgl.graph((features.edge_index[0], features.edge_index[1]))
+
+    G.ndata['f'] = torch.tensor(features.node_features,
+                                dtype=torch.float32).unsqueeze(-1)
+    G.ndata['x'] = torch.tensor(features.positions,
+                                dtype=torch.float32)  # Atomic positions
+    G.edata['d'] = torch.tensor(features.edge_features, dtype=torch.float32)
+    G.edata['w'] = torch.tensor(features.edge_weights, dtype=torch.float32)
+
+    # Compute SE(3) equivariant basis
+    basis = get_equivariant_basis(G, max_degree)
+
+    # Compute input features
+    r = torch.sqrt(torch.sum(G.edata['d']**2, -1, keepdim=True))
+    feat = torch.cat([G.edata['w'], r], -1) if "w" in G.edata.keys() else r
+
+    pairwise_conv = PairwiseConv(degree_in=0,
+                                 nc_in=nc_in,
+                                 degree_out=0,
+                                 nc_out=nc_out,
+                                 edge_dim=edge_dim)
+
+    # test SE(3) translation invariance
+    output_original = pairwise_conv(feat, basis)
+    G.ndata['x'] += torch.tensor([10.0, -5.0, 7.0])  # Apply translation
+    output_translated = pairwise_conv(feat, basis)
+    assert torch.allclose(output_original, output_translated,
+                          atol=1e-5), "Translation invariance failed!"
+
+    # test SE(3) rotation equivariance
+    axis = np.array([1.0, 1.0, 1.0])  # Rotate around (1,1,1) axis
+    angle = np.pi / 4  # 45-degree rotation
+    G.ndata['x'] = apply_rotation(G.ndata['x'], axis, angle)  # Apply rotation
+    basis_rotated = get_equivariant_basis(
+        G, max_degree)  # Compute new basis (spherical harmonics, irreps)
+    output_rotated = pairwise_conv(feat, basis_rotated)
+
+    assert not torch.allclose(output_original, output_rotated, atol=1e-5)
 
 
 @pytest.mark.torch

--- a/deepchem/models/torch_models/tests/test_se3_transformer.py
+++ b/deepchem/models/torch_models/tests/test_se3_transformer.py
@@ -11,10 +11,11 @@ except ModuleNotFoundError:
 
 
 @pytest.mark.torch
-def test_bn_layer():
-    from deepchem.models.torch_models.layers import BN
+def test_se3_layer_norm():
+    """Test SE3LayerNorm layer."""
+    from deepchem.models.torch_models.layers import SE3LayerNorm
     batch_size, num_channels = 10, 30
-    layer = BN(num_channels)
+    layer = SE3LayerNorm(num_channels)
     x = torch.randn(batch_size, num_channels)
     output = layer(x)
 
@@ -27,9 +28,9 @@ def test_bn_layer():
 @pytest.mark.torch
 @pytest.mark.parametrize("num_freq, in_dim, out_dim, edge_dim", [(5, 10, 15, 3),
                                                                  (2, 8, 16, 2)])
-def test_radial_func(num_freq, in_dim, out_dim, edge_dim):
-    from deepchem.models.torch_models.layers import RadialFunc
-    layer = RadialFunc(num_freq, in_dim, out_dim, edge_dim)
+def test_se3radial_func(num_freq, in_dim, out_dim, edge_dim):
+    from deepchem.models.torch_models.layers import SE3RadialFunc
+    layer = SE3RadialFunc(num_freq, in_dim, out_dim, edge_dim)
     x = torch.randn(8, edge_dim + 1)
     output = layer(x)
 
@@ -82,11 +83,11 @@ def get_equivariant_basis(G, max_degree):
 @pytest.mark.torch
 @pytest.mark.parametrize("max_degree, nc_in, nc_out, edge_dim",
                          [(3, 32, 128, 5)])
-def test_pairwiseconv_equivariance(max_degree, nc_in, nc_out, edge_dim):
-    """Test SE(3) equivariance of PairwiseConv using a real molecular graph (CCO)."""
+def test_se3pairwiseconv_equivariance(max_degree, nc_in, nc_out, edge_dim):
+    """Test SE(3) equivariance of SE3PairwiseConv using a real molecular graph (CCO)."""
     from rdkit import Chem
     import dgl
-    from deepchem.models.torch_models.layers import PairwiseConv
+    from deepchem.models.torch_models.layers import SE3PairwiseConv
 
     # Load molecule and featurize
     mol = Chem.MolFromSmiles("CCO")
@@ -94,12 +95,12 @@ def test_pairwiseconv_equivariance(max_degree, nc_in, nc_out, edge_dim):
                                                     embeded=True)
     mol_graph = featurizer.featurize([mol])[0]
 
-    # Initialize PairwiseConv layer
-    pairwise_conv = PairwiseConv(degree_in=0,
-                                 nc_in=32,
-                                 degree_out=0,
-                                 nc_out=128,
-                                 edge_dim=5)
+    # Initialize SE3PairwiseConv layer
+    pairwise_conv = SE3PairwiseConv(degree_in=0,
+                                    nc_in=32,
+                                    degree_out=0,
+                                    nc_out=128,
+                                    edge_dim=5)
 
     G = dgl.graph((mol_graph.edge_index[0], mol_graph.edge_index[1]))
     G.ndata['f'] = torch.tensor(mol_graph.node_features,

--- a/deepchem/utils/equivariance_utils.py
+++ b/deepchem/utils/equivariance_utils.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional
+from typing import Optional, List
 import torch
 import numpy as np
 
@@ -245,7 +245,7 @@ def irr_repr(order: int,
         The irreducible representation matrix of SO(3) for the specified order and angles.
     Examples
     --------
-    >>> irr_repr(1, torch.tensor(0.1), torch.tensor(0.2), torch.tensor(0.3))
+    >>> irr_repr(1, 0.1, 0.2, 0.3)
     tensor([[ 0.9216,  0.0587,  0.3836],
             [ 0.0198,  0.9801, -0.1977],
             [-0.3875,  0.1898,  0.9021]])
@@ -391,6 +391,25 @@ def get_matrix_kernel(A: torch.Tensor, eps: float = 1e-10) -> torch.Tensor:
     kernel = v.t()[s < eps]
     return kernel
 
+def get_matrices_kernel(As: List[torch.Tensor], eps: float = 1e-10) -> torch.Tensor:
+    """
+    Compute the common kernel of all the input matrices.
+
+    This function computes the shared null space of a collection of matrices.
+
+    Parameters
+    ----------
+    As : List[torch.Tensor]
+        List of input matrices.
+    eps : float, optional
+        Tolerance for singular values considered as zero (default is 1e-10).
+
+    Returns
+    -------
+    torch.Tensor
+        A matrix where each row is a basis vector of the common kernel.
+    """
+    return get_matrix_kernel(torch.cat(As, dim=0), eps)
 
 def basis_transformation_Q_J(J: int,
                              order_in: int,
@@ -441,7 +460,8 @@ def basis_transformation_Q_J(J: int,
     >>> basis_transformation_Q_J(1, 1, 1).shape
     torch.Size([9, 3])
     """
-
+    original_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.float64)
     def _R_tensor(a: float, b: float, c: float) -> torch.Tensor:
         """
         Compute the Kronecker product of irreducible representations.
@@ -511,14 +531,10 @@ def basis_transformation_Q_J(J: int,
                                       random_angle_higher,
                                       size=(num_samples, 3))
 
-    null_space = get_matrix_kernel(
-        torch.cat(
-            [_sylvester_submatrix(J, a, b, c) for a, b, c in random_angles],
-            dim=0), eps)
-
+    null_space = get_matrices_kernel([_sylvester_submatrix(J, a, b, c) for a, b, c in random_angles])
     Q_J = null_space[0]
     Q_J = Q_J.view((2 * order_out + 1) * (2 * order_in + 1), 2 * J + 1)
-
+    torch.set_default_dtype(original_dtype)
     return Q_J
 
 

--- a/deepchem/utils/equivariance_utils.py
+++ b/deepchem/utils/equivariance_utils.py
@@ -391,7 +391,9 @@ def get_matrix_kernel(A: torch.Tensor, eps: float = 1e-10) -> torch.Tensor:
     kernel = v.t()[s < eps]
     return kernel
 
-def get_matrices_kernel(As: List[torch.Tensor], eps: float = 1e-10) -> torch.Tensor:
+
+def get_matrices_kernel(As: List[torch.Tensor],
+                        eps: float = 1e-10) -> torch.Tensor:
     """
     Compute the common kernel of all the input matrices.
 
@@ -410,6 +412,7 @@ def get_matrices_kernel(As: List[torch.Tensor], eps: float = 1e-10) -> torch.Ten
         A matrix where each row is a basis vector of the common kernel.
     """
     return get_matrix_kernel(torch.cat(As, dim=0), eps)
+
 
 def basis_transformation_Q_J(J: int,
                              order_in: int,
@@ -462,6 +465,7 @@ def basis_transformation_Q_J(J: int,
     """
     original_dtype = torch.get_default_dtype()
     torch.set_default_dtype(torch.float64)
+
     def _R_tensor(a: float, b: float, c: float) -> torch.Tensor:
         """
         Compute the Kronecker product of irreducible representations.
@@ -531,7 +535,8 @@ def basis_transformation_Q_J(J: int,
                                       random_angle_higher,
                                       size=(num_samples, 3))
 
-    null_space = get_matrices_kernel([_sylvester_submatrix(J, a, b, c) for a, b, c in random_angles])
+    null_space = get_matrices_kernel(
+        [_sylvester_submatrix(J, a, b, c) for a, b, c in random_angles])
     Q_J = null_space[0]
     Q_J = Q_J.view((2 * order_out + 1) * (2 * order_in + 1), 2 * J + 1)
     torch.set_default_dtype(original_dtype)

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -366,12 +366,21 @@ The following layers are used for implementing GROVER model as described in the 
 .. autoclass:: deepchem.models.torch_models.grover.GroverFinetune
   :members:
 
-.. autoclass:: deepchem.models.torch_models.grover.EquivariantLinear
+.. autoclass:: deepchem.models.torch_models.layers.EquivariantLinear
   :members:
 
-.. autoclass:: deepchem.models.torch_models.grover.SphericalHarmonics
+.. autoclass:: deepchem.models.torch_models.layers.SphericalHarmonics
   :members:
- 
+
+.. autoclass:: deepchem.models.torch_models.layers.BN
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.RadialFunc
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.PairwiseConv
+  :members:
+
 Attention Layers
 ^^^^^^^^^^^^^^^^
 
@@ -381,7 +390,7 @@ Attention Layers
 .. autoclass:: deepchem.models.torch_models.attention.SelfAttention
   :members:
 
-.. autoclass:: deepchem.models.torch_models.attention.SE3Attention
+.. autoclass:: deepchem.models.torch_models.layers.SE3Attention
   :members:  
 
 Readout Layers

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -366,21 +366,6 @@ The following layers are used for implementing GROVER model as described in the 
 .. autoclass:: deepchem.models.torch_models.grover.GroverFinetune
   :members:
 
-.. autoclass:: deepchem.models.torch_models.layers.EquivariantLinear
-  :members:
-
-.. autoclass:: deepchem.models.torch_models.layers.SphericalHarmonics
-  :members:
-
-.. autoclass:: deepchem.models.torch_models.layers.BN
-  :members:
-
-.. autoclass:: deepchem.models.torch_models.layers.RadialFunc
-  :members:
-
-.. autoclass:: deepchem.models.torch_models.layers.PairwiseConv
-  :members:
-
 Attention Layers
 ^^^^^^^^^^^^^^^^
 
@@ -391,7 +376,25 @@ Attention Layers
   :members:
 
 .. autoclass:: deepchem.models.torch_models.layers.SE3Attention
-  :members:  
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.EquivariantLinear
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SphericalHarmonics
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3LayerNorm
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3RadialFunc
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3PairwiseConv
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.grover.Fiber
+  :members:
 
 Readout Layers
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description

Initial implementation of PairwiseConv, BN, and RadialFunc layers for the SE(3)-Transformer model. PairwiseConv ensures SE(3)-equivariant feature interactions, decomposing them into radial (distance-based) and angular (spherical harmonics) components. BN applies per-channel normalization for stability, while RadialFunc learns flexible distance-based interactions with batch normalization.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
