### PR TITLE
Update CONTRIBUTING.md - Include Upstream Remote Instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,7 @@ cd deepchem
 
 &nbsp;&nbsp;&nbsp;&nbsp; 1.1. If you already have DeepChem from source, update it by running
 ```bash
+git remote add upstream https://github.com/deepchem/deepchem
 git fetch upstream
 git rebase upstream/master
 ```


### PR DESCRIPTION
This PR updates the `CONTRIBUTING.md` file to include the step for contributors: setting up the upstream remote before fetching changes from the original DeepChem repository.  

The updated instructions now state that users should execute `git remote add upstream https://github.com/deepchem/deepchem` *before* running `git fetch`. This ensures contributors can track changes and merge updates seamlessly.

**Changes:**
- Added a new section to the `CONTRIBUTING.md` file outlining the importance of setting up the upstream remote using `git remote add upstream https://github.com/deepchem/deepchem`.

 **Checklist (add these items):**
 - [ ]  The added section about the `upstream` remote is clearly written and easy to understand.
 - [ ] The new instructions are consistent with other guidelines in the CONTRIBUTING.md file.

