### PR TITLE
fix compatibility issue with callback in tutorials

### DIFF
--- a/examples/tutorials/Advanced_Model_Training.ipynb
+++ b/examples/tutorials/Advanced_Model_Training.ipynb
@@ -198,7 +198,7 @@
     "                                      layer_sizes=[1000],\n",
     "                                      dropouts=0.2,\n",
     "                                      learning_rate=0.0001)\n",
-    "callback = dc.models.ValidationCallback(valid_dataset, 1000, metric)\n",
+    "callback = dc.models.ValidationCallback(valid_dataset, 1000, [metric])\n",
     "model.fit(train_dataset, nb_epoch=50, callbacks=callback)"
    ]
   },


### PR DESCRIPTION
## Description

This PR addresses an outdated usage of ValidationCallback in the tutorial, ensuring it aligns with current standards.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

This PR is straightforward and does not require extensive or complex verification.

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes

Before:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
File ~/Code/deepchem/deepchem/models/torch_models/torch_model.py:471, in TorchModel.fit_generator(self, generator, max_checkpoints_to_keep, checkpoint_interval, restore, variables, loss, callbacks, all_losses)
    [468](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/torch_models/torch_model.py:468) try:
    [469](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/torch_models/torch_model.py:469)     # NOTE In DeepChem > 2.8.0, callback signature is updated to allow
    [470](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/torch_models/torch_model.py:470)     # variable arguments.
--> [471](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/torch_models/torch_model.py:471)     c(self, current_step, iteration_loss=batch_loss)
    [472](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/torch_models/torch_model.py:472) except TypeError:
    [473](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/torch_models/torch_model.py:473)     # DeepChem <= 2.8.0, the callback should have this signature.

TypeError: ValidationCallback.__call__() got an unexpected keyword argument 'iteration_loss'
---> [90](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/callbacks.py:90) score = scores[self.metrics[self.save_metric].name]
     [91](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/callbacks.py:91) if not self.save_on_minimum:
     [92](https://file+.vscode-resource.vscode-cdn.net/Users/forcelss/Code/deepchem/~/Code/deepchem/deepchem/models/callbacks.py:92)     score = -score

TypeError: 'Metric' object is not subscriptable
```

After:


```
Step 1000 validation: roc_auc_score=0.725606
Step 2000 validation: roc_auc_score=0.763247
Step 3000 validation: roc_auc_score=0.761152
Step 4000 validation: roc_auc_score=0.759921
Step 5000 validation: roc_auc_score=0.76748
Step 6000 validation: roc_auc_score=0.76242
Step 7000 validation: roc_auc_score=0.761967
Step 8000 validation: roc_auc_score=0.759679
Step 9000 validation: roc_auc_score=0.764937
Step 10000 validation: roc_auc_score=0.766003
Step 11000 validation: roc_auc_score=0.772175
Step 12000 validation: roc_auc_score=0.765764
Step 13000 validation: roc_auc_score=0.771229
Step 14000 validation: roc_auc_score=0.762322
Step 15000 validation: roc_auc_score=0.767755
Step 16000 validation: roc_auc_score=0.767992
0.5388547897338867
```
