### PR TITLE
fix apple silicon env creation

### DIFF
--- a/requirements/env_mac_arm64.yml
+++ b/requirements/env_mac_arm64.yml
@@ -5,6 +5,6 @@ channels:
 dependencies:
   # - hhsuite // not available for Apple Silicon
   - vina
+  - boost
   - pip:
-    - vina
     - pysam


### PR DESCRIPTION
This PR fixes [Issue #4336]
## Description
- Add boost to the conda dependencies in requirements/env_mac_arm64.yml 
- Remove the vina entry in pip: to rely solely on the conda-forge version of vina like env_mac_3_11.yml and env_ubuntu.yml
