### PR TITLE
Fix smiles featurizer issue

### DIFF
--- a/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
+++ b/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
@@ -841,7 +841,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -866,8 +866,9 @@
     }
    ],
    "source": [
-    "tasks, datasets, transformers = dc.molnet.load_tox21(featurizer=smiles_featurizer)\n",
-    "print(datasets[0].X)"
+    "featurizer = dc.feat.CircularFingerprint(size=1024)\n",
+    "tasks, datasets, transformers = dc.molnet.load_tox21(featurizer=featurizer)\n",
+    "print(datasets[0].X.shape)"
    ]
   },
   {

--- a/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
+++ b/examples/tutorials/Going_Deeper_on_Molecular_Featurizations.ipynb
@@ -868,7 +868,7 @@
    "source": [
     "featurizer = dc.feat.CircularFingerprint(size=1024)\n",
     "tasks, datasets, transformers = dc.molnet.load_tox21(featurizer=featurizer)\n",
-    "print(datasets[0].X.shape)"
+    "print(datasets[0].X.shape) "
    ]
   },
   {


### PR DESCRIPTION
Fix #4344

This PR fixes an issue in the Going Deeper on Molecular Featurizations tutorial . The issue occurs when using different featurizers for dataset processing. The output shape varies based on the featurizer used. For example:

smiles_featurizer results in a sequence-based output.
CircularFingerprint(size=1024) produces a (6258, 1024) fixed-size feature matrix.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
