### PR TITLE
Remove extraneous whitespace from package description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ else:
 # Environment-specific dependencies.
 extras = {
     'jax': ['jax', 'jaxlib', 'dm-haiku', 'optax'],
-    'torch': ['torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1', 'dgllife'],
+    'torch': [
+        'torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1',
+        'dgllife'
+    ],
     'tensorflow': ['tensorflow', 'tensorflow_probability', 'tensorflow_addons'],
     'dqc': ['dqc', 'xitorch', 'torch==2.2.1', 'pylibxc2']
 }
@@ -55,8 +58,8 @@ setup(name='deepchem',
           'Programming Language :: Python :: 3.11',
       ],
       license='MIT',
-      description='Deep learning models for drug discovery, \
-        quantum chemistry, and the life sciences.',
+      description='Deep learning models for drug discovery, ' +
+      'quantum chemistry, and the life sciences.',
       keywords=[
           'deepchem',
           'chemistry',


### PR DESCRIPTION
## Description

Remove extraneous whitespace that appears in package description (see the spaces before quantum):


```bash
$ pip show deepchem
Name: deepchem
Version: 2.8.0
Summary: Deep learning models for drug discovery,         quantum chemistry, and the life sciences.
Home-page: https://github.com/deepchem/deepchem
Author: 
Author-email: 
License: MIT
Location: /usr/local/lib/python3.10/site-packages
Requires: joblib, numpy, pandas, rdkit, scikit-learn, scipy, sympy
Required-by:
```


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
