### PR TITLE
Fix Tutorial Atomic Contribution to Molecules

### DIFF
--- a/examples/tutorials/Atomic_Contributions_for_Molecules.ipynb
+++ b/examples/tutorials/Atomic_Contributions_for_Molecules.ipynb
@@ -169,7 +169,7 @@
         "from rdkit.Chem.Draw import IPythonConsole\n",
         "from rdkit import rdBase\n",
         "from deepchem import metrics\n",
-        "from IPython.display import Image, display\n",
+        "from IPython.display import Image, display, SVG=\n",
         "from rdkit.Chem.Draw import SimilarityMaps\n",
         "import torch\n",
         "\n",
@@ -646,6 +646,13 @@
         "            for n,atom in enumerate(range(mol.GetNumHeavyAtoms())):\n",
         "                wt[atom] = df.loc[Chem.MolToSmiles(mol),\"Contrib\"][n]\n",
         "        maps.append(SimilarityMaps.GetSimilarityMapFromWeights(mol,wt))\n",
+        "\n",
+        "         # create a drawing obj.\n",
+        "        drawObj = Draw.MolDraw2DSVG(700, 700)\n",
+        "        SimilarityMaps.GetSimilarityMapFromWeights(mol, wt, drawObj, contourLines=10)\n",
+        "        drawObj.FinishDrawing()\n",
+        "        map = drawObj.GetDrawingText()\n",
+        "        maps.append(map)\n",
         "    return maps    "
       ]
     },
@@ -794,7 +801,9 @@
       ],
       "source": [
         "np.random.seed(2000)\n",
-        "maps = vis_contribs(np.random.choice(np.array(mols),10), df)"
+        "maps = vis_contribs(np.random.choice(np.array(mols),10), df)\n",
+        "for map in maps:\n",
+        "      display(SVG(map))"
       ]
     },
     {


### PR DESCRIPTION

## Description

Fix #4346 

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

This PR addresses a TypeError encountered in the vis_contribs function when calling GetSimilarityMapFromWeights. The error indicates that a required positional argument, draw2d, is missing.

Modification Details:

The GetSimilarityMapFromWeights function call has been updated to include the missing draw2d argument (with the subsequent object creation), which is necessary for the function to execute and produce images correctly.
An Extra SVG import was deemed necessary.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
