### PR TITLE
Ram issue fix for DeepVariant

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -1997,8 +1997,6 @@ class BAMLoader(DataLoader):
     Here, we extract Query Name, Query Sequence, Query Length, Reference Name,
     Reference Start, CIGAR and Mapping Quality of each read in the BAM file.
     This class provides methods to load and featurize data from BAM files.
-    Additionally, we can also get pileups from BAM files by setting
-    get_pileup=True.
 
     Examples
     --------
@@ -2014,18 +2012,13 @@ class BAMLoader(DataLoader):
     or MacOS X. To use Pysam on Windows, use Windows Subsystem for Linux(WSL).
     """
 
-    def __init__(self,
-                 featurizer: Optional[Featurizer] = None,
-                 get_pileup: Optional[bool] = False):
+    def __init__(self, featurizer: Optional[Featurizer] = None):
         """Initialize BAMLoader.
 
         Parameters
         ----------
         featurizer: Featurizer (default: None)
             The Featurizer to be used for the loaded BAM data.
-        get_pileup: bool, optional (default: False)
-            If True, the pileup of reads at each position is
-            returned, to be used in DeepVariant.
 
        """
 
@@ -2038,10 +2031,7 @@ class BAMLoader(DataLoader):
             self.user_specified_features = featurizer.feature_fields
         elif featurizer is None:  # Default featurizer
             from deepchem.feat import BAMFeaturizer
-            if get_pileup:
-                featurizer = BAMFeaturizer(max_records=None, get_pileup=True)
-            else:
-                featurizer = BAMFeaturizer(max_records=None)
+            featurizer = BAMFeaturizer(max_records=None)
 
         # Set self.featurizer
         self.featurizer = featurizer

--- a/deepchem/data/tests/test_bam_loader.py
+++ b/deepchem/data/tests/test_bam_loader.py
@@ -56,17 +56,6 @@ class TestBAMLoader(unittest.TestCase):
 
         assert dataset.shape == (5, 9)
 
-    def test_bam_featurizer_with_pileup(self):
-        """
-        Tests BAMFeaturizer with pileup generation.
-        """
-        bam_featurizer = dc.feat.BAMFeaturizer(max_records=5, get_pileup=True)
-        bam_file_path = os.path.join(self.current_dir, "example.bam")
-        bamfile = pysam.AlignmentFile(bam_file_path, "rb")
-        dataset = bam_featurizer._featurize(bamfile)
-
-        assert dataset.shape == (5, 10)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/deepchem/feat/deepvariant_featurizer.py
+++ b/deepchem/feat/deepvariant_featurizer.py
@@ -1,12 +1,13 @@
 import numpy as np
 from collections import defaultdict
 from deepchem.feat import Featurizer
-from typing import List, Dict, Tuple, Any, Optional
+from typing import List, Dict, Tuple, Any, Optional, cast
 
 try:
     import dgl
     import torch
     import pysam
+    from pysam.libcalignedsegment import PileupRead, PileupColumn
 except ImportError:
     pass
 
@@ -56,16 +57,16 @@ class _Realigner(object):
             return pos, f"+{len(indel_seq)}{indel_seq}"
         elif indel.startswith('-'):
             del_len = int(indel[1:])
-            while pos > 0 and seq[pos - 1] == seq[pos + del_len - 1]:
+            # Check if the indices are within bounds before accessing
+            while (pos > 0 and pos + del_len - 1 < len(seq) and
+                   seq[pos - 1] == seq[pos + del_len - 1]):
                 pos -= 1
             return pos, f"-{del_len}"
         return pos, indel
 
     def process_pileup(
-            self, pileup_info: List[Dict[str,
-                                         Any]], reference_seq_dict: Dict[str,
-                                                                         str],
-            allele_counts: Dict[Tuple[str, int], Dict[str, Any]]) -> None:
+        self, input_file: str, reference_seq_dict: Dict[str, str]
+    ) -> Dict[Tuple[str, int], Dict[str, Any]]:
         """
         Process pileup information to extract allele counts. This function
         processes each pileup column to count the occurrences of each
@@ -73,108 +74,89 @@ class _Realigner(object):
 
         Parameters
         ----------
-
-        pileup_info : List[Dict[str, Any]]
-            List of dictionaries containing pileup information.
+        input_file : str
+            Path to the input BAM file.
         reference_seq_dict : Dict[str, str]
             Dictionary with chromosome names as keys and reference
             sequences as values.
-        allele_counts : Dict[Tuple[str, int], Dict[str, Any]]
-            Dictionary to store allele counts.
+
+        Returns
+        -------
+        Dict[Tuple[str, int], Dict[str, Any]]
+            Dictionary of allele counts.
 
         """
-        for pileupcolumn in pileup_info:
-            ref_base = reference_seq_dict[pileupcolumn['name']][
-                pileupcolumn['pos']]
+        allele_counts: Dict[Tuple[str, int], Dict[str, Any]] = {}
+        datapoint = pysam.AlignmentFile(input_file, "rb")
+        for pileup_item in datapoint.pileup():
+            pileupcolumn = cast(PileupColumn, pileup_item)
+            ref_pos = pileupcolumn.reference_pos
+            ref_name = pileupcolumn.reference_name
+            # Skip if reference sequence is not available
+            if ref_name not in reference_seq_dict:
+                continue
+
+            # Skip if position is out of bounds
+            if ref_pos >= len(reference_seq_dict[ref_name]):
+                continue
+
+            ref_base: str = reference_seq_dict[ref_name][ref_pos]
+
             allele_count: Dict[str, Any] = {
                 "reference_base": ref_base,
                 "read_alleles": defaultdict(int),
                 "coverage": 0
             }
-            for read_seq in pileupcolumn['reads']:
-                if read_seq[2]:
+            for pileup_read_item in pileupcolumn.pileups:
+                pileupread = cast(PileupRead, pileup_read_item)
+                read_info: List[Optional[Any]] = [
+                    pileupread.alignment.query_sequence,
+                    pileupread.query_position, pileupread.is_del,
+                    pileupread.is_refskip, pileupread.indel
+                ]
+                if read_info[2]:  # is_del
                     base = '-'
-                    print(allele_count)
                     allele_count["read_alleles"][base] += 1
                     allele_count["coverage"] += 1
-                elif read_seq[3]:
+                elif read_info[3]:  # is_refskip
                     base = 'N'
                     allele_count["read_alleles"][base] += 1
                     allele_count["coverage"] += 1
                 else:
                     indel = ""
-                    if read_seq[4] > 0:
-                        indel_seq = read_seq[0][read_seq[2]:read_seq[2] +
-                                                read_seq[4]]
-                        indel = f"+{read_seq[4]}{indel_seq}"
+                    if read_info[4] is not None and read_info[
+                            0] is not None and read_info[
+                                4] > 0:  # positive indel (insertion)
+                        indel_seq = read_info[0][read_info[1]:read_info[1] +
+                                                 read_info[4]]
+                        indel = f"+{read_info[4]}{indel_seq}"
                         new_pos, indel = self.left_align_indel(
-                            reference_seq_dict[pileupcolumn['name']]
-                            [0:pileupcolumn['pos'] + read_seq[4] + 1],
-                            pileupcolumn['pos'], indel)
-                    elif read_seq[4] < 0:
-                        indel = f"{read_seq[4]}"
+                            reference_seq_dict[ref_name][0:ref_pos +
+                                                         read_info[4] + 1],
+                            ref_pos, indel)
+                    elif read_info[4] is not None and read_info[
+                            0] is not None and read_info[
+                                4] < 0:  # negative indel (deletion)
+                        indel = f"{read_info[4]}"
                         new_pos, indel = self.left_align_indel(
-                            reference_seq_dict[pileupcolumn['name']]
-                            [0:pileupcolumn['pos'] + read_seq[4] + 1],
-                            pileupcolumn['pos'], indel)
+                            reference_seq_dict[ref_name][0:ref_pos +
+                                                         read_info[4] + 1],
+                            ref_pos, indel)
 
-                    base = read_seq[0][read_seq[1]]
+                    if read_info[1] is not None and read_info[0] is not None:
+                        base = read_info[0][read_info[1]]
 
-                    if base in {'A', 'C', 'G', 'T'}:
-                        if indel:
-                            allele_count["read_alleles"][base + indel] += 1
-                            allele_count["coverage"] += 1
-                        else:
-                            allele_count["read_alleles"][base] += 1
-                            allele_count["coverage"] += 1
-            pos = pileupcolumn['pos'] + 1
-            allele_counts[(pileupcolumn['name'], pos)] = allele_count
-
-    def generate_pileup_and_reads(
-        self, bamfiles: List[Any], reference_seq_dict: Dict[str, str]
-    ) -> Tuple[Dict[Tuple[str, int], Dict[str, Any]], List[Any]]:
-        """
-        Generate pileup and reads from BAM and reference FASTA files. This
-        function generates pileup information and reads from the provided
-        BAM files and reference sequences, returning both allele counts
-        and reads.
-
-        Parameters
-        ----------
-
-        bamfiles : List[Any]
-            List of BAM file data.
-        reference_seq_dict : Dict[str, str]
-            Dictionary with chromosome names as keys and reference
-
-        Returns
-        -------
-
-        Tuple[Dict[Tuple[str, int], Dict[str, Any]], List[Any]]
-            Dictionary of allele counts and list of reads.
-
-        """
-        allele_counts: Dict[Tuple[str, int], Dict[str, Any]] = {}
-        reads = []
-
-        for x in bamfiles:
-            chrom = x[3]  # Reference name
-
-            pileup_info = x[9] if len(x) > 9 else None
-            if pileup_info is None:
-                continue
-            for pileupcolumn in pileup_info:
-                for read_seq in pileupcolumn['reads']:
-                    reads.append(read_seq)
-
-            if chrom not in reference_seq_dict:
-                continue
-
-            if pileup_info:
-                self.process_pileup(pileup_info, reference_seq_dict,
-                                    allele_counts)
-
-        return allele_counts, reads
+                        if base in {'A', 'C', 'G', 'T'}:
+                            if indel:
+                                allele_count["read_alleles"][base + indel] += 1
+                                allele_count["coverage"] += 1
+                            else:
+                                allele_count["read_alleles"][base] += 1
+                                allele_count["coverage"] += 1
+            pos = ref_pos + 1
+            allele_counts[(ref_name, pos)] = allele_count
+        datapoint.close()
+        return allele_counts
 
     def update_counts(self, count: int, start: int, end: int,
                       window_counts: Dict[int, int]) -> None:
@@ -781,7 +763,8 @@ class RealignerFeaturizer(Featurizer):
         ----------
 
         datapoint : Tuple[str, str]
-            A tuple containing two strings representing allele counts and reads.
+            A tuple containing two strings representing path to bam file
+            and reference file.
 
         Returns
         -------
@@ -795,7 +778,7 @@ class RealignerFeaturizer(Featurizer):
 
         from deepchem.data import BAMLoader, FASTALoader
 
-        bam_loader = BAMLoader(get_pileup=True)
+        bam_loader = BAMLoader()
         bam_dataset = bam_loader.create_dataset(bamfile_path)
         bamfiles = bam_dataset.X
 
@@ -818,8 +801,8 @@ class RealignerFeaturizer(Featurizer):
             chrom_names[i]: seq for i, seq in enumerate(decoded_sequences)
         }
 
-        allele_counts, reads = self.realigner.generate_pileup_and_reads(
-            bamfiles, reference_seq_dict)
+        allele_counts = self.realigner.process_pileup(bamfile_path,
+                                                      reference_seq_dict)
         candidate_regions = self.realigner.select_candidate_regions(
             allele_counts)
         windows_haplotypes = self.realigner.process_candidate_windows(


### PR DESCRIPTION
## Description

Instead of storing Pileup information in memory, which required lot of RAM, this fix allows the code to calculate allelecounts directly without storing all the information in memory

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
