### PR TITLE
Feature/dummy featurizer canonicalization

### DIFF
--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -583,8 +583,9 @@ class DummyFeaturizer(Featurizer):
     >>> smi_map = [["C1=CC=CC=C1", "O=C(O)C"], ["CC(=O)O", "C1=CC=CC=C1"]]
     >>> featurizer = dc.feat.DummyFeaturizer(canonicalize=True)
     >>> featurizer.featurize(smi_map)
-    array([['C1=CC=CC=C1', 'CC(=O)O'],
-           ['CC(=O)O', 'C1=CC=CC=C1']], dtype='<U9')
+    array([['c1ccccc1', 'CC(=O)O'],
+           ['CC(=O)O', 'c1ccccc1']], dtype='<U8')
+ 
     """
 
     def __init__(self, canonicalize: bool = False, **kwargs):

--- a/deepchem/feat/base_classes.py
+++ b/deepchem/feat/base_classes.py
@@ -569,18 +569,24 @@ class UserDefinedFeaturizer(Featurizer):
         self.feature_fields = feature_fields
 
 class DummyFeaturizer(Featurizer):
-    """A no-op featurizer that optionally canonicalizes SMILES strings.
+    """
+    A no-op featurizer that optionally canonicalizes SMILES strings.
+
+    This featurizer simply returns the input data unchanged unless
+    the 'canonicalize' flag is set to True. In that case, each SMILES string
+    is converted to its canonical form using RDKit.
 
     Examples
     --------
     >>> import deepchem as dc
-    >>> smi_map = [["N#C[S-].O=C(CBr)c1ccc(C(F)(F)F)cc1>CCO.[K+]", "N#CSCC(=O)c1ccc(C(F)(F)F)cc1"],
-    ...            ["C1COCCN1.FCC(Br)c1cccc(Br)n1>CCN(C(C)C)C(C)C.CN(C)C=O.O", "FCC(c1cccc(Br)n1)N1CCOCC1"]]
+    >>> # Using valid SMILES strings: benzene and acetic acid.
+    >>> smi_map = [["C1=CC=CC=C1", "O=C(O)C"], ["CC(=O)O", "C1=CC=CC=C1"]]
     >>> featurizer = dc.feat.DummyFeaturizer(canonicalize=True)
     >>> featurizer.featurize(smi_map)
-    array([[<canonical SMILES>, <canonical SMILES>],
-           [<canonical SMILES>, <canonical SMILES>]])
+    array([['C1=CC=CC=C1', 'CC(=O)O'],
+           ['CC(=O)O', 'C1=CC=CC=C1']], dtype='<U9')
     """
+
     def __init__(self, canonicalize: bool = False, **kwargs):
         """
         Parameters

--- a/deepchem/feat/tests/test_dummy_featurizer.py
+++ b/deepchem/feat/tests/test_dummy_featurizer.py
@@ -1,27 +1,68 @@
 import unittest
-import deepchem as dc
 import numpy as np
-
+from rdkit import Chem
+import deepchem as dc
 
 class TestDummyFeaturizer(unittest.TestCase):
     """
-    Test for DummyFeaturizer.
+    Tests for the DummyFeaturizer.
     """
 
-    def test_featurize(self):
+    def setUp(self):
+        # Sample SMILES strings for testing.
+        self.smiles_list = [
+            "C1=CC=CC=C1",   # Benzene
+            "O=C(O)C",       # Acetic acid (non-canonical, may be standardized)
+            "CC(=O)O"        # Acetic acid alternative representation
+        ]
+        # Create a 2D array of SMILES for shape testing.
+        self.smiles_array = np.array([self.smiles_list, self.smiles_list])
+
+    def _get_expected_canonical(self, smiles):
         """
-        Test the featurize method on an array of inputs.
+        Compute the expected canonical SMILES using RDKit directly.
         """
-        input_array = np.array(
-            [[
-                "N#C[S-].O=C(CBr)c1ccc(C(F)(F)F)cc1>CCO.[K+]",
-                "N#CSCC(=O)c1ccc(C(F)(F)F)cc1"
-            ],
-             [
-                 "C1COCCN1.FCC(Br)c1cccc(Br)n1>CCN(C(C)C)C(C)C.CN(C)C=O.O",
-                 "FCC(c1cccc(Br)n1)N1CCOCC1"
-             ]])
-        featurizer = dc.feat.DummyFeaturizer()
-        out = featurizer.featurize(input_array)
-        assert isinstance(out, np.ndarray)
-        assert (out.shape == input_array.shape)
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            raise ValueError(f"Invalid SMILES string provided: {smiles}")
+        return Chem.MolToSmiles(mol, canonical=True)
+
+    def test_featurize_no_canonicalization(self):
+        """
+        When canonicalize is False, the featurizer should return the input unchanged.
+        """
+        featurizer = dc.feat.DummyFeaturizer(canonicalize=False)
+        output = featurizer.featurize(self.smiles_array)
+        # Output should be a numpy array with the same shape as the input.
+        self.assertIsInstance(output, np.ndarray)
+        self.assertEqual(output.shape, self.smiles_array.shape)
+        # Check that the output is identical to the input.
+        self.assertTrue(np.array_equal(output, self.smiles_array))
+
+    def test_featurize_with_canonicalization(self):
+        """
+        When canonicalize is True, the featurizer should return canonical SMILES strings.
+        """
+        featurizer = dc.feat.DummyFeaturizer(canonicalize=True)
+        output = featurizer.featurize(self.smiles_array)
+        # Ensure the shape is preserved.
+        self.assertEqual(output.shape, self.smiles_array.shape)
+        # Compare each element with RDKit's canonicalization.
+        for original, result in zip(self.smiles_array.flatten(), output.flatten()):
+            expected = self._get_expected_canonical(original)
+            self.assertEqual(result, expected)
+
+    def test_invalid_smiles_raises_error(self):
+        """
+        When canonicalization is enabled, an invalid SMILES string should raise a ValueError.
+        """
+        invalid_smiles = "invalid_smiles"
+        # Create an array that includes one invalid SMILES.
+        test_array = np.array([["C1=CC=CC=C1", invalid_smiles]])
+        featurizer = dc.feat.DummyFeaturizer(canonicalize=True)
+        with self.assertRaises(ValueError):
+            # This should raise a ValueError due to the invalid SMILES.
+            featurizer.featurize(test_array)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Description

Fix #4379 

This PR adds an optional canonicalization feature to the DummyFeaturizer class. When the canonicalize flag is set to True, the featurizer uses RDKit to convert input SMILES strings into their canonical forms. The corresponding tests have been updated to verify the following:

The featurizer returns the input unchanged when canonicalization is disabled.

The featurizer returns canonical SMILES when canonicalization is enabled.

An invalid SMILES string triggers a ValueError.

This enhancement ensures standardized SMILES outputs for downstream tasks, such as tokenization for transformer models.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [X] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [X] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
