### PR TITLE
Add ConversionErrorLogger utility with unit tests

### DIFF
--- a/deepchem/utils/conversion_errors.py
+++ b/deepchem/utils/conversion_errors.py
@@ -1,0 +1,21 @@
+from collections import Counter
+import pandas as pd
+
+class ConversionErrorLogger:
+    """Logs failed SMILES↔IUPAC conversions with error analysis."""
+
+    def __init__(self):
+        self.errors = []
+
+    def log_failure(self, input_str, output_str, error_type):
+        """Records a failed conversion."""
+        self.errors.append({
+            "input": input_str,
+            "output": output_str,
+            "error_type": error_type
+        })
+
+    def generate_report(self):
+        """Returns a DataFrame summarizing error types."""
+        error_counts = Counter(e["error_type"] for e in self.errors)
+        return pd.DataFrame(error_counts.items(), columns=["Error", "Count"])

--- a/deepchem/utils/tests/test_conversion_errors.py
+++ b/deepchem/utils/tests/test_conversion_errors.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from deepchem.utils.conversion_errors import ConversionErrorLogger
+
+def test_log_and_generate_report():
+    logger = ConversionErrorLogger()
+    
+    # Simulate logging of failures
+    logger.log_failure("C1=CC=CC=C1", "", "EmptyOutput")
+    logger.log_failure("O=C=O", "", "EmptyOutput")
+    logger.log_failure("CCO", "Invalid", "InvalidOutput")
+
+    # Generate the report
+    report = logger.generate_report()
+
+    # Assertions to verify correct error logging
+    assert isinstance(report, pd.DataFrame)
+    assert "Error" in report.columns
+    assert "Count" in report.columns
+    assert report.loc[report["Error"] == "EmptyOutput", "Count"].values[0] == 2
+    assert report.loc[report["Error"] == "InvalidOutput", "Count"].values[0] == 1


### PR DESCRIPTION
## Description

### Summary
This PR adds a new utility class `ConversionErrorLogger` to help track and log SMILES ↔ IUPAC conversion failures. This tool helps in identifying conversion issues during molecule processing.

**What's Included:**
- New utility: `deepchem/utils/conversion_errors.py`
- Unit test: `deepchem/utils/tests/test_conversion_errors.py`

This utility is intended to improve error tracking and debugging in cheminformatics workflows.



## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New unit tests pass locally with my changes
- [ x] I have checked my code and corrected any misspellings
