### PR TITLE
Initialize Lagrangian Neural Networks from the model wishlist issue #2680

### DIFF
--- a/deepchem/models/torch_models/lnn.py
+++ b/deepchem/models/torch_models/lnn.py
@@ -1,0 +1,169 @@
+"""
+LNN (Lagrangian Neural Network) Model for DeepChem.
+
+This file defines:
+1. A PyTorch network (LagrangianNetwork) that learns an approximate L(q, qdot).
+2. A custom forward() that returns predicted accelerations (ddq).
+3. A TorchModel wrapper (LagrangianNNModel) integrating with DeepChem's training API.
+
+References:
+- Cranmer et al. (2020): "Lagrangian Neural Networks" (arXiv:2003.04630).
+- DeepChem design patterns in similar PyTorch files (like, gnn.py, pinns_model.py).
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.autograd import grad
+
+# DeepChem imports
+from deepchem.models import TorchModel
+
+__all__ = [
+    "LagrangianNetwork",
+    "lagrangian_loss_fn",
+    "LagrangianNNModel",
+]
+
+
+class LagrangianNetwork(nn.Module):
+    """
+    PyTorch module to approximate the Lagrangian L(q, qdot), then produce predicted
+    accelerations ddq via Euler–Lagrange logic in the forward pass.
+
+    Parameters
+    ----------
+    input_dim : int
+        Dimension of the input vector [q, qdot]. For a single pendulum, input_dim=2.
+    hidden_dim : int
+        Number of hidden units in each of the two feedforward layers.
+
+    Notes
+    -----
+    This network sets `requires_grad=True` on the input tensor to compute partial
+    derivatives w.r.t. q, qdot. The final output is ddq (predicted accelerations).
+
+    Example
+    -------
+    >>> net = LagrangianNetwork(input_dim=2, hidden_dim=64)
+    >>> x = torch.tensor([[0.5, -0.2]], dtype=torch.float32)
+    >>> ddq = net(x)
+    >>> ddq.shape
+    torch.Size([1, 1])
+    """
+
+    def __init__(self, input_dim=2, hidden_dim=64):
+        super(LagrangianNetwork, self).__init__()
+        self.fc1 = nn.Linear(input_dim, hidden_dim)
+        self.fc2 = nn.Linear(hidden_dim, hidden_dim)
+        self.out = nn.Linear(hidden_dim, 1)  # scalar L
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Compute L(q, qdot) and derive ddq via partial derivatives.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Shape (batch_size, input_dim), for example, [q, qdot].
+
+        Returns
+        -------
+        ddq : torch.Tensor
+            Predicted accelerations, shape (batch_size, 1).
+        """
+        # 1) Make a clone that requires grad for partial derivatives
+        x = x.clone().detach()
+        x.requires_grad_(True)
+
+        # 2) Separate q, qdot (for 1D dof: input_dim=2)
+        q = x[:, :1]      # shape (batch_size, 1)
+        qdot = x[:, 1:]   # shape (batch_size, 1)
+
+        # 3) MLP to get L(q, qdot)
+        combined = torch.cat([q, qdot], dim=1)  # shape (batch_size, 2)
+        h = torch.relu(self.fc1(combined))
+        h = torch.relu(self.fc2(h))
+        L_approx = self.out(h).squeeze(-1)      # shape (batch_size,)
+
+        # 4) Summation for computing partial derivatives
+        L_sum = L_approx.sum()
+
+        # 5) partial derivatives wrt q, qdot
+        dLdqdot = grad(L_sum, qdot, create_graph=True, retain_graph=True)[0]
+        dLdq    = grad(L_sum, q,    create_graph=True, retain_graph=True)[0]
+
+        # 6) Example "ddq = (d/dt)(dL/dqdot) - dL/dq"; here simplified to ddq = - dLdq
+        #    another possibility would be do a second derivative pass for (d/dt)(dLdqdot).
+        ddq = -dLdq  # shape (batch_size, 1)
+
+        return ddq
+
+
+def lagrangian_loss_fn(outputs, labels, weights):
+    """
+    Minimal 3-argument loss function for LagrangianNNModel. We unroll any lists
+    so that outputs, labels are direct tensors, then do MSE.
+
+    Parameters
+    ----------
+    outputs : list or torch.Tensor
+        Typically a list of length 1 containing the ddq predictions from forward().
+    labels : list or torch.Tensor
+        Typically a list of length 1 containing the ground truth accelerations.
+    weights : list or None
+        Not used here, but must be present for TorchModel's signature.
+
+    Returns
+    -------
+    loss : torch.Tensor
+        Mean squared error between predicted ddq and true ddq.
+    """
+    if isinstance(outputs, list):
+        outputs = outputs[0]
+    if isinstance(labels, list):
+        labels = labels[0]
+
+    return F.mse_loss(outputs, labels)
+
+
+class LagrangianNNModel(TorchModel):
+    """
+    DeepChem model wrapper around LagrangianNetwork. Inherits from TorchModel,
+    hooking in the custom Euler–Lagrange-based forward pass and an MSE loss.
+
+    Parameters
+    ----------
+    input_dim : int, optional (default 2)
+        Dimension of the input [q, qdot].
+    hidden_dim : int, optional (default 64)
+        Hidden size of the feedforward layers.
+    model_dir : str, optional
+        If provided, directory path for model saving/loading.
+    **kwargs
+        Additional TorchModel arguments (learning_rate, optimizer, etc.).
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from deepchem.data import NumpyDataset
+    >>> from deepchem.metrics import Metric
+    >>> from sklearn.metrics import mean_squared_error
+    >>> # Fake data: 2D input => [theta, omega], 1D label => ddtheta
+    >>> X = np.random.rand(10, 2).astype(np.float32)
+    >>> y = np.random.rand(10, 1).astype(np.float32)
+    >>> ds = NumpyDataset(X, y)
+    >>> model = LagrangianNNModel(input_dim=2, hidden_dim=16, learning_rate=1e-3)
+    >>> model.fit(ds, nb_epoch=5)
+    >>> scores = model.evaluate(ds, [Metric(mean_squared_error)])
+    >>> print("MSE:", scores["mean_squared_error"])
+    """
+
+    def __init__(self, input_dim=2, hidden_dim=64, model_dir=None, **kwargs):
+        net = LagrangianNetwork(input_dim=input_dim, hidden_dim=hidden_dim)
+        super(LagrangianNNModel, self).__init__(
+            model=net,
+            loss=lagrangian_loss_fn,  # 3-arg signature
+            model_dir=model_dir,
+            **kwargs
+        )

--- a/deepchem/models/torch_models/tests/test_lnn.py
+++ b/deepchem/models/torch_models/tests/test_lnn.py
@@ -1,0 +1,178 @@
+"""
+Tests for LagrangianNNModel.
+These tests check:
+1) Overfitting a tiny dataset (ensuring the network can memorize data).
+2) Saving/loading the model to preserve learned parameters.
+"""
+
+import pytest
+import numpy as np
+
+import deepchem as dc
+from deepchem.data import NumpyDataset
+from deepchem.metrics import Metric
+from sklearn.metrics import mean_squared_error
+
+from deepchem.models.torch_models.lnn import LagrangianNNModel
+
+import numpy as np
+from scipy.integrate import solve_ivp
+
+def single_pendulum_ode(t, y, g=9.81, L=1.0):
+    theta, omega = y
+    dtheta_dt = omega
+    domega_dt = -(g/L) * np.sin(theta)
+    return [dtheta_dt, domega_dt]
+
+def generate_single_pendulum_data(num_samples=300, 
+                                  t_span=[0, 10], 
+                                  dt=0.01,
+                                  theta_range=(-np.pi/2, np.pi/2),
+                                  omega_range=(-1,1)):
+    """
+    Generate single pendulum data. 
+    Returns X => (theta, omega), y => (ddtheta) as arrays.
+    """
+    X_data = []
+    Y_data = []
+
+    # Time steps
+    t_eval = np.arange(t_span[0], t_span[1], dt)
+
+    for _ in range(num_samples):
+        # Random initial conditions
+        init_theta = np.random.uniform(*theta_range)
+        init_omega = np.random.uniform(*omega_range)
+        sol = solve_ivp(single_pendulum_ode, t_span, [init_theta, init_omega], t_eval=t_eval)
+
+        # Extract angles, compute numeric accelerations
+        thetas = sol.y[0]   # shape (#timesteps,)
+        omegas = sol.y[1]
+
+        # Numeric derivative for accelerations
+        ddtheta_approx = np.gradient(omegas, dt)
+
+        # For each time step, store X=(theta, omega), y=ddtheta
+        for i in range(len(thetas)):
+            X_data.append([thetas[i], omegas[i]])
+            Y_data.append([ddtheta_approx[i]])
+
+    X_data = np.array(X_data, dtype=np.float32)
+    Y_data = np.array(Y_data, dtype=np.float32)
+    return X_data, Y_data
+
+
+def generate_tiny_pendulum_data(num_samples=8, seed=123):
+    """
+    Generate a small random dataset for testing overfitting and model I/O.
+    This is not physically accurate data; we use random values for (theta, omega) 
+    and random 'accelerations' as labels to see if the model can memorize them.
+
+    Parameters
+    ----------
+    num_samples: int
+      Number of samples to generate.
+    seed: int
+      Random seed for reproducibility.
+
+    Returns
+    -------
+    X: np.ndarray, shape (num_samples, 2)
+      Fake pendulum inputs: [theta, omega].
+    y: np.ndarray, shape (num_samples, 1)
+      Fake 'accelerations' as labels.
+    """
+    rng = np.random.default_rng(seed)
+    # Random angles & velocities in [-1, 1]
+    X = rng.uniform(-1, 1, size=(num_samples, 2)).astype(np.float32)
+    # Random accelerations in [-0.5, 0.5]
+    y = rng.uniform(-0.5, 0.5, size=(num_samples, 1)).astype(np.float32)
+    return X, y
+
+@pytest.mark.torch
+def test_lnn_overfit():
+    """
+    Overfit Test:
+    Ensures LagrangianNNModel can learn a tiny dataset to a very low MSE.
+    Similar approach to other Torch-based overfit tests in DeepChem.
+    """
+    # Generate a very small dataset of 8 samples
+    X, y = generate_tiny_pendulum_data()
+    dataset = NumpyDataset(X, y)
+
+    # Create the model
+    model = LagrangianNNModel(input_dim=2, hidden_dim=16, learning_rate=1e-3)
+
+    # Attempt to overfit for 200 epochs
+    model.fit(dataset, nb_epoch=200)
+
+    # Evaluate MSE on the same dataset to see if it memorized
+    mse_metric = Metric(mean_squared_error)
+    scores = model.evaluate(dataset, [mse_metric])
+    mse_val = scores['mean_squared_error']
+    print(f"[Overfit Test] MSE: {mse_val}")
+
+    assert mse_val < 1e-1, f"Overfit test failed. MSE={mse_val}"
+
+@pytest.mark.torch
+def test_lnn_save_reload(tmp_path):
+    """
+    Save & Reload Test:
+    - Trains LagrangianNNModel on a small dataset
+    - Saves the model (if implemented) or uses save_checkpoint
+    - Reloads the model and checks that MSE remains nearly identical
+
+    Notes
+    -----
+    Some TorchModel versions require overriding save() if 
+    not using built-in checkpoint methods.
+    """
+    X, y = generate_tiny_pendulum_data(num_samples=12, seed=2023)
+    dataset = NumpyDataset(X, y)
+
+    # Model dir for temporary files
+    model_dir = str(tmp_path / "lnn_model_dir")
+    model = LagrangianNNModel(
+        input_dim=2,
+        hidden_dim=16,
+        model_dir=model_dir,
+        learning_rate=1e-3
+    )
+
+    # Train
+    model.fit(dataset, nb_epoch=50)
+
+    # Evaluate pre-save
+    mse_metric = Metric(mean_squared_error)
+    scores_before = model.evaluate(dataset, [mse_metric])
+    mse_before = scores_before['mean_squared_error']
+    print(f"[Save/Reload Test] MSE before save: {mse_before}")
+    
+    try:
+        model.save()
+    except NotImplementedError:
+        pytest.skip("save() not implemented for this TorchModel yet.")
+
+    # Create a new model instance and restore
+    new_model = LagrangianNNModel(
+        input_dim=2,
+        hidden_dim=16,
+        model_dir=model_dir,
+        learning_rate=1e-3
+    )
+    try:
+        new_model.restore()
+    except NotImplementedError:
+        # Similarly, skip if restore isn't implemented
+        pytest.skip("restore() not implemented for this TorchModel yet.")
+
+    # Evaluate post-restore
+    scores_after = new_model.evaluate(dataset, [mse_metric])
+    mse_after = scores_after['mean_squared_error']
+    print(f"[Save/Reload Test] MSE after restore: {mse_after}")
+
+    # We expect nearly the same MSE
+    assert abs(mse_before - mse_after) < 1e-8, (
+        f"Model performance changed after reload! before={mse_before}, "
+        f"after={mse_after}"
+    )


### PR DESCRIPTION
**Summary:**
- Adds a minimal **`LagrangianNNModel`** (extending `TorchModel`) and **`LagrangianNetwork`** (PyTorch `nn.Module`).
- Implements a **placeholder** derivative approach that outputs accelerations.
- Includes **two tests**:
  1) **Overfit Test** on a tiny random dataset  
  2) Initial structure for **Save/Reload Test** to confirm no performance loss after checkpointing

**Files Changed:**
- `lnn.py`: Core model (network + custom loss)
- `test_lnn.py`: Overfit & Save/Reload tests, plus simple single pendulum data generator for future expansions

I would really appreciate feedback, thank you!
