### PR TITLE
CI formatting fixes (mypy, flake8 and yapf)

### DIFF
--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -978,8 +978,8 @@ class FASTALoader(DataLoader):
             Legacy mode is only tested for ACTGN charsets, and will be deprecated.
 
         use_raw_fasta: bool (default False)
-            Whether to use FASTAFeaturizer for parsing. If True, uses pysam to extract 
-            sequences directly from FASTA files, returning a numpy array of shape 
+            Whether to use FASTAFeaturizer for parsing. If True, uses pysam to extract
+            sequences directly from FASTA files, returning a numpy array of shape
             (n_sequences, 2) where each row contains [sequence_name, sequence].
             This is useful for handling large FASTA files efficiently and when raw
             sequence data with headers is needed.

--- a/deepchem/feat/bert_tokenizer.py
+++ b/deepchem/feat/bert_tokenizer.py
@@ -53,5 +53,6 @@ class BertFeaturizer(Featurizer):
         """
 
         # the encoding is natively a dictionary with keys 'input_ids', 'token_type_ids', and 'attention_mask'
-        encoding = list(self.tokenizer(datapoint, **kwargs).values())
+        encoding = list(self.tokenizer(datapoint,
+                                       **kwargs).values())  # type: ignore
         return encoding

--- a/deepchem/feat/reaction_featurizer.py
+++ b/deepchem/feat/reaction_featurizer.py
@@ -96,18 +96,20 @@ class RxnFeaturizer(Featurizer):
 
         source_encoding = np.asarray(
             list(
-                self.tokenizer(source,
-                               padding='max_length',
-                               truncation=True,
-                               max_length=self.max_length,
-                               **kwargs).values()))
+                self.tokenizer(
+                    source,  # type: ignore
+                    padding='max_length',
+                    truncation=True,
+                    max_length=self.max_length,
+                    **kwargs).values()))
         target_encoding = np.asarray(
             list(
-                self.tokenizer(target,
-                               padding='max_length',
-                               truncation=True,
-                               max_length=self.max_length,
-                               **kwargs).values()))
+                self.tokenizer(
+                    target,  # type: ignore
+                    padding='max_length',
+                    truncation=True,
+                    max_length=self.max_length,
+                    **kwargs).values()))
         return [source_encoding, target_encoding]
 
     def __call__(self, *args, **kwargs) -> np.ndarray:

--- a/deepchem/feat/smiles_tokenizer.py
+++ b/deepchem/feat/smiles_tokenizer.py
@@ -106,7 +106,8 @@ class SmilesTokenizer(BertTokenizer):
     def vocab_list(self):
         return list(self.vocab.keys())
 
-    def _tokenize(self, text: str, max_seq_length: int = 512, **kwargs):
+    def _tokenize(  # type: ignore
+            self, text: str, max_seq_length: int = 512, **kwargs):
         """Tokenize a string into a list of tokens.
 
         Parameters

--- a/deepchem/feat/tests/test_FASTAFeaturizer.py
+++ b/deepchem/feat/tests/test_FASTAFeaturizer.py
@@ -5,13 +5,6 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-try:
-    import pysam
-except ImportError as e:
-    logger.warning(
-        f'Skipped loading biological sequence featurizer, missing a dependency. {e}'
-    )
-
 
 class TestFASTAFeaturizer(unittest.TestCase):
 

--- a/deepchem/feat/vocabulary_builders/hf_vocab.py
+++ b/deepchem/feat/vocabulary_builders/hf_vocab.py
@@ -61,7 +61,7 @@ class HuggingFaceVocabularyBuilder(VocabularyBuilder):
         """
         from transformers import PreTrainedTokenizerFast
         tokenizer = PreTrainedTokenizerFast(tokenizer_file=fname)
-        return tokenizer
+        return tokenizer  # type: ignore
 
     def save(self, fname: str) -> None:
         """Saves vocabulary to a file

--- a/deepchem/models/torch_models/antibody_modeling.py
+++ b/deepchem/models/torch_models/antibody_modeling.py
@@ -154,15 +154,19 @@ class DeepAbLLM(HuggingFaceModel):
             model_path, do_lower_case=False)
         model_config: AutoConfig = AutoConfig.from_pretrained(
             pretrained_model_name_or_path=model_path,
-            vocab_size=tokenizer.vocab_size)
-        model_config.update(config)
+            vocab_size=tokenizer.vocab_size)  # type: ignore
+        model_config.update(config)  # type: ignore
         self.is_esm_variant: bool = is_esm_variant
         model: Union[AutoModel, AutoModelForMaskedLM]
         if task == "mlm":
             model = AutoModelForMaskedLM.from_config(model_config)
         else:
             model = AutoModel.from_config(model_config)
-        super().__init__(model=model, task=task, tokenizer=tokenizer, **kwargs)
+        super().__init__(
+            model=model,  # type: ignore
+            task=task,
+            tokenizer=tokenizer,  # type: ignore
+            **kwargs)
 
     def _mask_seq_pos(
         self,

--- a/deepchem/models/torch_models/ferminet.py
+++ b/deepchem/models/torch_models/ferminet.py
@@ -142,8 +142,9 @@ class Ferminet(torch.nn.Module):
         one_electron_vector_permuted = one_electron_vector.permute(0, 2, 1,
                                                                    3).float()
         # setting the fermient layer and fermient envelope layer batch size to be that of the current batch size of the model. This enables for vectorized calculations of hessians and jacobians.
-        self.ferminet_layer[0].batch_size = self.batch_size
-        self.ferminet_layer_envelope[0].batch_size = self.batch_size
+        self.ferminet_layer[0].batch_size = self.batch_size  # type: ignore
+        self.ferminet_layer_envelope[
+            0].batch_size = self.batch_size  # type: ignore
         one_electron, _ = self.ferminet_layer[0].forward(
             one_electron.to(torch.float32), two_electron.to(torch.float32))
         self.psi, self.psi_up, self.psi_down = self.ferminet_layer_envelope[
@@ -580,7 +581,7 @@ class FerminetModel(TorchModel):
             hook function to modify the gradients
             """
             # using non-local variables as a means of parameter passing
-            nonlocal energy_local, energy_mean
+            nonlocal energy_local, energy_mean  # noqa: F824
             new_grad = (2 / random_walk_steps) * (
                 (energy_local - energy_mean) * grad)
             return new_grad.float()

--- a/deepchem/models/torch_models/oneformer.py
+++ b/deepchem/models/torch_models/oneformer.py
@@ -146,10 +146,11 @@ class OneFormer(HuggingFaceModel):
         self.model_processor.image_processor.num_text = self.model.config.num_queries - self.model.config.text_encoder_n_ctx
         assert self.model_processor.image_processor.num_text == self.model.config.num_queries - self.model.config.text_encoder_n_ctx
 
-        super().__init__(model=self.model,
-                         task=self.task,
-                         tokenizer=None,
-                         **kwargs)
+        super().__init__(
+            model=self.model,
+            task=self.task,
+            tokenizer=None,  # type: ignore
+            **kwargs)
 
     def _prepare_batch(self, batch: Tuple[Any, Any, Any]):
         """

--- a/deepchem/models/torch_models/progressive_multitask.py
+++ b/deepchem/models/torch_models/progressive_multitask.py
@@ -274,7 +274,7 @@ class ProgressiveMultitask(nn.Module):
                 layer_outputs.append(x_)
 
             out_layer_idx = len(self.layer_sizes)
-            x_ = self.layers[task][out_layer_idx](x_)
+            x_ = self.layers[task][out_layer_idx](x_)  # type: ignore
             if task > 0:
                 adapter_out = self._get_lateral_contrib(layer_logits, task,
                                                         out_layer_idx)


### PR DESCRIPTION
## Description
Several CI formatting issues have appeared (mypy and flake8) across `deepchem`. The code and changes are safe to merge, in my opinion, but I'm still looking for the cause(s) of bugs (maybe library versions and compatibility).

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
