### PR TITLE
Add SE(3)-Transformer attention layers and equivariance utils

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -5,6 +5,7 @@ import itertools
 import sympy as sym
 from typing import Any, Tuple, Optional, Sequence, List, Union, Callable, Dict, TypedDict
 from collections.abc import Sequence as SequenceCollection
+from packaging import version
 try:
     import torch
     from torch import Tensor
@@ -8001,3 +8002,458 @@ class SE3AvgPooling(nn.Module):
                 "SE3AvgPooling for type > 1 is not implemented.")
 
         return pooled
+
+
+class SE3MultiHeadAttention(nn.Module):
+    """
+    SE(3)-Equivariant Multi-Headed Self-Attention for Graph Neural Networks.
+    This layer extends multi-head self-attention (MHA) to SE(3)-equivariant 
+    representations. Instead of using dot-product attention in standard Transformers, 
+    this module computes SE(3)-equivariant attention scores over graph edges
+    while preserving SE(3) symmetry.
+    Given a graph G = (V, E), where:
+    - Nodes store queries (q_i ∈ R^m).
+    - Edges store keys (k_ij ∈ R^m) & values (v_ij ∈ R^m).
+    The attention weight is computed using a dot product between the key and 
+    the query followed by a softmax operation:
+    $$
+    a_{ij} = \text{softmax} \left( \frac{k_{ij} \cdot q_i}{\sqrt{d_k}} \right)
+    $$
+    The final node update aggregates weighted values:
+    $$
+    h_i = \sum_{j \in \mathcal{N}(i)} a_{ij} v_{ij}
+    $$
+    SE(3) Equivariance:
+    - The above equations are applied separately for each degree (l) in the SE(3) 
+      representation, ensuring equivariance is preserved across scalar (l=0), vector (l=1), 
+      and higher-degree features.
+   Usage in SE(3)-Transformers:
+    - This layer replaces MHA in SE(3)-Transformers by applying equivariant self-attention 
+      over graph edges.
+    - Used inside `GSE3Res` blocks for message passing.
+    - Preserves SE(3) symmetry when computing interactions.
+    Example
+    -------
+    >>> import torch
+    >>> import dgl
+    >>> import deepchem as dc
+    >>> from rdkit import Chem
+    >>> from deepchem.models.torch_models.layers import Fiber, SE3MultiHeadAttention
+    # Create a molecular graph from SMILES
+    >>> mol = Chem.MolFromSmiles("CCO")
+    # Extract SE(3)-equivariant features
+    >>> featurizer = dc.feat.EquivariantGraphFeaturizer(fully_connected=True, embeded=True)
+    >>> features = featurizer.featurize([mol])[0]
+    #  Convert features into a DGL graph
+    >>> G = dgl.graph((features.edge_index[0], features.edge_index[1]), num_nodes=len(features.node_features))
+    # Assign SE(3)-equivariant node & edge features
+    >>> G.ndata['f'] = torch.tensor(features.node_features, dtype=torch.float32).unsqueeze(-1)
+    >>> G.ndata['x'] = torch.tensor(features.positions, dtype=torch.float32)  # 3D coordinates
+    >>> G.edata['d'] = torch.tensor(features.edge_features, dtype=torch.float32)  # Edge distances
+    >>> G.edata['w'] = torch.tensor(features.edge_weights, dtype=torch.float32)  # Edge weights
+    #  Define Fiber Representations for Input & Output
+    >>> f_value = Fiber(dictionary={0: 16, 1: 32})  # Scalars (degree 0) & Vectors (degree 1)
+    >>> f_key = Fiber(dictionary={0: 16, 1: 32})  # Same as values for attention
+    # Initialize `SE3MultiHeadAttention` (Multi-Headed SE(3)-Equivariant Attention)
+    >>> n_heads = 4
+    >>> gmab = SE3MultiHeadAttention(f_value, f_key, n_heads)
+    # Convert Node Features into the Correct Format
+    >>> v = {str(d): torch.randn(G.num_edges(), f_value.structure_dict[d], 2 * d + 1) for d in f_value.structure_dict}
+    >>> k = {str(d): torch.randn(G.num_edges(), f_key.structure_dict[d], 2 * d + 1) for d in f_key.structure_dict}
+    >>> q = {str(d): torch.randn(G.num_nodes(), f_key.structure_dict[d], 2 * d + 1) for d in f_key.structure_dict}
+    # Apply `SE3MultiHeadAttention` Layer (SE(3)-Equivariant Attention)
+    >>> output = gmab(v, k=k, q=q, G=G)
+    >>> for key, tensor in output.items():
+    ...    print(tensor.shape)
+    torch.Size([3, 16, 1])
+    torch.Size([3, 32, 3])
+    References
+    ----------
+    .. [1] SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+           Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+           NeurIPS 2020, https://arxiv.org/abs/2006.10503
+    """
+
+    def __init__(self, f_value: Fiber, f_key: Fiber, n_heads: int) -> None:
+        """
+        Initialize the SE(3)-equivariant multi-head self-attention layer.
+        
+        Parameters
+        ----------
+        f_value : Fiber
+            Fiber representation of the values in attention.
+        f_key : Fiber
+            Fiber representation of the keys in attention.
+        n_heads : int
+            Number of attention heads.
+        """
+        import dgl
+
+        super().__init__()
+        self.f_value = f_value
+        self.f_key = f_key
+        self.n_heads = n_heads
+        self.new_dgl = version.parse(dgl.__version__) > version.parse('0.4.4')
+
+    def udf_u_mul_e(self, d_out: int) -> Callable:
+        """
+        Compute the weighted sum for a single output feature type.
+        
+        This function applies the attention weights to the value features 
+        during message passing in the graph.
+        
+        Parameters
+        ----------
+        d_out : int
+            Degree of the output representation in SE(3) space.
+        
+        Returns
+        -------
+        function
+            A function to be used in DGL's message-passing framework.
+        """
+
+        def fnc(edges):
+            attn = edges.data['a']
+            value = edges.data[f'v{d_out}']
+            msg = attn.unsqueeze(-1).unsqueeze(-1) * value
+            return {'m': msg}
+
+        return fnc
+
+    def forward(self, v: Dict[Any,
+                              torch.Tensor], k: Optional[Dict[Any,
+                                                              torch.Tensor]],
+                q: Optional[Dict[Any, torch.Tensor]], G,
+                **kwargs) -> Dict[str, torch.Tensor]:
+        """
+        Forward pass of SE(3)-equivariant multi-headed attention.
+        
+        Applies equivariant self-attention over graph edges, computing 
+        attention scores and updating node features accordingly.
+        
+        Parameters
+        ----------
+        v : Dict
+            Dictionary of value tensors indexed by their degree.
+        k : Dict, optional
+            Dictionary of key tensors indexed by their degree (default: None).
+        q : Dict, optional
+            Dictionary of query tensors indexed by their degree (default: None).
+        G : dgl.DGLGraph
+            Graph object containing node and edge features.
+        
+        Returns
+        -------
+        Dict
+            Dictionary of updated node features indexed by their degree.
+        """
+        from deepchem.utils.equivariance_utils import fiber2head
+        import dgl.function as fn
+        from dgl.nn.functional import edge_softmax
+
+        with G.local_scope():
+            for m, d in self.f_value.structure:
+                G.edata[f'v{d}'] = v[f'{d}'].view(-1, self.n_heads,
+                                                  m // self.n_heads, 2 * d + 1)
+
+            if k is not None:
+                G.edata['k'] = fiber2head(k,
+                                          self.n_heads,
+                                          self.f_key,
+                                          squeeze=True)
+
+            if q is not None:
+                G.ndata['q'] = fiber2head(q,
+                                          self.n_heads,
+                                          self.f_key,
+                                          squeeze=True)
+
+            G.apply_edges(fn.e_dot_v('k', 'q', 'e'))
+            e = G.edata.pop('e')
+
+            if self.new_dgl:
+                n_edges = G.edata['k'].shape[0]
+                e = e.view([n_edges, self.n_heads])
+
+            e = e / np.sqrt(self.f_key.n_features)
+            G.edata['a'] = edge_softmax(G, e)
+
+            for d in self.f_value.degrees:
+                G.update_all(self.udf_u_mul_e(d), fn.sum('m', f'out{d}'))
+
+            output = {
+                f'{d}': G.ndata[f'out{d}'].view(-1, m, 2 * d + 1)
+                for m, d in self.f_value.structure
+            }
+            return output
+
+
+class SE3AttentiveSelfInteraction(nn.Module):
+    """
+    A self-interaction layer with an attention mechanism that preserves SE(3) equivariance.
+    This layer applies learnable self-interactions using attention weights
+    to dynamically control the contribution of different feature components. It enables 
+    adaptive transformation of SE(3)-equivariant features while preserving equivariance.
+    Instead of applying a fixed transformation to each feature type, this layer computes 
+    attention weights based on input feature relationships. These weights determine how 
+    much each feature contributes to the output.
+    Mathematically, this can be expressed as:
+        h_out[d] = softmax(W_d * (h_in[d] ⊗ h_in[d])) * h_in[d]
+    where:
+    - h_in[d]  is the input feature tensor of degree `d`.
+    - W_d      is the learnable attention weight matrix for degree `d`.
+    - ⊗        represents an inner product to compute self-attention scalars.
+    - h_out[d] is the transformed output feature tensor.
+    This method enables a data-dependent feature transformation, which is 
+    particularly useful for learning complex interactions in SE(3)-equivariant models.
+    Parameters
+    ----------
+    f_in : Any
+        The input Fiber structure that defines feature multiplicities and degrees.
+    f_out : Any
+        The output Fiber structure that defines transformed feature dimensions.
+    
+    Example
+    -------
+    >>> from rdkit import Chem
+    >>> import dgl
+    >>> import torch
+    >>> import deepchem as dc
+    >>> from deepchem.models.torch_models.layers import Fiber, SE3AttentiveSelfInteraction
+    >>> # Create a molecular graph from SMILES
+    >>> mol = Chem.MolFromSmiles("CCO")
+    >>> # Use EquivariantGraphFeaturizer to extract SE(3)-equivariant features
+    >>> featurizer = dc.feat.EquivariantGraphFeaturizer(fully_connected=True, embeded=True)
+    >>> features = featurizer.featurize([mol])[0]
+    >>> G = dgl.graph((features.edge_index[0], features.edge_index[1]), num_nodes=len(features.node_features))
+    >>> # Assign SE(3)-equivariant node features
+    >>> G.ndata['f'] = torch.tensor(features.node_features, dtype=torch.float32).unsqueeze(-1)  # Node features
+    >>> G.ndata['x'] = torch.tensor(features.positions, dtype=torch.float32)  # 3D coordinates
+    >>> f_in = Fiber(dictionary={0: 16, 1: 32})  # Input fiber: scalars & vectors
+    >>> f_out = Fiber(dictionary={0: 32, 1: 64})  # Output fiber
+    >>> # Initialize SE(3)-Equivariant Attentive Self-Interaction Layer
+    >>> g_att = SE3AttentiveSelfInteraction(f_in, f_out)
+    >>> # Convert Node Features into the Correct Format
+    >>> h = {str(d): torch.randn(G.num_nodes(), f_in.structure_dict[d], 2 * d + 1) for d in f_in.structure_dict}
+    >>> # Apply `SE3AttentiveSelfInteraction` Layer (SE(3)-Equivariant Self-Interaction with Attention)
+    >>> output = g_att(h)
+    >>> print(output['0'].shape)
+    torch.Size([3, 32, 1])
+    >>> print(output['1'].shape)
+    torch.Size([3, 64, 3])
+    References
+    ----------
+    .. [1] SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+           Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+           NeurIPS 2020, https://arxiv.org/abs/2006.10503
+    """
+
+    def __init__(self, f_in: Fiber, f_out: Fiber) -> None:
+        """
+        Initializes the SE3AttentiveSelfInteraction layer.
+        Parameters
+        ----------
+        f_in (Fiber):
+            The input fiber structure defining feature multiplicities and degrees.
+        f_out (Fiber):
+            The output fiber structure defining transformed feature dimensions.
+        """
+        super().__init__()
+        self.f_in = f_in
+        self.f_out = f_out
+        self.nonlin = nn.LeakyReLU()
+        self.num_layers = 2
+        self.eps = 1e-12  # Regularization to prevent numerical instability
+
+        # Learnable attention-based transformations for each feature degree
+        self.transform: nn.ModuleDict = nn.ModuleDict()
+        for degree, m_in in self.f_in.structure_dict.items():
+            m_out = self.f_out.structure_dict[degree]
+            self.transform[str(degree)] = self._build_net(m_in, m_out)
+
+    def _build_net(self, m_in: int, m_out: int) -> nn.Sequential:
+        """
+        Constructs a small *fully connected* network to compute attention weights.
+        Parameters
+        ----------
+        m_in : int
+            The input multiplicity for the given degree.
+        m_out : int
+            The output multiplicity for the given degree.
+        Returns
+        -------
+        nn.Sequential
+            A small MLP that predicts attention weights.
+        """
+
+        n_hidden = m_in * m_out
+        cur_inpt = m_in * m_in
+        net: List[nn.Module] = []
+
+        for i in range(1, self.num_layers + 1):
+            net.append(nn.LayerNorm(cur_inpt))
+            net.append(self.nonlin)
+
+            # Linear transformation layer
+            linear_layer = nn.Linear(cur_inpt,
+                                     n_hidden,
+                                     bias=(i == self.num_layers))
+            nn.init.kaiming_uniform_(
+                linear_layer.weight)  # weight initialization
+            net.append(linear_layer)
+
+            cur_inpt = n_hidden  # Update for next layer
+
+        return nn.Sequential(*net)  # Convert layer list to `nn.Sequential`
+
+    def forward(self, features: Dict[str, torch.Tensor],
+                **kwargs: Any) -> Dict[str, torch.Tensor]:
+        """
+        Forward pass of the *SE(3)-equivariant* attentive self-interaction layer.
+        This function applies *self-attention* to modify each feature type using 
+        dynamically learned weights. The transformation for each degree `d` follows:
+            - Compute feature-wise scalar attention weights.
+            - Normalize features using softmax attention.
+            - Apply the learned attention weights to the input.
+        Parameters
+        ----------
+        features : Dict[str, torch.Tensor]
+            Dictionary containing input node features for each feature type.
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            Dictionary containing transformed node features for each feature type.
+        """
+        output = {}
+        for k, v in features.items():
+            first_dims = v.shape[:-2]
+            m_in = self.f_in.structure_dict[int(k)]
+            m_out = self.f_out.structure_dict[int(k)]
+
+            # Compute self-attention scalars (dot product of input features)
+            scalars = torch.einsum('...ac,...bc->...ab',
+                                   [v, v])  # [..., m_in, m_in]
+            scalars = scalars.view(
+                *first_dims,
+                m_in * m_in)  # Flatten for MLP input [..., m_in*m_in]
+            sign = scalars.sign()
+            scalars = scalars.abs_().clamp_min(
+                self.eps)  # Prevent numerical issues
+            scalars *= sign
+
+            # Compute attention weights
+            att_weights = self.transform[str(k)](scalars)  # [..., m_out * m_in]
+            att_weights = att_weights.view(
+                *first_dims, m_out, m_in)  # Reshape to [..., m_out, m_in]
+            att_weights = F.softmax(input=att_weights,
+                                    dim=-1)  # Normalize with softmax
+
+            # Apply learned attention weights to input
+            output[k] = torch.einsum('...nm,...md->...nd', [att_weights, v])
+
+        return output
+
+
+class SE3SelfInteraction(nn.Module):
+    """
+    A linear SE(3)-equivariant layer, equivalent to a 1x1 convolution.
+    This layer applies independent linear transformations to each feature type 
+    while preserving SE(3) equivariance. It acts as a self-interaction layer 
+    by linearly transforming node features without aggregating information from 
+    neighbors.
+    Mathematically, this operation is similar to a fully connected transformation, 
+    but applied independently to each *feature type (degree)* in the SE(3)-equivariant 
+    representation.
+    This is equivalent to a self-interaction layer in Tensor Field Networks (TFN), 
+    where each SE(3)-invariant or equivariant feature undergoes a learned transformation.
+    
+    Example
+    -------
+    >>> from rdkit import Chem
+    >>> import dgl
+    >>> import torch
+    >>> import deepchem as dc
+    >>> from deepchem.models.torch_models.layers import Fiber, SE3SelfInteraction
+    >>> # Create a molecular graph from SMILES
+    >>> mol = Chem.MolFromSmiles("CCO")
+    >>> # Use EquivariantGraphFeaturizer to extract SE(3)-equivariant features
+    >>> featurizer = dc.feat.EquivariantGraphFeaturizer(fully_connected=True, embeded=True)
+    >>> features = featurizer.featurize([mol])[0]
+    >>> G = dgl.graph((features.edge_index[0], features.edge_index[1]), num_nodes=len(features.node_features))
+    >>> # Assign SE(3)-equivariant node features
+    >>> G.ndata['f'] = torch.tensor(features.node_features, dtype=torch.float32).unsqueeze(-1)  # Node features
+    >>> G.ndata['x'] = torch.tensor(features.positions, dtype=torch.float32)  # 3D coordinates
+    >>> # Define Fiber Representations for Input & Output
+    >>> f_in = Fiber(dictionary={0: 16, 1: 32})  # Input fiber: scalars & vectors
+    >>> f_out = Fiber(dictionary={0: 32, 1: 64})  # Output fiber
+    >>> # Initialize SE(3)-Equivariant 1x1 Convolution Layer
+    >>> g1x1 = SE3SelfInteraction(f_in, f_out)
+    >>> # Convert Node Features into the Correct Format
+    >>> h = {str(d): torch.randn(G.num_nodes(), f_in.structure_dict[d], 2 * d + 1) for d in f_in.structure_dict}
+    >>> # Apply `SE3SelfInteraction` Layer (SE(3)-Equivariant Linear Transformation)
+    >>> output = g1x1(h)
+    >>> print(output['0'].shape)
+    torch.Size([3, 32, 1])
+    >>> print(output['1'].shape)
+    torch.Size([3, 64, 3])
+    References
+    ----------
+    .. [1] SE(3)-Transformers: 3D Roto-Translation Equivariant Attention Networks
+           Fabian B. Fuchs, Daniel E. Worrall, Volker Fischer, Max Welling
+           NeurIPS 2020, https://arxiv.org/abs/2006.10503
+    """
+
+    def __init__(self,
+                 f_in: Fiber,
+                 f_out: Fiber,
+                 learnable: bool = True) -> None:
+        """
+        Initializes the `SE3SelfInteraction` layer.
+        Parameters
+        ----------
+        f_in : Fiber
+            The input Fiber structure that defines the feature multiplicities and degrees.
+        f_out : Fiber
+            The output Fiber structure that defines the transformed feature dimensions.
+        learnable : bool, optional
+            If True, the transformation matrices are trainable parameters.
+        """
+        super().__init__()
+        self.f_in = f_in
+        self.f_out = f_out
+
+        # Learnable linear transformations for each feature type
+        self.transform = nn.ParameterDict()
+        for m_out, d_out in self.f_out.structure:
+            m_in = self.f_in.structure_dict[d_out]
+            self.transform[str(d_out)] = nn.Parameter(torch.randn(m_out, m_in) /
+                                                      np.sqrt(m_in),
+                                                      requires_grad=learnable)
+
+    def forward(self, features: Dict[str, torch.Tensor],
+                **kwargs: Any) -> Dict[str, torch.Tensor]:
+        """
+        Forward pass of the SE(3)-equivariant 1x1 convolution.
+        This function applies a linear transformation *separately to each 
+        feature type (degree) in the SE(3)-equivariant representation.
+        Mathematically, this operation is performed as:
+            h_out[d] = W_d * h_in[d]
+        where:
+        - h_in[d]  is the input feature tensor of type d.
+        - W_d      is the learned transformation matrix for type d.
+        - h_out[d] is the transformed feature tensor of type d.
+        Parameters
+        ----------
+        features : Dict[str, torch.Tensor]
+            Dictionary containing input node features for each feature type.
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            Dictionary containing transformed node features for each feature type.
+        """
+        output = {}
+        for k, v in features.items():
+            if str(k) in self.transform.keys():
+                output[k] = torch.matmul(self.transform[str(k)], v)
+        return output

--- a/deepchem/models/torch_models/tests/test_se3_transformer.py
+++ b/deepchem/models/torch_models/tests/test_se3_transformer.py
@@ -37,6 +37,28 @@ def test_se3radial_func(num_freq, in_dim, out_dim, edge_dim):
     assert output.shape == (8, out_dim, 1, in_dim, 1, num_freq)
 
 
+def create_test_graph(smiles):
+    """Helper function to create a test molecular graph from SMILES."""
+    from rdkit import Chem
+    import deepchem as dc
+    import dgl
+
+    mol = Chem.MolFromSmiles(smiles)
+    featurizer = dc.feat.EquivariantGraphFeaturizer(fully_connected=True,
+                                                    embeded=True)
+    features = featurizer.featurize([mol])[0]
+
+    G = dgl.graph((features.edge_index[0], features.edge_index[1]),
+                  num_nodes=len(features.node_features))
+    G.ndata['f'] = torch.tensor(features.node_features,
+                                dtype=torch.float32).unsqueeze(-1)
+    G.ndata['x'] = torch.tensor(features.positions, dtype=torch.float32)
+    G.edata['d'] = torch.tensor(features.edge_features, dtype=torch.float32)
+    G.edata['w'] = torch.tensor(features.edge_weights, dtype=torch.float32)
+
+    return G, features
+
+
 def rotation_matrix(axis, angle):
     """Generate a 3D rotation matrix."""
     axis = axis / np.linalg.norm(axis)
@@ -373,3 +395,192 @@ def test_feature_indices_fiber():
         1: (2, 2 + 2 * (2 * 1 + 1))
     }
     assert fiber.feature_indices == expected_indices
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize("smiles, n_heads, feature_dims", [
+    ("CCO", 4, {
+        0: 16,
+        1: 32
+    }),
+    ("CCC", 8, {
+        0: 32,
+        1: 64
+    }),
+])
+def test_se3_multi_head_attention_forward(smiles, n_heads, feature_dims):
+    """Test forward pass and shape consistency of SE3MultiHeadAttention layer."""
+    from deepchem.models.torch_models.layers import SE3MultiHeadAttention, Fiber
+
+    G, _ = create_test_graph(smiles)
+
+    # Fiber representation
+    f_value = Fiber(dictionary={0: feature_dims[0], 1: feature_dims[1]})
+    f_key = Fiber(dictionary={0: feature_dims[0] * 2, 1: feature_dims[1] * 2})
+
+    # Initialize SE3MultiHeadAttention
+    gmab = SE3MultiHeadAttention(f_value, f_key, n_heads)
+
+    # Create value, key, query tensors
+    v = {
+        str(d): torch.randn(G.num_edges(), f_value.structure_dict[d], 2 * d + 1)
+        for d in f_value.structure_dict
+    }
+    k = {
+        str(d): torch.randn(G.num_edges(), f_key.structure_dict[d], 2 * d + 1)
+        for d in f_key.structure_dict
+    }
+    q = {
+        str(d): torch.randn(G.num_nodes(), f_key.structure_dict[d], 2 * d + 1)
+        for d in f_key.structure_dict
+    }
+
+    # Apply `SE3MultiHeadAttention` Layer (SE(3)-Equivariant Attention)
+    output = gmab(v, k=k, q=q, G=G)
+    # Check output shapes
+    for d in feature_dims:
+        assert output[str(d)].shape == (G.num_nodes(), feature_dims[d],
+                                        2 * d + 1)
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize("smiles, n_heads, feature_dims", [
+    ("CCO", 4, {
+        0: 16,
+        1: 32
+    }),
+    ("CCC", 8, {
+        0: 32,
+        1: 64
+    }),
+])
+def test_se3_multi_head_attention_equivariance(smiles, n_heads, feature_dims):
+    """Test SE(3) equivariance by applying random rotation."""
+    from deepchem.models.torch_models.layers import SE3MultiHeadAttention, Fiber
+
+    G, _ = create_test_graph(smiles)
+
+    # Fiber representation
+    f_value = Fiber(dictionary={0: feature_dims[0], 1: feature_dims[1]})
+    f_key = Fiber(dictionary={0: feature_dims[0] * 2, 1: feature_dims[1] * 2})
+
+    gmab = SE3MultiHeadAttention(f_value, f_key, n_heads)
+
+    v = {
+        str(d): torch.randn(G.num_edges(), feature_dims[d], 2 * d + 1)
+        for d in feature_dims
+    }
+    k = {
+        str(d): torch.randn(G.num_edges(), feature_dims[d], 2 * d + 1)
+        for d in feature_dims
+    }
+    q = {
+        str(d): torch.randn(G.num_nodes(), feature_dims[d], 2 * d + 1)
+        for d in feature_dims
+    }
+
+    output_original = gmab(v, k=k, q=q, G=G)
+
+    # Apply random rotation
+    axis = np.array([1.0, 0.0, 0.0])  # Rotate around x-axis
+    angle = np.pi / 4  # 45-degree rotation
+    G.ndata['x'] = apply_rotation(G.ndata['x'], axis, angle)
+
+    # Compute output with rotation
+    output_rotated = gmab(v, k=k, q=q, G=G)
+
+    # Test for equivariance
+    for d in feature_dims:
+        assert torch.allclose(output_original[str(d)],
+                              output_rotated[str(d)],
+                              atol=1e-5)
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize(
+    "smiles, f_in_dict, f_out_dict",
+    [
+        ("CCO", {
+            0: 16,
+            1: 32
+        }, {
+            0: 32,
+            1: 64
+        }),  # Standard case
+        ("CCO", {
+            0: 8,
+            1: 16
+        }, {
+            0: 16,
+            1: 32
+        }),  # Smaller fiber sizes
+        ("CCO", {
+            0: 32,
+            1: 64
+        }, {
+            0: 64,
+            1: 128
+        }),  # Larger fiber sizes
+    ])
+def test_gattentive_selfint(smiles, f_in_dict, f_out_dict):
+    """Test SE3AttentiveSelfInteraction with various input/output fibers."""
+    from deepchem.models.torch_models.layers import SE3AttentiveSelfInteraction, Fiber
+    G, _ = create_test_graph(smiles)
+    f_in = Fiber(dictionary=f_in_dict)
+    f_out = Fiber(dictionary=f_out_dict)
+
+    g_att = SE3AttentiveSelfInteraction(f_in, f_out)
+    h = {
+        str(d): torch.randn(G.num_nodes(), f_in_dict[d], 2 * d + 1)
+        for d in f_in_dict
+    }
+    output = g_att(h)
+
+    for d in f_out_dict:
+        assert output[str(d)].shape == (G.num_nodes(), f_out_dict[d], 2 * d + 1)
+
+
+@pytest.mark.torch
+@pytest.mark.parametrize("smiles, f_in_dict, f_out_dict", [("CCO", {
+    0: 16,
+    1: 32
+}, {
+    0: 32,
+    1: 64
+}), ("CCC", {
+    0: 8,
+    1: 16
+}, {
+    0: 16,
+    1: 32
+})])
+def test_se3_self_interaction(smiles, f_in_dict, f_out_dict):
+    """Test SE3SelfInteraction with various input/output fibers."""
+    from deepchem.models.torch_models.layers import SE3SelfInteraction, Fiber
+    G, _ = create_test_graph(smiles)
+    f_in = Fiber(dictionary=f_in_dict)
+    f_out = Fiber(dictionary=f_out_dict)
+    g1x1 = SE3SelfInteraction(f_in, f_out)
+
+    h = {
+        str(d): torch.randn(G.num_nodes(), f_in.structure_dict[d], 2 * d + 1)
+        for d in f_in.structure_dict
+    }
+    output = g1x1(h)
+
+    # Shape validation
+    for d in f_out_dict:
+        assert output[str(d)].shape == (G.num_nodes(), f_out_dict[d], 2 * d + 1)
+
+        # Output type validation
+        assert isinstance(output[str(d)], torch.Tensor)
+
+        # Value properties (ensure non-zero values in output)
+        assert torch.any(output[str(d)] != 0)
+
+        # SE(3) Equivariance Check
+        transformed_input = {k: v * 2 for k, v in h.items()}
+        transformed_output = g1x1(transformed_input)
+        assert torch.allclose(output[str(d)] * 2,
+                              transformed_output[str(d)],
+                              atol=1e-5)

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -402,6 +402,15 @@ Attention Layers
 .. autoclass:: deepchem.models.torch_models.layers.SE3AvgPooling
   :members:
 
+.. autoclass:: deepchem.models.torch_models.layers.SE3MultiHeadAttention
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3AttentiveSelfInteraction
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3SelfInteraction
+  :members:
+
 Readout Layers
 ^^^^^^^^^^^^^^
 

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -835,7 +835,9 @@ for additional information regarding equivariance and Deepchem's support for equ
 
 .. autofunction:: deepchem.utils.equivariance_utils.get_r
 
-.. autofunction:: deepchem.utils.equivariance_utils.get_basis_and_r  
+.. autofunction:: deepchem.utils.equivariance_utils.get_equivariant_basis_and_r
+
+.. autofunction:: deepchem.utils.equivariance_utils.fiber2head
 
 Miscellaneous Utilities
 -----------------------


### PR DESCRIPTION
## Description

I've added SE3SelfInteraction, SE3MultiHeadAttention, and SE3AttentionLayer layers to enhance SE(3)-equivariant transformations and attention mechanisms. Also, I implemented a fiber2head utility function to handle SE(3)-equivariant features for downstream tasks using a multihead attention step. This PR is based on a previously reviewed version, #4372, but I have opened a new PR due to rebase issues.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
