### PR TITLE
CI fixes related to jax tests (python 3.9, 3.10, and 3.11)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,7 +9,7 @@ tensorflow==2.15.0
 transformers>=4.34.1
 torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
 lightning
-jax
+jax==0.4.30
 dm-haiku==0.0.13
 optax
 rdkit

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,7 +10,7 @@ transformers>=4.34.1
 torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
 lightning
 jax
-dm-haiku
+dm-haiku==0.0.13
 optax
 rdkit
 torch_geometric

--- a/requirements/jax/env_jax.cpu.yml
+++ b/requirements/jax/env_jax.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - pip:
     - -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jax
-    - jaxlib
+    - jax==0.4.30
+    - jaxlib==0.4.30
     - dm-haiku==0.0.13
     - optax

--- a/requirements/jax/env_jax.cpu.yml
+++ b/requirements/jax/env_jax.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - pip:
     - -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jax
-    - jaxlib
+    - jax==0.4.30
+    - jaxlib==0.4.30
     - dm-haiku
     - optax

--- a/requirements/jax/env_jax.cpu.yml
+++ b/requirements/jax/env_jax.cpu.yml
@@ -1,7 +1,7 @@
 dependencies:
   - pip:
     - -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jax==0.4.30
-    - jaxlib==0.4.30
-    - dm-haiku
+    - jax
+    - jaxlib
+    - dm-haiku==0.0.13
     - optax

--- a/requirements/jax/env_jax.gpu.yml
+++ b/requirements/jax/env_jax.gpu.yml
@@ -1,5 +1,5 @@
 dependencies:
   - pip:
     - -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jax==0.4.30
-    - jaxlib==0.4.30
+    - jax
+    - jaxlib

--- a/requirements/jax/env_jax.gpu.yml
+++ b/requirements/jax/env_jax.gpu.yml
@@ -1,5 +1,5 @@
 dependencies:
   - pip:
     - -f https://storage.googleapis.com/jax-releases/jax_releases.html
-    - jax
-    - jaxlib
+    - jax==0.4.30
+    - jaxlib==0.4.30

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 # Environment-specific dependencies.
 extras = {
-    'jax': ['jax', 'jaxlib', 'dm-haiku==0.0.13', 'optax'],
+    'jax': ['jax==0.4.30', 'jaxlib==0.4.30', 'dm-haiku==0.0.13', 'optax'],
     'torch': [
         'torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1',
         'dgllife'

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,11 @@ else:
 
 # Environment-specific dependencies.
 extras = {
-    'jax': ['jax', 'jaxlib', 'dm-haiku', 'optax'],
-    'torch': ['torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1', 'dgllife'],
+    'jax': ['jax==0.4.30', 'jaxlib==0.4.30', 'dm-haiku', 'optax'],
+    'torch': [
+        'torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1',
+        'dgllife'
+    ],
     'tensorflow': ['tensorflow', 'tensorflow_probability', 'tensorflow_addons'],
     'dqc': ['dqc', 'xitorch', 'torch==2.2.1', 'pylibxc2']
 }

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ else:
 
 # Environment-specific dependencies.
 extras = {
-    'jax': ['jax==0.4.30', 'jaxlib==0.4.30', 'dm-haiku', 'optax'],
+    'jax': ['jax', 'jaxlib', 'dm-haiku==0.0.13', 'optax'],
     'torch': [
         'torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1',
         'dgllife'


### PR DESCRIPTION
## Description

Pinned `jax` version to 0.4.30 because version 0.6.0 produces an error in python 3.9 and 3.10:

`AttributeError: jax.core.JaxprEqn was removed in JAX v0.6.0. Use jax.extend.core.JaxprEqn instead, and see https://docs.jax.dev/en/latest/jax.extend.html for details.`


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
