### PR TITLE
Add SE(3) graph convolution and residual attention ayers

### DIFF
--- a/deepchem/utils/equivariance_utils.py
+++ b/deepchem/utils/equivariance_utils.py
@@ -247,12 +247,12 @@ def get_r(G) -> torch.Tensor:
     >>> print(r.shape)  # (num_edges, 1)
     torch.Size([6, 1])
     >>> print(r)
-    tensor([[1.5317],
-            [2.3267],
-            [1.5317],
-            [1.4096],
-            [2.3267],
-            [1.4096]])
+    tensor([[1.5046],
+            [2.3705],
+            [1.5046],
+            [1.4031],
+            [2.3705],
+            [1.4031]])
     """
     cloned_d = torch.clone(G.edata['d'])
     if G.edata['d'].requires_grad:

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -411,6 +411,18 @@ Attention Layers
 .. autoclass:: deepchem.models.torch_models.layers.SE3SelfInteraction
   :members:
 
+.. autoclass:: deepchem.models.torch_models.layers.SE3GraphConv
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3GraphNorm
+  :members:
+
+  .. autoclass:: deepchem.models.torch_models.layers.SE3PartialEdgeConv
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.layers.SE3ResidualAttention
+  :members:
+
 Readout Layers
 ^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description

This PR introduces 4 SE(3)-equivariant layers: 3 graph neural network layers (SE3GraphConv, SE3GraphNorm, SE3PartialEdgeConv) and a SE3ResidualAttention. Also, fix SE(3) layers doctests.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
