### PR TITLE
Improvement/use npz format

### DIFF
--- a/deepchem/utils/data_utils.py
+++ b/deepchem/utils/data_utils.py
@@ -590,7 +590,7 @@ def load_from_disk(filename: str) -> Any:
         try:
             with gzip.open(filename, 'rb') as infs:
                 return np.load(infs, allow_pickle=True)
-        except Exception as e:
+        except Exception:
             raise ValueError("Could not load gzip data from %s" % filename)
     elif extension == ".npy":
         return np.load(filename, allow_pickle=True)


### PR DESCRIPTION
## Description

Fix #(issue)
This PR updates DiskDataset storage utils to use the compressed `.npz` format (using `numpy.savez_compressed`) for saving high-dimensional numpy arrays.



## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
