### PR TITLE
Porting InceptionResnetA and InceptionResnetB layer to torch

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -43,6 +43,8 @@ from deepchem.models.torch_models.robust_multitask import RobustMultitask, Robus
 from deepchem.models.torch_models.IRV import IRVLayer, MultitaskIRVClassifier
 from deepchem.models.torch_models.pinns_model import PINNModel
 from deepchem.models.torch_models.chemnet_layers import Stem
+from deepchem.models.torch_models.chemnet_layers import InceptionResnetA
+from deepchem.models.torch_models.chemnet_layers import InceptionResnetB
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel
     from deepchem.models.torch_models.gnn import GNN, GNNHead, GNNModular

--- a/deepchem/models/torch_models/chemnet_layers.py
+++ b/deepchem/models/torch_models/chemnet_layers.py
@@ -73,3 +73,168 @@ class Stem(nn.Module):
         """
         conv1 = self.conv_layer(inputs)
         return self.activation_layer(conv1)
+
+
+class InceptionResnetA(nn.Module):
+    """
+    Implements the Inception-ResNet-A block from the Inception-ResNet architecture
+    as described in https://arxiv.org/abs/1710.0223.
+
+    This block combines multiple convolutional branches with varying receptive fields,
+    concatenates their outputs, projects them back to the input dimensions using a
+    1x1 convolution, and adds the result to the original input (residual connection).
+    A ReLU activation is applied at the end.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import torch
+    >>> from deepchem.models.torch_models.chemnet_layers import InceptionResnetA
+    >>> in_channels = 64
+    >>> out_channels = 32
+    >>> input_tensor = np.random.rand(1, in_channels, 28, 28).astype(np.float32) # (Batch, Channels, Height, Width)
+    >>> input_tensor_torch = torch.from_numpy(input_tensor)
+    >>> layer = InceptionResnetA(in_channels, out_channels)
+    >>> output_tensor = layer(input_tensor_torch)
+    >>> output_tensor.shape
+    torch.Size([1, 64, 28, 28])
+    """
+
+    def __init__(self, in_channels: int, out_channels: int) -> None:
+        """
+        Initializes the Inception-ResNet-A block.
+
+        Parameters
+        ----------
+        in_channels : int
+            Number of input channels.
+        out_channels : int
+            Number of filters in the convolutional branches.
+        """
+        super(InceptionResnetA, self).__init__()
+
+        self.branch1 = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+
+        self.branch2 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=1),
+            nn.Conv2d(out_channels, out_channels, kernel_size=3, padding=1))
+
+        self.branch3 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=1),
+            nn.Conv2d(out_channels,
+                      int(out_channels * 1.5),
+                      kernel_size=3,
+                      padding=1),
+            nn.Conv2d(int(out_channels * 1.5),
+                      out_channels * 2,
+                      kernel_size=3,
+                      padding=1))
+
+        self.conv_linear = nn.Conv2d(out_channels * 4,
+                                     in_channels,
+                                     kernel_size=1)
+        self.activation = nn.ReLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Forward pass of the Inception-ResNet-A block.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch_size, in_channels, H, W).
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of the same shape as input (batch_size, in_channels, H, W),
+            after applying the Inception-ResNet-A transformations and residual connection.
+        """
+        branches = [self.branch1(x), self.branch2(x), self.branch3(x)]
+        concat = torch.cat(branches, dim=1)
+        linear = self.conv_linear(concat)
+        return self.activation(x + linear)
+
+
+class InceptionResnetB(nn.Module):
+    """
+    Implements the Inception-ResNet-B block from the Inception-ResNet architecture
+    as described in https://arxiv.org/abs/1710.0223.
+
+    This block consists of two parallel branches:
+    - A simple 1x1 convolution.
+    - A deeper sequence with asymmetric convolutions (1x7 followed by 7x1) for
+      efficient large receptive field learning.
+
+    Outputs from both branches are concatenated and passed through a 1x1 convolution
+    to project back to the original input dimension, and added to the input
+    (residual connection). A ReLU activation follows.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import torch
+    >>> from deepchem.models.torch_models.chemnet_layers import InceptionResnetB
+    >>> in_channels = 64
+    >>> out_channels = 32
+    >>> input_tensor = np.random.rand(1, in_channels, 28, 28).astype(np.float32)
+    >>> input_tensor_torch = torch.from_numpy(input_tensor)
+    >>> layer = InceptionResnetB(in_channels, out_channels)
+    >>> output_tensor = layer(input_tensor_torch)
+    >>> output_tensor.shape
+    torch.Size([1, 64, 28, 28])
+    """
+
+    def __init__(self, in_channels, out_channels):
+        """
+        Initializes the Inception-ResNet-B block.
+
+        Parameters
+        ----------
+        in_channels : int
+            Number of input channels.
+        out_channels : int
+            Number of filters used in the convolutional branches.
+        """
+        super().__init__()
+
+        # Branch 1: 1x1 Convolution
+        self.branch1 = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+
+        # Branch 2: 1x1 → 1x7 → 7x1 Convolutions
+        self.branch2 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=1),
+            nn.Conv2d(out_channels,
+                      int(out_channels * 1.25),
+                      kernel_size=(1, 7),
+                      padding=(0, 3)),
+            nn.Conv2d(int(out_channels * 1.25),
+                      int(out_channels * 1.5),
+                      kernel_size=(7, 1),
+                      padding=(3, 0)))
+
+        # Project concatenated features back to input channel dimension
+        self.conv_linear = nn.Conv2d(out_channels + int(out_channels * 1.5),
+                                     in_channels,
+                                     kernel_size=1)
+        self.activation = nn.ReLU()
+
+    def forward(self, x):
+        """
+        Forward pass of the Inception-ResNet-B block.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input tensor of shape (batch_size, in_channels, H, W)
+
+        Returns
+        -------
+        torch.Tensor
+            Output tensor of shape (batch_size, in_channels, H, W)
+        """
+        branch1 = self.branch1(x)
+        branch2 = self.branch2(x)
+        concat = torch.cat([branch1, branch2], dim=1)
+        linear = self.conv_linear(concat)
+        return self.activation(x + linear)

--- a/deepchem/models/torch_models/tests/test_chemception_layers.py
+++ b/deepchem/models/torch_models/tests/test_chemception_layers.py
@@ -46,3 +46,97 @@ def test_Stem():
 
     assert output_torch.shape == output_tf.shape
     assert np.allclose(output_torch, output_tf, atol=1e-2)
+
+
+@pytest.mark.torch
+def test_InceptionResnetA():
+    """
+    Test InceptionResnetA layer against manually verified TensorFlow output
+    using fixed weights and bias.
+    """
+    input_np = np.array(
+        [[[[0.2712, 0.5123, 0.6565, 0.1889], [0.6174, 0.0609, 0.4317, 0.0775],
+           [0.6640, 0.1586, 0.4666, 0.4570], [0.5987, 0.7010, 0.8050, 0.7374]],
+          [[0.1532, 0.5063, 0.9928, 0.1148], [0.7192, 0.8554, 0.4936, 0.5310],
+           [0.8861, 0.4392, 0.8616, 0.7651], [0.2985, 0.0640, 0.7019, 0.8535]],
+          [[0.7230, 0.9014, 0.4116, 0.8261], [0.4230, 0.5786, 0.8521, 0.7080],
+           [0.1534, 0.5855, 0.2708, 0.3537], [0.4066, 0.1785, 0.3009, 0.0765]]]
+        ],
+        dtype=np.float32)
+
+    tf_outptut = np.array(
+        [[[[25.955153, 25.837152, 26.406952], [41.345757, 41.33976, 41.73486],
+           [41.573402, 41.909702, 41.3285], [25.353184, 25.279083, 25.990383]],
+          [[40.21292, 40.31472, 40.01852], [63.13939, 63.933887, 63.65709],
+           [64.421364, 64.48326, 64.84176], [39.861595, 40.315094, 40.492096]],
+          [[38.42537, 38.64747, 37.91477], [60.783154, 61.063755, 61.210052],
+           [63.015915, 63.410915, 62.820118], [39.95585, 40.263947, 39.852547]],
+          [[23.25519, 22.95499, 23.063091], [37.369038, 36.732037, 36.84654],
+           [39.336445, 39.233345, 38.832344], [25.398687, 25.514788, 24.737787]]
+         ]],
+        dtype=np.float32)
+
+    tf_outptut = tf_outptut.transpose(
+        0, 3, 1, 2)  # Convert to (Batch, Channels, Height, Width)
+
+    input_torch = torch.tensor(input_np)
+
+    InceptionResnetA_torch = layers.InceptionResnetAInceptionResnetA(
+        in_channels=3, out_channels=32)
+
+    for m in InceptionResnetA_torch.modules():
+        if isinstance(m, torch.nn.Conv2d):
+            torch.nn.init.constant_(m.weight, 0.05)
+            if m.bias is not None:
+                torch.nn.init.constant_(m.bias, 0.0)
+
+    output_torch = InceptionResnetA_torch(input_torch).detach().numpy()
+
+    assert output_torch.shape == tf_outptut.shape
+    assert np.allclose(output_torch, tf_outptut, atol=1e-4)
+
+
+@pytest.mark.torch
+def test_InceptionResnetB():
+    """
+    Test InceptionResnetB layer against manually verified TensorFlow output
+    using fixed weights and bias.
+    """
+    input_np = np.array([[[[0.983, 0.457, 0.008], [0.662, 0.623, 0.405],
+                           [0.862, 0.3, 0.211], [0.169, 0.461, 0.367]],
+                          [[0.401, 0.457, 0.898], [0.962, 0.556, 0.989],
+                           [0.466, 0.403, 0.097], [0.832, 0.376, 0.483]],
+                          [[0.425, 0.28, 0.33], [0.446, 0.357, 0.709],
+                           [0.343, 0.876, 0.899], [0.624, 0.071, 0.498]],
+                          [[0.901, 0.504, 0.256], [0.422, 0.551, 0.476],
+                           [0.874, 0.634, 0.305], [0.007, 0.063, 0.393]]]],
+                        dtype=np.float32)
+    tf_outptut = np.array(
+        [[[[10.1888895, 9.6628895, 9.21389], [9.887249, 9.848249, 9.630249],
+           [10.06189, 9.499889, 9.41089], [9.338809, 9.63081, 9.536809]],
+          [[9.63153, 9.68753, 10.12853], [10.252609, 9.846609, 10.27961],
+           [9.633329, 9.57033, 9.26433], [10.057329, 9.60133, 9.708329]],
+          [[9.59785, 9.452849, 9.50285], [9.65701, 9.56801, 9.92001],
+           [9.60249, 10.13549, 10.15849], [9.809489, 9.25649, 9.68349]],
+          [[10.123931, 9.726931, 9.47893], [9.627972, 9.756971, 9.681972],
+           [10.109091, 9.869091, 9.5400915], [9.134091, 9.190091, 9.520091]]]],
+        dtype=np.float32)
+
+    tf_outptut = tf_outptut.transpose(
+        0, 3, 1, 2)  # Convert to (Batch, Channels, Height, Width)
+
+    input_torch = torch.tensor(input_np)
+
+    InceptionResnetB_torch = layers.InceptionResnetB(in_channels=3,
+                                                     out_channels=32)
+
+    for m in InceptionResnetB_torch.modules():
+        if isinstance(m, torch.nn.Conv2d):
+            torch.nn.init.constant_(m.weight, 0.05)
+            if m.bias is not None:
+                torch.nn.init.constant_(m.bias, 0.0)
+
+    output_torch = InceptionResnetB_torch(input_torch).detach().numpy()
+
+    assert output_torch.shape == tf_outptut.shape
+    assert np.allclose(output_torch, tf_outptut, atol=1e-4)

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -306,6 +306,12 @@ Torch Layers
 .. autoclass:: deepchem.models.torch_models.chemnet_layers.Stem
   :members:
 
+.. autoclass:: deepchem.models.torch_models.chemnet_layers.InceptionResnetA
+  :members:
+
+.. autoclass:: deepchem.models.torch_models.chemnet_layers.InceptionResnetB
+  :members:
+
 Flow Layers
 ^^^^^^^^^^^
 


### PR DESCRIPTION
## This PR ports InceptionResnetA and InceptionResnetB layers used in ChemCeption as defined in https://arxiv.org/abs/1706.06689



- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings