### PR TITLE
Fix linting and SpectralConv import issues in CI

### DIFF
--- a/deepchem/models/torch_models/tests/test_spectral_conv.py
+++ b/deepchem/models/torch_models/tests/test_spectral_conv.py
@@ -1,5 +1,4 @@
 import pytest
-from deepchem.models.torch_models.layers import SpectralConv
 
 try:
     import torch
@@ -12,6 +11,7 @@ except ModuleNotFoundError:
 @pytest.mark.torch
 def test_spectral_conv_output_shape():
     """Test if spectral convolution output shape is correct"""
+    from deepchem.models.torch_models.layers import SpectralConv
     conv = SpectralConv(in_channels=4, out_channels=8, modes=12, dims=2)
     x = torch.randn(2, 4, 64, 64)  # batch=2, channels=4, H=64, W=64
     y = conv(x)
@@ -21,6 +21,7 @@ def test_spectral_conv_output_shape():
 @pytest.mark.torch
 def test_spectral_conv_exact_output():
     """Test the exact output values of spectral convolution with controlled weights"""
+    from deepchem.models.torch_models.layers import SpectralConv
     conv = SpectralConv(in_channels=1, out_channels=1, modes=2, dims=1)
 
     with torch.no_grad():
@@ -39,6 +40,7 @@ def test_spectral_conv_exact_output():
 @pytest.mark.torch
 def test_spectral_conv_gradient_flow():
     """Test if gradients flow through spectral convolution"""
+    from deepchem.models.torch_models.layers import SpectralConv
     conv = SpectralConv(3, 6, modes=10, dims=2)
     x = torch.randn(2, 3, 64, 64, requires_grad=True)
     y = conv(x)
@@ -54,6 +56,7 @@ def test_spectral_conv_gradient_flow():
 ])
 def test_spectral_conv_dims(dims, input_shape):
     """Test if spectral convolution works with different dimensions 1D, 2D, 3D"""
+    from deepchem.models.torch_models.layers import SpectralConv
     conv = SpectralConv(in_channels=4, out_channels=6, modes=8, dims=dims)
     x = torch.randn(*input_shape)
     y = conv(x)

--- a/requirements/env_test.yml
+++ b/requirements/env_test.yml
@@ -2,7 +2,7 @@ dependencies:
   - pip:
     - flake8
     - flaky
-    - mypy
+    - mypy==1.15.0
     - pytest
     - pytest-cov
     - types-setuptools

--- a/requirements/env_test.yml
+++ b/requirements/env_test.yml
@@ -2,7 +2,7 @@ dependencies:
   - pip:
     - flake8
     - flaky
-    - mypy==1.15.0
+    - mypy<=1.15.0
     - pytest
     - pytest-cov
     - types-setuptools


### PR DESCRIPTION
## Description

Fix #(issue)

Pin mypy version to 1.15.0 and import issues in `SpectralConv` that caused breakages in various CI tests.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
