### PR TITLE
Fixes: Code Formatting CI fixes

### DIFF
--- a/deepchem/utils/conformers.py
+++ b/deepchem/utils/conformers.py
@@ -268,7 +268,8 @@ class ConformerGenerator(object):
         new_mol.RemoveAllConformers()
         conf_ids = [conf.GetId() for conf in mol.GetConformers()]
         for i in keep:
-            conf = mol.GetConformer(conf_ids[i])
+            idx = int(i)
+            conf = mol.GetConformer(conf_ids[idx])
             new_mol.AddConformer(conf, assignId=True)
         return new_mol
 


### PR DESCRIPTION
## Description
The Code Formatting CI is failing because of errors in three files.
This PR is a fix to those errors.

Fix #(issue)

- Error-1: In utils/conformers.py,  np.argsort returns a numpy array of integers, but their type is numpy integer, not Python int. So, at line 271, conf_ids is a list[int], so doing conf_ids[I], where i is a numpy.int64 confuses mypy, which expects i to be a plain int.


<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
