### PR TITLE
Fixed rdMolDescriptors import

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1011,6 +1011,7 @@ class MolecularWeightSplitter(Splitter):
         """
         try:
             from rdkit import Chem
+            from rdkit.Chem import rdMolDescriptors
         except ModuleNotFoundError:
             raise ImportError("This function requires RDKit to be installed.")
 
@@ -1021,7 +1022,7 @@ class MolecularWeightSplitter(Splitter):
         mws = []
         for smiles in dataset.ids:
             mol = Chem.MolFromSmiles(smiles)
-            mw = Chem.rdMolDescriptors.CalcExactMolWt(mol)
+            mw = rdMolDescriptors.CalcExactMolWt(mol)
             mws.append(mw)
 
         # Sort by increasing MW


### PR DESCRIPTION
## Description

Fixed import of rdMolDescriptors. The previous import method failed for me using rdkit 2025.3.2 and Python 3.13.2, making it impossible to use MolecularWeightSplitter.split()

## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [X] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [X]] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [n.a.] I have commented my code, particularly in hard-to-understand areas
- [n.a.] I have made corresponding changes to the documentation
- [n.a.] I have added tests that prove my fix is effective or that my feature works
- [n.a.] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
