### PR TITLE
Fix: Corrected MoleculeNet cheatsheet documentation link (Fixes #4512)

### DIFF
--- a/docs/source/api_reference/moleculenet_datasets_description.csv
+++ b/docs/source/api_reference/moleculenet_datasets_description.csv
@@ -5,7 +5,7 @@ BBBC (BBBC001),Images of HT29 colon cancer cells,Images,6,`ref <https://data.bro
 BBBC (BBBC002),Images of Drosophilia Kc167 cells,Images,50,`ref <https://data.broadinstitute.org/bbbc/BBBC002/>`_
 BBBC (BBBC003),DIC Images of Mouse Embryos,Images,15,`ref <https://data.broadinstitute.org/bbbc/BBBC003/>`_
 BBBC (BBBC004),Synthetic Images of clustered nuclei,Images,20,`ref <https://data.broadinstitute.org/bbbc/BBBC004/>`_
-BBBC (BBBC004),Synthetic Images of clustered nuclei,Images,19200,`ref <https://data.broadinstitute.org/bbbc/BBBC005/>`_
+BBBC (BBBC005),Synthetically generated fluorescent cell population images,Images,19200,`ref <https://data.broadinstitute.org/bbbc/BBBC005/>`_
 BBBP,Blood-Brain Barrier Penetration designed for the modeling and prediction of barrier permeability,Binary labels on permeability properties,2000,`ref <https://pubs.rsc.org/en/content/articlehtml/2018/sc/c7sc02664a>`_
 Cell Counting,Synthetic emulations of fluorescence microscopic images of bacterial cells,Images,200,`ref <http://www.robots.ox.ac.uk/~vgg/research/counting/index_org.html.>`_
 ChEMBL (set = ‘sparse’),A sparse subset of ChEMBL with activity data for one target,Molecules,244 245,`ref <https://www.ebi.ac.uk/chembl/.>`_


### PR DESCRIPTION
## Description

Fix #4512 

This PR corrects the MoleculeNet cheatsheet documentation by replacing the duplicate `bbbc_004` entry with the correct `bbbc_005` entry. The fix updates `docs/source/api_reference/moleculenet_datasets_description.csv` with the proper dataset name, description, and data point count for BBBC005.

Motivation:
The MoleculeNet cheatsheet had two identical entries for bbbc_004. This caused confusion for users referencing BBBC datasets. The change ensures each dataset is uniquely listed with accurate metadata.

No additional dependencies were introduced.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
