### PR TITLE
Adding the TorchModel class for ChemCeption

### DIFF
--- a/deepchem/models/torch_models/ChemCeption.py
+++ b/deepchem/models/torch_models/ChemCeption.py
@@ -9,8 +9,6 @@ from deepchem.data import Dataset
 from deepchem.metrics import to_one_hot
 from deepchem.data.datasets import pad_batch
 
-import torchvision.transforms as T
-
 DEFAULT_INCEPTION_BLOCKS = {"A": 3, "B": 3, "C": 3}
 
 
@@ -316,11 +314,6 @@ augmentation during batch generation.
 
                 n_batches = 0
 
-                aug = T.Compose(
-                    [T.ToPILImage(),
-                     T.RandomRotation(180),
-                     T.ToTensor()])
-
                 for (X_b, y_b, w_b,
                      ids_b) in dataset.iterbatches(batch_size=self.batch_size,
                                                    deterministic=deterministic,
@@ -330,9 +323,9 @@ augmentation during batch generation.
                     for img in X_b:
                         img = torch.tensor(img, dtype=torch.float32)
                         if img.shape[0] == 1:
-                            img = aug(img.squeeze(0)).unsqueeze(0)
+                            img = torch.flip(img, dims=[1, 2])
                         else:
-                            img = aug(img.permute(1, 2, 0)).permute(2, 0, 1)
+                            img = torch.flip(img, dims=[1, 2])
                         X_b_aug.append(img)
 
                     X_b = torch.stack(X_b_aug).to(torch.float32).numpy()

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -50,6 +50,7 @@ from deepchem.models.torch_models.chemnet_layers import ReductionA
 from deepchem.models.torch_models.chemnet_layers import ReductionB
 from deepchem.models.torch_models.hnn import HNN, HNNModel
 from deepchem.models.torch_models.ChemCeption import ChemCeption
+from deepchem.models.torch_models.ChemCeption import ChemCeptionModel
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel

--- a/deepchem/models/torch_models/tests/test_chemcetion.py
+++ b/deepchem/models/torch_models/tests/test_chemcetion.py
@@ -1,12 +1,51 @@
 import pytest
 import numpy as np
 import deepchem as dc
+import os
+from deepchem.feat import SmilesToImage
+from deepchem.molnet.load_function.chembl25_datasets import CHEMBL25_TASKS
+import tempfile
 try:
     import torch
     from deepchem.models.torch_models import ChemCeption
+    from deepchem.models.torch_models import ChemceptionModel
     has_torch = True
 except:
     has_torch = False
+
+
+def get_chemception_dataset(mode="classification", data_points=10, n_tasks=5):
+    dataset_file = os.path.join(os.path.dirname(__file__), "assets",
+                                "chembl_25_small.csv")
+
+    img_size = 80
+    img_spec = "engd"
+    res = 0.5
+    feat = SmilesToImage(img_size=img_size, img_spec=img_spec, res=res)
+
+    loader = dc.data.CSVLoader(tasks=CHEMBL25_TASKS,
+                               smiles_field='smiles',
+                               featurizer=feat)
+    dataset = loader.create_dataset(inputs=[dataset_file],
+                                    shard_size=10000,
+                                    data_dir=tempfile.mkdtemp())
+
+    w = np.ones(shape=(data_points, n_tasks))
+
+    if mode == 'classification':
+        y = np.random.randint(0, 2, size=(data_points, n_tasks))
+        metric = dc.metrics.Metric(dc.metrics.roc_auc_score,
+                                   np.mean,
+                                   mode="classification")
+    else:
+        y = np.random.normal(size=(data_points, n_tasks))
+        metric = dc.metrics.Metric(dc.metrics.mean_absolute_error,
+                                   mode="regression")
+
+    dataset = dc.data.NumpyDataset(dataset.X[:data_points], y, w,
+                                   dataset.ids[:data_points])
+
+    return dataset, metric
 
 
 @pytest.mark.torch
@@ -37,3 +76,59 @@ def test_chemception_forward():
     output = model(image)
 
     assert np.shape(output) == (1, n_tasks, n_classes)
+
+
+@pytest.mark.torch
+def test_chemception_base_forward():
+    img_size = 80
+    n_tasks = 5
+    n_classes = 2
+    data_points = 20
+    smiles = ["CCO", "CCN", "CCC", "CCCl", "CNO"] * (data_points // 5)
+    y = np.random.randint(0, n_classes,
+                          size=(len(smiles), n_tasks)).astype(np.float32)
+
+    featurizer = SmilesToImage(img_size=img_size, res=img_size)
+    X = featurizer.featurize(smiles)
+    X = np.transpose(X, (0, 3, 1, 2))
+
+    dataset = dc.data.NumpyDataset(X, y)
+
+    model = ChemceptionModel(img_size=img_size,
+                             n_tasks=n_tasks,
+                             n_classes=n_classes,
+                             mode="regression",
+                             augment=True)
+
+    model.fit(dataset, nb_epoch=5)
+    preds = model.predict_on_batch(dataset.X)
+    assert preds.shape == (data_points, n_tasks)
+
+
+@pytest.mark.torch
+def test_chemception_reload():
+    n_tasks = 5
+    img_size = 80
+    model_dir = tempfile.mkdtemp()
+
+    dataset, metric = get_chemception_dataset(mode="regression",
+                                              img_size=img_size,
+                                              n_tasks=n_tasks,
+                                              data_points=10)
+
+    model = ChemceptionModel(img_size=img_size,
+                             n_tasks=n_tasks,
+                             model_dir=model_dir,
+                             mode="regression",
+                             augment=True)
+    model.fit(dataset, nb_epoch=10)
+    scores = model.evaluate(dataset, [metric], [])
+
+    reloaded_model = ChemceptionModel(img_size=img_size,
+                                      n_tasks=n_tasks,
+                                      model_dir=model_dir,
+                                      mode="regression",
+                                      augment=True)
+    reloaded_model.restore()
+    reloaded_scores = reloaded_model.evaluate(dataset, [metric], [])
+    assert scores == reloaded_scores

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -738,3 +738,9 @@ ChemCeption
 ----------------
 .. autoclass:: deepchem.models.torch_models.ChemCeption.ChemCeption
   :members:
+
+ChemCeption
+--------------------
+
+.. autoclass:: deepchem.models.torch_models.ChemceptionModel
+  :members:


### PR DESCRIPTION
## This PR adds Chemception TorchModel wrapper for DeepChem, enabling training and evaluation of model on molecular image representations as described inhttps://arxiv.org/abs/1706.06689.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings