### PR TITLE
Exclude HF tests from CI unit-tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,8 +194,8 @@ jobs:
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') && matrix.python-version == '3.11'}}
       shell: bash -l {0}
-      run: pytest -v -m "not jax and not torch and not tensorflow and not dqc" --ignore='deepchem/utils/test/test_sequence_utils.py' deepchem
+      run: pytest -v -m "not jax and not torch and not tensorflow and not dqc and not hf" --ignore='deepchem/utils/test/test_sequence_utils.py' deepchem
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') && matrix.python-version != '3.11'}}
       shell: bash -l {0}
-      run: pytest -v -m "not jax and not torch and not tensorflow and not dqc" deepchem
+      run: pytest -v -m "not jax and not torch and not tensorflow and not dqc and not hf" deepchem


### PR DESCRIPTION
## Description

Current CI checks for `unit-test` include HF tests, which some of them require high memmory usage (chemberta). However, a dedicated check for HF exists under the name of `HF-tests`. In this PR, HF tests are excluded from `test.yml` pytests.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
