### PR TITLE
`unit-test` doctest memory improvements.

### DIFF
--- a/.github/workflows/hf_setup.yml
+++ b/.github/workflows/hf_setup.yml
@@ -143,6 +143,10 @@ jobs:
       id: install
       shell: bash -l {0}
       run: pip install -e .
+    - name: Doctest Linux
+      if: ${{ (runner.os == 'Linux') && always() }}
+      shell: bash -l {0}
+      run: DGLBACKEND=pytorch pytest -v --doctest-modules deepchem/models/torch_models/antibody_modeling.py deepchem/models/torch_models/chemberta.py deepchem/models/torch_models/hf_models.py deepchem/models/torch_models/molformer.py deepchem/models/torch_models/oneformer.py deepchem/models/torch_models/prot_bert.py --doctest-continue-on-failure
     - name: PyTest
       if: ${{ (success() || failure()) && (steps.install.outcome == 'failure' || steps.install.outcome == 'success') }}
       shell: bash -l {0}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -185,7 +185,7 @@ jobs:
     - name: Doctest Linux
       if: ${{ (runner.os == 'Linux') && always() }}
       shell: bash -l {0}
-      run: DGLBACKEND=pytorch pytest -v --ignore-glob='deepchem/**/test*.py' --ignore-glob='deepchem/models/jax_models/*' --ignore-glob='deepchem/models/dft/*' --ignore='deepchem/utils/dftutils.py' --doctest-modules deepchem --doctest-continue-on-failure
+      run: DGLBACKEND=pytorch pytest -v --ignore-glob='deepchem/**/test*.py' --ignore-glob='deepchem/models/jax_models/*' --ignore-glob='deepchem/models/dft/*' --ignore='deepchem/utils/dftutils.py' --ignore='deepchem/models/torch_models/antibody_modeling.py' --ignore='deepchem/models/torch_models/chemberta.py' --ignore='deepchem/models/torch_models/hf_models.py' --ignore='deepchem/models/torch_models/molformer.py' --ignore='deepchem/models/torch_models/oneformer.py' --ignore='deepchem/models/torch_models/prot_bert.py' --doctest-modules deepchem --doctest-continue-on-failure
     - name: Doctest Windows
       if: ${{ (runner.os == 'Windows') && always() }}
       # Seperate test avoiding Jax in windows since Jax is not supported in Windows


### PR DESCRIPTION
## Description

`unit-test` for 3.8, 3.10, and 3.11 is constantly failing due to memory issues. Some of the bottlenecks are HF tests. I've removed HF pytests, since these were tested in `hf-test`. In this PR, I move HF doctest from test.yml to hf env.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
