### PR TITLE
Fix TensorFlow deprecated experimental_relax_shapes parameter

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -509,7 +509,7 @@ class KerasModel(Model):
         separate function for each new set of variables.
         """
 
-        @tf.function(experimental_relax_shapes=True)
+        @tf.function(reduce_retracing=True)
         def apply_gradient_for_batch(inputs, labels, weights, loss):
             with tf.GradientTape() as tape:
                 outputs = self.model(inputs, training=True)
@@ -715,7 +715,7 @@ class KerasModel(Model):
         else:
             return final_results
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function(reduce_retracing=True)
     def _compute_model(self, inputs: Sequence):
         """Evaluate the model for a set of inputs."""
         return self.model(inputs, training=False)

--- a/deepchem/models/normalizing_flows.py
+++ b/deepchem/models/normalizing_flows.py
@@ -197,7 +197,7 @@ class NormalizingFlowModel(KerasModel):
 
         """
 
-        @tf.function(experimental_relax_shapes=True)
+        @tf.function(reduce_retracing=True)
         def apply_gradient_for_batch(inputs, labels, weights, loss):
             with tf.GradientTape() as tape:
                 tape.watch(self.flow.trainable_variables)

--- a/deepchem/rl/a2c.py
+++ b/deepchem/rl/a2c.py
@@ -358,7 +358,7 @@ class A2C(object):
             ]
         return results
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function(reduce_retracing=True)
     def _compute_model(self, inputs):
         return self._model.model(inputs)
 
@@ -477,7 +477,7 @@ class A2C(object):
         self._apply_gradients(inputs, actions_matrix, discounted_rewards,
                               advantages)
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function(reduce_retracing=True)
     def _apply_gradients(self, inputs, actions_matrix, discounted_rewards,
                          advantages):
         """Compute the gradient of the loss function for a rollout and update the model."""

--- a/deepchem/rl/ppo.py
+++ b/deepchem/rl/ppo.py
@@ -255,7 +255,7 @@ class PPO(object):
                 manager.save()
                 checkpoint_time = time.time()
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function(reduce_retracing=True)
     def _apply_gradients(self, inputs, actions_matrix, discounted_rewards,
                          advantages, action_prob):
         """Compute the gradient of the loss function for a batch and update the model."""
@@ -385,7 +385,7 @@ class PPO(object):
             ]
         return results
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function(reduce_retracing=True)
     def _compute_model(self, inputs):
         return self._model.model(inputs)
 
@@ -566,6 +566,6 @@ class _Worker(object):
         state = state + rnn_states
         return [np.expand_dims(s, axis=0) for s in state]
 
-    @tf.function(experimental_relax_shapes=True)
+    @tf.function(reduce_retracing=True)
     def _compute_model(self, inputs):
         return self.model.model(inputs)


### PR DESCRIPTION
This PR fixes TensorFlow deprecated experimental_relax_shapes parameter

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Run `yapf -i <modified file>` and check no errors (yapf version must be 0.32.0)
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings