### PR TITLE
Fix typo in "Introduction_to_Equivariance" tutorial

### DIFF
--- a/examples/tutorials/Introduction_to_Equivariance.ipynb
+++ b/examples/tutorials/Introduction_to_Equivariance.ipynb
@@ -107,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 11,
    "id": "42ae0033-c324-43bd-9ba9-68e6e9069c28",
    "metadata": {
     "tags": []
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 12,
    "id": "e82efaa7-e346-41b6-a96a-2984201db714",
    "metadata": {
     "tags": []
@@ -196,7 +196,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "id": "4079ef6a-b1cf-47ef-90b6-804f9464e91c",
    "metadata": {
     "tags": []
@@ -206,10 +206,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "without change: 9.945112980229641\n",
-      "after permutation: 9.461406567572851\n",
-      "after translation: 5.963826685170721\n",
-      "after rotation: 7.191211524244547\n"
+      "without change: 4.0914311641808805\n",
+      "after permutation: 2.2352187612800325\n",
+      "after translation: -0.15670614466272526\n",
+      "after rotation: 0.5155425905215248\n"
      ]
     }
    ],
@@ -242,7 +242,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 14,
    "id": "e5460352-2479-4530-a826-4a3302db4eaf",
    "metadata": {
     "tags": []
@@ -304,7 +304,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 15,
    "id": "30da435a-da11-47c9-956b-1cf6607388ee",
    "metadata": {
     "tags": []
@@ -314,10 +314,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "without change: -19.370847873678944\n",
-      "after permutation: -19.370847873678944\n",
-      "after translation: -67.71502903638384\n",
-      "after rotation: 5.311140035302996\n"
+      "without change: 63.42865014451651\n",
+      "after permutation: 63.42865014451651\n",
+      "after translation: 100.62562776977552\n",
+      "after rotation: 66.30189546860115\n"
      ]
     }
    ],
@@ -342,7 +342,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 16,
    "id": "3cb34fd9-4221-4dde-839d-9f4a7e68be5d",
    "metadata": {
     "tags": []
@@ -404,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 17,
    "id": "6ab288bb-8a33-495a-a962-c0e93a64269d",
    "metadata": {
     "tags": []
@@ -414,10 +414,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "without change: 193.79734623037373\n",
-      "after permutation: 193.79734623037385\n",
-      "after translation: 193.79734623037368\n",
-      "after rotation: 188.36773620787383\n"
+      "without change: 238.7885470896204\n",
+      "after permutation: 238.78854708962035\n",
+      "after translation: 238.78854708962035\n",
+      "after rotation: 262.5920439748347\n"
      ]
     }
    ],
@@ -443,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 18,
    "id": "18216f40-b88d-4459-9b1b-a32cdf890afb",
    "metadata": {
     "tags": []
@@ -518,7 +518,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 19,
    "id": "2100fdb4-c204-45e1-b25c-152fc540d9b9",
    "metadata": {
     "tags": []
@@ -528,18 +528,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "without change: 585.1386319324105\n",
-      "after permutation: 585.1386319324106\n",
-      "after translation: 585.1386319324105\n",
-      "after rotation: 585.1386319324105\n"
+      "without change: 654.3040623148685\n",
+      "after permutation: 654.3040623148685\n",
+      "after translation: 654.3040623148685\n",
+      "after rotation: 654.3040623148685\n"
      ]
     }
    ],
    "source": [
-    "print(\"without change:\", hidden_model_permute_trans_rotate(R_i, X_i, w1, w2, b1, b2))\n",
-    "print(\"after permutation:\", hidden_model_permute_trans_rotate(permuted_R_i, X_i, w1, w2, b1, b2))\n",
-    "print(\"after translation:\", hidden_model_permute_trans_rotate(R_i + np.array([3, 3, 3]), X_i, w1, w2, b1, b2))\n",
-    "print(\"after rotation:\", hidden_model_permute_trans_rotate(rotate.apply(R_i), X_i, w1, w2, b1, b2))"
+    "print(\"without change:\", hidden_model_permute_translate_rotate(R_i, X_i, w1, w2, b1, b2))\n",
+    "print(\"after permutation:\", hidden_model_permute_translate_rotate(permuted_R_i, X_i, w1, w2, b1, b2))\n",
+    "print(\"after translation:\", hidden_model_permute_translate_rotate(R_i + np.array([3, 3, 3]), X_i, w1, w2, b1, b2))\n",
+    "print(\"after rotation:\", hidden_model_permute_translate_rotate(rotate.apply(R_i), X_i, w1, w2, b1, b2))"
    ]
   },
   {
@@ -584,7 +584,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "deepchem",
    "language": "python",
    "name": "python3"
   },
@@ -598,7 +598,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.8.20"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

Fix #4543 

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Fixed typo of `hidden_model_permute_trans_rotate` to  `hidden_model_permute_translate_rotate` in `Introuduction_to_Equivariance.ipynb` inside `examples/tutorials/`.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
