### PR TITLE
fix: Correct spelling 'vectures' to 'vectors' throughout codebase

### DIFF
--- a/deepchem/models/layers.py
+++ b/deepchem/models/layers.py
@@ -82,7 +82,7 @@ class GraphConv(tf.keras.layers.Layer):
     """Graph Convolutional Layers
 
     This layer implements the graph convolution introduced in [1]_.  The graph
-    convolution combines per-node feature vectures in a nonlinear fashion with
+    convolution combines per-node feature vectors in a nonlinear fashion with
     the feature vectors for neighboring nodes.  This "blends" information in
     local neighborhoods of a graph.
 

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -6063,7 +6063,7 @@ class GraphConv(nn.Module):
     """Graph Convolutional Layers
 
     This layer implements the graph convolution introduced in [1]_.  The graph
-    convolution combines per-node feature vectures in a nonlinear fashion with
+    convolution combines per-node feature vectors in a nonlinear fashion with
     the feature vectors for neighboring nodes.  This "blends" information in
     local neighborhoods of a graph.
 

--- a/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
+++ b/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
@@ -175,7 +175,7 @@
    "source": [
     "The results are pretty good, and `GraphConvModel` is very easy to use. But what's going on under the hood? Could we build GraphConvModel ourselves? Of course! DeepChem provides Keras layers for all the calculations involved in a graph convolution. We are going to apply the following layers from DeepChem.\n",
     "\n",
-    "-  `GraphConv` layer: This layer implements the graph convolution. The graph convolution combines per-node feature vectures in a nonlinear fashion with the feature vectors for neighboring nodes.  This \"blends\" information in local neighborhoods of a graph.\n",
+    "-  `GraphConv` layer: This layer implements the graph convolution. The graph convolution combines per-node feature vectors in a nonlinear fashion with the feature vectors for neighboring nodes.  This \"blends\" information in local neighborhoods of a graph.\n",
     "\n",
     "- `GraphPool` layer: This layer does a max-pooling over the feature vectors of atoms in a neighborhood. You can think of this layer as analogous to a max-pooling layer for 2D convolutions but which operates on graphs instead. \n",
     "\n",


### PR DESCRIPTION
## Description

Fix typo “vectures” → “vectors” in docstrings and documentation.  
No related issue.

## Type of change

- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
