### PR TITLE
Fix input dtype handling in keras_model.py (Keras3 vs Keras2)

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -281,7 +281,10 @@ class KerasModel(Model):
         if (self.model.inputs is not None) and len(self.model.inputs) > 0:
             self._input_shapes = [t.shape for t in self.model.inputs]
             self._input_dtypes = [
-                t.dtype.as_numpy_dtype for t in self.model.inputs
+                t.dtype.as_numpy_dtype
+                if hasattr(t.dtype, 'as_numpy_dtype')
+                else np.dtype(t.dtype)
+                for t in self.model.inputs
             ]
         else:
             self._input_shapes = [(None,) + i.shape[1:] for i in example_inputs]


### PR DESCRIPTION
In Keras3 model.dtype return a string instead of a tf.dtype due to its support for multiple backend. as a result we need to convert the 'float32' explicitly by calling np.dtype(t.dtype).