### PR TITLE
docstring fix: formatting spaces

### DIFF
--- a/deepchem/models/torch_models/lnn.py
+++ b/deepchem/models/torch_models/lnn.py
@@ -214,6 +214,7 @@ class LNNModel(TorchModel):
     activation_fn : str, default 'softplus'
         Activation function to use in the hidden layers. Softplus is preferred
         for Lagrangian learning as it ensures smooth derivatives.
+
     Examples
     --------
     >>> import deepchem as dc


### PR DESCRIPTION
## Description

This if follow up PR after - [deepchem lnn model](https://github.com/deepchem/deepchem/pull/4539)
it fixes the docstring formatting


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ x ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ x ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ x ] Run `mypy -p deepchem` and check no errors
  - [ x ] Run `flake8 <modified file> --count` and check no errors
  - [ x ] Run `python -m doctest <modified file>` and check no errors
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ x ] I have checked my code and corrected any misspellings
