### PR TITLE
Enhance tutorial with RDKit installation and config info (Fixes #4555)

### DIFF
--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -91,6 +91,22 @@
     "!pip install tf_keras"
    ]
   },
+ {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Installing rdkit ensures the availability of RDKit Chemistry Toolkit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
   {
    "cell_type": "markdown",
    "metadata": {},


### PR DESCRIPTION
Added installation instructions for RDKit

## Description

Fix #4555

This PR adds installation instructions for the RDKit toolkit to the first tutorial "The Basic Tools of the Deep Life Sciences".
DeepChem notebooks that use RDKit currently assume it is available, but RDKit is not installed by default.
I added a notebook cell that installs RDKit via pip, ensuring the notebook runs successfully without errors.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
