### PR TITLE
Add DataLoader tutorial

### DIFF
--- a/examples/tutorials/Introduction_to_DataLoaders.ipynb
+++ b/examples/tutorials/Introduction_to_DataLoaders.ipynb
@@ -116,9 +116,9 @@
         "\n",
         "A DataLoader is DeepChem's tool for preparing raw data files for machine learning. It handles the entire pipeline from file to DeepChem dataset object:\n",
         "\n",
-        "```\n",
-        "Raw File (CSV/SDF/JSON) → DataLoader → DeepChem Dataset Object → Model Training\n",
-        "```\n",
+        "<p align=\"center\">\n",
+        "  <img src=\"https://raw.githubusercontent.com/AshwinSaklecha/assets/main/Flowchart.png\" width=\"800\"/>\n",
+        "</p>\n",
         "\n",
         "When working with molecular data, you typically need to load chemical structures from files, convert them to numerical features, extract labels, handle missing or invalid data, and manage memory for large datasets. Writing this code manually is time-consuming and error-prone. DataLoaders automate all of these steps.\n",
         "\n",
@@ -542,7 +542,7 @@
         "\n",
         "In previous tutorials, you may have seen code like `tasks, datasets, transformers = dc.molnet.load_delaney()` followed by `train, valid, test = datasets`. MoleculeNet functions use DataLoaders internally. When you call `dc.molnet.load_delaney()`, it's using CSVLoader behind the scenes to load and process the data.\n",
         "\n",
-        "You can use MoleculeNet for convenience with standard datasets, or use DataLoaders directly when you need custom processing or are working with your own data."
+        "You can use MoleculeNet for convenience with standard datasets, or use DataLoaders directly when you need custom processing or are working with your own data. When using the manual approach, you'll also need a Splitter to divide your data into training, validation, and test sets. `RandomSplitter` assigns samples randomly to each split, which is ideal when your data points are independent. To learn more about different splitters and when to use them, see the [Working With Splitters](https://github.com/deepchem/deepchem/blob/master/examples/tutorials/Working_With_Splitters.ipynb) tutorial."
       ]
     },
     {


### PR DESCRIPTION
## Description

This PR adds a new DataLoader tutorial notebook. It covers CSVLoader, SDFLoader, featurization, multitask loading, and dataset sharding, starting from a simple example and moving to real datasets. This tutorial fills a gap mentioned in the DeepChem tutorial wishlist, since DeepChem does not currently have a DataLoader-focused tutorial.

There is no linked issue for this PR.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
