### PR TITLE
Add functionality of shuffle and random seed for ScaffoldSplit

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1523,6 +1523,7 @@ class ScaffoldSplitter(Splitter):
         frac_valid: float = 0.1,
         frac_test: float = 0.1,
         seed: Optional[int] = None,
+        shuffle: bool = False,
         log_every_n: Optional[int] = 1000
     ) -> Tuple[List[int], List[int], List[int]]:
         """
@@ -1540,6 +1541,8 @@ class ScaffoldSplitter(Splitter):
             The fraction of data to be used for the test split.
         seed: int, optional (default None)
             Random seed to use.
+        shuffle: bool, optional (default False)
+            Whether to shuffle the scaffold_sets before splitting.
         log_every_n: int, optional (default 1000)
             Controls the logger by dictating how often logger outputs
             will be produced.
@@ -1552,6 +1555,10 @@ class ScaffoldSplitter(Splitter):
         """
         np.testing.assert_almost_equal(frac_train + frac_valid + frac_test, 1.)
         scaffold_sets = self.generate_scaffolds(dataset)
+        
+        if seed is not None and shuffle:
+            rng = random.Random(seed)
+            rng.shuffle(scaffold_sets)
 
         train_cutoff = frac_train * len(dataset)
         valid_cutoff = (frac_train + frac_valid) * len(dataset)
@@ -1603,7 +1610,7 @@ class ScaffoldSplitter(Splitter):
                 else:
                     scaffolds[scaffold].append(ind)
 
-        # Sort from largest to smallest scaffold sets
+        # Sort scaffold_sets by size (length) in descending order, then by the first element
         scaffolds = {key: sorted(value) for key, value in scaffolds.items()}
         scaffold_sets = [
             scaffold_set

--- a/deepchem/splits/tests/test_scaffold_splitter.py
+++ b/deepchem/splits/tests/test_scaffold_splitter.py
@@ -1,10 +1,31 @@
 import unittest
 
 import deepchem as dc
+import numpy as np
 from deepchem.splits.splitters import ScaffoldSplitter
 
 
 class TestScaffoldSplitter(unittest.TestCase):
+
+    @staticmethod
+    def _make_dataset():
+        smiles = np.array([
+            "c1ccccc1",
+            "Cc1ccccc1",
+            "Oc1ccccc1",
+            "Nc1ccccc1",
+            "c1ccncc1",
+            "c1ncccc1",
+            "c1cnccc1",
+            "C1CCCCC1",
+            "C1CCCC1",
+            "C1CCNCC1",
+            "c1ccc2ccccc2c1",
+            "c1ccc2ncccc2c1",
+        ])
+        X = np.zeros((len(smiles), 1))
+        y = np.zeros((len(smiles), 1))
+        return dc.data.NumpyDataset(X=X, y=y, ids=smiles)
 
     def test_scaffolds(self):
         tox21_tasks, tox21_datasets, transformers = \
@@ -34,3 +55,30 @@ class TestScaffoldSplitter(unittest.TestCase):
         invalid_smiles = r's1cc(nc1\[NH]=C(\N)N)C'
         scaffold = _generate_scaffold(invalid_smiles)
         self.assertIsNone(scaffold)
+
+    def test_shuffle_false_keeps_existing_behavior(self):
+        dataset = self._make_dataset()
+        splitter = ScaffoldSplitter()
+
+        split_default = splitter.split(dataset, seed=7)
+        split_explicit_false = splitter.split(dataset, seed=7, shuffle=False)
+
+        self.assertEqual(split_default, split_explicit_false)
+
+    def test_shuffle_true_is_deterministic_with_seed(self):
+        dataset = self._make_dataset()
+        splitter = ScaffoldSplitter()
+
+        split_a = splitter.split(dataset, seed=7, shuffle=True)
+        split_b = splitter.split(dataset, seed=7, shuffle=True)
+
+        self.assertEqual(split_a, split_b)
+
+    def test_shuffle_flag_changes_split_order(self):
+        dataset = self._make_dataset()
+        splitter = ScaffoldSplitter()
+
+        split_unshuffled = splitter.split(dataset, seed=7, shuffle=False)
+        split_shuffled = splitter.split(dataset, seed=7, shuffle=True)
+
+        self.assertNotEqual(split_unshuffled, split_shuffled)


### PR DESCRIPTION
## Description

Fix #(issue)

This PR adds an optional `shuffle` argument to `ScaffoldSplitter.split()` and implements seed-controlled shuffling of `scaffold_sets` when `shuffle=True`.  
This provides users with deterministic randomization of scaffold ordering before applying the train/valid/test fractional split, which is often useful for improving the robustness of scaffold-based dataset splits.

In addition, I updated the comment above the scaffold sorting block to more accurately reflect its behavior ("Sort scaffold_sets by size (length) in descending order, then by the first element").


### Background / Motivation [[link](https://github.com/deepchem/deepchem/pull/4544)]

In earlier discussions (Oct 15), I noted that while the current `ScaffoldSplitter` is intentionally deterministic for reproducibility, many benchmarking workflows benefit from running multiple independent scaffold splits to assess model sensitivity. A seed-controlled shuffle of scaffold ordering enables this while preserving reproducibility.

The DeepChem team (e.g., @rbharath) mentioned openness to a randomized scaffold splitter, provided the behavior is clearly documented and does not break existing pipelines. This PR follows that guidance by adding an optional `shuffle` flag (default `False`), so the current deterministic behavior remains unchanged.

Related discussion: [[link](https://github.com/deepchem/deepchem/issues/3370)], [[link](https://github.com/deepchem/deepchem/issues/3370#issue-1682445517)]

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
