### PR TITLE
Add overwrite safety checks and tests for save_to_disk (Fix #3402)

### DIFF
--- a/deepchem/utils/data_utils.py
+++ b/deepchem/utils/data_utils.py
@@ -488,7 +488,10 @@ def _get_file_type(input_file: str) -> str:
         raise ValueError("Unrecognized extension %s" % file_extension)
 
 
-def save_to_disk(dataset: Any, filename: str, compress: int = 3, overwrite: bool = False):
+def save_to_disk(dataset: Any,
+                 filename: str,
+                 compress: int = 3,
+                 overwrite: bool = False):
     """Save a dataset to file.
 
     Parameters
@@ -509,8 +512,7 @@ def save_to_disk(dataset: Any, filename: str, compress: int = 3, overwrite: bool
         if path.is_dir():
             raise IsADirectoryError(
                 f"Expected a file path but got directory '{filename}'. "
-                "Please provide a file path (e.g. 'path/to/file.joblib')."
-            )
+                "Please provide a file path (e.g. 'path/to/file.joblib').")
         # It's a file; warn before overwriting unless overwrite=True
         elif not overwrite:
             warnings.warn(
@@ -525,6 +527,7 @@ def save_to_disk(dataset: Any, filename: str, compress: int = 3, overwrite: bool
         np.save(filename, dataset)
     else:
         raise ValueError("Filename with unsupported extension: %s" % filename)
+
 
 def load_from_disk(filename: str) -> Any:
     """Load a dataset from file.

--- a/deepchem/utils/test/test_data_utils.py
+++ b/deepchem/utils/test/test_data_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from deepchem.utils.data_utils import load_sdf_files, save_to_disk
 
+
 class TestFileLoading(unittest.TestCase):
 
     def test_load_sdf_files(self):
@@ -22,6 +23,7 @@ class TestFileLoading(unittest.TestCase):
         self.assertEqual(len(eval(df['pos_x'][0])), n_atoms_mol1)
         self.assertEqual(len(eval(df['pos_y'][0])), n_atoms_mol1)
         self.assertEqual(len(eval(df['pos_y'][0])), n_atoms_mol1)
+
 
 class TestSaveToDisk(unittest.TestCase):
 
@@ -45,8 +47,7 @@ class TestSaveToDisk(unittest.TestCase):
                 save_to_disk(np.ones(1), file_path, overwrite=True)
 
             self.assertFalse(
-                any(isinstance(warn.message, UserWarning) for warn in w)
-            )
+                any(isinstance(warn.message, UserWarning) for warn in w))
 
     def test_save_to_disk_directory_error(self):
         # Passing a directory path should raise IsADirectoryError


### PR DESCRIPTION
## Description

Fixes #3402

This PR implements safety checks for `save_to_disk` to prevent accidental data loss, addressing Issue #3402.

### What was happening before?
`save_to_disk` would silently overwrite existing files or even entire directories when given a path that already contained data. This behavior could lead to unexpected data loss for users.

### What this PR changes
- Added an `overwrite` flag (default `False`) to `save_to_disk`
- If the target path is a **directory**, raise `IsADirectoryError`
- If the target is an existing **file** and `overwrite=False`, emit a `UserWarning` before overwriting
- If `overwrite=True`, overwrite without warning
- Updated the docstring in `data_utils.py`
- Added 3 new unit tests in `test_data_utils.py`:
  - warns when overwriting an existing file with `overwrite=False`
  - no warning when `overwrite=True`
  - directory path raises `IsADirectoryError`

### Why this is important
This prevents accidental overwriting of user data and provides explicit control via the `overwrite` flag. 
The default behavior remains backward compatible while making destructive behavior more explicit and safer for users.

---

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

---

## Checklist

- [X] My code follows the style guidelines of this project
- [x] Run `yapf -i <modified file>` and check no errors
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [X] I have commented my code where necessary
- [X] I have added tests that prove my fix is effective
- [X] New unit tests pass locally with my changes
- [X] I have checked my code for misspellings

