### PR TITLE
 Add DFT neural functionals documentation and tutorial

### DIFF
--- a/examples/dft/README.md
+++ b/examples/dft/README.md
@@ -1,0 +1,95 @@
+This directory contains examples demonstrating DeepChem's Density Functional Theory (DFT) capabilities with neural network exchange-correlation functionals.
+
+## Overview
+
+DeepChem implements neural network-based XC functionals that can be trained to replace or augment traditional density functionals. This approach, based on the paper ["Learning the exchange-correlation functional from nature with fully differentiable density functional theory"](https://arxiv.org/abs/2309.15985), enables learning XC functionals from high-quality quantum chemistry data.
+
+## Available Examples
+
+### 1. `neural_xc_tutorial.py`
+Comprehensive tutorial demonstrating:
+- **NNLDA**: Neural Local Density Approximation functional
+- **NNPBE**: Neural PBE (GGA) functional  
+- **HybridXC**: Combining traditional and neural functionals
+
+**Key Concepts Covered:**
+- Creating custom neural network architectures for XC functionals
+- Understanding LDA vs GGA functional families
+- Hybrid functional mixing strategies
+- Training considerations for neural XC functionals
+
+**Usage:**
+```bash
+python neural_xc_tutorial.py
+Requirements:
+
+PyTorch
+
+DeepChem
+
+DQC (Differentiable Quantum Chemistry)
+
+Neural XC Functional Families
+Local Density Approximation (LDA)
+Depends only on electron density ρ(r)
+
+Fast but less accurate
+
+Good for prototyping and learning
+
+DeepChem Implementation: NNLDA
+
+Generalized Gradient Approximation (GGA)
+Depends on density ρ(r) and gradient ∇ρ(r)
+
+More accurate than LDA
+
+Captures non-local effects
+
+DeepChem Implementation: NNPBE
+
+Hybrid Functionals
+Mix traditional and neural functionals
+
+Formula: E_xc = α × E_traditional + (1-α) × E_neural
+
+Allows gradual transition to learned functionals
+
+DeepChem Implementation: HybridXC
+
+Current Limitations
+Limited functional types: Only LDA and GGA neural implementations
+
+No meta-GGA: Missing SCAN, M06-L, etc.
+
+No range-separated hybrids: ωB97X, CAM-B3LYP not implemented
+
+Scalability: Large systems may require optimization
+
+Future Directions
+Potential contributions (great for GSoC projects!):
+
+Implement neural meta-GGA functionals (SCAN, r²SCAN, M06-L)
+
+Add range-separated hybrid support (ωB97X, LC-ωPBE)
+
+Improve GPU acceleration for large molecular systems
+
+Create comprehensive benchmark suite
+
+Add training utilities and pretrained models
+
+Extend to periodic systems (solids, surfaces)
+
+References
+Kasim & Vinko, "Learning the exchange-correlation functional from nature with fully differentiable density functional theory", Physical Review Letters 127.12 (2021)
+
+DeepChem DFT Infrastructure Paper: arxiv.org/abs/2309.15985
+
+Contributing
+Contributions are welcome! See DeepChem's contribution guidelines.
+
+For questions about DFT examples, please post in the DeepChem Forum.
+
+Author: Utkarsh Khajuria (@UtkarsHMer05)
+Date: December 2025

--- a/examples/dft/neural_xc_tutorial.py
+++ b/examples/dft/neural_xc_tutorial.py
@@ -1,0 +1,130 @@
+"""
+Tutorial: Neural Network Exchange-Correlation Functionals in DeepChem
+======================================================================
+
+This tutorial demonstrates how to use neural network-based XC functionals
+(NNLDA and NNPBE) for DFT calculations in DeepChem.
+
+Author: Utkarsh Khajuria (GSoC 2026 Preparation)
+Date: December 2025
+"""
+
+import torch
+import torch.nn as nn
+from deepchem.models.dft.nnxc import NNLDA, NNPBE, HybridXC
+try:
+    from dqc.utils.datastruct import ValGrad
+except:
+    from deepchem.utils.dftutils import ValGrad
+import warnings
+warnings.filterwarnings('ignore')
+
+print("=" * 70)
+print("NEURAL XC FUNCTIONAL TUTORIAL - DeepChem DFT")
+print("=" * 70)
+
+# Part 1: Understanding NNLDA (Neural LDA Functional)
+print("\n### Part 1: Neural LDA Functional ###\n")
+print("LDA (Local Density Approximation) functionals depend only on")
+print("electron density ρ(r) at each point in space.")
+print("\nIn NNLDA, we replace the traditional LDA functional with a")
+print("neural network that learns the exchange-correlation energy.")
+
+# Create a simple neural network model
+class SimpleXCNet(nn.Module):
+    """Simple 2-layer neural network for XC functional"""
+    def __init__(self, input_size=2, hidden_size=16):
+        super(SimpleXCNet, self).__init__()
+        self.net = nn.Sequential(
+            nn.Linear(input_size, hidden_size),
+            nn.Tanh(),
+            nn.Linear(hidden_size, 1)
+        )
+    
+    def forward(self, x):
+        return self.net(x)
+
+# Initialize the model
+torch.manual_seed(42)
+xc_model = SimpleXCNet(input_size=2, hidden_size=16)
+print(f"\n✓ Created neural network with {sum(p.numel() for p in xc_model.parameters())} parameters")
+
+# Create NNLDA functional
+nnlda = NNLDA(xc_model)
+print("✓ Initialized NNLDA functional")
+
+# Create sample density information
+n_points = 10  # Number of grid points
+densinfo = ValGrad(value=torch.rand(n_points).requires_grad_())
+
+# Compute exchange-correlation energy density
+try:
+    exc_density = nnlda.get_edensityxc(densinfo)
+    print(f"✓ Computed XC energy density at {n_points} grid points")
+    print(f"  Shape: {exc_density.shape}")
+    print(f"  Sample values: {exc_density[:3].detach().numpy()}")
+except Exception as e:
+    print(f"✗ NNLDA computation failed: {e}")
+
+# Part 2: Understanding NNPBE (Neural PBE Functional)
+print("\n\n### Part 2: Neural PBE (GGA) Functional ###\n")
+print("PBE is a GGA (Generalized Gradient Approximation) functional")
+print("that depends on both density ρ(r) AND its gradient ∇ρ(r).")
+print("\nThis captures non-local effects better than LDA.")
+
+# Create NNPBE functional
+try:
+    nnpbe = NNPBE(xc_model)
+    print("\n✓ Initialized NNPBE functional")
+    
+    # For GGA functionals, we need gradient information too
+    densinfo_gga = ValGrad(
+        value=torch.rand(n_points).requires_grad_(),
+        grad=torch.rand(n_points, 3).requires_grad_()  # 3D gradient
+    )
+    
+    exc_density_gga = nnpbe.get_edensityxc(densinfo_gga)
+    print(f"✓ Computed GGA XC energy density")
+    print(f"  Input: density + gradient at {n_points} points")
+    print(f"  Output shape: {exc_density_gga.shape}")
+except Exception as e:
+    print(f"✗ NNPBE computation failed: {e}")
+
+# Part 3: Hybrid Functionals
+print("\n\n### Part 3: Hybrid XC Functionals ###\n")
+print("HybridXC combines traditional functionals with neural networks:")
+print("E_xc = α * E_xc^traditional + (1-α) * E_xc^neural")
+print("\nThis allows gradual transition from known functionals to learned ones.")
+
+try:
+    # Create hybrid functional mixing LDA with neural network
+    hybrid_xc = HybridXC("lda_x", xc_model, aweight0=0.5)
+    print("\n✓ Created HybridXC with 50% LDA, 50% neural")
+    
+    exc_hybrid = hybrid_xc.get_edensityxc(densinfo)
+    print(f"✓ Computed hybrid XC energy density")
+    print(f"  Traditional (LDA) weight: 0.5")
+    print(f"  Neural network weight: 0.5")
+except Exception as e:
+    print(f"✗ HybridXC computation failed: {e}")
+
+# Part 4: Training Considerations
+print("\n\n### Part 4: Training Neural XC Functionals ###\n")
+print("To train these functionals, you typically:")
+print("1. Collect reference DFT data (high-level calculations)")
+print("2. Define loss function (energy errors, forces, etc.)")
+print("3. Optimize neural network parameters")
+print("4. Validate on test molecules")
+print("\nSee the full XCModel class in dftxc.py for training implementation.")
+
+print("\n" + "=" * 70)
+print("TUTORIAL COMPLETE")
+print("=" * 70)
+print("\nNext steps:")
+print("- Read the paper: arxiv.org/abs/2309.15985")
+print("- Explore deepchem/models/dft/dftxc.py for training")
+print("- Check deepchem/models/tests/ for more examples")
+print("\nFor GSoC 2026: Consider implementing neural versions of:")
+print("  • Meta-GGA functionals (SCAN, M06-L)")
+print("  • Range-separated hybrids (ωB97X)")
+print("  • Double-hybrid functionals (B2PLYP)")


### PR DESCRIPTION
## Summary
This PR adds comprehensive documentation for DeepChem's neural exchange-correlation functionals in the DFT module.

## Changes
- **README.md** for `examples/dft/` directory
  - Overview of neural XC functionals (NNLDA, NNPBE, HybridXC)
  - Usage instructions and requirements
  - Future directions for contributors
  
- **neural_xc_tutorial.py** 
  - Demonstrates NNLDA (Local Density Approximation)
  - Demonstrates NNPBE (GGA functional)
  - Demonstrates HybridXC (mixing traditional + neural)
  - Includes training considerations
  - Error handling for missing dependencies

## Motivation
The DFT module currently lacks comprehensive examples and documentation. This PR provides:
- Clear explanations of neural XC functional concepts
- Practical code examples users can run
- References to the foundational paper (arxiv.org/abs/2309.15985)
- Suggestions for future GSoC contributions

## Testing
- Verified Python syntax
- Tested import structure
- Confirmed documentation formatting

## References
- Paper: "Learning the exchange-correlation functional from nature with fully differentiable density functional theory" ([arxiv.org/abs/2309.15985](https://arxiv.org/abs/2309.15985))
- Related: DeepChem DFT module (`deepchem/models/dft/`)

## Additional Context
Preparing for GSoC 2026 "Improve DFT Support" project. This is the first in a series of contributions to enhance DeepChem's DFT capabilities.
