### PR TITLE
Fix installation command in 'Basic Tools' tutorial

### DIFF
--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -72,7 +72,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --pre deepchem[tensorflow]"
+    "!pip install --pre deepchem"
    ]
   },
   {


### PR DESCRIPTION
## Description

This PR fixes a `pip install` error in the "The Basic Tools of the Deep Life Sciences" tutorial notebook.

**The Issue:**
The command `!pip install deepchem[tensorflow]` currently causes installation failures in Google Colab due to dependency conflicts with the latest environment.

**The Fix:**
Updated the installation command to `!pip install --pre deepchem` as recommended by the maintainers in the Discord community. This ensures the tutorial runs correctly for new users.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings