### PR TITLE
Fix SingletaskStratifiedSplitter API signature mismatc

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -660,15 +660,13 @@ class SingletaskStratifiedSplitter(Splitter):
         """
         self.task_number = task_number
 
-
-    def k_fold_split(
-            self,
-            dataset: Dataset,
-            k: int,
-            directories: Optional[List[str]] = None,
-            seed: Optional[int] = None,
-            log_every_n: Optional[int] = None,
-            **kwargs) -> List[Tuple[Dataset, Dataset]]:
+    def k_fold_split(self,
+                     dataset: Dataset,
+                     k: int,
+                     directories: Optional[List[str]] = None,
+                     seed: Optional[int] = None,
+                     log_every_n: Optional[int] = None,
+                     **kwargs) -> List[Tuple[Dataset, Dataset]]:
         """
         Splits compounds into k-folds using stratified sampling.
         Overriding base class k_fold_split.
@@ -705,28 +703,28 @@ class SingletaskStratifiedSplitter(Splitter):
 
         # 3. The Loop (Simpler & Stateless)
         fold_datasets = []
-        
+
         for fold in range(k):
             train_dir = directories[2 * fold]
             cv_dir = directories[2 * fold + 1]
 
             # A. Identify Validation Indices (For this specific fold)
             fold_inds = stratified_folds[fold]
-            
+
             # B. Identify Training Indices (All OTHER folds combined)
             # We construct this by looking at the original 'stratified_folds' list
             train_folds = [stratified_folds[i] for i in range(k) if i != fold]
             train_inds = np.concatenate(train_folds)
-            
+
             # C. Create Datasets directly from the ORIGINAL dataset
             # This avoids the "shrinking index" bug that would appear if implemented exactly
             # same as the base class k_fold_split implementation.
             # .select() handles the disk writing to the specific directories.
             train_dataset = dataset.select(train_inds, select_dir=train_dir)
             cv_dataset = dataset.select(fold_inds, select_dir=cv_dir)
-            
+
             fold_datasets.append((train_dataset, cv_dataset))
-            
+
         return fold_datasets
 
     def split(

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -619,7 +619,6 @@ class TestSplitter(unittest.TestCase):
         """
         Test that SingletaskStratifiedSplitter.k_fold_split returns
         List[Tuple[Dataset, Dataset]] matching the base Splitter API.
-        
         This is a regression test for the FIXME that was fixed to ensure
         LSP compliance.
         """
@@ -646,7 +645,7 @@ class TestSplitter(unittest.TestCase):
                 f"Fold {fold_idx} tuple length is {len(fold)}, expected 2"
 
             train_dataset, cv_dataset = fold
-            
+
             # Both should be Dataset objects
             assert isinstance(train_dataset, dc.data.Dataset), \
                 f"Train dataset in fold {fold_idx} is not a Dataset"


### PR DESCRIPTION
## Summary
Fixed `SingletaskStratifiedSplitter.k_fold_split` to return `List[Tuple[Dataset, Dataset]]` instead of `List[Dataset]`, making it consistent with the base `Splitter.k_fold_split` API.

## Changes
- Modified return type annotation to `List[Tuple[Dataset, Dataset]]`
- Refactored implementation to return (train, cv) tuples for each fold
- Removed the FIXME comment that flagged this issue
- Added regression test `test_singletask_stratified_k_fold_split_signature` in `deepchem/splits/tests/test_splitter.py`

## Fixes
Fixes #4619
Resolves the FIXME at line 663 in `deepchem/splits/splitters.py` regarding LSP violation.