### PR TITLE
Fix Delaney (ESOL) link in Getting Started examples

### DIFF
--- a/docs/source/api_reference/moleculenet.rst
+++ b/docs/source/api_reference/moleculenet.rst
@@ -103,6 +103,8 @@ Clintox Datasets
 
 .. autofunction:: deepchem.molnet.load_clintox
 
+.. _delaney-datasets:
+
 Delaney Datasets
 ----------------
 

--- a/docs/source/get_started/examples.rst
+++ b/docs/source/get_started/examples.rst
@@ -42,7 +42,7 @@ Before jumping in to examples, we'll import our libraries and ensure our doctest
 Delaney (ESOL)
 ----------------
 
-Examples of training models on the Delaney (ESOL) dataset included in :doc:`MoleculeNet <../api_reference/moleculenet>`.
+Examples of training models on the Delaney (ESOL) dataset included in :ref:`delaney-datasets`.
 
 We'll be using its :code:`smiles` field to train models to predict its experimentally measured solvation energy (:code:`expt`).
 
@@ -82,8 +82,8 @@ First, we'll load the dataset with :func:`load_delaney() <deepchem.molnet.load_d
 
 GraphConvModel
 ^^^^^^^^^^^^^^
-The default `featurizer <./featurizers.html>`_ for Delaney is :code:`ECFP`, short for
-`"Extended-connectivity fingerprints." <./featurizers.html#circularfingerprint>`_
+The default :doc:`featurizer <../api_reference/featurizers>` for Delaney is :code:`ECFP`, short for
+:ref:`Extended-connectivity fingerprints <circularfingerprint>`
 For a :class:`GraphConvModel <deepchem.models.GraphConvModel>`, we'll reload our datasets with :code:`featurizer='GraphConv'`:
 
 .. doctest:: delaney

--- a/docs/source/get_started/issues.rst
+++ b/docs/source/get_started/issues.rst
@@ -11,7 +11,7 @@ save you some headache by listing features that we know are partially or complet
 broken.
 
 *Note: This list is likely to be non-exhaustive. If we missed something, 
-please let us know [here](https://github.com/deepchem/deepchem/issues/2376).*
+please let us know `here <https://github.com/deepchem/deepchem/issues/2376>`_.*
 
 +--------------------------------+-------------------+---------------------------------------------------+
 | Feature                        | Deepchem response | Tracker and notes                                 |
@@ -31,7 +31,7 @@ been thoroughly tested to the level of other Deepchem modules, and could be
 potentially problematic in production environments.
 
 *Note: This list is likely to be non-exhaustive. If we missed something, 
-please let us know [here](https://github.com/deepchem/deepchem/issues/2376).*
+please let us know `here <https://github.com/deepchem/deepchem/issues/2376>`_*
 
 +--------------------------------+---------------------------------------------------+
 | Feature                        | Tracker and notes                                 |


### PR DESCRIPTION
## Description

Fixes #4627

Updates the Delaney (ESOL) example to link directly to the Delaney Datasets section in the MoleculeNet API docs using a Sphinx section reference.

Documentation-only change.