### PR TITLE
Fix table overflow in documentation tables

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,5 @@
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+  white-space: normal;
+  word-break: break-word;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,6 +89,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_css_files = [
+    'custom.css',
+]
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.


### PR DESCRIPTION
Fixes #4629
Adds a small CSS override to allow long identifiers in tables to wrap instead of overflowing the page width.


