### PR TITLE
Clarify restore=False behavior in Model.fit docstring

### DIFF
--- a/deepchem/models/jax_models/jax_model.py
+++ b/deepchem/models/jax_models/jax_model.py
@@ -250,7 +250,9 @@ class JaxModel(Model):
             Set this to 0 to disable automatic checkpointing.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of hk.Variable
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -335,7 +335,9 @@ class KerasModel(Model):
             order is used for each epoch.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of tf.Variable
             the variables to train.  If None (the default), all trainable variables in
             the model are used.
@@ -386,7 +388,9 @@ class KerasModel(Model):
             Set this to 0 to disable automatic checkpointing.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of tf.Variable
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/seqtoseq.py
+++ b/deepchem/models/seqtoseq.py
@@ -240,7 +240,9 @@ class SeqToSeq(KerasModel):
             the frequency at which to write checkpoints, measured in training steps.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         """
         self.fit_generator(self._generate_batches(sequences),
                            max_checkpoints_to_keep=max_checkpoints_to_keep,

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -328,7 +328,9 @@ class HuggingFaceModel(TorchModel):
             Set this to 0 to disable automatic checkpointing.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of torch.nn.Parameter
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/torch_models/modular.py
+++ b/deepchem/models/torch_models/modular.py
@@ -162,7 +162,9 @@ class ModularTorchModel(TorchModel):
             Set this to 0 to disable automatic checkpointing.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of torch.nn.Parameter
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/torch_models/oneformer.py
+++ b/deepchem/models/torch_models/oneformer.py
@@ -239,7 +239,9 @@ class OneFormer(HuggingFaceModel):
             Set this to 0 to disable automatic checkpointing.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of torch.nn.Parameter
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/torch_models/progressive_multitask.py
+++ b/deepchem/models/torch_models/progressive_multitask.py
@@ -496,7 +496,9 @@ class ProgressiveMultitaskModel(TorchModel):
             order is used for each epoch.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of torch.nn.Parameter
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -315,7 +315,9 @@ class TorchModel(Model):
             order is used for each epoch.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of torch.nn.Parameter
             the variables to train.  If None (the default), all trainable variables in
             the model are used.
@@ -366,7 +368,9 @@ class TorchModel(Model):
             Set this to 0 to disable automatic checkpointing.
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         variables: list of torch.nn.Parameter or torch.nn.ParameterList
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/rl/a2c.py
+++ b/deepchem/rl/a2c.py
@@ -230,7 +230,9 @@ class A2C(object):
             the time interval at which to save checkpoints, measured in seconds
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         """
         if restore:
             self.restore()

--- a/deepchem/rl/ppo.py
+++ b/deepchem/rl/ppo.py
@@ -205,7 +205,9 @@ class PPO(object):
             the time interval at which to save checkpoints, measured in seconds
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         """
         step_count = 0
         workers = []

--- a/deepchem/rl/torch_rl/torch_a2c.py
+++ b/deepchem/rl/torch_rl/torch_a2c.py
@@ -355,7 +355,9 @@ class A2C(object):
             the time interval at which to save checkpoints, measured in seconds
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         """
         if restore:
             self.restore()

--- a/deepchem/rl/torch_rl/torch_ppo.py
+++ b/deepchem/rl/torch_rl/torch_ppo.py
@@ -288,7 +288,9 @@ class PPO(object):
             the time interval at which to save checkpoints, measured in seconds
         restore: bool
             if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            from there. If False, do not load a checkpoint from disk. Note that if the model
+            has already been trained, setting restore=False will continue training from the
+            current weights in memory;it does not reset the model weights to random initialization.
         """
         step_count: int = 0
         workers: List[_Worker] = []


### PR DESCRIPTION
## Description

Fix #1491 

Previously, the documentation stated that restore=False would "retrain the model from scratch," implying that weights would be re-initialized to random values. This was misleading. As confirmed in the linked issue, the behavior changed when DeepChem switched to using persistent Sessions, but the documentation was not updated to reflect this.

I have updated the docstring in deepchem/models/models.py to accurately describe the current behavior.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
