### PR TITLE
Fix API reference table overflow on ReadTheDocs

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,45 @@
+/* Fix for API reference tables overflowing page width */
+/* Long identifiers (featurizer names, class names) should wrap */
+
+/* Make tables responsive and prevent overflow */
+.wy-table-responsive table {
+    width: 100%;
+    table-layout: fixed;
+}
+
+/* Allow word wrapping in table cells */
+.wy-table-responsive table td,
+.wy-table-responsive table th {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    hyphens: auto;
+}
+
+/* Specifically target code elements in tables to allow wrapping */
+.wy-table-responsive table td code,
+.wy-table-responsive table th code {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    white-space: pre-wrap;
+}
+
+/* Ensure the table container doesn't overflow */
+.wy-table-responsive {
+    overflow-x: auto;
+    max-width: 100%;
+}
+
+/* Allow long class/function names to wrap */
+.rst-content table.docutils td,
+.rst-content table.docutils th {
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}
+
+/* Handle inline literals (backtick text) in tables */
+.rst-content table.docutils td code.literal,
+.rst-content table.docutils td code.xref,
+.rst-content table.docutils td a code {
+    white-space: pre-wrap;
+    word-break: break-word;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -90,6 +90,9 @@ html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+# Custom CSS file to fix table overflow issues
+html_css_files = ['custom.css']
+
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
 html_logo = '_static/logo.png'


### PR DESCRIPTION
fix #4629

Fix API reference table overflow on ReadTheDocs where long identifiers (featurizer names like `CircularFingerprint`, `ElementPropertyFingerprint`, `BindingPocketFeaturizer`) cause tables to extend beyond the content area.

**Changes:**
- Add `docs/source/_static/custom.css` with word-wrap styles for table cells
- Enable wrapping for long identifiers like featurizer names
- Register custom CSS in Sphinx `conf.py` via `html_css_files`

# Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

# Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
