### PR TITLE
Fix MoleculeNet link to navigate to Delaney Datasets section

### DIFF
--- a/docs/source/api_reference/moleculenet.rst
+++ b/docs/source/api_reference/moleculenet.rst
@@ -103,6 +103,8 @@ Clintox Datasets
 
 .. autofunction:: deepchem.molnet.load_clintox
 
+.. _delaney-dataset:
+
 Delaney Datasets
 ----------------
 

--- a/docs/source/get_started/examples.rst
+++ b/docs/source/get_started/examples.rst
@@ -42,7 +42,7 @@ Before jumping in to examples, we'll import our libraries and ensure our doctest
 Delaney (ESOL)
 ----------------
 
-Examples of training models on the Delaney (ESOL) dataset included in `MoleculeNet <./moleculenet.html>`_.
+Examples of training models on the Delaney (ESOL) dataset included in :ref:`MoleculeNet <delaney-dataset>`.
 
 We'll be using its :code:`smiles` field to train models to predict its experimentally measured solvation energy (:code:`expt`).
 


### PR DESCRIPTION
fix #4627

Fix the MoleculeNet link in the Delaney (ESOL) example to navigate directly to the Delaney Datasets section.

**Changes:**
- Add Sphinx label `.. _delaney-dataset:` to the Delaney Datasets section in `moleculenet.rst`
- Update `examples.rst` to use `:ref:` directive instead of raw HTML link for proper section navigation

# Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

# Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
