### PR TITLE
Fix RDKit installation in Colab tutorials for Python 3.12

### DIFF
--- a/examples/tutorials/An_Introduction_To_MoleculeNet.ipynb
+++ b/examples/tutorials/An_Introduction_To_MoleculeNet.ipynb
@@ -40,6 +40,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "RDKit is required for molecular featurization (e.g., GraphConv). Install it via pip:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "We can now import the `deepchem` package to play with."
    ]
   },

--- a/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
+++ b/examples/tutorials/Introduction_to_Graph_Convolutions.ipynb
@@ -42,6 +42,22 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RDKit is required for molecular featurization (e.g., GraphConv). Install it via pip:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "BX2erW0ncj1W"

--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -79,6 +79,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "RDKit is required for molecular featurization (e.g., GraphConv). Install it via pip:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Installing tf_keras ensures the availability of legacy optimizers."
    ]
   },

--- a/examples/tutorials/Working_With_Datasets.ipynb
+++ b/examples/tutorials/Working_With_Datasets.ipynb
@@ -38,6 +38,22 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "RDKit is required for molecular featurization (e.g., GraphConv). Install it via pip:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install rdkit"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "colab_type": "text",
     "id": "Jk47QTZ95zF-"


### PR DESCRIPTION
fix #4632
Fix RDKit installation in Colab tutorials for Python 3.12.

Google Colab now uses Python 3.12 by default, which causes the GraphConv featurizer to fail with `ImportError: This class requires RDKit to be installed` because:
- `rdkit-pypi` is no longer available for Python 3.12
- `apt-get install python3-rdkit` causes version mismatch errors

**Solution:** Add `!pip install rdkit` to tutorials that use GraphConv featurizer. The `rdkit` package now provides working pip wheels for Python 3.12.

**Tutorials updated:**
- `The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb` (Tutorial 1)
- `Introduction_to_Graph_Convolutions.ipynb`
- `An_Introduction_To_MoleculeNet.ipynb`
- `Working_With_Datasets.ipynb`

#Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

# Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

