### PR TITLE
Fix tensorflow extra installation issues in google colab tutorials

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@ extras = {
         'torch==2.2.1', 'torchvision', 'pytorch-lightning', 'dgl<2.2.1',
         'dgllife'
     ],
-    'tensorflow': ['tensorflow', 'tensorflow_probability', 'tensorflow_addons'],
+    'tensorflow': [
+        'tensorflow',
+        'tensorflow_probability',
+        "tensorflow_addons; python_version < '3.12'",
+    ],
     'dqc': ['dqc', 'xitorch', 'torch==2.2.1', 'pylibxc2']
 }
 


### PR DESCRIPTION
## Description

Since late August 2025, google colab defaults to python 3.12, causing tensorflow DeepChem tutorials to break due to `tensorflow_addons` incompatibility. This change updates the `tensorflow` extra to skip `tensorflow_addons` on python >= 3.12, restoring Colab compatibility. 

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
