### PR TITLE
maintainence- fixed numpy-2.0 aliases and update version constraints

### DIFF
--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -1700,8 +1700,8 @@ class IRVTransformer(Transformer):
         X1 and X2 are sliced into pieces with shard_size rows(columns)
         then multiplied together and concatenated to the proper size
         """
-        X1 = np.float_(X1)
-        X2 = np.float_(X2)
+        X1 = np.float64(X1)
+        X2 = np.float64(X2)
         X1_shape = X1.shape
         X2_shape = X2.shape
         assert X1_shape[1] == X2_shape[0]

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(name='deepchem',
       },
       install_requires=[
           'joblib',
-          'numpy<2',
+          'numpy>=1.21',
           'pandas',
           'scikit-learn',
           'sympy',


### PR DESCRIPTION
## Description

Fixes the NumPy 2.0 compatibility issue within the Transformation stage of the DeepChem pipeline.

This PR initiates the migration to NumPy 2.0 by performing two critical updates:
1. **Alias Update:** Replaces the deprecated `np.float_` alias with the explicit `np.float64` in `transformers.py`.
2. **Infrastructure Update:** Modifies `setup.py` to remove the `numpy<2` version restriction, enabling installation in modern environments.

**Motivation:**
DeepChem currently encounters `AttributeError` or installation blocks in environments using NumPy 2.0.2 due to the removal of legacy type aliases. By adopting `np.float64`, we ensure backward compatibility with NumPy 1.x while satisfying the requirements for NumPy 2.x.

**Technical Notes:**
- The syntax change was verified using the Ruff linter (rule NPY201).
- Local testing on NumPy 2.0.2 currently results in an `AttributeError` from RDKit (`_ARRAY_API not found`). This is a documented binary (ABI) incompatibility in the current version of RDKit and is independent of the logic changes in this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Maintenance (NumPy 2.0 Migration)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] Changes are restricted to transformers.py and setup.py to maintain a surgical fix