### PR TITLE
Inspect dataset cli

### DIFF
--- a/deepchem/data/inspect_dataset.py
+++ b/deepchem/data/inspect_dataset.py
@@ -1,0 +1,104 @@
+"""Small CLI and library helpers to inspect tabular datasets.
+
+Usage:
+    python -m deepchem.data.inspect_dataset path/to/data.csv --n-sample 5
+
+The module focuses on lightweight, dependency-minimal inspection using pandas.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict, Any
+
+import numpy as np
+import pandas as pd
+
+
+def load_table(path: str) -> pd.DataFrame:
+    path = str(path)
+    if path.endswith(".csv") or path.endswith(".txt"):
+        return pd.read_csv(path)
+    if path.endswith(".tsv"):
+        return pd.read_csv(path, sep="\t")
+    # For SDF or other formats, users can pass a DataFrame directly.
+    raise ValueError("Unsupported file type. Pass a CSV/TSV or a DataFrame.")
+
+
+def inspect_dataframe(df: pd.DataFrame, n_sample: int = 5) -> Dict[str, Any]:
+    summary: Dict[str, Any] = {}
+    summary["n_examples"] = int(len(df))
+    summary["n_columns"] = int(len(df.columns))
+    summary["columns"] = []
+
+    for col in df.columns:
+        col_ser = df[col]
+        col_info: Dict[str, Any] = {"name": col, "dtype": str(col_ser.dtype)}
+        col_info["n_missing"] = int(col_ser.isna().sum())
+        if pd.api.types.is_numeric_dtype(col_ser):
+            col_info["mean"] = None if col_ser.dropna().empty else float(col_ser.mean())
+            col_info["std"] = None if col_ser.dropna().empty else float(col_ser.std())
+            col_info["min"] = None if col_ser.dropna().empty else float(col_ser.min())
+            col_info["max"] = None if col_ser.dropna().empty else float(col_ser.max())
+        else:
+            top = col_ser.dropna().astype(str).value_counts().head(5).to_dict()
+            col_info["top_values"] = {k: int(v) for k, v in top.items()}
+            # If column looks like SMILES, include length stats
+            if col.lower() in ("smiles", "smile"):
+                lengths = col_ser.dropna().astype(str).map(len)
+                if not lengths.empty:
+                    col_info["smiles_len_mean"] = float(lengths.mean())
+                    col_info["smiles_len_std"] = float(lengths.std())
+        summary["columns"].append(col_info)
+
+    # Simple task/label heuristics: look for columns named 'label' or starting with 'task'
+    task_cols = [c for c in df.columns if c.lower().startswith("task") or c.lower() == "label"]
+    summary["task_columns"] = task_cols
+
+    # Basic class balance for task columns when possible
+    balances = {}
+    for tc in task_cols:
+        ser = df[tc]
+        counts = ser.dropna().value_counts().to_dict()
+        balances[tc] = {str(k): int(v) for k, v in counts.items()}
+    summary["task_balances"] = balances
+
+    # Samples
+    try:
+        sample_df = df.sample(min(n_sample, len(df)), random_state=0)
+        # Convert to plain Python types
+        summary["samples"] = json.loads(sample_df.to_json(orient="records"))
+    except Exception:
+        summary["samples"] = []
+
+    return summary
+
+
+def print_summary(summary: Dict[str, Any], out=sys.stdout) -> None:
+    json.dump(summary, out, indent=2)
+    out.write("\n")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Inspect tabular datasets (CSV/TSV)")
+    p.add_argument("path", help="Path to CSV/TSV file")
+    p.add_argument("--n-sample", type=int, default=5, help="Number of example rows to show")
+    return p
+
+
+def main(argv=None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        df = load_table(args.path)
+    except Exception as e:
+        print(f"Error loading dataset: {e}", file=sys.stderr)
+        return 2
+
+    summary = inspect_dataframe(df, n_sample=args.n_sample)
+    print_summary(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deepchem/data/inspect_dataset.py
+++ b/deepchem/data/inspect_dataset.py
@@ -1,32 +1,76 @@
 """Small CLI and library helpers to inspect tabular datasets.
 
-Usage:
+Usage (CLI)
+-----------
+Run from the command line with:
+
+.. code-block:: bash
+
     python -m deepchem.data.inspect_dataset path/to/data.csv --n-sample 5
 
-The module focuses on lightweight, dependency-minimal inspection using pandas.
+This module focuses on lightweight, dependency-minimal inspection using
+pandas and is intended to provide a quick overview of tabular datasets.
 """
+
 from __future__ import annotations
 
 import argparse
 import json
 import sys
-from typing import Dict, Any
+from typing import Any, Dict, Optional, Sequence
 
-import numpy as np
 import pandas as pd
 
 
 def load_table(path: str) -> pd.DataFrame:
+    """Load a tabular dataset from disk into a DataFrame.
+
+    Parameters
+    ----------
+    path : str
+        Path to a CSV, TXT (comma-separated), or TSV file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The loaded table.
+
+    Raises
+    ------
+    ValueError
+        If the file extension is not supported.
+    """
     path = str(path)
     if path.endswith(".csv") or path.endswith(".txt"):
         return pd.read_csv(path)
     if path.endswith(".tsv"):
         return pd.read_csv(path, sep="\t")
-    # For SDF or other formats, users can pass a DataFrame directly.
-    raise ValueError("Unsupported file type. Pass a CSV/TSV or a DataFrame.")
+    raise ValueError("Unsupported file type. Expected a CSV, TXT, or TSV path.")
 
 
 def inspect_dataframe(df: pd.DataFrame, n_sample: int = 5) -> Dict[str, Any]:
+    """Compute a lightweight summary for a tabular dataset.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        Input dataset to inspect.
+    n_sample : int, optional (default 5)
+        Number of example rows to include in the summary. The actual
+        number of sampled rows is ``min(n_sample, len(df))``.
+
+    Returns
+    -------
+    dict
+        A JSON-serializable summary with the following keys:
+
+        - ``"n_examples"`` : int, number of rows
+        - ``"n_columns"`` : int, number of columns
+        - ``"columns"`` : list of per-column statistics
+        - ``"task_columns"`` : list of column names that look like labels/tasks
+        - ``"task_balances"`` : dict mapping task columns to value counts
+        - ``"samples"`` : list of sampled rows as plain Python dicts
+    """
     summary: Dict[str, Any] = {}
     summary["n_examples"] = int(len(df))
     summary["n_columns"] = int(len(df.columns))
@@ -36,38 +80,50 @@ def inspect_dataframe(df: pd.DataFrame, n_sample: int = 5) -> Dict[str, Any]:
         col_ser = df[col]
         col_info: Dict[str, Any] = {"name": col, "dtype": str(col_ser.dtype)}
         col_info["n_missing"] = int(col_ser.isna().sum())
+
         if pd.api.types.is_numeric_dtype(col_ser):
-            col_info["mean"] = None if col_ser.dropna().empty else float(col_ser.mean())
-            col_info["std"] = None if col_ser.dropna().empty else float(col_ser.std())
-            col_info["min"] = None if col_ser.dropna().empty else float(col_ser.min())
-            col_info["max"] = None if col_ser.dropna().empty else float(col_ser.max())
+            non_missing = col_ser.dropna()
+            if non_missing.empty:
+                col_info["mean"] = None
+                col_info["std"] = None
+                col_info["min"] = None
+                col_info["max"] = None
+            else:
+                col_info["mean"] = float(non_missing.mean())
+                col_info["std"] = float(non_missing.std())
+                col_info["min"] = float(non_missing.min())
+                col_info["max"] = float(non_missing.max())
         else:
             top = col_ser.dropna().astype(str).value_counts().head(5).to_dict()
             col_info["top_values"] = {k: int(v) for k, v in top.items()}
-            # If column looks like SMILES, include length stats
+
+            # If column looks like SMILES, include length statistics.
             if col.lower() in ("smiles", "smile"):
                 lengths = col_ser.dropna().astype(str).map(len)
                 if not lengths.empty:
                     col_info["smiles_len_mean"] = float(lengths.mean())
                     col_info["smiles_len_std"] = float(lengths.std())
+
         summary["columns"].append(col_info)
 
-    # Simple task/label heuristics: look for columns named 'label' or starting with 'task'
-    task_cols = [c for c in df.columns if c.lower().startswith("task") or c.lower() == "label"]
+    # Simple task/label heuristics: look for columns named 'label' or starting with 'task'.
+    task_cols = [
+        c for c in df.columns
+        if c.lower().startswith("task") or c.lower() == "label"
+    ]
     summary["task_columns"] = task_cols
 
-    # Basic class balance for task columns when possible
-    balances = {}
+    # Basic class balance for task columns when possible.
+    balances: Dict[str, Dict[str, int]] = {}
     for tc in task_cols:
         ser = df[tc]
         counts = ser.dropna().value_counts().to_dict()
         balances[tc] = {str(k): int(v) for k, v in counts.items()}
     summary["task_balances"] = balances
 
-    # Samples
+    # Sample example rows and convert them to plain Python types.
     try:
         sample_df = df.sample(min(n_sample, len(df)), random_state=0)
-        # Convert to plain Python types
         summary["samples"] = json.loads(sample_df.to_json(orient="records"))
     except Exception:
         summary["samples"] = []
@@ -76,18 +132,47 @@ def inspect_dataframe(df: pd.DataFrame, n_sample: int = 5) -> Dict[str, Any]:
 
 
 def print_summary(summary: Dict[str, Any], out=sys.stdout) -> None:
+    """Print a JSON summary to a file-like object.
+
+    Parameters
+    ----------
+    summary : dict
+        Summary dictionary produced by :func:`inspect_dataframe`.
+    out : file-like, optional
+        Stream to write JSON to. Defaults to ``sys.stdout``.
+    """
     json.dump(summary, out, indent=2)
     out.write("\n")
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    p = argparse.ArgumentParser(description="Inspect tabular datasets (CSV/TSV)")
-    p.add_argument("path", help="Path to CSV/TSV file")
-    p.add_argument("--n-sample", type=int, default=5, help="Number of example rows to show")
-    return p
+    """Build the argument parser for the inspect_dataset CLI."""
+    parser = argparse.ArgumentParser(
+        description="Inspect tabular datasets (CSV/TSV)")
+    parser.add_argument("path", help="Path to CSV/TSV file")
+    parser.add_argument(
+        "--n-sample",
+        type=int,
+        default=5,
+        help="Number of example rows to show",
+    )
+    return parser
 
 
-def main(argv=None) -> int:
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Entry point for the inspect_dataset CLI.
+
+    Parameters
+    ----------
+    argv : Sequence[str], optional
+        Command-line arguments to parse. If ``None``, uses ``sys.argv[1:]``.
+
+    Returns
+    -------
+    int
+        Exit code compatible with :func:`sys.exit`. Returns 0 on success
+        and 2 if the dataset cannot be loaded.
+    """
     args = _build_parser().parse_args(argv)
     try:
         df = load_table(args.path)

--- a/deepchem/data/tests/test_inspect_dataset.py
+++ b/deepchem/data/tests/test_inspect_dataset.py
@@ -4,21 +4,30 @@ from deepchem.data.inspect_dataset import inspect_dataframe
 
 
 def test_inspect_dataframe_basic():
-    df = pd.DataFrame(
-        {
-            "a": [1.0, 2.0, 3.0, None],
-            "label": [1, 0, 1, None],
-            "smiles": ["CCO", "C", "CCCC", None],
-        }
-    )
+    """Basic sanity check for inspect_dataframe on a small toy dataset."""
+    df = pd.DataFrame({
+        "a": [1.0, 2.0, 3.0, None],
+        "label": [1, 0, 1, None],
+        "smiles": ["CCO", "C", "CCCC", None],
+    })
 
     summary = inspect_dataframe(df, n_sample=2)
+
+    # High-level counts.
     assert summary["n_examples"] == 4
     assert summary["n_columns"] == 3
+
+    # Task column detection.
     assert "label" in summary["task_columns"]
-    # Check missing counts reported
+
+    # Check missing counts reported.
     col_info = {c["name"]: c for c in summary["columns"]}
     assert col_info["a"]["n_missing"] == 1
     assert col_info["smiles"]["n_missing"] == 1
-    # Samples list length should be 2
+
+    # Samples list length should be 2.
     assert len(summary["samples"]) == 2
+    # Samples should be dicts with the expected keys.
+    assert all(isinstance(s, dict) for s in summary["samples"])
+    assert all(
+        {"a", "label", "smiles"} <= set(s.keys()) for s in summary["samples"])

--- a/deepchem/data/tests/test_inspect_dataset.py
+++ b/deepchem/data/tests/test_inspect_dataset.py
@@ -1,0 +1,24 @@
+import pandas as pd
+
+from deepchem.data.inspect_dataset import inspect_dataframe
+
+
+def test_inspect_dataframe_basic():
+    df = pd.DataFrame(
+        {
+            "a": [1.0, 2.0, 3.0, None],
+            "label": [1, 0, 1, None],
+            "smiles": ["CCO", "C", "CCCC", None],
+        }
+    )
+
+    summary = inspect_dataframe(df, n_sample=2)
+    assert summary["n_examples"] == 4
+    assert summary["n_columns"] == 3
+    assert "label" in summary["task_columns"]
+    # Check missing counts reported
+    col_info = {c["name"]: c for c in summary["columns"]}
+    assert col_info["a"]["n_missing"] == 1
+    assert col_info["smiles"]["n_missing"] == 1
+    # Samples list length should be 2
+    assert len(summary["samples"]) == 2


### PR DESCRIPTION
## Description

This PR adds a lightweight dataset inspection utility to DeepChem.

- Introduces `deepchem.data.inspect_dataset.inspect_dataframe`, which summarizes tabular datasets (row/column counts, missing values, per-column stats, task columns, class balance, and sampled rows).
- Adds a CLI so users can run:

  ```bash
  python -m deepchem.data.inspect_dataset path/to/data.csv --n-sample 5


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings


Note: I attempted to run pytest deepchem/data/tests/test_inspect_dataset.py, but test collection failed due to missing optional dependencies (torch, tqdm) imported elsewhere in DeepChem. Since this feature is isolated to deepchem.data.inspect_dataset, I’m relying on CI to run the full environment and I will fix any issues that show up there.
