### PR TITLE
Fix RDKit import issues in Colab with Python 3.12 for DeepChem tutorials

### DIFF
--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -72,6 +72,11 @@
    },
    "outputs": [],
    "source": [
+    "# If you face an RDKit import error (for example, circular import issues),\n",
+    "# remove the '#' from the next line to uninstall and reinstall RDKit cleanly.\n",
+    "# !pip uninstall rdkit -y\n",
+    "\n",
+    "!pip install rdkit\n",
     "!pip install --pre deepchem[tensorflow]"
    ]
   },


### PR DESCRIPTION
# Fix RDKit import issues in Colab with Python 3.12 for DeepChem tutorials

## Description
This PR fixes an import error with RDKit when running DeepChem tutorials in Google Colab on Python 3.12.  
Colab’s default environment currently does not fully support RDKit with Python 3.12, which leads to `ImportError: cannot import name 'rdBase'`.

## Changes
- Improved the Setup code cell in `The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb`.
- Added a beginner-friendly comment above the RDKit install/uninstall cell explaining that the uninstall line can be uncommented if an import error occurs.
- Updated installation commands to ensure the tutorials run smoothly in Colab without crashing on Python 3.12.

## Type of change
- [x] Documentation / tutorial fix (modification for notebook documents)
- [ ] Bug fix 
- [ ] New feature 


## Checklist
- [x] All tutorial cells run successfully in Colab with Python 3.12
- [x] Changes are contained in the notebook; no core DeepChem code modified
- [x] Self-reviewed changes and added explanatory comments for beginners
- [x] Verified that all installation instructions work and no import errors occur

## Motivation
This improves the beginner experience by avoiding RDKit import errors in Colab for Python 3.12 users.

This is my first contribution to DeepChem, and I’m excited to contribute more! I would greatly appreciate suggestions or feedback.