### PR TITLE
add SA Score

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -48,7 +48,7 @@ from deepchem.feat.molecule_featurizers import SNAPFeaturizer
 from deepchem.feat.molecule_featurizers import RDKitConformerFeaturizer
 from deepchem.feat.molecule_featurizers import MXMNetFeaturizer
 from deepchem.feat.molecule_featurizers import EquivariantGraphFeaturizer
-
+from deepchem.feat.molecule_featurizers import SAScoreFeaturizer
 # complex featurizers
 from deepchem.feat.complex_featurizers import RdkitGridFeaturizer
 from deepchem.feat.complex_featurizers import NeighborListAtomicCoordinates

--- a/deepchem/feat/molecule_featurizers/__init__.py
+++ b/deepchem/feat/molecule_featurizers/__init__.py
@@ -25,3 +25,4 @@ from deepchem.feat.molecule_featurizers.snap_featurizer import SNAPFeaturizer
 from deepchem.feat.molecule_featurizers.conformer_featurizer import RDKitConformerFeaturizer
 from deepchem.feat.molecule_featurizers.mxmnet_featurizer import MXMNetFeaturizer
 from deepchem.feat.molecule_featurizers.equivariant_graph_featurizer import EquivariantGraphFeaturizer
+from deepchem.feat.molecule_featurizers.sascorer_featuriser import SAScoreFeaturizer

--- a/deepchem/feat/molecule_featurizers/sascorer_featuriser.py
+++ b/deepchem/feat/molecule_featurizers/sascorer_featuriser.py
@@ -1,0 +1,54 @@
+import numpy as np
+from deepchem.feat import MolecularFeaturizer
+from deepchem.utils.sascore import SAScorer
+from deepchem.utils.typing import RDKitMol
+
+class SAScoreFeaturizer(MolecularFeaturizer):
+    """
+    Synthetic Accessibility Score (SAScore) Featurizer.
+
+    This featurizer computes the SAScore for a molecule, which is a 
+    value between 1 (easy to synthesize) and 10 (hard to synthesize).
+    It uses the rule-based fragment contributions and complexity 
+    penalties defined by Ertl and Schuffenhauer.
+
+    Note
+    ----
+    This featurizer requires the 'fpscores.pkl.gz' file, which will be 
+    automatically downloaded to the DeepChem data directory upon first use.
+    """
+
+    def __init__(self):
+        """Initialize the SAScore Featurizer."""
+        self.scorer = None
+
+    def _featurize(self, datapoint: RDKitMol) -> np.ndarray:
+        """
+        Calculate SAScore for a single molecule.
+
+        Parameters
+        ----------
+        datapoint: RDKitMol
+            RDKit molecule object.
+
+        Returns
+        -------
+        np.ndarray
+            A 1D numpy array containing the SAScore. 
+            Returns [np.nan] if featurization fails.
+        """
+        # Lazy initialization of the scorer to ensure data 
+        # is only downloaded/loaded when actually needed.
+        if self.scorer is None:
+            self.scorer = SAScorer()
+
+        try:
+            score = self.scorer.calculate_score(datapoint)
+            if score is None:
+                return np.array([np.nan])
+            return np.array([score], dtype=np.float32)
+        except Exception as e:
+            # Log the error but don't crash the entire pipeline
+            import logging
+            logging.getLogger(__name__).warning(f"Featurization failed: {e}")
+            return np.array([np.nan])

--- a/deepchem/utils/sascore.py
+++ b/deepchem/utils/sascore.py
@@ -1,0 +1,163 @@
+import os
+import math
+import pickle
+import gzip
+import logging
+from typing import Optional
+from rdkit import Chem
+from rdkit.Chem import rdFingerprintGenerator, rdMolDescriptors
+from deepchem.utils.data_utils import get_data_dir, download_url
+
+logger = logging.getLogger(__name__)
+
+# REFERENCE ----- Official RDKit fragment scores source
+SAS_URL = "https://raw.githubusercontent.com/rdkit/rdkit/master/Contrib/SA_Score/fpscores.pkl.gz"
+
+class SAScorer:
+    """
+    SAScore Calculator adapted for DeepChem.
+    """
+    def __init__(self, fscore_path: Optional[str] = None):
+        self.fscore_path = fscore_path
+        self._fscores = None
+        self.mfpgen = rdFingerprintGenerator.GetMorganGenerator(radius=2)
+        
+        # Load scores immediately upon initialization
+        self._load_fragment_scores()
+
+    def _load_fragment_scores(self):
+        """Loads scores from path or downloads them if missing."""
+        if self.fscore_path is None:
+            # Use DeepChem's default data directory
+            data_dir = get_data_dir()
+            self.fscore_path = os.path.join(data_dir, "fpscores.pkl.gz")
+            
+        if not os.path.exists(self.fscore_path):
+            logger.info("Downloading SAScore fragment scores...")
+            download_url(SAS_URL, dest_dir=get_data_dir())
+
+        # Logic from readFragmentScores adapted for the class
+        with gzip.open(self.fscore_path, 'rb') as f:
+            data = pickle.load(f)
+        
+        out_dict = {}
+        for i in data:
+            for j in range(1, len(i)):
+                out_dict[i[j]] = float(i[0])
+        self._fscores = out_dict
+
+    def calculate_score(self, mol: Chem.Mol) -> float:
+        """The math logic from RDKit goes here..."""
+        if not mol or mol.GetNumAtoms() == 0:
+            return 0.0
+        if not mol.GetNumAtoms():
+           return None
+
+        if self._fscores is None:
+            self._load_fragment_scores()    
+        # fragment score
+        sfp = self.mfpgen.GetSparseCountFingerprint(mol)
+
+        score1 = 0.
+        nf = 0
+        nze = sfp.GetNonzeroElements()
+        for id, count in nze.items():
+            nf += count
+            score1 += self._fscores.get(id, -4) * count
+
+        score1 /= nf
+
+        # features score
+        nAtoms = mol.GetNumAtoms()
+        nChiralCenters = len(Chem.FindMolChiralCenters(mol, includeUnassigned=True))
+        ri = mol.GetRingInfo()
+        nBridgeheads, nSpiro = SAScorer.numBridgeheadsAndSpiro(mol, ri)
+        nMacrocycles = 0
+        for x in ri.AtomRings():
+            if len(x) > 8:
+                nMacrocycles += 1
+        sizePenalty = nAtoms**1.005 - nAtoms
+        stereoPenalty = math.log10(nChiralCenters + 1)
+        spiroPenalty = math.log10(nSpiro + 1)
+        bridgePenalty = math.log10(nBridgeheads + 1)
+        macrocyclePenalty = 0.
+        # ---------------------------------------
+        # This differs from the paper, which defines:
+        #  macrocyclePenalty = math.log10(nMacrocycles+1)
+        # This form generates better results when 2 or more macrocycles are present
+        if nMacrocycles > 0:
+            macrocyclePenalty = math.log10(2)
+
+        score2 = 0. - sizePenalty - stereoPenalty - spiroPenalty - bridgePenalty - macrocyclePenalty
+
+        # correction for the fingerprint density
+        # not in the original publication, added in version 1.1
+        # to make highly symmetrical molecules easier to synthetise
+        score3 = 0.
+        numBits = len(nze)
+        if nAtoms > numBits:
+            score3 = math.log(float(nAtoms) / numBits) * .5
+
+        sascore = score1 + score2 + score3
+
+        # need to transform "raw" value into scale between 1 and 10
+        min = -4.0
+        max = 2.5
+        sascore = 11. - (sascore - min + 1) / (max - min) * 9.
+
+        # smooth the 10-end
+        if sascore > 8.:
+            sascore = 8. + math.log(sascore + 1. - 9.)
+        if sascore > 10.:
+            sascore = 10.0
+        elif sascore < 1.:
+            sascore = 1.0
+
+        return sascore
+
+
+def processMols(mols):
+  print('smiles\tName\tsa_score')
+  for i, m in enumerate(mols):
+    if m is None:
+      continue
+
+    s = SAScorer.calculate_score(m)
+
+    smiles = Chem.MolToSmiles(m)
+    if s is None:
+      print(f"{smiles}\t{m.GetProp('_Name')}\t{s}")
+    else:
+      print(f"{smiles}\t{m.GetProp('_Name')}\t{s:3f}")
+
+
+#AS MENTIONED IN THE SAScore's repo:
+#  Copyright (c) 2013, Novartis Institutes for BioMedical Research Inc.
+#  All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#     * Neither the name of Novartis Institutes for BioMedical Research Inc.
+#       nor the names of its contributors may be used to endorse or promote
+#       products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#


### PR DESCRIPTION
## issue #4660 
## Description
This PR adds the Synthetic Accessibility Score (SAScore) algorithm and a corresponding SAScoreFeaturizer to DeepChem.

-- A summary of the changes --
Implemented the 'SAScorer' class in the deepchem/utils. This is a rule-based algorithm based on Ertl and Schuffenhauer (2009) that calculates molecular complexity, and has been complimenting scscorer in the field of computational chemical sciences.


- [x] New feature (non-breaking change which adds functionality)

## Checklist



- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)

  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)

  - [ ] Run `mypy -p deepchem` and check no errors

  - [x] Run `flake8 <modified file> --count` and check no errors

  - [ ] Run `python -m doctest <modified file>` and check no errors

- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation

- [ ] I have added tests that prove my fix is effective or that my feature works

- [ ] New unit tests pass locally with my changes

- [ ] I have checked my code and corrected any misspellings

- References:
> Ertl, P.; Schuffenhauer, A. Estimation of synthetic accessibility score of drug-like molecules based on molecular complexity and fragment contributions. J. Cheminf. 2009, 1 (1), No. 8. [DOI: 10.1186/1758-2946-1-8](https://doi.org/10.1186/1758-2946-1-8).
> https://github.com/rdkit/rdkit/blob/master/Contrib/SA_Score/sascorer.py 

Note:
I am open to discussions as to how to test this file script further to include tutorial script!
