### PR TITLE
feat(dmpnn): add cache_mapper to DMPNNFeaturizer for faster training (~1.6x speedup)

### DIFF
--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -1,4 +1,7 @@
-from typing import Optional, Sequence
+from typing import Optional, Sequence, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from deepchem.models.torch_models.dmpnn import DMPNNFeatures
 
 import numpy as np
 
@@ -105,6 +108,9 @@ class GraphData:
 
         for key, value in self.kwargs.items():
             setattr(self, key, value)
+
+        # Cache for DMPNN featurizer optimizaiton
+        self._cache_dmpnn: Optional['DMPNNFeatures'] = None
 
     def __repr__(self) -> str:
         """Returns a string containing the printable representation of the object"""

--- a/deepchem/feat/graph_data.py
+++ b/deepchem/feat/graph_data.py
@@ -257,9 +257,14 @@ class GraphData:
         graph_copy.kwargs = {}
         for key, value in self.kwargs.items():
             if isinstance(value, np.ndarray):
-                value = torch.from_numpy(value).to(device)
-                graph_copy.kwargs[key] = value
-                setattr(graph_copy, key, value)
+                # Normalize to numeric numpy array (handles lists and object arrays)
+                arr = np.asanyarray(value)
+                if arr.dtype == object:
+                    pass
+                else:
+                    value = torch.from_numpy(arr).to(device)
+            graph_copy.kwargs[key] = value
+            setattr(graph_copy, key, value)
 
         return graph_copy
 

--- a/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
@@ -404,15 +404,15 @@ class DMPNNFeaturizer(MolecularFeaturizer):
     .. [1] Kearnes, Steven, et al. "Molecular graph convolutions: moving beyond fingerprints."
         Journal of computer-aided molecular design 30.8 (2016):595-608.
 
+    Note
+    ----
+        This class requires RDKit to be installed.
+
         When cache_mapper=True (default), this featurizer caches the internal
         _MapperDMPNN transformation on the returned GraphData object (_cached_dmpnn
         attribute) to avoid repeated computation during model training. This optimization
-        provides 2-3x training speedup and is transparent to users while maintaining full
+        provides ~1.6-2x training speedup and is transparent to users while maintaining full
         backward compatibility. Set cache_mapper=False for memory-constrained scenarios.
-
-        Note
-    ----
-    This class requires RDKit to be installed.
 
     """
 

--- a/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
@@ -550,9 +550,9 @@ class DMPNNFeaturizer(MolecularFeaturizer):
                                                        self.features_generators)
         # Creates GraphData representation (preserves the existing API)
         graph_data = GraphData(node_features=f_atoms,
-                         edge_index=edge_index,
-                         edge_features=f_bonds,
-                         global_features=global_features)
+                               edge_index=edge_index,
+                               edge_features=f_bonds,
+                               global_features=global_features)
         # Conditionally cache mapper transformation for performance
         if self.cache_mapper:
             # Lazy import to avoid unnecessary torch dependencies during featurization

--- a/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
+++ b/deepchem/feat/molecule_featurizers/dmpnn_featurizer.py
@@ -562,6 +562,7 @@ class DMPNNFeaturizer(MolecularFeaturizer):
 
             # _cached_dmpnn is pickle-safe (uses __slots__)
             # and avoids repeated mapper construction during training.
-            graph_data._cached_dmpnn = DMPNNFeatures.from_mapper(mapper)
+            graph_data._cached_dmpnn = DMPNNFeatures.from_mapper(mapper) # type: ignore[attr-defined]
+            # NumPy arrays are used internally; runtime type is safe but mypy cannot infer this.
 
         return graph_data

--- a/deepchem/models/torch_models/dmpnn.py
+++ b/deepchem/models/torch_models/dmpnn.py
@@ -448,6 +448,7 @@ class DMPNN(nn.Module):
 
         return final_output
 
+
 class DMPNNFeatures:
     """Cached container for pre-processed DMPNN features.
 
@@ -470,7 +471,7 @@ class DMPNNFeatures:
         Global molecular features
     """
 
-    __slots__= (
+    __slots__ = (
         'atom_features',
         'f_ini_atoms_bonds',
         'atom_to_incoming_bonds',
@@ -478,21 +479,18 @@ class DMPNNFeatures:
         'global_features',
     )
 
-    def __init__(
-        self,
-        atom_features: np.ndarray,
-        f_ini_atoms_bonds: np.ndarray,
-        atom_to_incoming_bonds: List,
-        mapping: np.ndarray,
-        global_features: Optional[np.ndarray] = None
-    ):
+    def __init__(self,
+                 atom_features: np.ndarray,
+                 f_ini_atoms_bonds: np.ndarray,
+                 atom_to_incoming_bonds: np.ndarray,
+                 mapping: np.ndarray,
+                 global_features: Optional[np.ndarray] = None):
         """Initialize DMPNNFeatures with pre-computed arrays."""
         self.atom_features = atom_features
         self.f_ini_atoms_bonds = f_ini_atoms_bonds
         self.atom_to_incoming_bonds = atom_to_incoming_bonds
         self.mapping = mapping
         self.global_features = global_features
-
 
     @classmethod
     def from_mapper(cls, mapper: '_MapperDMPNN') -> 'DMPNNFeatures':
@@ -508,13 +506,11 @@ class DMPNNFeatures:
         DMPNNFeatures
             Cached features object
         """
-        return cls(
-            atom_features = mapper.atom_features,
-            f_ini_atoms_bonds = mapper.f_ini_atoms_bonds,
-            atom_to_incoming_bonds = mapper.atom_to_incoming_bonds,
-            mapping = mapper.mapping,
-            global_features = mapper.global_features
-        )
+        return cls(atom_features=mapper.atom_features,
+                   f_ini_atoms_bonds=mapper.f_ini_atoms_bonds,
+                   atom_to_incoming_bonds=mapper.atom_to_incoming_bonds,
+                   mapping=mapper.mapping,
+                   global_features=mapper.global_features)
 
     def to_tuple(self):
         """Convert to tuple format expected by model.
@@ -525,14 +521,13 @@ class DMPNNFeatures:
             (atom_features, f_ini_atoms_bonds, atom_to_incoming_bonds,
                 mapping, global_features)
         """
-        return(
+        return (
             self.atom_features,
             self.f_ini_atoms_bonds,
             self.atom_to_incoming_bonds,
             self.mapping,
             self.global_features,
         )
-
 
 
 class DMPNNModel(TorchModel):
@@ -816,8 +811,9 @@ class DMPNNModel(TorchModel):
                 max_num_bonds: int = 1
 
                 for graph in X_b:
-                    # Checked for called mapper output (OPTIMIZED PATH)
-                    if hasattr(graph, '_cached_dmpnn') and graph._cached_dmpnn is not None:
+                    # Checked for cached mapper output (OPTIMIZED PATH)
+                    if hasattr(graph, '_cached_dmpnn'
+                              ) and graph._cached_dmpnn is not None:
                         # Use pre-computed features directly
                         # Avoids repeated _MapperDMPNN construction
                         graph_tuple = graph._cached_dmpnn.to_tuple()

--- a/deepchem/models/torch_models/dmpnn.py
+++ b/deepchem/models/torch_models/dmpnn.py
@@ -482,7 +482,7 @@ class DMPNNFeatures:
     def __init__(self,
                  atom_features: np.ndarray,
                  f_ini_atoms_bonds: np.ndarray,
-                 atom_to_incoming_bonds: np.ndarray,
+                 atom_to_incoming_bonds: Union[List[List[int]], np.ndarray],
                  mapping: np.ndarray,
                  global_features: Optional[np.ndarray] = None):
         """Initialize DMPNNFeatures with pre-computed arrays."""

--- a/deepchem/models/torch_models/dmpnn.py
+++ b/deepchem/models/torch_models/dmpnn.py
@@ -811,7 +811,7 @@ class DMPNNModel(TorchModel):
                 max_num_bonds: int = 1
 
                 for graph in X_b:
-                    # Checked for cached mapper output (OPTIMIZED PATH)
+                    # Checked for cached mapper output (OPTIMIZED PATH).
                     if hasattr(graph, '_cached_dmpnn'
                               ) and graph._cached_dmpnn is not None:
                         # Use pre-computed features directly
@@ -830,7 +830,7 @@ class DMPNNModel(TorchModel):
                         pyg_graph['atom_to_incoming_bonds'].shape[1])
                     pyg_graphs_list.append(pyg_graph)
 
-                # pad all mappings to maximum number of incoming bonds in the batch
+                # Pad all mappings to maximum number of incoming bonds in the batch
                 for graph in pyg_graphs_list:
                     required_padding: int = max_num_bonds - graph[
                         'atom_to_incoming_bonds'].shape[1]

--- a/deepchem/models/torch_models/dmpnn.py
+++ b/deepchem/models/torch_models/dmpnn.py
@@ -448,6 +448,92 @@ class DMPNN(nn.Module):
 
         return final_output
 
+class DMPNNFeatures:
+    """Cached container for pre-processed DMPNN features.
+
+    This class stores the output of _MapperDMPNN transformation
+    to avoid recomputing it for each batch during training.
+
+    Uses __slots__ for efficient pickling with DiskDataset.
+
+    Attributes
+    ----------
+    atom_features : np.ndarray
+        Atom features array
+    f_ini_atoms_bonds : np.ndarray
+        Initial atom-bond features
+    atom_to_incoming_bonds : List
+        Mapping from atoms to incoming bonds
+    mapping : np.ndarray
+        Index mapping array
+    global_features : Optional[np.ndarray]
+        Global molecular features
+    """
+
+    __slots__= (
+        'atom_features',
+        'f_ini_atoms_bonds',
+        'atom_to_incoming_bonds',
+        'mapping',
+        'global_features',
+    )
+
+    def __init__(
+        self,
+        atom_features: np.ndarray,
+        f_ini_atoms_bonds: np.ndarray,
+        atom_to_incoming_bonds: List,
+        mapping: np.ndarray,
+        global_features: Optional[np.ndarray] = None
+    ):
+        """Initialize DMPNNFeatures with pre-computed arrays."""
+        self.atom_features = atom_features
+        self.f_ini_atoms_bonds = f_ini_atoms_bonds
+        self.atom_to_incoming_bonds = atom_to_incoming_bonds
+        self.mapping = mapping
+        self.global_features = global_features
+
+
+    @classmethod
+    def from_mapper(cls, mapper: '_MapperDMPNN') -> 'DMPNNFeatures':
+        """Create DMPNNFeatures from a _MapperDMPNN instance.
+
+        Parameters
+        ----------
+        mapper : _MapperDMPNN
+            Mapper instance containing transformed features
+
+        Returns
+        -------
+        DMPNNFeatures
+            Cached features object
+        """
+        return cls(
+            atom_features = mapper.atom_features,
+            f_ini_atoms_bonds = mapper.f_ini_atoms_bonds,
+            atom_to_incoming_bonds = mapper.atom_to_incoming_bonds,
+            mapping = mapper.mapping,
+            global_features = mapper.global_features
+        )
+
+    def to_tuple(self):
+        """Convert to tuple format expected by model.
+
+        Returns
+        -------
+        tuple
+            (atom_features, f_ini_atoms_bonds, atom_to_incoming_bonds,
+                mapping, global_features)
+        """
+        return(
+            self.atom_features,
+            self.f_ini_atoms_bonds,
+            self.atom_to_incoming_bonds,
+            self.mapping,
+            self.global_features,
+        )
+
+
 
 class DMPNNModel(TorchModel):
     """Directed Message Passing Neural Network
@@ -730,9 +816,19 @@ class DMPNNModel(TorchModel):
                 max_num_bonds: int = 1
 
                 for graph in X_b:
-                    # generate concatenated feature vector and mappings
-                    mapper: _MapperDMPNN = _MapperDMPNN(graph)
-                    pyg_graph: _ModData = self._to_pyg_graph(mapper.values)
+                    # Checked for called mapper output (OPTIMIZED PATH)
+                    if hasattr(graph, '_cached_dmpnn') and graph._cached_dmpnn is not None:
+                        # Use pre-computed features directly
+                        # Avoids repeated _MapperDMPNN construction
+                        graph_tuple = graph._cached_dmpnn.to_tuple()
+                    else:
+                        # This path handles:
+                        # - Old datasets without cache
+                        # - Featurizer with cache_mapper=False
+                        # - Manually created GraphData objects
+                        mapper = _MapperDMPNN(graph)
+                        graph_tuple = mapper.values
+                    pyg_graph = self._to_pyg_graph(graph_tuple)
                     max_num_bonds = max(
                         max_num_bonds,
                         pyg_graph['atom_to_incoming_bonds'].shape[1])

--- a/deepchem/models/torch_models/dmpnn.py
+++ b/deepchem/models/torch_models/dmpnn.py
@@ -488,7 +488,11 @@ class DMPNNFeatures:
         """Initialize DMPNNFeatures with pre-computed arrays."""
         self.atom_features = atom_features
         self.f_ini_atoms_bonds = f_ini_atoms_bonds
-        self.atom_to_incoming_bonds = atom_to_incoming_bonds
+        # Normalize to numeric numpy array (handles lists and object arrays)
+        arr = np.asanyarray(atom_to_incoming_bonds)
+        if arr.dtype == object:
+            arr = np.asarray(atom_to_incoming_bonds, dtype=np.int64)
+        self.atom_to_incoming_bonds = arr
         self.mapping = mapping
         self.global_features = global_features
 

--- a/deepchem/models/torch_models/tests/test_dmpnn_cache.py
+++ b/deepchem/models/torch_models/tests/test_dmpnn_cache.py
@@ -1,0 +1,35 @@
+def test_numerical_parity_minimal():
+    """
+    Test that cached values are same as recomputed values
+    """
+    from deepchem.feat import DMPNNFeaturizer
+    from deepchem.models.torch_models.dmpnn import _MapperDMPNN
+    import numpy as np
+    smiles = "CCO" # Ethanol
+    featurizer = DMPNNFeaturizer(cache_mapper=True)
+    graph = featurizer.featurize([smiles])[0]
+    cached_values = graph._cached_dmpnn.to_tuple()
+    mapper = _MapperDMPNN(graph)
+    recomputed_values = mapper.values
+    for cached, recomputed in zip(cached_values, recomputed_values):
+        if cached is None:
+            assert recomputed is None
+            continue
+        cached_nparray = cached.detach().cpu().numpy() if hasattr(cached,'detach') else cached
+        recomputed_nparray = recomputed.detach().cpu().numpy() if hasattr(recomputed, 'detach') else recomputed
+        np.testing.assert_array_almost_equal(cached_nparray, recomputed_nparray,decimal=6)
+
+def test_serilization():
+    """
+    Test that the cahced data passes pickling (DiskDataset Compatibility)
+    """
+    import pickle
+    from deepchem.feat import DMPNNFeaturizer
+    featurizer = DMPNNFeaturizer(cache_mapper=True)
+    graph = featurizer.featurize(['CCO'])[0]
+    assert graph._cached_dmpnn is not None
+    pickle_data = pickle.dumps(graph)
+    restored_graph = pickle.loads(pickle_data)
+    assert hasattr(restored_graph, '_cached_dmpnn')
+    assert restored_graph._cached_dmpnn is not None
+    assert restored_graph._cached_dmpnn.mapping.shape == graph._cached_dmpnn.mapping.shape


### PR DESCRIPTION
## Description

Fixes #4015

This PR optimizes `DMPNNModel` training and inference by caching the
`_MapperDMPNN` transformation at the featurization stage instead of recomputing
it for every molecule in every batch.

Previously, `_MapperDMPNN` was constructed repeatedly inside
`DMPNNModel.default_generator`, causing significant overhead and low GPU
utilization. This change introduces an optional caching mechanism that computes
the mapper once per molecule and reuses it across epochs and batches.

Key changes:
- Add `cache_mapper` option to `DMPNNFeaturizer` (default: `True`)
- Introduce a lightweight `DMPNNFeatures` container for cached mapper outputs
- Update `DMPNNModel` to reuse cached features when available
- Preserve backward compatibility for existing datasets

Local benchmarking shows a ~1.5-1.7 speedup in training time.

---

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend discussing the modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

---

## Checklist

- [x] My code follows the style guidelines of this project  
  https://deepchem.readthedocs.io/en/latest/development_guide/coding.html
  - [x] Run `yapf -i <modified file>` (**yapf version 0.32.0**)
  - [ ] Run `mypy -p deepchem`
  - [x] Run `flake8 <modified file> --count`
  - [ ] Run `python -m doctest <modified file>`
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

---

## Benchmark (Local)

![Benchmark Results](https://github.com/user-attachments/assets/1a51d58f-d958-4062-a1de-57aef1e4ddf6)
