### PR TITLE
Improve test coverage for max_pair_distance_pairs input validation

### DIFF
--- a/deepchem/feat/tests/test_weave.py
+++ b/deepchem/feat/tests/test_weave.py
@@ -2,10 +2,33 @@
 Tests for weave featurizer.
 """
 import numpy as np
+import pytest
 import deepchem as dc
 from deepchem.feat.graph_features import max_pair_distance_pairs
+from rdkit import Chem
 
+def test_max_pair_distance_greater_than_N():
+    mol = Chem.MolFromSmiles('CCC')  # 3 atoms
+    # Test max_pair_distance >= N
+    # For CCC (3 atoms), max distance is 2.
+    # If we pass 3 or 100, it should be equivalent to None (all pairs).
+    # All pairs for 3 atoms = 3*3 = 9 pairs.
+    pair_edges_large = max_pair_distance_pairs(mol, 100)
+    assert pair_edges_large.shape == (2, 9)
 
+    pair_edges_exact_N = max_pair_distance_pairs(mol, 3)
+    assert pair_edges_exact_N.shape == (2, 9)
+
+def test_max_pair_distance_zero_raises():
+    mol = Chem.MolFromSmiles("CC")
+    with pytest.raises(ValueError, match="positive integer or None"):
+        max_pair_distance_pairs(mol, 0)
+
+def test_max_pair_distance_negative_raises():
+    mol = Chem.MolFromSmiles("CC")
+    with pytest.raises(ValueError, match="positive integer or None"):
+        max_pair_distance_pairs(mol, -1)
+        
 def test_max_pair_distance_pairs():
     """Test that max pair distance pairs are computed properly."""
     from rdkit import Chem


### PR DESCRIPTION
## Description

Adds test coverage for previously untested edge cases in
`max_pair_distance_pairs`.

The implementation already defines behavior for:
- `max_pair_distance >= num_atoms` behaving like `None`
- `max_pair_distance <= 0` raising `ValueError`

These behaviors were not previously covered by tests. This PR adds
explicit assertions to validate and document the intended behavior.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New unit tests pass locally with my changes

