### PR TITLE
Remove PubChemPy dependency (#3078)

### DIFF
--- a/docs/source/get_started/requirements.rst
+++ b/docs/source/get_started/requirements.rst
@@ -83,10 +83,6 @@ DeepChem has a number of "soft" requirements.
 |                                |               | :code:`dc.trans.transformers`                     |
 |                                |               |                                                   |
 +--------------------------------+---------------+---------------------------------------------------+
-| `PubChemPy`_                   | latest        | :code:`dc.feat.molecule_featurizers`              |
-|                                |               |                                                   |
-|                                |               |                                                   |
-+--------------------------------+---------------+---------------------------------------------------+
 | `pyGPGO`_                      | latest        | :code:`dc.hyper.gaussian_process`                 |
 |                                |               |                                                   |
 |                                |               |                                                   |
@@ -172,7 +168,6 @@ DeepChem has a number of "soft" requirements.
 .. _`OpenMM`: http://openmm.org/
 .. _`PDBFixer`: https://github.com/pandegroup/pdbfixer
 .. _`Pillow`: https://pypi.org/project/Pillow/
-.. _`PubChemPy`: https://pubchempy.readthedocs.io/en/latest/
 .. _`pyGPGO`: https://pygpgo.readthedocs.io/en/latest/
 .. _`Pymatgen`: https://pymatgen.org/
 .. _`PyTorch`: https://pytorch.org/

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -19,7 +19,6 @@ dependencies:
     - mordred
     - networkx
     - pillow
-    - pubchempy
     - pyGPGO
     - pymatgen
     - simdna

--- a/requirements/env_common_3_8.yml
+++ b/requirements/env_common_3_8.yml
@@ -18,7 +18,6 @@ dependencies:
     - mordred
     - networkx
     - pillow
-    - pubchempy
     - pyGPGO
     - pymatgen
     - simdna


### PR DESCRIPTION
  ## Description

  Fix #3078

  Removes `PubChemPy` as a dependency by replacing it with direct PubChem REST API calls using Python standard library only (`urllib`, `base64`, `json`). This is part of the "Trimming Unnecessary Optional Dependencies" initiative.

  ### Changes
  - `deepchem/feat/molecule_featurizers/pubchem_fingerprint.py` - Replaced PubChemPy with direct REST API
  - `requirements/env_common.yml` - Removed pubchempy
  - `requirements/env_common_3_8.yml` - Removed pubchempy
  - `docs/source/get_started/requirements.rst` - Removed from soft dependencies

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [x] Documentations (modification for documents)

  ## Checklist

  - [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
    - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
    - [x] Run `mypy -p deepchem` and check no errors
    - [x] Run `flake8 <modified file> --count` and check no errors
    - [x] Run `python -m doctest <modified file>` and check no errors
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] New unit tests pass locally with my changes
  - [x] I have checked my code and corrected any misspellings
