### PR TITLE
Fix typo in Introduction_to_Equivariance tutorial

### DIFF
--- a/examples/tutorials/Introduction_to_Equivariance.ipynb
+++ b/examples/tutorials/Introduction_to_Equivariance.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "e4cc07ed",
+   "id": "0",
    "metadata": {
     "tags": []
    },
@@ -35,7 +35,7 @@
     }
    },
    "cell_type": "markdown",
-   "id": "5ab7f770",
+   "id": "1",
    "metadata": {},
    "source": [
     "## What is Equivariance <a class=\"anchor\" id=\"equivariance\"></a>\n",
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2840f0e2-a382-42c7-9666-f9c12331700a",
+   "id": "2",
    "metadata": {},
    "source": [
     "## Why Do We Need Equivariance <a class=\"anchor\" id=\"whyeq\"></a>\n",
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7eea2761-2091-4106-a72e-59d5f2804476",
+   "id": "3",
    "metadata": {},
    "source": [
     "\n",
@@ -107,8 +107,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
-   "id": "42ae0033-c324-43bd-9ba9-68e6e9069c28",
+   "execution_count": null,
+   "id": "4",
    "metadata": {
     "tags": []
    },
@@ -126,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "baa3d8db-ae89-4fa2-af22-36b8e3a8375c",
+   "id": "5",
    "metadata": {
     "tags": []
    },
@@ -138,8 +138,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "e82efaa7-e346-41b6-a96a-2984201db714",
+   "execution_count": null,
+   "id": "6",
    "metadata": {
     "tags": []
    },
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "173d1fd8-4506-49f1-ac01-bcff95c524b6",
+   "id": "7",
    "metadata": {},
    "source": [
     "Although our model is not trained, we are not concerned about. Since, we only want see if our model is affected by permutations, translations and rotations"
@@ -196,23 +196,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "id": "4079ef6a-b1cf-47ef-90b6-804f9464e91c",
+   "execution_count": null,
+   "id": "8",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "without change: 9.945112980229641\n",
-      "after permutation: 9.461406567572851\n",
-      "after translation: 5.963826685170721\n",
-      "after rotation: 7.191211524244547\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import scipy.spatial.transform as transform\n",
     "\n",
@@ -229,7 +218,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e68d437b-0ec5-4575-a77d-1b58cd66f9cd",
+   "id": "9",
    "metadata": {},
    "source": [
     "As expected, our model is not invariant to any permutations, translations, or rotations. Let's fix them.\n",
@@ -242,8 +231,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
-   "id": "e5460352-2479-4530-a826-4a3302db4eaf",
+   "execution_count": null,
+   "id": "10",
    "metadata": {
     "tags": []
    },
@@ -292,7 +281,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e3713a7-9fe3-49a8-b62e-c8461640dae8",
+   "id": "11",
    "metadata": {},
    "source": [
     "In the original implementation, the model computes intermediate activations v for each input position separately and then concatenates them along the axis 0. By summing across axis 0  with (np.sum(v, axis=0)), the model effectively collapses all the intermediate activations into a single vector, regardless of the order of the input positions.\n",
@@ -304,23 +293,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
-   "id": "30da435a-da11-47c9-956b-1cf6607388ee",
+   "execution_count": null,
+   "id": "12",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "without change: -19.370847873678944\n",
-      "after permutation: -19.370847873678944\n",
-      "after translation: -67.71502903638384\n",
-      "after rotation: 5.311140035302996\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"without change:\", hidden_model_perm(R_i, X_i, w1, w2, b1, b2))\n",
     "print(\"after permutation:\", hidden_model_perm(permuted_R_i, X_i, w1, w2, b1, b2))\n",
@@ -330,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85af7fa4-22bb-4414-b4c0-267922799aac",
+   "id": "13",
    "metadata": {},
    "source": [
     "Indeed! As anticipated, our model demonstrates invariance to permutations while remaining sensitive to translations or rotations.\n",
@@ -342,8 +320,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
-   "id": "3cb34fd9-4221-4dde-839d-9f4a7e68be5d",
+   "execution_count": null,
+   "id": "14",
    "metadata": {
     "tags": []
    },
@@ -392,7 +370,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62b80eee-a5b7-4fdd-a666-f97a4a6459af",
+   "id": "15",
    "metadata": {},
    "source": [
     "To achieve translational invariance, the function calculates pairwise distances between the position values in the r array. This is done by subtracting r from r[:, np.newaxis], which broadcasts r along a new axis, enabling element-wise subtraction.\n",
@@ -404,23 +382,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
-   "id": "6ab288bb-8a33-495a-a962-c0e93a64269d",
+   "execution_count": null,
+   "id": "16",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "without change: 193.79734623037373\n",
-      "after permutation: 193.79734623037385\n",
-      "after translation: 193.79734623037368\n",
-      "after rotation: 188.36773620787383\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"without change:\", hidden_model_permute_translate(R_i, X_i, w1, w2, b1, b2))\n",
     "print(\"after permutation:\", hidden_model_permute_translate(permuted_R_i, X_i, w1, w2, b1, b2))\n",
@@ -430,7 +397,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4e549ad4-ab89-46e6-bace-5bb372454892",
+   "id": "17",
    "metadata": {},
    "source": [
     "Yes! Our model is invariant to both permutations and translations but not to rotations.\n",
@@ -443,8 +410,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
-   "id": "18216f40-b88d-4459-9b1b-a32cdf890afb",
+   "execution_count": null,
+   "id": "18",
    "metadata": {
     "tags": []
    },
@@ -504,7 +471,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a17f9a5-f76d-4f78-b71a-7d30db8f19e8",
+   "id": "19",
    "metadata": {},
    "source": [
     "The hidden_model_permute_trans_rotate function achieves rotational invariance through the utilization of pairwise squared distances between atoms, instead of the pairwise vectors themselves. By using squared distances, the function is able to incorporate directional information while still maintaining simplicity in the calculation.\n",
@@ -518,33 +485,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
-   "id": "2100fdb4-c204-45e1-b25c-152fc540d9b9",
+   "execution_count": null,
+   "id": "20",
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "without change: 585.1386319324105\n",
-      "after permutation: 585.1386319324106\n",
-      "after translation: 585.1386319324105\n",
-      "after rotation: 585.1386319324105\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "print(\"without change:\", hidden_model_permute_trans_rotate(R_i, X_i, w1, w2, b1, b2))\n",
-    "print(\"after permutation:\", hidden_model_permute_trans_rotate(permuted_R_i, X_i, w1, w2, b1, b2))\n",
-    "print(\"after translation:\", hidden_model_permute_trans_rotate(R_i + np.array([3, 3, 3]), X_i, w1, w2, b1, b2))\n",
-    "print(\"after rotation:\", hidden_model_permute_trans_rotate(rotate.apply(R_i), X_i, w1, w2, b1, b2))"
+    "print(\"without change:\", hidden_model_permute_translate_rotate(R_i, X_i, w1, w2, b1, b2))\n",
+    "print(\"after permutation:\", hidden_model_permute_translate_rotate(permuted_R_i, X_i, w1, w2, b1, b2))\n",
+    "print(\"after translation:\", hidden_model_permute_translate_rotate(R_i + np.array([3, 3, 3]), X_i, w1, w2, b1, b2))\n",
+    "print(\"after rotation:\", hidden_model_permute_translate_rotate(rotate.apply(R_i), X_i, w1, w2, b1, b2))"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "02baf45a-0c07-4e8e-9bfd-5c27c2c00daf",
+   "id": "21",
    "metadata": {},
    "source": [
     "Yes! Now our model is invariant to both permutations, translations, and rotations.\n",
@@ -554,7 +510,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "440eaddf-9a3b-4d64-8859-7179e6e9f9f1",
+   "id": "22",
    "metadata": {},
    "source": [
     "# References <a class=\"anchor\" id=\"ref\"></a>\n",
@@ -567,7 +523,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c83d1c38-413a-4322-b7b3-11b9d337b31c",
+   "id": "23",
    "metadata": {},
    "source": [
     "# Congratulations! Time to join the Community!\n",


### PR DESCRIPTION
## Description

Fixes #4543

Fixes a typo in the Introduction_to_Equivariance tutorial.

## Type of change

- [x] Documentations (modification for documents)

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings

