### PR TITLE
Expose HuggingFace hidden states for embedding extraction

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -217,7 +217,7 @@ class HuggingFaceModel(TorchModel):
         2. A pretrain model has different number of target tasks for pretraining and a finetune
             model has different number of target tasks for finetuning. Thus, they both have different
             number of projection outputs in the last layer. To avoid a mismatch
-            in the weights of the output projection layer (last layer) between
+            in the weights of the output projection layer () between
             the pretrain model and current model, we delete the projection
             layers weights.
         """


### PR DESCRIPTION
### Summary
This PR addresses part of issue #2301 by enabling access to high-level
representations (last hidden layer embeddings) from HuggingFace models
wrapped by DeepChem.

### What this PR does
- Preserves HuggingFace model outputs instead of discarding them
- Ensures `output_hidden_states=True` is set by default in the wrapper
- Adds support for retrieving last hidden layer embeddings via
  `other_output_types=["embeddings"]`
- Keeps default behavior unchanged (logits returned unless embeddings are requested)

### Why this is needed
HuggingFace models already provide hidden states, but the current
`HuggingFaceModel` wrapper only exposes logits. Many downstream workflows
(e.g., clustering, similarity search, transfer learning) require access
to embeddings rather than task-specific outputs.

### Backward compatibility
This change is fully backward compatible. Existing workflows are
unaffected unless embeddings are explicitly requested.

Ref: #2301
