### PR TITLE
Add SE(3)-Transformer and TFN models to dgl try-except block in` __init__.py`

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -52,8 +52,6 @@ from deepchem.models.torch_models.hnn import HNN, HNNModel
 from deepchem.models.torch_models.ChemCeption import ChemCeption
 from deepchem.models.torch_models.fno import FNO, FNOModel
 from deepchem.models.torch_models.lnn import LNN, LNNModel
-from deepchem.models.torch_models.se3_transformer import SE3Transformer, SE3TransformerModel
-from deepchem.models.torch_models.tfn import TFN, TFNModel
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel
@@ -62,6 +60,8 @@ try:
     from deepchem.models.torch_models.gnn3d import Net3D, InfoMax3DModular
     from deepchem.models.torch_models.weavemodel_pytorch import Weave, WeaveModel
     from deepchem.models.torch_models.mxmnet import MXMNet
+    from deepchem.models.torch_models.se3_transformer import SE3Transformer, SE3TransformerModel
+    from deepchem.models.torch_models.tfn import TFN, TFNModel
 except ModuleNotFoundError as e:
     logger.warning(
         f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}'


### PR DESCRIPTION
## Description

Currently, when importing torch models, `SE(3)-Transformer and TFNs` failed due to dgl import issues. In this PR, I added these 2 models to try-except block when import torch models.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
