### PR TITLE
Docs] Clarify that seed is unused in ScaffoldSplitter (Fixes #4517)

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1513,6 +1513,9 @@ class ScaffoldSplitter(Splitter):
     - This class requires RDKit to be installed.
     - When a SMILES representation of a molecule is invalid, the splitter skips processing
     the datapoint i.e it will not include the molecule in any splits.
+    - The `seed` parameter in the splitting methods is included for API consistency
+    with other splitters but is **ignored** by this splitter. Scaffold splitting is
+    deterministic and depends only on the molecular structures in the dataset.
 
     """
 


### PR DESCRIPTION
## Description
This PR updates the docstring for `ScaffoldSplitter` to explicitly state that the `seed` parameter is ignored.

## Context
As discussed in issue #4517, `ScaffoldSplitter` is deterministic based on molecular structure, but the API includes a `seed` parameter for consistency with other splitters. This has caused confusion for users expecting the split to change when the seed changes.

## Verification
- Ran reproduction script locally: Confirmed splits are identical regardless of seed.
- Ran tests: `deepchem/splits/tests/test_scaffold_splitter.py` passed.

Closes #4517