### PR TITLE
Refactor(torch): Replace LazyLinear with Linear in CNNModule.

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -319,10 +319,14 @@ class CNNModule(nn.Module):
 
             in_shape = out_shape
 
-        self.classifier_ffn = nn.LazyLinear(self.n_tasks * self.n_classes)
-        self.output_layer = nn.LazyLinear(self.n_tasks)
-        self.uncertainty_layer = nn.LazyLinear(self.n_tasks)
+        # Input dim is equal to the number of filters in the last layer
+        # because Global Pooling reduces spatial dimensions to 1x1
+        input_dim = layer_filters[-1]
 
+        self.classifier_ffn = nn.Linear(input_dim, self.n_tasks * self.n_classes)
+        self.output_layer = nn.Linear(input_dim, self.n_tasks)
+        self.uncertainty_layer = nn.Linear(input_dim, self.n_tasks)
+        
     def forward(self, inputs: OneOrMany[torch.Tensor]) -> List[Any]:
         """
         Parameters


### PR DESCRIPTION
## Description
Fix #4692

This PR replaces the experimental `nn.LazyLinear` layers in `CNNModule` with standard `nn.Linear` layers to improve PyTorch stability.

**Changes:**
- Replaced `nn.LazyLinear` with `nn.Linear` for `classifier_ffn`, `output_layer`, and `uncertainty_layer`.
- Calculated `input_dim` explicitly using `layer_filters[-1]`. This is valid because `CNNModule` uses global pooling (Max/Avg), which reduces spatial dimensions to (1x1), leaving only the channel dimension (number of filters) as the input for the Linear layer.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes