### PR TITLE
Add option to disable DiskDataset caching via memory_cache_size

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2214,7 +2214,30 @@ class DiskDataset(Dataset):
         Batch
             A batch data for i-th shard.
         """
+ 
+        # If caching is disabled, always load directly from disk
+        if self._memory_cache_size <= 0:
+            row = self.metadata_df.iloc[i]
 
+            X = np.array(load_from_disk(os.path.join(self.data_dir, row['X'])))
+
+            if row['y'] is not None:
+                y = np.array(load_from_disk(os.path.join(self.data_dir, row['y'])))
+            else:
+                y = None
+
+            if row['w'] is not None:
+                w = np.array(load_from_disk(os.path.join(self.data_dir, row['w'])))
+            else:
+                w = None
+
+            ids = np.array(
+                load_from_disk(os.path.join(self.data_dir, row['ids'])),
+                dtype=object
+            )
+
+            return (X, y, w, ids)
+    
         # See if we have a cached copy of this shard.
         if self._cached_shards is None:
             self._cached_shards = [None] * self.get_number_shards()

--- a/deepchem/data/tests/test_diskdataset_cache.py
+++ b/deepchem/data/tests/test_diskdataset_cache.py
@@ -1,0 +1,18 @@
+import pytest
+
+pytest.importorskip("rdkit")
+
+import numpy as np
+from deepchem.data.datasets import DiskDataset
+
+
+def test_diskdataset_disable_cache():
+    """Test that setting memory_cache_size=0 disables DiskDataset caching."""
+
+    X = np.array([{"a": i} for i in range(3)], dtype=object)
+    dataset = DiskDataset.from_numpy(X)
+
+    dataset.memory_cache_size = 0
+    dataset.get_shard(0)
+
+    assert dataset._cached_shards is None


### PR DESCRIPTION
## Description

Fixes #4061

This PR adds support for disabling DiskDataset caching by allowing memory_cache_size to be set to 0.

Previously, DiskDataset caching relied on ndarray.nbytes, which can significantly underestimate actual memory usage for object-dtype arrays. This could lead to unbounded memory growth when working with such datasets.

With this change, users can explicitly disable caching when needed, providing a safe and simple workaround without changing existing default behavior.

A unit test is included to verify that caching is disabled when memory_cache_size = 0. The test is expected to run successfully in CI environments where RDKit is available.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
