### PR TITLE
Fix k_fold_split for RandomGroupSplitter (#3253)

### DIFF
--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -101,6 +101,25 @@ class TestSplitter(unittest.TestCase):
                 else:
                     assert class_ind[s] == split_idx
 
+    def test_random_group_k_fold_split(self):
+        """Test RandomGroupSplitter k_fold_split method (Issue #3253)."""
+        dataset = dc.data.NumpyDataset(np.arange(12))
+        groups = [0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3]
+        folds = dc.splits.RandomGroupSplitter(groups).k_fold_split(dataset,
+                                                                   3,
+                                                                   seed=42)
+        assert len(folds) == 3
+        all_cv_ids = []
+        for train, cv in folds:
+            assert set(train.ids).isdisjoint(set(cv.ids))
+            assert len(set(train.ids) | set(cv.ids)) == 12
+            for idx in cv.ids:
+                assert all(j in set(cv.ids)
+                           for j, g in enumerate(groups)
+                           if g == groups[idx])
+            all_cv_ids.extend(cv.ids)
+        assert sorted(all_cv_ids) == list(range(12))
+
     def test_singletask_random_split(self):
         """
         Test singletask RandomSplitter class.


### PR DESCRIPTION
Fixes #3253

The base class [k_fold_split](cci:1://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/splitters.py:715:4-761:28) method iteratively shrinks `rem_dataset` while `self.groups` stays fixed length, causing `AssertionError`. This PR overrides [k_fold_split](cci:1://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/splitters.py:715:4-761:28) in [RandomGroupSplitter](cci:2://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/splitters.py:390:0-551:9) to properly handle group-based splitting, ensuring all samples from the same group stay together across folds.

### Changes:

- Added [k_fold_split](cci:1://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/splitters.py:715:4-761:28) method to [RandomGroupSplitter](cci:2://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/splitters.py:390:0-551:9) in [deepchem/splits/splitters.py](cci:7://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/splitters.py:0:0-0:0)
- Added [test_random_group_k_fold_split](cci:1://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/tests/test_splitter.py:103:4-122:52) test in [deepchem/splits/tests/test_splitter.py](cci:7://file:///Users/nakshatrasharma/Desktop/deepchem/deepchem/splits/tests/test_splitter.py:0:0-0:0)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors (pre-existing errors only, not from this PR)
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (auto-generated via Sphinx)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings