### PR TITLE
Add differentiable bond angle geometry layer

### DIFF
--- a/deepchem/models/torch_models/differentiable_geometry.py
+++ b/deepchem/models/torch_models/differentiable_geometry.py
@@ -1,0 +1,93 @@
+"""Differentiable molecular geometry operations for PyTorch."""
+
+import torch
+import torch.nn as nn
+
+
+class DifferentiablePairwiseDistanceLayer(nn.Module):
+    """Compute pairwise Euclidean distances from atomic coordinates.
+
+    This layer computes the pairwise distance matrix between all atoms
+    in a molecule in a fully differentiable manner, enabling gradient
+    flow for molecular geometry optimization tasks.
+
+    Examples
+    --------
+    >>> import torch
+    >>> layer = DifferentiablePairwiseDistanceLayer()
+    >>> coords = torch.randn(2, 10, 3, requires_grad=True)
+    >>> distances = layer(coords)
+    >>> distances.shape
+    torch.Size([2, 10, 10])
+    """
+
+    def __init__(self):
+        super(DifferentiablePairwiseDistanceLayer, self).__init__()
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        """Compute pairwise distances.
+
+        Parameters
+        ----------
+        coords : torch.Tensor
+            Atomic coordinates of shape (batch, atoms, 3)
+
+        Returns
+        -------
+        torch.Tensor
+            Pairwise distance matrix of shape (batch, atoms, atoms)
+        """
+        return torch.cdist(coords, coords, p=2)
+
+
+class DifferentiableBondAngleLayer(nn.Module):
+    """Compute bond angles from atomic coordinates using 3-point geometry.
+
+    This layer computes bond angles for all atom triplets (i-j-k) where
+    the angle is centered at atom j. The computation is fully vectorized
+    and differentiable, supporting gradient-based optimization.
+
+    Examples
+    --------
+    >>> import torch
+    >>> layer = DifferentiableBondAngleLayer()
+    >>> coords = torch.randn(2, 5, 3, requires_grad=True)
+    >>> angles = layer(coords)
+    >>> angles.shape
+    torch.Size([2, 5, 5, 5])
+    """
+
+    def __init__(self, eps: float = 1e-7):
+        super(DifferentiableBondAngleLayer, self).__init__()
+        self.eps = eps
+
+    def forward(self, coords: torch.Tensor) -> torch.Tensor:
+        """Compute bond angles for all atom triplets.
+
+        Parameters
+        ----------
+        coords : torch.Tensor
+            Atomic coordinates of shape (batch, atoms, 3)
+
+        Returns
+        -------
+        torch.Tensor
+            Bond angles in radians of shape (batch, atoms, atoms, atoms)
+            where angles[b, i, j, k] is the angle i-j-k centered at j
+        """
+        coords_i = coords.unsqueeze(2).unsqueeze(3)
+        coords_j = coords.unsqueeze(1).unsqueeze(3)
+        coords_k = coords.unsqueeze(1).unsqueeze(2)
+
+        vec_ji = coords_i - coords_j
+        vec_jk = coords_k - coords_j
+
+        norm_ji = torch.norm(vec_ji, dim=-1, keepdim=True).clamp(min=self.eps)
+        norm_jk = torch.norm(vec_jk, dim=-1, keepdim=True).clamp(min=self.eps)
+
+        cos_angle = (vec_ji * vec_jk).sum(dim=-1) / (
+            norm_ji.squeeze(-1) * norm_jk.squeeze(-1))
+
+        cos_angle = torch.clamp(cos_angle, -1.0 + self.eps, 1.0 - self.eps)
+
+        return torch.acos(cos_angle)

--- a/deepchem/models/torch_models/tests/test_differentiable_bond_angle.py
+++ b/deepchem/models/torch_models/tests/test_differentiable_bond_angle.py
@@ -1,0 +1,60 @@
+"""Tests for differentiable bond angle layer."""
+
+import pytest
+import torch
+from deepchem.models.torch_models.differentiable_geometry import DifferentiableBondAngleLayer
+
+
+def test_bond_angle_layer_instantiation():
+    """Test layer can be instantiated."""
+    layer = DifferentiableBondAngleLayer()
+    assert isinstance(layer, torch.nn.Module)
+
+
+def test_bond_angle_output_shape():
+    """Test output shape is correct."""
+    layer = DifferentiableBondAngleLayer()
+    batch_size, num_atoms = 3, 5
+    coords = torch.randn(batch_size, num_atoms, 3)
+    angles = layer(coords)
+    assert angles.shape == (batch_size, num_atoms, num_atoms, num_atoms)
+
+
+def test_bond_angle_gradient_flow():
+    """Test gradients flow through the layer."""
+    layer = DifferentiableBondAngleLayer()
+    coords = torch.randn(2, 4, 3, requires_grad=True)
+    angles = layer(coords)
+    loss = angles.sum()
+    loss.backward()
+    assert coords.grad is not None
+    assert coords.grad.shape == coords.shape
+
+
+def test_bond_angle_range():
+    """Test bond angles are in valid range [0, pi]."""
+    layer = DifferentiableBondAngleLayer()
+    coords = torch.randn(2, 6, 3)
+    angles = layer(coords)
+    assert torch.all(angles >= 0.0)
+    assert torch.all(angles <= torch.pi + 1e-5)
+
+
+def test_bond_angle_numerical_stability():
+    """Test layer handles edge cases without NaN."""
+    layer = DifferentiableBondAngleLayer()
+    # Test with coincident points (edge case)
+    coords = torch.randn(1, 3, 3)
+    angles = layer(coords)
+    assert not torch.any(torch.isnan(angles))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(),
+                    reason="CUDA not available")
+def test_bond_angle_gpu_compatibility():
+    """Test layer works on GPU."""
+    layer = DifferentiableBondAngleLayer().cuda()
+    coords = torch.randn(2, 4, 3, device='cuda')
+    angles = layer(coords)
+    assert angles.device.type == 'cuda'
+    assert angles.shape == (2, 4, 4, 4)


### PR DESCRIPTION
## Description

This pull request adds a new differentiable molecular geometry primitive to DeepChem by introducing a bond angle computation layer implemented in PyTorch.

The new layer enables efficient and fully differentiable computation of bond angles for all atom triplets (i–j–k), making it suitable for geometry-aware molecular modeling and gradient-based optimization workflows. This contribution aligns with DeepChem’s Differentiable Algorithm Wishlist.

No existing APIs or behavior are modified.

## What’s New

- Added `DifferentiableBondAngleLayer` to `deepchem/models/torch_models/differentiable_geometry.py`
- Input: atomic coordinates tensor of shape `(batch, atoms, 3)`
- Output: bond angle tensor of shape `(batch, atoms, atoms, atoms)` in radians
- Fully vectorized PyTorch implementation
- Autograd-compatible and GPU-safe

## Implementation Details

- Numerically stable normalization with epsilon protection
- Cosine values clamped to valid domain before applying `acos`
- Pure tensor operations (no Python loops)
- Preserves full gradient flow for backpropagation
- No external dependencies introduced

## Test Coverage

New unit tests validate:

- Output shape correctness
- Gradient propagation
- Numerical stability (no NaNs)
- Valid angle range `[0, π]`
- CPU and GPU compatibility (when CUDA is available)

## Compatibility

- Non-breaking change
- No modifications to existing functionality
- Fully backward compatible
- Follows DeepChem coding standards

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings