### PR TITLE
Fix HuggingFaceModel text generation by routing through model.generate()

### DIFF
--- a/deepchem/models/tests/test_hf_models.py
+++ b/deepchem/models/tests/test_hf_models.py
@@ -1,0 +1,36 @@
+import importlib.util
+import pytest
+
+if importlib.util.find_spec("rdkit") is None:
+    pytest.skip("rdkit not installed", allow_module_level=True)
+
+if importlib.util.find_spec("transformers") is None:
+    pytest.skip("transformers not installed", allow_module_level=True)
+
+import deepchem as dc
+from transformers import AutoTokenizer, AutoModelForCausalLM
+from deepchem.models.torch_models.hf_models import HuggingFaceModel
+
+
+@pytest.mark.slow
+def test_huggingface_generation_from_prompt():
+    tokenizer = AutoTokenizer.from_pretrained("gpt2")
+    tokenizer.pad_token = tokenizer.eos_token
+
+    model = AutoModelForCausalLM.from_pretrained("gpt2")
+
+    hf_model = HuggingFaceModel(
+        model=model,
+        tokenizer=tokenizer,
+        task="generation",
+        batch_size=1,
+    )
+
+    dataset = dc.data.NumpyDataset(X=["The molecule binds to"])
+
+    outputs = hf_model.predict(dataset, max_length=20)
+
+    assert isinstance(outputs, list)
+    assert len(outputs) == 1
+    assert isinstance(outputs[0], str)
+    assert outputs[0].startswith("The molecule binds to")


### PR DESCRIPTION
## Enable text generation in `HuggingFaceModel.predict()`

This PR adds support for text generation in `HuggingFaceModel.predict()`.

---

### Problem

`HuggingFaceModel.predict()` currently routes through `TorchModel._predict()`, which assumes batches unpack into `(inputs, labels, weights)`.

This breaks generation workflows because:

- Labels and weights are not present  
- Hugging Face generation models require `model.generate()` instead of a standard forward pass  

As a result, generation tasks fail even though the underlying Hugging Face models support them.

---

### Solution

This PR adds generation support while preserving DeepChem’s existing design:

- Detect generation use cases inside `HuggingFaceModel.predict()` when generation arguments (e.g., `max_length`) are provided  
- Route generation calls through `model.generate()` instead of the standard forward pass  
- Keep `TorchModel` unchanged to avoid affecting other model types  
- Preserve existing classification and regression behavior  

This makes generation a natural extension of the current API without introducing task-specific logic into the tokenizer or core model classes.

---

### Tests

Added a unit test that:

- Uses a small causal language model  
- Provides a prompt as input  
- Verifies that `HuggingFaceModel.predict()` returns generated text  
- Confirms generation works without requiring labels or weights  

This test directly covers the failure mode fixed in this PR.

---

### Design Notes

- Generation logic is contained within `HuggingFaceModel`  
- No changes were made to `TorchModel` internals  
- Existing model behavior remains unchanged for non-generation tasks  
