### PR TITLE
add dark mode toggle for Sphinx documentation

### DIFF
--- a/docs/source/_static/dark_mode.css
+++ b/docs/source/_static/dark_mode.css
@@ -1,0 +1,170 @@
+/* Theme tokens for DeepChem docs dark-mode support. */
+:root {
+  --dc-bg: #fcfcfc;
+  --dc-surface: #ffffff;
+  --dc-sidebar: #343131;
+  --dc-sidebar-search: #2b2929;
+  --dc-border: #d9d9d9;
+  --dc-text: #1f2937;
+  --dc-text-muted: #4b5563;
+  --dc-link: #2563eb;
+  --dc-code-bg: #f4f4f5;
+  --dc-code-text: #111827;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme]) {
+    --dc-bg: #0f141d;
+    --dc-surface: #151c27;
+    --dc-sidebar: #0b1019;
+    --dc-sidebar-search: #111827;
+    --dc-border: #2e3a4f;
+    --dc-text: #e5e7eb;
+    --dc-text-muted: #c0c7d4;
+    --dc-link: #8cb4ff;
+    --dc-code-bg: #0b1220;
+    --dc-code-text: #dbeafe;
+  }
+}
+
+html[data-theme="light"] {
+  --dc-bg: #fcfcfc;
+  --dc-surface: #ffffff;
+  --dc-sidebar: #343131;
+  --dc-sidebar-search: #2b2929;
+  --dc-border: #d9d9d9;
+  --dc-text: #1f2937;
+  --dc-text-muted: #4b5563;
+  --dc-link: #2563eb;
+  --dc-code-bg: #f4f4f5;
+  --dc-code-text: #111827;
+}
+
+html[data-theme="dark"] {
+  --dc-bg: #0f141d;
+  --dc-surface: #151c27;
+  --dc-sidebar: #0b1019;
+  --dc-sidebar-search: #111827;
+  --dc-border: #2e3a4f;
+  --dc-text: #e5e7eb;
+  --dc-text-muted: #c0c7d4;
+  --dc-link: #8cb4ff;
+  --dc-code-bg: #0b1220;
+  --dc-code-text: #dbeafe;
+}
+
+body,
+.wy-body-for-nav,
+.wy-nav-content-wrap {
+  background: var(--dc-bg);
+  color: var(--dc-text);
+}
+
+.wy-nav-content {
+  background: var(--dc-surface);
+  color: var(--dc-text);
+}
+
+.wy-nav-side {
+  background: var(--dc-sidebar);
+}
+
+.wy-side-nav-search,
+.wy-side-nav-search > div.version {
+  background: var(--dc-sidebar-search);
+}
+
+.wy-menu-vertical a,
+.wy-breadcrumbs,
+.wy-breadcrumbs a,
+.rst-content,
+.rst-content p,
+.rst-content li {
+  color: var(--dc-text);
+}
+
+a,
+a:visited,
+.rst-content a,
+.rst-content a:visited {
+  color: var(--dc-link);
+}
+
+.wy-menu-vertical a:hover,
+.wy-menu-vertical a:focus {
+  background: rgba(140, 180, 255, 0.18);
+}
+
+.wy-menu-vertical li.current > a,
+.wy-menu-vertical li.current > a:hover {
+  background: rgba(140, 180, 255, 0.2);
+}
+
+.wy-menu-vertical li.toctree-l2.current > a,
+.wy-menu-vertical li.toctree-l3.current > a {
+  border-right: 2px solid var(--dc-link);
+}
+
+pre,
+code,
+.rst-content tt.literal,
+.rst-content code.literal {
+  background: var(--dc-code-bg);
+  color: var(--dc-code-text);
+  border-color: var(--dc-border);
+}
+
+.highlight {
+  background: var(--dc-code-bg);
+}
+
+.wy-table-responsive table td,
+.wy-table-responsive table th,
+.rst-content table.docutils td,
+.rst-content table.docutils th {
+  border-color: var(--dc-border);
+  color: var(--dc-text);
+}
+
+.wy-table-responsive table tr:nth-child(2n-1) td {
+  background: rgba(127, 127, 127, 0.06);
+}
+
+input[type="text"],
+input[type="email"],
+input[type="search"],
+input[type="password"],
+textarea {
+  background: var(--dc-surface);
+  color: var(--dc-text);
+  border-color: var(--dc-border);
+}
+
+.wy-alert,
+.rst-content .admonition,
+.rst-content .note,
+.rst-content .warning {
+  background: var(--dc-surface);
+  border-color: var(--dc-border);
+}
+
+.dc-theme-toggle {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  z-index: 1000;
+  padding: 0.45rem 0.7rem;
+  border: 1px solid var(--dc-border);
+  border-radius: 999px;
+  background: var(--dc-surface);
+  color: var(--dc-text);
+  font-size: 0.8rem;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.dc-theme-toggle:hover,
+.dc-theme-toggle:focus {
+  outline: none;
+  border-color: var(--dc-link);
+}

--- a/docs/source/_static/theme_toggle.js
+++ b/docs/source/_static/theme_toggle.js
@@ -1,0 +1,51 @@
+(function () {
+  var STORAGE_KEY = "dc-docs-theme";
+  var MODES = ["auto", "dark", "light"];
+
+  function getStoredMode() {
+    var mode = window.localStorage.getItem(STORAGE_KEY);
+    return MODES.indexOf(mode) === -1 ? "auto" : mode;
+  }
+
+  function setTheme(mode) {
+    if (mode === "auto") {
+      document.documentElement.removeAttribute("data-theme");
+    } else {
+      document.documentElement.setAttribute("data-theme", mode);
+    }
+    window.localStorage.setItem(STORAGE_KEY, mode);
+    return mode;
+  }
+
+  function updateButtonLabel(button, mode) {
+    button.textContent = "Theme: " + mode;
+    button.setAttribute("aria-label", "Theme mode is " + mode + ". Click to cycle.");
+    button.setAttribute("title", "Theme mode: " + mode);
+  }
+
+  function nextMode(mode) {
+    var idx = MODES.indexOf(mode);
+    return MODES[(idx + 1) % MODES.length];
+  }
+
+  function initThemeToggle() {
+    var mode = setTheme(getStoredMode());
+    var button = document.createElement("button");
+    button.className = "dc-theme-toggle";
+    button.type = "button";
+    updateButtonLabel(button, mode);
+
+    button.addEventListener("click", function () {
+      mode = setTheme(nextMode(mode));
+      updateButtonLabel(button, mode);
+    });
+
+    document.body.appendChild(button);
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initThemeToggle);
+  } else {
+    initThemeToggle();
+  }
+})();

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,6 +100,14 @@ html_theme_options = {
     'display_version': True,
 }
 
+html_css_files = [
+    'dark_mode.css',
+]
+
+html_js_files = [
+    'theme_toggle.js',
+]
+
 copybutton_remove_prompts = True
 
 # -- Source code links ---------------------------------------------------


### PR DESCRIPTION
## Description

Fix #4729
Adds dark mode support for DeepChem documentation built with Sphinx RTD theme.

### Summary of Changes
- Added `dark_mode.css` with light/dark CSS variables and RTD-theme overrides.
Added `theme_toggle.js` with a floating theme toggle button.
- Supports three modes: auto (system preference), dark, and light.
- Persists user theme choice in `localStorage`.
Wired assets in `conf.py` via `html_css_files` and `html_js_files`.

### Motivation and Context
Issue #4729 requests dark mode support to improve readability and accessibility during long documentation sessions. This PR introduces a minimal, non-breaking implementation without changing the existing docs theme.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
