### PR TITLE
Fix/maml device mismatch

### DIFF
--- a/deepchem/metalearning/tests/test_maml_pytorch.py
+++ b/deepchem/metalearning/tests/test_maml_pytorch.py
@@ -58,11 +58,11 @@ class TestMAML(unittest.TestCase):
                 self.phase = np.pi * np.random.random()
 
             def get_batch(self):
-                device = self.w1.device 
-                
+                device = self.w1.device
+
                 x_np = np.random.uniform(-5.0, 5.0, (self.batch_size, 1))
                 y_np = self.amplitude * np.sin(x_np + self.phase)
-                
+
                 return [
                     torch.tensor(x_np, device=device),
                     torch.tensor(y_np, device=device)


### PR DESCRIPTION
## Description
Fixes `RuntimeError` and `TypeError` in deepchem/metalearning/tests/test_maml_pytorch.py when running on CUDA-enabled devices.
### Context:
When running the test suite on a GPU (verified on NVIDIA RTX 4060), test_maml_pytorch failed with two specific errors:

- `Device Mismatch`: SineLearner.get_batch initialized data on CPU by default, causing a crash when interacting with model weights that MAML had moved to GPU (RuntimeError: Expected all tensors to be on the same device).

- `Tensor Conversion`: The validation loop attempted to call .numpy() directly on the loss tensor returned by the model. When the model is on GPU, this raises TypeError: can't convert cuda:0 device type tensor to numpy.

### Changes:
Updated `SineLearner.get_batch` to dynamically detect the device of the model parameters (self.w1.device) and initialize input tensors on that same device.
Updated the validation loop to explicitly call `.detach().cpu().numpy()` on the loss tensor, ensuring compatibility with both CPU and GPU execution.

### Verification
- Before Fix
<img width="1918" height="665" alt="MAML_FAIL_!" src="https://github.com/user-attachments/assets/fbdbd462-1617-4e2c-8f5f-42ba822759fd" />
<img width="1918" height="460" alt="MAML_FAIL_2" src="https://github.com/user-attachments/assets/c797fea5-a4bb-4f9c-8af8-a0df94fbad46" />
- After Fix
<img width="1918" height="875" alt="MAML_PASSED" src="https://github.com/user-attachments/assets/4dc2b51b-1b05-4558-8f7f-eb69be3ebf01" />

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x ] Run `mypy -p deepchem` and check no errors
  - [x ] Run `flake8 <modified file> --count` and check no errors
  - [x ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
