### PR TITLE
docs: Add MKL 2025.0.0 troubleshooting to installation guide

### DIFF
--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -270,6 +270,29 @@ but if you want to install all the soft-dependencies at once, then take a look a
 `deepchem/requirements <https://github.com/deepchem/deepchem/tree/master/requirements>`_
 
 
+Troubleshooting
+---------------
+
+**MKL 2025.0.0 Compatibility Issue with PyTorch**
+
+When using Conda to install PyTorch, the dependency resolver may select
+``mkl=2025.0.0`` (which satisfies PyTorch's loose ``mkl >=2018`` constraint).
+MKL 2025.0.0 introduces ABI changes that are incompatible with PyTorch 2.5.x
+binaries, causing the following error when importing DeepChem:
+
+.. code-block:: text
+
+    ImportError: .../libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent
+
+To resolve this, pin MKL to a compatible version before installing DeepChem:
+
+.. code-block:: bash
+
+    conda install "mkl<2025" packaging -y
+
+For more details, see `GitHub Issue #4698 <https://github.com/deepchem/deepchem/issues/4698>`_.
+
+
 .. _`DeepChem Tutorials`: https://github.com/deepchem/deepchem/tree/master/examples/tutorials
 .. _`forum post`: https://forum.deepchem.io/t/getting-deepchem-running-in-colab/81/7
 .. _`DockerHub`: https://hub.docker.com/repository/docker/deepchemio/deepchem


### PR DESCRIPTION
Adds a **Troubleshooting** section to the installation guide documenting the MKL 2025.0.0 / PyTorch ABI incompatibility.

**Problem:** When installing DeepChem via Conda, the dependency resolver now selects `mkl=2025.0.0` by default (satisfying PyTorch's loose `mkl >=2018` constraint). MKL 2025.0.0 introduces ABI changes incompatible with PyTorch 2.5.x binaries, causing new users to hit:

ImportError: .../libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent


**Workaround documented:** `conda install "mkl<2025" packaging -y`

Refs #4698

## Description

Adds a Troubleshooting section to [docs/source/get_started/installation.rst](cci:7://file:///run/media/santhankumar/New%20Volume/deepchem/docs/source/get_started/installation.rst:0:0-0:0) to help new users who encounter the `undefined symbol: iJIT_NotifyEvent` ImportError when using DeepChem with PyTorch installed via Conda. The root cause is an ABI incompatibility between MKL 2025.0.0 and PyTorch 2.5.x binaries. The documented fix is to pin MKL to a compatible version (`mkl<2025`).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings