### PR TITLE
[WIP] Add RFDiffusion model for protein backbone generation

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -76,6 +76,8 @@ from deepchem.feat.material_featurizers import LCNNFeaturizer
 from deepchem.feat.atomic_conformation import AtomicConformation
 from deepchem.feat.atomic_conformation import AtomicConformationFeaturizer
 
+from deepchem.feat.protein_backbone_featurizer import ProteinBackboneFeaturizer
+
 from deepchem.feat.huggingface_featurizer import HuggingFaceFeaturizer
 
 # biological sequence featurizers

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -19,10 +19,13 @@ class ProteinBackboneFeaturizer(Featurizer):
     from PDB structures. It is designed for use with protein structure generation
     models like RFDiffusion that operate on backbone geometry.
 
-    The featurizer returns an array of shape (L, 3, 3) where:
+    Each protein is featurized as an array of shape (L, 3, 3) where:
     - L is the number of residues
     - The second dimension corresponds to [N, CA, C] atoms
     - The third dimension contains [x, y, z] coordinates in Angstroms
+
+    Since proteins have variable lengths, this featurizer returns a list of
+    numpy arrays rather than a single stacked array.
 
     This class requires BioPython to be installed.
 
@@ -41,8 +44,10 @@ class ProteinBackboneFeaturizer(Featurizer):
     ...     pdb_file = f.name
     >>> featurizer = dc.feat.ProteinBackboneFeaturizer()
     >>> features = featurizer.featurize([pdb_file])
-    >>> features.shape
-    (1, 1, 3, 3)
+    >>> len(features)
+    1
+    >>> features[0].shape
+    (1, 3, 3)
     >>> os.unlink(pdb_file)
 
     References
@@ -65,6 +70,42 @@ class ProteinBackboneFeaturizer(Featurizer):
                 "ProteinBackboneFeaturizer requires BioPython to be installed. "
                 "Install it with: pip install biopython")
         self.max_length = max_length
+    
+    def featurize(self, datapoints, log_every_n=1000, **kwargs):
+        """Calculate features for datapoints.
+        
+        Parameters
+        ----------
+        datapoints : Iterable[str]
+            Paths to PDB files.
+        log_every_n : int, default 1000
+            Log every n datapoints.
+        
+        Returns
+        -------
+        list of np.ndarray
+            List of arrays, each of shape (L, 3, 3) containing backbone
+            atom coordinates for one protein.
+        """
+        import logging
+        logger = logging.getLogger(__name__)
+        
+        datapoints = list(datapoints)
+        features = []
+        for i, point in enumerate(datapoints):
+            if i % log_every_n == 0:
+                logger.info("Featurizing datapoint %i" % i)
+            try:
+                feat = self._featurize(point, **kwargs)
+                if feat.size > 0:  # Only append non-empty arrays
+                    features.append(feat)
+                else:
+                    logger.warning(f"Failed to featurize datapoint {i}. Skipping.")
+            except Exception as e:
+                logger.warning(f"Failed to featurize datapoint {i}: {e}. Skipping.")
+        
+        # Return as list, not numpy array, since proteins have variable lengths
+        return features
 
     def _featurize(self, datapoint: str, **kwargs) -> np.ndarray:
         """Extract backbone coordinates from a PDB file.

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -1,0 +1,130 @@
+"""
+Protein Backbone Featurizer for structural diffusion models.
+"""
+import numpy as np
+from typing import Any
+from deepchem.feat.base_classes import Featurizer
+
+try:
+    from Bio.PDB import PDBParser, is_aa
+    has_biopython = True
+except ImportError:
+    has_biopython = False
+
+
+class ProteinBackboneFeaturizer(Featurizer):
+    """Featurizes protein structures by extracting backbone atom coordinates.
+
+    This featurizer extracts the N, CA (Cα), and C backbone atom coordinates
+    from PDB structures. It is designed for use with protein structure generation
+    models like RFDiffusion that operate on backbone geometry.
+
+    The featurizer returns an array of shape (L, 3, 3) where:
+    - L is the number of residues
+    - The second dimension corresponds to [N, CA, C] atoms
+    - The third dimension contains [x, y, z] coordinates in Angstroms
+
+    This class requires BioPython to be installed.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import tempfile
+    >>> import os
+    >>> # Create a minimal PDB file for testing
+    >>> pdb_content = '''ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
+    ... ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
+    ... ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
+    ... END'''
+    >>> with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as f:
+    ...     f.write(pdb_content)
+    ...     pdb_file = f.name
+    >>> featurizer = dc.feat.ProteinBackboneFeaturizer()
+    >>> features = featurizer.featurize([pdb_file])
+    >>> features.shape
+    (1, 1, 3, 3)
+    >>> os.unlink(pdb_file)
+
+    References
+    ----------
+    .. [1] Watson, J. L., et al. "De novo design of protein structure and function
+       with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+    """
+
+    def __init__(self, max_length: int = 512):
+        """Initialize the ProteinBackboneFeaturizer.
+
+        Parameters
+        ----------
+        max_length : int, default 512
+            Maximum number of residues to extract. Longer proteins will be
+            truncated from the center.
+        """
+        if not has_biopython:
+            raise ImportError(
+                "ProteinBackboneFeaturizer requires BioPython to be installed. "
+                "Install it with: pip install biopython")
+        self.max_length = max_length
+
+    def _featurize(self, datapoint: str, **kwargs) -> np.ndarray:
+        """Extract backbone coordinates from a PDB file.
+
+        Parameters
+        ----------
+        datapoint : str
+            Path to a PDB file.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape (L, 3, 3) containing backbone atom coordinates,
+            where L is the number of residues, or empty array on failure.
+        """
+        try:
+            parser = PDBParser(QUIET=True)
+            structure = parser.get_structure('protein', datapoint)
+
+            # Extract backbone coordinates
+            coords_list = []
+            for model in structure:
+                for chain in model:
+                    for residue in chain:
+                        # Only process amino acids
+                        if not is_aa(residue, standard=True):
+                            continue
+
+                        # Get N, CA, C atoms
+                        try:
+                            n_coord = residue['N'].get_coord()
+                            ca_coord = residue['CA'].get_coord()
+                            c_coord = residue['C'].get_coord()
+
+                            # Stack as (3, 3) array: [N, CA, C] x [x, y, z]
+                            backbone = np.array(
+                                [n_coord, ca_coord, c_coord], dtype=np.float32)
+                            coords_list.append(backbone)
+                        except KeyError:
+                            # Skip residues missing backbone atoms
+                            continue
+
+                # Only use first model
+                break
+
+            if len(coords_list) == 0:
+                return np.array([])
+
+            # Stack all residues
+            coords = np.stack(coords_list, axis=0)  # (L, 3, 3)
+
+            # Truncate if too long
+            L = coords.shape[0]
+            if L > self.max_length:
+                # Center crop
+                start = (L - self.max_length) // 2
+                coords = coords[start:start + self.max_length]
+
+            return coords
+
+        except Exception as e:
+            # Return empty array on any error
+            return np.array([])

--- a/deepchem/feat/tests/test_protein_backbone_featurizer.py
+++ b/deepchem/feat/tests/test_protein_backbone_featurizer.py
@@ -1,0 +1,131 @@
+"""
+Tests for ProteinBackboneFeaturizer.
+"""
+import unittest
+import tempfile
+import os
+import numpy as np
+import deepchem as dc
+
+try:
+    from Bio.PDB import PDBParser
+    has_biopython = True
+except ImportError:
+    has_biopython = False
+
+
+class TestProteinBackboneFeaturizer(unittest.TestCase):
+    """Test ProteinBackboneFeaturizer class."""
+
+    def setUp(self):
+        """Create minimal PDB file for testing."""
+        # Minimal PDB with 3 residues
+        self.pdb_content = """ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
+ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
+ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
+ATOM      4  N   GLY A   2       1.500   2.000   1.000  1.00  0.00           N
+ATOM      5  CA  GLY A   2       2.000   3.350   1.000  1.00  0.00           C
+ATOM      6  C   GLY A   2       1.500   4.000   2.000  1.00  0.00           C
+ATOM      7  N   VAL A   3       1.000   3.500   3.000  1.00  0.00           N
+ATOM      8  CA  VAL A   3       0.500   4.000   4.000  1.00  0.00           C
+ATOM      9  C   VAL A   3       1.000   5.400   4.000  1.00  0.00           C
+END
+"""
+        self.pdb_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.pdb', delete=False)
+        self.pdb_file.write(self.pdb_content)
+        self.pdb_file.close()
+
+    def tearDown(self):
+        """Clean up temporary file."""
+        if os.path.exists(self.pdb_file.name):
+            os.unlink(self.pdb_file.name)
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_featurizer_init(self):
+        """Test featurizer initialization."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=128)
+        assert featurizer.max_length == 128
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_featurize_single_pdb(self):
+        """Test featurizing a single PDB file."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer()
+        features = featurizer.featurize([self.pdb_file.name])
+
+        # Should have shape (1, L, 3, 3)
+        # where L is number of residues (3 in this case)
+        assert features.shape[0] == 1  # One protein
+        assert features.shape[1] == 3  # Three residues
+        assert features.shape[2] == 3  # N, CA, C atoms
+        assert features.shape[3] == 3  # x, y, z coordinates
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_backbone_coordinates(self):
+        """Test that backbone coordinates are correctly extracted."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer()
+        features = featurizer.featurize([self.pdb_file.name])
+
+        coords = features[0]  # (L, 3, 3)
+
+        # Check first residue N atom coordinates
+        np.testing.assert_array_almost_equal(coords[0, 0], [0.0, 0.0, 0.0])
+
+        # Check first residue CA atom coordinates
+        np.testing.assert_array_almost_equal(coords[0, 1], [1.458, 0.0, 0.0])
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_truncation(self):
+        """Test that long proteins are truncated."""
+        # Create a longer PDB file
+        long_pdb_content = ""
+        for i in range(20):
+            n = i * 3 + 1
+            long_pdb_content += f"ATOM  {n:5d}  N   ALA A{i+1:4d}       {float(i):.3f}   0.000   0.000  1.00  0.00           N\n"
+            long_pdb_content += f"ATOM  {n+1:5d}  CA  ALA A{i+1:4d}       {float(i)+1:.3f}   0.000   0.000  1.00  0.00           C\n"
+            long_pdb_content += f"ATOM  {n+2:5d}  C   ALA A{i+1:4d}       {float(i)+2:.3f}   0.000   0.000  1.00  0.00           C\n"
+        long_pdb_content += "END\n"
+
+        pdb_file2 = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.pdb', delete=False)
+        pdb_file2.write(long_pdb_content)
+        pdb_file2.close()
+
+        try:
+            featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=10)
+            features = featurizer.featurize([pdb_file2.name])
+
+            # Should be truncated to max_length
+            assert features[0].shape[0] == 10
+        finally:
+            os.unlink(pdb_file2.name)
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_invalid_pdb(self):
+        """Test handling of invalid PDB files."""
+        # Create invalid PDB file
+        invalid_pdb = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.pdb', delete=False)
+        invalid_pdb.write("This is not a valid PDB file\n")
+        invalid_pdb.close()
+
+        try:
+            featurizer = dc.feat.ProteinBackboneFeaturizer()
+            features = featurizer.featurize([invalid_pdb.name])
+
+            # Should return empty array for failed featurization
+            assert features[0].size == 0
+        finally:
+            os.unlink(invalid_pdb.name)
+
+    def test_requires_biopython(self):
+        """Test that error is raised if BioPython is not installed."""
+        if has_biopython:
+            self.skipTest("BioPython is installed")
+
+        with self.assertRaises(ImportError):
+            dc.feat.ProteinBackboneFeaturizer()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -49,6 +49,7 @@ try:
     from deepchem.models.torch_models import CNN
     from deepchem.models.torch_models import ScaledDotProductAttention, SelfAttention
     from deepchem.models.torch_models import GroverReadout
+    from deepchem.models.torch_models import BackboneDiffusion, RFDiffusionModel
 except ModuleNotFoundError as e:
     logger.warning(
         f'Skipped loading some PyTorch models, missing a dependency. {e}')

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -52,6 +52,7 @@ from deepchem.models.torch_models.hnn import HNN, HNNModel
 from deepchem.models.torch_models.ChemCeption import ChemCeption
 from deepchem.models.torch_models.fno import FNO, FNOModel
 from deepchem.models.torch_models.lnn import LNN, LNNModel
+from deepchem.models.torch_models.rfdiffusion import BackboneDiffusion, RFDiffusionModel
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -1925,23 +1925,20 @@ class NeighborList(nn.Module):
         Parameters
         ----------
         inputs: torch.Tensor
-            Shape (num_atoms, ndim) or (batch_size, num_atoms, ndim)
+            Shape (num_atoms, ndim)
 
         Returns
         -------
         neighbor_list: torch.Tensor
-            Shape `(N_atoms, M_nbrs)` or `(batch_size, N_atoms, M_nbrs)`
+            Shape `(N_atoms, M_nbrs)`
         """
         if isinstance(inputs, SequenceCollection):
             if len(inputs) != 1:
                 raise ValueError("NeighborList can only have one input")
             inputs = inputs[0]
-        if len(inputs.shape) == 2:
-            inputs = inputs.unsqueeze(0)
-            return self.compute_nbr_list(inputs).squeeze(0)
-        elif len(inputs.shape) != 3:
-             # TODO(rbharath): Support batching
-             raise ValueError("Parent tensor must be (num_atoms, ndim) or (batch_size, num_atoms, ndim)")
+        if len(inputs.shape) != 2:
+            # TODO(rbharath): Support batching
+            raise ValueError("Parent tensor must be (num_atoms, ndum)")
         return self.compute_nbr_list(inputs)
 
     def compute_nbr_list(self, coords: torch.Tensor) -> torch.Tensor:
@@ -1952,50 +1949,43 @@ class NeighborList(nn.Module):
         Parameters
         ----------
         coords: torch.Tensor
-            Shape (B, N_atoms, ndim)
+            Shape (N_atoms, ndim)
 
         Returns
         -------
         nbr_list: torch.Tensor
-            Shape (B, N_atoms, M_nbrs) of atom indices
+            Shape (N_atoms, M_nbrs) of atom indices
         """
-        B = coords.shape[0]
         # Shape (n_cells, ndim)
         cells = self.get_cells()
 
-        # List of length B*N_atoms, each element of different length uniques_i
+        # List of length N_atoms, each element of different length uniques_i
         nbrs = self.get_atoms_in_nbrs(coords, cells)
-        padding = torch.full((self.M_nbrs,), -1).to(coords.device).long()
+        padding = torch.full((self.M_nbrs,), -1)
         padded_nbrs = [
             torch.concat([unique_nbrs, padding], 0) for unique_nbrs in nbrs
         ]
 
-        # List of length B*N_atoms, each element of different length uniques_i
-        # List of length B*N_atoms, each a tensor of shape
+        # List of length N_atoms, each element of different length uniques_i
+        # List of length N_atoms, each a tensor of shape
         # (uniques_i, ndim)
-        nbr_coords = []
-        for i, atom_nbrs in enumerate(nbrs):
-             # Determine which batch this atom belongs to
-             batch_idx = i // self.N_atoms
-             # Select neighbors from that batch's coordinates
-             # atom_nbrs contains indices local to the molecule (0 to N-1)
-             nbr_coords.append(torch.index_select(coords[batch_idx], 0, atom_nbrs))
+        nbr_coords = [
+            torch.index_select(coords, 0, atom_nbrs) for atom_nbrs in nbrs
+        ]
 
         # Add phantom atoms that exist far outside the box
         coord_padding = torch.full((self.M_nbrs, self.ndim),
-                                   2 * self.stop).to(torch.float).to(coords.device)
+                                   2 * self.stop).to(torch.float)
         padded_nbr_coords = [
             torch.cat([nbr_coord, coord_padding], 0) for nbr_coord in nbr_coords
         ]
 
-        # List of length B*N_atoms, each of shape (1, ndim)
-        # Flatten coords to (B*N, D) then split
-        flat_coords = coords.reshape(-1, self.ndim)
-        atom_coords = torch.tensor_split(flat_coords, B * self.N_atoms)
+        # List of length N_atoms, each of shape (1, ndim)
+        atom_coords = torch.tensor_split(coords, self.N_atoms)
 
         # TODO(rbharath): How does distance need to be modified here to
         # account for periodic boundary conditions?
-        # List of length B*N_atoms each of shape (M_nbrs)
+        # List of length N_atoms each of shape (M_nbrs)
         padded_dists = [
             torch.sum((atom_coord - padded_nbr_coord)**2, dim=-1)
             for (atom_coord,
@@ -2007,18 +1997,14 @@ class NeighborList(nn.Module):
             for padded_dist in padded_dists
         ]
 
-        # B*N_atoms elts of size (M_nbrs,) each
+        # N_atoms elts of size (M_nbrs,) each
         padded_neighbor_list = [
             torch.gather(padded_atom_nbrs, 0, padded_closest_nbr)
             for (padded_atom_nbrs,
                  padded_closest_nbr) in zip(padded_nbrs, padded_closest_nbrs)
         ]
 
-        # (B*N, M_nbrs)
-        neighbor_list_flat = torch.stack(padded_neighbor_list)
-        
-        # Reshape to (B, N, M_nbrs)
-        neighbor_list = neighbor_list_flat.view(B, self.N_atoms, self.M_nbrs)
+        neighbor_list = torch.stack(padded_neighbor_list)
 
         return neighbor_list
 
@@ -2029,86 +2015,52 @@ class NeighborList(nn.Module):
         Parameters
         ----------
         coords: torch.Tensor
-            Shape (B, N_atoms, ndim)
+            Shape (N_atoms, ndim)
         cells: torch.Tensor
-            Shape (n_cells, ndim)
 
         Returns
         -------
         atoms_in_nbrs: List[torch.Tensor]
-            List of length B * N_atoms, each element is a tensor of indices
+            (N_atoms, n_nbr_cells, M_nbrs)
         """
-        B = coords.shape[0]
-        N_atoms = self.N_atoms
-        
-        # Shape (B, N_atoms, 1)
+        # Shape (N_atoms, 1)
         cells_for_atoms = self.get_cells_for_atoms(coords, cells)
 
         # Find M_nbrs atoms closest to each cell
-        # Shape (B, n_cells, M_nbrs)
+        # Shape (n_cells, M_nbrs)
         closest_atoms = self.get_closest_atoms(coords, cells)
 
-        # Associate each cell with its neighbor cells.
+        # Associate each cell with its neighbor cells. Assumes periodic boundary
+        # conditions, so does wrapround. O(constant)
         # Shape (n_cells, n_nbr_cells)
         neighbor_cells = self.get_neighbor_cells(cells)
-        
-        # We need to gather the atoms in neighbor cells for each atom.
-        # cells_for_atoms: (B, N, 1) tells us the cell index for each atom.
-        # neighbor_cells -> [cell_idx] -> [neighbor_cell_indices]
-        # closest_atoms -> [batch, cell_idx] -> [atom_indices]
-        
-        # First, match atoms to their neighbor cells.
-        # (C, n_nbr_cells) -> (B, N, n_nbr_cells)
-        neighbor_cells_expanded = neighbor_cells.unsqueeze(0).expand(B, -1, -1) # (B, C, n_nbr_cells)
-        
-        # Gather neighbor cells for each atom
-        # cells_for_atoms is (B, N, 1). We need to gather along dim 1 of neighbor_cells_expanded
-        # cells_for_atoms_rep = cells_for_atoms.expand(-1, -1, neighbor_cells.shape[1]) # (B, N, n_nbr_cells)
-        
-        # To use gather, indices must have same dims.
-        # We want to select from neighbor_cells (C, n_nbrs) using indices (B, N).
-        # Easier to flatten B*N temporarily or loop over B.
-        
-        atoms_in_nbrs_list = []
-        
-        # Loop over batch is simplest and likely efficient enough for typical batch sizes
-        for b in range(B):
-            # For this batch element:
-            # cell_indices: (N, 1)
-            cell_indices = cells_for_atoms[b]
-            
-            # nbr_cell_indices: (N, n_nbr_cells)
-            # neighbor_cells is (n_cells, n_nbr_cells)
-            # We select rows from neighbor_cells based on cell_indices
-            nbr_cell_indices = neighbor_cells[cell_indices.squeeze(-1)] 
-            
-            # Now we have the indices of cells that are neighbors to each atom's cell.
-            # We need to find which atoms are in those cells.
-            # closest_atoms[b]: (n_cells, M_nbrs)
-            
-            # Gather atoms from closest_atoms[b] using nbr_cell_indices
-            # nbr_cell_indices is (N, n_nbr_cells) flattened -> (N * n_nbr_cells)
-            flat_nbr_cell_indices = nbr_cell_indices.flatten()
-            
-            # atoms_in_cells: (N * n_nbr_cells, M_nbrs)
-            atoms_in_cells = closest_atoms[b][flat_nbr_cell_indices]
-            
-            # Reshape to (N, n_nbr_cells * M_nbrs)
-            atoms_per_atom = atoms_in_cells.view(N_atoms, -1)
-            
-            # Now get uniques for each atom
-            for i in range(N_atoms):
-                unique_nbrs = torch.unique(atoms_per_atom[i], sorted=False)
-                # Remove self (assumed to be first? logic from original code)
-                # TODO: The assumption that identity is first might be fragile, but preserving original logic.
-                if len(unique_nbrs) > 1:
-                     unique_nbrs = unique_nbrs[1:]
-                else:
-                    # If only self or empty?
-                    pass 
-                atoms_in_nbrs_list.append(unique_nbrs)
-                
-        return atoms_in_nbrs_list
+
+        # Shape (N_atoms, n_nbr_cells)
+        neighbor_cells = torch.squeeze(
+            torch.index_select(neighbor_cells, 0,
+                               torch.squeeze(cells_for_atoms)))
+
+        # Shape (N_atoms, n_nbr_cells, M_nbrs)
+        atoms_in_nbrs = torch.index_select(closest_atoms, 0,
+                                           neighbor_cells.flatten())
+
+        # Shape (N_atoms, n_nbr_cells*M_nbrs)
+        atoms_in_nbrs = torch.reshape(atoms_in_nbrs, [self.N_atoms, -1])
+
+        # List of length N_atoms, each element length uniques_i
+        nbrs_per_atom = torch.split(atoms_in_nbrs, self.N_atoms)
+
+        uniques = [
+            torch.unique(atom_nbrs, sorted=False)
+            for atom_nbrs in nbrs_per_atom[0]
+        ]
+
+        # TODO(rbharath): FRAGILE! Uses fact that identity seems to be the first
+        # element removed to remove self from list of neighbors. Need to verify
+        # this holds more broadly or come up with robust alternative.
+        uniques = [unique[1:] for unique in uniques]
+
+        return uniques
 
     def get_closest_atoms(self, coords: torch.Tensor,
                           cells: torch.Tensor) -> torch.Tensor:
@@ -2119,33 +2071,32 @@ class NeighborList(nn.Module):
         Parameters
         ----------
         coords: torch.Tensor
-            (B, N_atoms, ndim) shape.
+            (N_atoms, ndim) shape.
         cells: torch.Tensor
             (n_cells, ndim) shape.
 
         Returns
         -------
         closest_inds: torch.Tensor
-            Of shape (B, n_cells, M_nbrs)
+            Of shape (n_cells, M_nbrs)
         """
         N_atoms, n_cells, ndim, M_nbrs = (self.N_atoms, self.n_cells, self.ndim,
                                           self.M_nbrs)
-        # coords: (B, N, D)
-        # cells: (C, D)
-        
-        # Expand for broadcasting
-        # coords: (B, 1, N, D)
-        coords_ex = coords.unsqueeze(1)
-        # cells: (1, C, 1, D)
-        cells_ex = cells.unsqueeze(0).unsqueeze(2)
-        
-        # Calculate squared distances
-        # (B, C, N)
-        dists = torch.sum((coords_ex - cells_ex)**2, dim=-1)
-        
-        # Find k atoms closest to each cell
-        # (B, C, M_nbrs)
-        closest_inds = torch.topk(dists, k=M_nbrs, largest=False, dim=-1)[1]
+        # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
+        tiled_cells = torch.reshape(torch.tile(cells, (1, N_atoms)),
+                                    (N_atoms * n_cells, ndim))
+
+        # Shape (N_atoms*n_cells, ndim) after tile
+        tiled_coords = torch.tile(coords, (n_cells, 1))
+
+        # Shape (N_atoms*n_cells)
+        coords_vec = torch.sum((tiled_coords - tiled_cells)**2, dim=-1)
+        # Shape (n_cells, N_atoms)
+        coords_norm = torch.reshape(coords_vec, (n_cells, N_atoms))
+
+        # Find k atoms closest to this cell.
+        # Tensor of shape (n_cells, M_nbrs)
+        closest_inds = torch.topk(coords_norm, k=M_nbrs, largest=False)[1]
 
         return closest_inds
 
@@ -2156,28 +2107,26 @@ class NeighborList(nn.Module):
         Parameters
         ----------
         coords: torch.Tensor
-            Shape (B, N_atoms, ndim)
+            Shape (N_atoms, ndim)
         cells: torch.Tensor
             (n_cells, ndim) shape.
         Returns
         -------
         cells_for_atoms: torch.Tensor
-            Shape (B, N_atoms, 1)
+            Shape (N_atoms, 1)
         """
-        # coords: (B, N, D)
-        # cells: (C, D)
-        
-        # Expand for broadcasting
-        # coords: (B, N, 1, D)
-        coords_ex = coords.unsqueeze(2)
-        # cells: (1, 1, C, D)
-        cells_ex = cells.unsqueeze(0).unsqueeze(0)
-        
-        # Dists: (B, N, C)
-        dists = torch.sum((coords_ex - cells_ex)**2, dim=-1)
-        
-        # Closest cell index: (B, N, 1)
-        closest_inds = torch.topk(dists, k=1, largest=False, dim=-1)[1]
+        N_atoms, n_cells, ndim = self.N_atoms, self.n_cells, self.ndim
+        n_cells = int(n_cells)
+        # Tile both cells and coords to form arrays of size (N_atoms*n_cells, ndim)
+        tiled_cells = torch.tile(cells, (N_atoms, 1))
+
+        # Shape (N_atoms*n_cells, 1) after tile
+        tiled_coords = torch.reshape(torch.tile(coords, (1, n_cells)),
+                                     (n_cells * N_atoms, ndim))
+        coords_vec = torch.sum((tiled_coords - tiled_cells)**2, dim=-1)
+        coords_norm = torch.reshape(coords_vec, (N_atoms, n_cells))
+
+        closest_inds = torch.topk(coords_norm, k=1, largest=False)[1]
 
         return closest_inds
 

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -545,17 +545,20 @@ class CosineSchedule:
         device = x_t.device
         noise_pred = model([x_t, t])
 
+        # Use CPU indices for schedule tensor indexing (buffers stay on CPU)
+        t_cpu = t.cpu()
+
         # Predict x0
-        sqrt_recip = self.sqrt_recip_alpha_cumprod[t].to(device)
-        sqrt_recipm1 = self.sqrt_recipm1_alpha_cumprod[t].to(device)
+        sqrt_recip = self.sqrt_recip_alpha_cumprod[t_cpu].to(device)
+        sqrt_recipm1 = self.sqrt_recipm1_alpha_cumprod[t_cpu].to(device)
         while sqrt_recip.dim() < x_t.dim():
             sqrt_recip = sqrt_recip.unsqueeze(-1)
             sqrt_recipm1 = sqrt_recipm1.unsqueeze(-1)
         x0_pred = sqrt_recip * x_t - sqrt_recipm1 * noise_pred
 
         # Posterior mean
-        coef1 = self.posterior_mean_coef1[t].to(device)
-        coef2 = self.posterior_mean_coef2[t].to(device)
+        coef1 = self.posterior_mean_coef1[t_cpu].to(device)
+        coef2 = self.posterior_mean_coef2[t_cpu].to(device)
         while coef1.dim() < x_t.dim():
             coef1 = coef1.unsqueeze(-1)
             coef2 = coef2.unsqueeze(-1)
@@ -567,7 +570,7 @@ class CosineSchedule:
         while nonzero_mask.dim() < x_t.dim():
             nonzero_mask = nonzero_mask.unsqueeze(-1)
 
-        var = self.posterior_variance[t].to(device)
+        var = self.posterior_variance[t_cpu].to(device)
         while var.dim() < x_t.dim():
             var = var.unsqueeze(-1)
 

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -1,0 +1,957 @@
+"""RFDiffusion Model for Protein Backbone Generation.
+
+This module implements a denoising diffusion probabilistic model (DDPM) for
+generating protein backbone structures. It follows the approach described in
+RFDiffusion [1]_, adapted for DeepChem's TorchModel interface.
+
+The model learns to denoise protein backbone coordinates (N, CA, C atoms)
+through a reverse diffusion process. Given noisy coordinates and a timestep,
+it predicts the noise that was added, enabling iterative refinement from
+pure noise to valid protein backbones.
+
+References
+----------
+.. [1] Watson, J. L., et al. "De novo design of protein structure and function
+   with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+.. [2] Ho, J., Jain, A., & Abbeel, P. "Denoising diffusion probabilistic
+   models." NeurIPS 2020.
+.. [3] Nichol, A. Q., & Dhariwal, P. "Improved denoising diffusion
+   probabilistic models." ICML 2021.
+
+Notes
+-----
+This class requires PyTorch to be installed.
+"""
+
+import math
+import logging
+import numpy as np
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError('These classes require PyTorch to be installed.')
+
+from deepchem.data import Dataset
+from deepchem.models.torch_models.torch_model import TorchModel
+from deepchem.models.losses import Loss
+
+logger = logging.getLogger(__name__)
+
+
+class SinusoidalTimestepEmbedding(nn.Module):
+    """Sinusoidal embedding for diffusion timesteps.
+
+    Maps integer timesteps to continuous vector representations using
+    sinusoidal functions, following the positional encoding scheme from
+    the Transformer architecture [1]_.
+
+    Parameters
+    ----------
+    dim : int
+        Dimensionality of the output embedding.
+
+    References
+    ----------
+    .. [1] Vaswani, A., et al. "Attention is all you need." NeurIPS 2017.
+
+    Examples
+    --------
+    >>> import torch
+    >>> emb = SinusoidalTimestepEmbedding(64)
+    >>> t = torch.tensor([0, 100, 500, 999])
+    >>> output = emb(t)
+    >>> output.shape
+    torch.Size([4, 64])
+    """
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """Compute timestep embeddings.
+
+        Parameters
+        ----------
+        t : torch.Tensor
+            Integer timesteps of shape ``(batch_size,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embeddings of shape ``(batch_size, dim)``.
+        """
+        device = t.device
+        half_dim = self.dim // 2
+        emb = math.log(10000) / (half_dim - 1)
+        emb = torch.exp(torch.arange(half_dim, device=device) * -emb)
+        emb = t.float().unsqueeze(1) * emb.unsqueeze(0)
+        emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
+        return emb
+
+
+class ResidueEmbedding(nn.Module):
+    """Embed per-residue backbone coordinates into feature vectors.
+
+    Each residue is represented by 9 values (N, CA, C atoms x 3 coordinates).
+    This module projects them into a higher-dimensional feature space.
+
+    Parameters
+    ----------
+    coord_dim : int, default 9
+        Input coordinate dimension (3 atoms * 3 xyz = 9).
+    embed_dim : int, default 256
+        Output embedding dimension.
+
+    Examples
+    --------
+    >>> import torch
+    >>> emb = ResidueEmbedding(9, 128)
+    >>> x = torch.randn(2, 50, 9)
+    >>> output = emb(x)
+    >>> output.shape
+    torch.Size([2, 50, 128])
+    """
+
+    def __init__(self, coord_dim: int = 9, embed_dim: int = 256) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(coord_dim, embed_dim),
+            nn.LayerNorm(embed_dim),
+            nn.GELU(),
+            nn.Linear(embed_dim, embed_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Project coordinates to embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Backbone coordinates of shape ``(batch, num_residues, coord_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embeddings of shape ``(batch, num_residues, embed_dim)``.
+        """
+        return self.net(x)
+
+
+class PositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding for residue positions along the chain.
+
+    Injects information about relative position of each residue in the
+    protein sequence, following standard Transformer positional encoding.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Feature dimension.
+    max_len : int, default 512
+        Maximum supported sequence length.
+
+    Examples
+    --------
+    >>> import torch
+    >>> pe = PositionalEncoding(128, max_len=256)
+    >>> x = torch.randn(2, 50, 128)
+    >>> output = pe(x)
+    >>> output.shape
+    torch.Size([2, 50, 128])
+    """
+
+    def __init__(self, embed_dim: int, max_len: int = 512) -> None:
+        super().__init__()
+        pe = torch.zeros(max_len, embed_dim)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, embed_dim, 2).float() *
+            (-math.log(10000.0) / embed_dim))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        self.register_buffer('pe', pe.unsqueeze(0))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Add positional encoding to input features.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(batch, seq_len, embed_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Input with positional encoding added, same shape.
+        """
+        return x + self.pe[:, :x.size(1), :]
+
+
+class DiffusionTransformerBlock(nn.Module):
+    """Transformer block with diffusion timestep conditioning.
+
+    Standard self-attention block augmented with adaptive layer norm
+    conditioning on the diffusion timestep. The timestep embedding is
+    used to compute scale and shift parameters that modulate the
+    intermediate representations.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Hidden dimension size.
+    num_heads : int, default 8
+        Number of attention heads.
+    mlp_ratio : float, default 4.0
+        Expansion ratio for the feedforward network.
+    dropout : float, default 0.1
+        Dropout probability.
+
+    Examples
+    --------
+    >>> import torch
+    >>> block = DiffusionTransformerBlock(128, num_heads=4)
+    >>> x = torch.randn(2, 50, 128)
+    >>> t_emb = torch.randn(2, 128)
+    >>> output = block(x, t_emb)
+    >>> output.shape
+    torch.Size([2, 50, 128])
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 num_heads: int = 8,
+                 mlp_ratio: float = 4.0,
+                 dropout: float = 0.1) -> None:
+        super().__init__()
+        self.norm1 = nn.LayerNorm(embed_dim)
+        self.attn = nn.MultiheadAttention(embed_dim,
+                                          num_heads,
+                                          dropout=dropout,
+                                          batch_first=True)
+        self.norm2 = nn.LayerNorm(embed_dim)
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, int(embed_dim * mlp_ratio)),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(int(embed_dim * mlp_ratio), embed_dim),
+            nn.Dropout(dropout),
+        )
+        self.time_mlp = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(embed_dim, embed_dim * 2),
+        )
+
+    def forward(self, x: torch.Tensor,
+                t_emb: torch.Tensor) -> torch.Tensor:
+        """Forward pass with timestep conditioning.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input features of shape ``(batch, seq_len, embed_dim)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(batch, embed_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Output features, same shape as input.
+        """
+        # Adaptive layer norm with time conditioning
+        time_cond = self.time_mlp(t_emb)
+        scale, shift = time_cond.chunk(2, dim=-1)
+        scale = scale.unsqueeze(1)
+        shift = shift.unsqueeze(1)
+
+        h = self.norm1(x)
+        h = h * (1 + scale) + shift
+        attn_out, _ = self.attn(h, h, h)
+        x = x + attn_out
+
+        x = x + self.mlp(self.norm2(x))
+        return x
+
+
+class BackboneDiffusion(nn.Module):
+    """Neural network for protein backbone denoising diffusion.
+
+    This is the core denoiser network that predicts the noise added to
+    protein backbone coordinates during the forward diffusion process.
+    It processes flattened backbone coordinates (N, CA, C per residue)
+    through a Transformer with timestep conditioning.
+
+    The architecture uses:
+
+    - Sinusoidal timestep embeddings
+    - Per-residue coordinate embeddings
+    - Positional encoding for sequence position
+    - Transformer blocks with adaptive time conditioning
+    - Zero-initialized output projection (standard for diffusion [1]_)
+
+    Parameters
+    ----------
+    coord_dim : int, default 9
+        Input coordinate dimension. Default is 9 for 3 backbone atoms
+        (N, CA, C) times 3 spatial dimensions (x, y, z).
+    embed_dim : int, default 256
+        Hidden dimension for the Transformer.
+    time_dim : int, default 128
+        Dimension of the timestep embedding before projection.
+    num_layers : int, default 8
+        Number of Transformer blocks.
+    num_heads : int, default 8
+        Number of attention heads per block.
+    max_seq_len : int, default 512
+        Maximum supported protein length (in residues).
+    dropout : float, default 0.1
+        Dropout probability.
+
+    References
+    ----------
+    .. [1] Ho, J., Jain, A., & Abbeel, P. "Denoising diffusion probabilistic
+       models." NeurIPS 2020.
+
+    Examples
+    --------
+    >>> import torch
+    >>> model = BackboneDiffusion(coord_dim=9, embed_dim=128, num_layers=4)
+    >>> noisy_coords = torch.randn(4, 50, 9)
+    >>> timesteps = torch.randint(0, 1000, (4,))
+    >>> noise_pred = model(noisy_coords, timesteps)
+    >>> noise_pred.shape
+    torch.Size([4, 50, 9])
+    """
+
+    def __init__(self,
+                 coord_dim: int = 9,
+                 embed_dim: int = 256,
+                 time_dim: int = 128,
+                 num_layers: int = 8,
+                 num_heads: int = 8,
+                 max_seq_len: int = 512,
+                 dropout: float = 0.1) -> None:
+        super().__init__()
+        self.coord_dim = coord_dim
+        self.embed_dim = embed_dim
+
+        # Timestep embedding
+        self.time_embedding = SinusoidalTimestepEmbedding(time_dim)
+        self.time_mlp = nn.Sequential(
+            nn.Linear(time_dim, embed_dim),
+            nn.SiLU(),
+            nn.Linear(embed_dim, embed_dim),
+        )
+
+        # Coordinate embedding
+        self.coord_embed = ResidueEmbedding(coord_dim, embed_dim)
+
+        # Positional encoding
+        self.pos_encoding = PositionalEncoding(embed_dim, max_seq_len)
+
+        # Transformer layers
+        self.layers = nn.ModuleList([
+            DiffusionTransformerBlock(embed_dim,
+                                     num_heads,
+                                     dropout=dropout)
+            for _ in range(num_layers)
+        ])
+
+        # Output projection to predict noise
+        self.output_norm = nn.LayerNorm(embed_dim)
+        self.output_proj = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim),
+            nn.GELU(),
+            nn.Linear(embed_dim, coord_dim),
+        )
+
+        # Zero-initialize output for stable diffusion training
+        nn.init.zeros_(self.output_proj[-1].weight)
+        nn.init.zeros_(self.output_proj[-1].bias)
+
+    def forward(self, inputs: List[torch.Tensor]) -> torch.Tensor:
+        """Predict noise from noisy backbone coordinates and timesteps.
+
+        Parameters
+        ----------
+        inputs : list of torch.Tensor
+            A list of two tensors:
+            - ``inputs[0]``: Noisy backbone coordinates of shape
+              ``(batch, num_residues, coord_dim)``
+            - ``inputs[1]``: Integer timesteps of shape ``(batch,)``
+
+        Returns
+        -------
+        torch.Tensor
+            Predicted noise of shape ``(batch, num_residues, coord_dim)``.
+        """
+        x_noisy, t = inputs[0], inputs[1]
+
+        # Ensure t is long for embedding lookup
+        t = t.long()
+
+        # Timestep embedding
+        t_emb = self.time_embedding(t)
+        t_emb = self.time_mlp(t_emb)
+
+        # Embed noisy coordinates
+        h = self.coord_embed(x_noisy)
+
+        # Add positional encoding
+        h = self.pos_encoding(h)
+
+        # Apply transformer blocks
+        for layer in self.layers:
+            h = layer(h, t_emb)
+
+        # Predict noise
+        h = self.output_norm(h)
+        noise_pred = self.output_proj(h)
+
+        return noise_pred
+
+
+class CosineSchedule:
+    """Cosine variance schedule for the diffusion process.
+
+    Implements the cosine schedule from Improved DDPM [1]_, which provides
+    better sample quality than the linear schedule for many domains.
+
+    Parameters
+    ----------
+    num_timesteps : int, default 1000
+        Total number of diffusion timesteps.
+    s : float, default 0.008
+        Small offset to prevent singularity at t=0.
+
+    References
+    ----------
+    .. [1] Nichol, A. Q., & Dhariwal, P. "Improved denoising diffusion
+       probabilistic models." ICML 2021.
+
+    Examples
+    --------
+    >>> schedule = CosineSchedule(num_timesteps=100)
+    >>> import torch
+    >>> x0 = torch.randn(2, 10, 9)
+    >>> t = torch.tensor([0, 50])
+    >>> noisy_x, noise = schedule.q_sample(x0, t)
+    >>> noisy_x.shape
+    torch.Size([2, 10, 9])
+    """
+
+    def __init__(self, num_timesteps: int = 1000, s: float = 0.008) -> None:
+        self.num_timesteps = num_timesteps
+
+        # Compute cosine schedule
+        steps = num_timesteps + 1
+        t = torch.linspace(0, num_timesteps, steps) / num_timesteps
+        alpha_cumprod = torch.cos((t + s) / (1 + s) * math.pi / 2)**2
+        alpha_cumprod = alpha_cumprod / alpha_cumprod[0]
+        betas = 1 - (alpha_cumprod[1:] / alpha_cumprod[:-1])
+        betas = torch.clamp(betas, 0, 0.999)
+
+        alphas = 1.0 - betas
+        alpha_cumprod = torch.cumprod(alphas, dim=0)
+        alpha_cumprod_prev = F.pad(alpha_cumprod[:-1], (1, 0), value=1.0)
+
+        # Store precomputed values
+        self.betas = betas
+        self.alphas = alphas
+        self.alpha_cumprod = alpha_cumprod
+        self.sqrt_alpha_cumprod = torch.sqrt(alpha_cumprod)
+        self.sqrt_one_minus_alpha_cumprod = torch.sqrt(1.0 - alpha_cumprod)
+        self.sqrt_recip_alpha_cumprod = torch.sqrt(1.0 / alpha_cumprod)
+        self.sqrt_recipm1_alpha_cumprod = torch.sqrt(1.0 / alpha_cumprod - 1)
+
+        # Posterior variance for reverse sampling
+        self.posterior_variance = (betas * (1.0 - alpha_cumprod_prev) /
+                                  (1.0 - alpha_cumprod))
+        self.posterior_log_variance = torch.log(
+            torch.clamp(self.posterior_variance, min=1e-20))
+        self.posterior_mean_coef1 = (betas * torch.sqrt(alpha_cumprod_prev) /
+                                    (1.0 - alpha_cumprod))
+        self.posterior_mean_coef2 = ((1.0 - alpha_cumprod_prev) *
+                                    torch.sqrt(alphas) /
+                                    (1.0 - alpha_cumprod))
+
+    def q_sample(
+        self,
+        x0: torch.Tensor,
+        t: torch.Tensor,
+        noise: Optional[torch.Tensor] = None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Forward diffusion: add noise to clean data.
+
+        Samples from q(x_t | x_0) = N(x_t; sqrt(alpha_cumprod_t) * x_0,
+        (1 - alpha_cumprod_t) * I).
+
+        Parameters
+        ----------
+        x0 : torch.Tensor
+            Clean data of shape ``(batch, ...)``.
+        t : torch.Tensor
+            Integer timesteps of shape ``(batch,)``.
+        noise : torch.Tensor, optional
+            Pre-sampled noise. If None, noise is sampled from N(0, I).
+
+        Returns
+        -------
+        noisy_x : torch.Tensor
+            Noisy data, same shape as x0.
+        noise : torch.Tensor
+            The noise that was added, same shape as x0.
+        """
+        if noise is None:
+            noise = torch.randn_like(x0)
+
+        sqrt_alpha = self.sqrt_alpha_cumprod[t].to(x0.device)
+        sqrt_one_minus_alpha = self.sqrt_one_minus_alpha_cumprod[t].to(
+            x0.device)
+
+        # Expand for broadcasting
+        while sqrt_alpha.dim() < x0.dim():
+            sqrt_alpha = sqrt_alpha.unsqueeze(-1)
+            sqrt_one_minus_alpha = sqrt_one_minus_alpha.unsqueeze(-1)
+
+        noisy_x = sqrt_alpha * x0 + sqrt_one_minus_alpha * noise
+        return noisy_x, noise
+
+    @torch.no_grad()
+    def p_sample(self, model: nn.Module, x_t: torch.Tensor,
+                 t: torch.Tensor) -> torch.Tensor:
+        """Reverse diffusion: denoise by one step.
+
+        Samples from p(x_{t-1} | x_t) using the model's noise prediction.
+
+        Parameters
+        ----------
+        model : nn.Module
+            The denoiser network.
+        x_t : torch.Tensor
+            Current noisy data of shape ``(batch, num_residues, coord_dim)``.
+        t : torch.Tensor
+            Current timestep of shape ``(batch,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Denoised data at timestep t-1, same shape as x_t.
+        """
+        device = x_t.device
+        noise_pred = model([x_t, t])
+
+        # Predict x0
+        sqrt_recip = self.sqrt_recip_alpha_cumprod[t].to(device)
+        sqrt_recipm1 = self.sqrt_recipm1_alpha_cumprod[t].to(device)
+        while sqrt_recip.dim() < x_t.dim():
+            sqrt_recip = sqrt_recip.unsqueeze(-1)
+            sqrt_recipm1 = sqrt_recipm1.unsqueeze(-1)
+        x0_pred = sqrt_recip * x_t - sqrt_recipm1 * noise_pred
+
+        # Posterior mean
+        coef1 = self.posterior_mean_coef1[t].to(device)
+        coef2 = self.posterior_mean_coef2[t].to(device)
+        while coef1.dim() < x_t.dim():
+            coef1 = coef1.unsqueeze(-1)
+            coef2 = coef2.unsqueeze(-1)
+        posterior_mean = coef1 * x0_pred + coef2 * x_t
+
+        # Add noise (except at t=0)
+        noise = torch.randn_like(x_t)
+        nonzero_mask = (t != 0).float().to(device)
+        while nonzero_mask.dim() < x_t.dim():
+            nonzero_mask = nonzero_mask.unsqueeze(-1)
+
+        var = self.posterior_variance[t].to(device)
+        while var.dim() < x_t.dim():
+            var = var.unsqueeze(-1)
+
+        return posterior_mean + nonzero_mask * torch.sqrt(var) * noise
+
+    @torch.no_grad()
+    def sample(self, model: nn.Module, shape: Tuple[int, ...],
+               device: torch.device) -> torch.Tensor:
+        """Generate samples via full reverse diffusion.
+
+        Starts from Gaussian noise and iteratively denoises for
+        ``num_timesteps`` steps to produce clean samples.
+
+        Parameters
+        ----------
+        model : nn.Module
+            The denoiser network.
+        shape : tuple of int
+            Shape of the samples to generate ``(batch, num_residues, coord_dim)``.
+        device : torch.device
+            Device to generate samples on.
+
+        Returns
+        -------
+        torch.Tensor
+            Generated samples of the given shape.
+        """
+        model.eval()
+        x = torch.randn(shape, device=device)
+
+        for t_val in reversed(range(self.num_timesteps)):
+            t = torch.full((shape[0],), t_val, device=device, dtype=torch.long)
+            x = self.p_sample(model, x, t)
+
+        return x
+
+
+class RFDiffusionModel(TorchModel):
+    """RFDiffusion model for protein backbone generation using DeepChem.
+
+    This model implements a denoising diffusion probabilistic model (DDPM) for
+    generating protein backbone structures. It wraps the BackboneDiffusion
+    neural network in DeepChem's TorchModel interface, enabling standard
+    DeepChem workflows for training, prediction, and model management.
+
+    The model operates on protein backbone coordinates represented as
+    flattened arrays of shape ``(num_residues, 9)``, where 9 corresponds
+    to 3 backbone atoms (N, CA, C) times 3 spatial dimensions (x, y, z).
+
+    Training uses the standard DDPM objective: sample a random timestep,
+    add noise to the clean coordinates, and train the model to predict
+    the added noise. This is handled internally by overriding
+    ``default_generator`` so that ``model.fit(dataset)`` works directly
+    with DeepChem datasets.
+
+    Parameters
+    ----------
+    embed_dim : int, default 256
+        Hidden dimension for the Transformer backbone.
+    time_dim : int, default 128
+        Dimension of the timestep embedding.
+    num_layers : int, default 8
+        Number of Transformer blocks.
+    num_heads : int, default 8
+        Number of attention heads per block.
+    num_diffusion_steps : int, default 1000
+        Number of timesteps in the diffusion process.
+    max_seq_len : int, default 512
+        Maximum supported protein length in residues.
+    dropout : float, default 0.1
+        Dropout probability.
+    batch_size : int, default 4
+        Batch size for training.
+    learning_rate : float, default 1e-4
+        Learning rate for the Adam optimizer.
+    device : torch.device, optional
+        Device to use. If None, automatically selects GPU if available.
+    **kwargs
+        Additional keyword arguments passed to ``TorchModel``.
+
+    Examples
+    --------
+    Training on a DeepChem dataset:
+
+    >>> import numpy as np
+    >>> import deepchem as dc
+    >>> # Create a small dataset of protein backbone coordinates
+    >>> # Each protein: (num_residues, 9) where 9 = 3 atoms * 3 xyz
+    >>> proteins = [np.random.randn(20, 9).astype(np.float32) for _ in range(10)]
+    >>> X = np.empty(10, dtype=object)
+    >>> for i, p in enumerate(proteins):
+    ...     X[i] = p
+    >>> y = np.zeros((10, 1), dtype=np.float32)
+    >>> dataset = dc.data.NumpyDataset(X=X, y=y)
+    >>> model = dc.models.RFDiffusionModel(
+    ...     embed_dim=64, num_layers=2, num_heads=4,
+    ...     num_diffusion_steps=100, batch_size=2)
+    >>> loss = model.fit(dataset, nb_epoch=1)
+
+    Generating new protein backbones:
+
+    >>> samples = model.generate(num_samples=2, seq_length=20)
+    >>> samples.shape
+    (2, 20, 9)
+
+    Using with the CATH dataset:
+
+    >>> tasks, datasets, transformers = dc.molnet.load_cath(  # doctest: +SKIP
+    ...     featurizer='ProteinBackbone', splitter='random')
+    >>> train, valid, test = datasets  # doctest: +SKIP
+    >>> model = dc.models.RFDiffusionModel(  # doctest: +SKIP
+    ...     embed_dim=256, num_layers=8, batch_size=4)
+    >>> loss = model.fit(train, nb_epoch=100)  # doctest: +SKIP
+
+    References
+    ----------
+    .. [1] Watson, J. L., et al. "De novo design of protein structure and
+       function with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+    .. [2] Ho, J., Jain, A., & Abbeel, P. "Denoising diffusion probabilistic
+       models." NeurIPS 2020.
+
+    Notes
+    -----
+    This class requires PyTorch to be installed.
+    """
+
+    def __init__(self,
+                 embed_dim: int = 256,
+                 time_dim: int = 128,
+                 num_layers: int = 8,
+                 num_heads: int = 8,
+                 num_diffusion_steps: int = 1000,
+                 max_seq_len: int = 512,
+                 dropout: float = 0.1,
+                 batch_size: int = 4,
+                 learning_rate: float = 1e-4,
+                 device: Optional[torch.device] = None,
+                 **kwargs) -> None:
+        self.num_diffusion_steps = num_diffusion_steps
+        self.max_seq_len = max_seq_len
+        self.coord_dim = 9  # N, CA, C backbone atoms * 3 xyz
+
+        # Create the diffusion schedule
+        self.schedule = CosineSchedule(num_timesteps=num_diffusion_steps)
+
+        # Create the denoiser network
+        model = BackboneDiffusion(
+            coord_dim=self.coord_dim,
+            embed_dim=embed_dim,
+            time_dim=time_dim,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            max_seq_len=max_seq_len,
+            dropout=dropout,
+        )
+
+        # Custom loss function for diffusion training.
+        # The model predicts noise, and we compute MSE against the true noise.
+        # The default_generator yields (inputs=[noisy_coords, timesteps],
+        #   labels=[noise], weights=[ones]), so the loss receives
+        #   outputs=[predicted_noise] and labels=[true_noise].
+        def diffusion_loss(outputs: List, labels: List,
+                           weights: List) -> torch.Tensor:
+            pred_noise = outputs[0]
+            true_noise = labels[0]
+            w = weights[0]
+
+            # MSE loss per element
+            loss = F.mse_loss(pred_noise, true_noise, reduction='none')
+
+            # Apply weights and average
+            if w.dim() < loss.dim():
+                w = w.reshape(w.shape + (1,) * (loss.dim() - w.dim()))
+            loss = (loss * w).mean()
+            return loss
+
+        super(RFDiffusionModel, self).__init__(model,
+                                               loss=diffusion_loss,
+                                               batch_size=batch_size,
+                                               learning_rate=learning_rate,
+                                               device=device,
+                                               **kwargs)
+
+    def _normalize_coords(self, coords: np.ndarray) -> np.ndarray:
+        """Normalize protein coordinates for diffusion training.
+
+        Centers coordinates around the CA centroid and scales to unit
+        variance. This normalization is important for stable diffusion
+        training since the noise schedule assumes data near zero.
+
+        Parameters
+        ----------
+        coords : np.ndarray
+            Backbone coordinates of shape ``(num_residues, 3, 3)`` or
+            ``(num_residues, 9)``.
+
+        Returns
+        -------
+        np.ndarray
+            Normalized coordinates of shape ``(num_residues, 9)``.
+        """
+        if coords.ndim == 3 and coords.shape[1] == 3 and coords.shape[2] == 3:
+            # Shape (L, 3, 3) -> (L, 9)
+            coords = coords.reshape(-1, 9)
+
+        # Center around CA centroid (CA is indices 3,4,5 in the flattened rep)
+        ca_coords = coords[:, 3:6]
+        centroid = ca_coords.mean(axis=0, keepdims=True)
+        coords = coords - np.tile(centroid, 3)  # Subtract from all 3 atoms
+
+        # Scale to unit variance
+        std = coords.std()
+        if std > 1e-6:
+            coords = coords / std
+
+        return coords.astype(np.float32)
+
+    def _pad_coords(self, coords: np.ndarray,
+                    max_len: int) -> Tuple[np.ndarray, int]:
+        """Pad coordinates to a fixed length.
+
+        Parameters
+        ----------
+        coords : np.ndarray
+            Coordinates of shape ``(num_residues, 9)``.
+        max_len : int
+            Target length to pad to.
+
+        Returns
+        -------
+        padded : np.ndarray
+            Padded coordinates of shape ``(max_len, 9)``.
+        orig_len : int
+            Original length before padding.
+        """
+        orig_len = coords.shape[0]
+        if orig_len >= max_len:
+            # Center crop
+            start = (orig_len - max_len) // 2
+            return coords[start:start + max_len], max_len
+        else:
+            padded = np.zeros((max_len, self.coord_dim), dtype=np.float32)
+            padded[:orig_len] = coords
+            return padded, orig_len
+
+    def default_generator(
+            self,
+            dataset: Dataset,
+            epochs: int = 1,
+            mode: str = 'fit',
+            deterministic: bool = True,
+            pad_batches: bool = True) -> Iterable[Tuple[List, List, List]]:
+        """Create a generator for diffusion training batches.
+
+        This overrides the parent ``default_generator`` to implement the
+        diffusion training procedure. For each batch of protein coordinates:
+
+        1. Normalize and pad coordinates to a consistent length
+        2. Sample random diffusion timesteps
+        3. Add noise according to the cosine schedule
+        4. Yield ``(inputs, labels, weights)`` where:
+           - inputs = [noisy_coords, timesteps]
+           - labels = [true_noise]
+           - weights = [ones]
+
+        Parameters
+        ----------
+        dataset : Dataset
+            A DeepChem dataset where ``X`` contains protein backbone
+            coordinate arrays.
+        epochs : int, default 1
+            Number of epochs to iterate over the data.
+        mode : str, default 'fit'
+            One of 'fit', 'predict', or 'uncertainty'.
+        deterministic : bool, default True
+            Whether to iterate in order or shuffle each epoch.
+        pad_batches : bool, default True
+            Whether to pad the last batch.
+
+        Yields
+        ------
+        tuple of (list, list, list)
+            ``([noisy_coords, timesteps], [noise], [weights])``
+        """
+        for epoch in range(epochs):
+            for (X_b, y_b, w_b,
+                 ids_b) in dataset.iterbatches(batch_size=self.batch_size,
+                                               deterministic=deterministic,
+                                               pad_batches=pad_batches):
+                batch_coords = []
+                batch_size = len(X_b)
+
+                # Find max length in this batch for padding
+                lengths = []
+                normalized = []
+                for i in range(batch_size):
+                    coords = X_b[i]
+                    if isinstance(coords, np.ndarray) and coords.size > 0:
+                        c = self._normalize_coords(coords)
+                        normalized.append(c)
+                        lengths.append(c.shape[0])
+                    else:
+                        # Handle empty or invalid entries (from pad_batches)
+                        normalized.append(
+                            np.zeros((1, self.coord_dim), dtype=np.float32))
+                        lengths.append(1)
+
+                max_len = min(max(lengths), self.max_seq_len)
+
+                # Pad all to same length
+                for c in normalized:
+                    padded, _ = self._pad_coords(c, max_len)
+                    batch_coords.append(padded)
+
+                # Stack into batch
+                coords_batch = np.stack(batch_coords,
+                                        axis=0)  # (B, max_len, 9)
+
+                if mode == 'predict':
+                    # For prediction mode, just yield coordinates
+                    yield ([coords_batch], [y_b], [w_b])
+                    continue
+
+                # Diffusion training: sample timesteps and add noise
+                t = np.random.randint(0,
+                                      self.num_diffusion_steps,
+                                      size=(batch_size,))
+
+                coords_tensor = torch.tensor(coords_batch,
+                                             dtype=torch.float32)
+                t_tensor = torch.tensor(t, dtype=torch.long)
+
+                noisy_coords, noise = self.schedule.q_sample(
+                    coords_tensor, t_tensor)
+
+                # Convert back to numpy for TorchModel pipeline
+                noisy_np = noisy_coords.numpy()
+                noise_np = noise.numpy()
+                t_np = t.astype(np.float32)
+
+                weights = np.ones((batch_size, 1), dtype=np.float32)
+
+                yield ([noisy_np, t_np], [noise_np], [weights])
+
+    def generate(self,
+                 num_samples: int = 1,
+                 seq_length: int = 50,
+                 device: Optional[torch.device] = None) -> np.ndarray:
+        """Generate new protein backbone structures.
+
+        Starts from pure Gaussian noise and iteratively denoises for
+        ``num_diffusion_steps`` steps using the learned reverse process.
+
+        Parameters
+        ----------
+        num_samples : int, default 1
+            Number of protein structures to generate.
+        seq_length : int, default 50
+            Length of each generated protein (number of residues).
+        device : torch.device, optional
+            Device to use for generation. Defaults to model device.
+
+        Returns
+        -------
+        np.ndarray
+            Generated backbone coordinates of shape
+            ``(num_samples, seq_length, 9)``.
+
+        Examples
+        --------
+        >>> import deepchem as dc
+        >>> model = dc.models.RFDiffusionModel(
+        ...     embed_dim=64, num_layers=2, num_heads=4,
+        ...     num_diffusion_steps=50, batch_size=2)
+        >>> samples = model.generate(num_samples=2, seq_length=30)
+        >>> samples.shape
+        (2, 30, 9)
+        """
+        if device is None:
+            device = self.device
+
+        self.model.eval()
+        shape = (num_samples, seq_length, self.coord_dim)
+        samples = self.schedule.sample(self.model, shape, device)
+        self.model.train()
+
+        return samples.cpu().numpy()

--- a/deepchem/models/torch_models/tests/test_rfdiffusion.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion.py
@@ -1,0 +1,446 @@
+"""Tests for RFDiffusion model.
+
+These tests verify that the RFDiffusion model correctly implements
+DeepChem's TorchModel interface and produces valid outputs for
+protein backbone generation tasks.
+"""
+
+import numpy as np
+import pytest
+import tempfile
+import os
+
+import deepchem as dc
+from deepchem.models.torch_models.rfdiffusion import (
+    SinusoidalTimestepEmbedding,
+    ResidueEmbedding,
+    PositionalEncoding,
+    DiffusionTransformerBlock,
+    BackboneDiffusion,
+    CosineSchedule,
+    RFDiffusionModel,
+)
+
+try:
+    import torch
+    import torch.nn.functional as F
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSinusoidalTimestepEmbedding:
+    """Tests for SinusoidalTimestepEmbedding."""
+
+    def test_output_shape(self):
+        """Test that output has correct shape."""
+        emb = SinusoidalTimestepEmbedding(64)
+        t = torch.tensor([0, 50, 100, 999])
+        output = emb(t)
+        assert output.shape == (4, 64)
+
+    def test_different_timesteps_differ(self):
+        """Test that different timesteps produce different embeddings."""
+        emb = SinusoidalTimestepEmbedding(64)
+        t = torch.tensor([0, 500])
+        output = emb(t)
+        assert not torch.allclose(output[0], output[1])
+
+    def test_not_all_zeros(self):
+        """Test that output is non-trivial."""
+        emb = SinusoidalTimestepEmbedding(32)
+        t = torch.tensor([100])
+        output = emb(t)
+        assert not torch.allclose(output, torch.zeros_like(output))
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestResidueEmbedding:
+    """Tests for ResidueEmbedding."""
+
+    def test_output_shape(self):
+        """Test that output has correct shape."""
+        emb = ResidueEmbedding(9, 128)
+        x = torch.randn(2, 50, 9)
+        output = emb(x)
+        assert output.shape == (2, 50, 128)
+
+    def test_gradient_flow(self):
+        """Test that gradients flow through the embedding."""
+        emb = ResidueEmbedding(9, 64)
+        x = torch.randn(1, 10, 9, requires_grad=True)
+        output = emb(x)
+        loss = output.sum()
+        loss.backward()
+        assert x.grad is not None
+        assert x.grad.shape == x.shape
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestPositionalEncoding:
+    """Tests for PositionalEncoding."""
+
+    def test_output_shape(self):
+        """Test that output preserves input shape."""
+        pe = PositionalEncoding(128, max_len=256)
+        x = torch.randn(2, 50, 128)
+        output = pe(x)
+        assert output.shape == (2, 50, 128)
+
+    def test_adds_to_input(self):
+        """Test that positional encoding modifies the input."""
+        pe = PositionalEncoding(64, max_len=100)
+        x = torch.zeros(1, 10, 64)
+        output = pe(x)
+        assert not torch.allclose(output, x)
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestDiffusionTransformerBlock:
+    """Tests for DiffusionTransformerBlock."""
+
+    def test_output_shape(self):
+        """Test that output matches input shape."""
+        block = DiffusionTransformerBlock(128, num_heads=4)
+        x = torch.randn(2, 50, 128)
+        t_emb = torch.randn(2, 128)
+        output = block(x, t_emb)
+        assert output.shape == (2, 50, 128)
+
+    def test_time_conditioning_matters(self):
+        """Test that different timesteps produce different outputs."""
+        block = DiffusionTransformerBlock(64, num_heads=4)
+        block.eval()
+        x = torch.randn(1, 10, 64)
+        t1 = torch.randn(1, 64)
+        t2 = torch.randn(1, 64) * 5
+        out1 = block(x, t1)
+        out2 = block(x, t2)
+        assert not torch.allclose(out1, out2)
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestBackboneDiffusion:
+    """Tests for BackboneDiffusion network."""
+
+    def test_output_shape(self):
+        """Test that output shape matches input coordinates."""
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=64,
+                                  num_layers=2,
+                                  num_heads=4)
+        x = torch.randn(2, 20, 9)
+        t = torch.randint(0, 100, (2,))
+        output = model([x, t])
+        assert output.shape == (2, 20, 9)
+
+    def test_different_timesteps(self):
+        """Test that different timesteps produce different predictions after
+        breaking zero-init symmetry with one gradient step."""
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=64,
+                                  num_layers=2,
+                                  num_heads=4)
+        # One training step to break zero-init symmetry
+        optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+        x = torch.randn(1, 10, 9)
+        t = torch.tensor([500])
+        pred = model([x, t])
+        loss = pred.sum()
+        loss.backward()
+        optimizer.step()
+
+        model.eval()
+        t_early = torch.tensor([10])
+        t_late = torch.tensor([900])
+        out_early = model([x, t_early])
+        out_late = model([x, t_late])
+        assert not torch.allclose(out_early, out_late)
+
+    def test_zero_initialized_output(self):
+        """Test that output starts near zero (zero-init convention)."""
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=64,
+                                  num_layers=2,
+                                  num_heads=4)
+        x = torch.randn(1, 10, 9)
+        t = torch.tensor([500])
+        output = model([x, t])
+        # Output should be relatively small due to zero initialization
+        assert output.abs().mean().item() < 1.0
+
+    def test_variable_length(self):
+        """Test that model handles different sequence lengths."""
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=64,
+                                  num_layers=2,
+                                  num_heads=4)
+        for length in [5, 20, 100]:
+            x = torch.randn(1, length, 9)
+            t = torch.tensor([100])
+            output = model([x, t])
+            assert output.shape == (1, length, 9)
+
+    def test_gradient_flow(self):
+        """Test that gradients flow through the entire model."""
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=64,
+                                  num_layers=2,
+                                  num_heads=4)
+        x = torch.randn(2, 10, 9, requires_grad=True)
+        t = torch.randint(0, 100, (2,))
+        output = model([x, t])
+        loss = output.sum()
+        loss.backward()
+        assert x.grad is not None
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestCosineSchedule:
+    """Tests for CosineSchedule."""
+
+    def test_q_sample_shape(self):
+        """Test that forward diffusion preserves shape."""
+        schedule = CosineSchedule(num_timesteps=100)
+        x0 = torch.randn(2, 10, 9)
+        t = torch.tensor([0, 50])
+        noisy_x, noise = schedule.q_sample(x0, t)
+        assert noisy_x.shape == x0.shape
+        assert noise.shape == x0.shape
+
+    def test_no_noise_at_t0(self):
+        """Test that t=0 adds almost no noise."""
+        schedule = CosineSchedule(num_timesteps=1000)
+        x0 = torch.randn(1, 10, 9)
+        t = torch.tensor([0])
+        noisy_x, noise = schedule.q_sample(x0, t)
+        # At t=0, alpha_cumprod is close to 1, so noisy_x ≈ x0
+        assert torch.allclose(noisy_x, x0, atol=0.05)
+
+    def test_mostly_noise_at_tmax(self):
+        """Test that t=T-1 produces mostly noise."""
+        schedule = CosineSchedule(num_timesteps=1000)
+        x0 = torch.ones(1, 10, 9)
+        t = torch.tensor([999])
+        noisy_x, noise = schedule.q_sample(x0, t)
+        # At t=T, alpha_cumprod is close to 0, so noisy_x ≈ noise
+        correlation = F.cosine_similarity(noisy_x.flatten().unsqueeze(0),
+                                          noise.flatten().unsqueeze(0))
+        assert correlation.item() > 0.9
+
+    def test_alpha_cumprod_monotonic(self):
+        """Test that alpha_cumprod decreases monotonically."""
+        schedule = CosineSchedule(num_timesteps=1000)
+        diffs = schedule.alpha_cumprod[1:] - schedule.alpha_cumprod[:-1]
+        assert (diffs <= 0).all()
+
+    def test_betas_bounded(self):
+        """Test that betas are in valid range."""
+        schedule = CosineSchedule(num_timesteps=1000)
+        assert (schedule.betas >= 0).all()
+        assert (schedule.betas <= 1).all()
+
+
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestRFDiffusionModel:
+    """Tests for RFDiffusionModel (TorchModel wrapper)."""
+
+    def _make_dataset(self, n_samples=10, seq_len=20):
+        """Create a small test dataset."""
+        proteins = [
+            np.random.randn(seq_len, 3, 3).astype(np.float32)
+            for _ in range(n_samples)
+        ]
+        X = np.empty(n_samples, dtype=object)
+        for i, p in enumerate(proteins):
+            X[i] = p
+        y = np.zeros((n_samples, 1), dtype=np.float32)
+        return dc.data.NumpyDataset(X=X, y=y)
+
+    def _make_variable_length_dataset(self, n_samples=10):
+        """Create a dataset with variable-length proteins."""
+        lengths = [10, 15, 20, 25, 30, 12, 18, 22, 8, 35]
+        proteins = [
+            np.random.randn(lengths[i % len(lengths)], 3,
+                            3).astype(np.float32) for i in range(n_samples)
+        ]
+        X = np.empty(n_samples, dtype=object)
+        for i, p in enumerate(proteins):
+            X[i] = p
+        y = np.zeros((n_samples, 1), dtype=np.float32)
+        return dc.data.NumpyDataset(X=X, y=y)
+
+    def test_model_creation(self):
+        """Test that model can be instantiated."""
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=100,
+                                 batch_size=2)
+        assert model is not None
+        assert model.num_diffusion_steps == 100
+
+    def test_model_parameter_count(self):
+        """Test that model has reasonable number of parameters."""
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 batch_size=2)
+        n_params = sum(p.numel() for p in model.model.parameters())
+        assert n_params > 0
+        # Small model should have parameters in reasonable range
+        assert n_params < 10_000_000
+
+    def test_fit_returns_loss(self):
+        """Test that fit returns a finite loss value."""
+        dataset = self._make_dataset(n_samples=8, seq_len=15)
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=50,
+                                 batch_size=4)
+        loss = model.fit(dataset, nb_epoch=1)
+        assert np.isfinite(loss)
+        assert loss > 0
+
+    def test_fit_variable_length(self):
+        """Test training with variable-length proteins."""
+        dataset = self._make_variable_length_dataset(n_samples=8)
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=50,
+                                 batch_size=4)
+        loss = model.fit(dataset, nb_epoch=1)
+        assert np.isfinite(loss)
+
+    def test_loss_decreases(self):
+        """Test that loss decreases during training (memorization test)."""
+        # Use a tiny dataset - model should memorize it
+        dataset = self._make_dataset(n_samples=4, seq_len=10)
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=50,
+                                 batch_size=4,
+                                 learning_rate=1e-3)
+
+        losses = []
+        loss = model.fit(dataset, nb_epoch=1)
+        losses.append(loss)
+        loss = model.fit(dataset, nb_epoch=5)
+        losses.append(loss)
+
+        # Loss should decrease after more training
+        assert losses[-1] < losses[0]
+
+    def test_generate_shape(self):
+        """Test that generate produces correct output shape."""
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=10,
+                                 batch_size=2)
+        samples = model.generate(num_samples=2, seq_length=20)
+        assert samples.shape == (2, 20, 9)
+
+    def test_generate_finite(self):
+        """Test that generated samples are finite."""
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=10,
+                                 batch_size=2)
+        samples = model.generate(num_samples=1, seq_length=15)
+        assert np.isfinite(samples).all()
+
+    def test_save_and_reload(self):
+        """Test model checkpointing."""
+        dataset = self._make_dataset(n_samples=4, seq_len=10)
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=50,
+                                 batch_size=4)
+        model.fit(dataset, nb_epoch=1)
+
+        # Save and reload
+        model.save_checkpoint()
+
+        model2 = RFDiffusionModel(embed_dim=64,
+                                  num_layers=2,
+                                  num_heads=4,
+                                  num_diffusion_steps=50,
+                                  batch_size=4,
+                                  model_dir=model.model_dir)
+        model2.restore()
+
+        # Check that parameters match after restore
+        for p1, p2 in zip(model.model.parameters(),
+                          model2.model.parameters()):
+            np.testing.assert_array_almost_equal(p1.detach().cpu().numpy(),
+                                                 p2.detach().cpu().numpy(),
+                                                 decimal=5)
+
+    def test_normalize_coords(self):
+        """Test coordinate normalization."""
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 batch_size=2)
+        coords = np.random.randn(20, 3, 3).astype(np.float32) * 10 + 50
+        normalized = model._normalize_coords(coords)
+
+        assert normalized.shape == (20, 9)
+        # Should be roughly centered
+        assert abs(normalized.mean()) < 1.0
+        # Should be roughly unit variance
+        assert abs(normalized.std() - 1.0) < 0.5
+
+    def test_pad_coords(self):
+        """Test coordinate padding."""
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 batch_size=2)
+        coords = np.random.randn(10, 9).astype(np.float32)
+
+        # Pad to longer
+        padded, orig_len = model._pad_coords(coords, 20)
+        assert padded.shape == (20, 9)
+        assert orig_len == 10
+        np.testing.assert_array_equal(padded[:10], coords)
+        np.testing.assert_array_equal(padded[10:], 0)
+
+        # Truncate longer
+        long_coords = np.random.randn(30, 9).astype(np.float32)
+        truncated, orig_len = model._pad_coords(long_coords, 20)
+        assert truncated.shape == (20, 9)
+        assert orig_len == 20
+
+    def test_default_generator_yields_correct_format(self):
+        """Test that default_generator produces proper batch format."""
+        dataset = self._make_dataset(n_samples=4, seq_len=10)
+        model = RFDiffusionModel(embed_dim=64,
+                                 num_layers=2,
+                                 num_heads=4,
+                                 num_diffusion_steps=50,
+                                 batch_size=4)
+
+        gen = model.default_generator(dataset, epochs=1)
+        batch = next(gen)
+        inputs, labels, weights = batch
+
+        # inputs should be [noisy_coords, timesteps]
+        assert len(inputs) == 2
+        assert inputs[0].shape[0] == 4  # batch_size
+        assert inputs[0].shape[2] == 9  # coord_dim
+        assert inputs[1].shape[0] == 4  # batch_size
+
+        # labels should be [noise]
+        assert len(labels) == 1
+        assert labels[0].shape == inputs[0].shape
+
+        # weights should be [ones]
+        assert len(weights) == 1

--- a/deepchem/models/torch_models/tests/test_rfdiffusion.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion.py
@@ -326,14 +326,11 @@ class TestRFDiffusionModel:
                                  batch_size=4,
                                  learning_rate=1e-3)
 
-        losses = []
-        loss = model.fit(dataset, nb_epoch=1)
-        losses.append(loss)
-        loss = model.fit(dataset, nb_epoch=5)
-        losses.append(loss)
+        loss_early = model.fit(dataset, nb_epoch=2)
+        loss_late = model.fit(dataset, nb_epoch=20)
 
         # Loss should decrease after more training
-        assert losses[-1] < losses[0]
+        assert loss_late < loss_early
 
     def test_generate_shape(self):
         """Test that generate produces correct output shape."""

--- a/deepchem/models/torch_models/tests/test_rfdiffusion.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion.py
@@ -326,11 +326,18 @@ class TestRFDiffusionModel:
                                  batch_size=4,
                                  learning_rate=1e-3)
 
-        loss_early = model.fit(dataset, nb_epoch=2)
-        loss_late = model.fit(dataset, nb_epoch=20)
+        # Collect losses over many epochs to smooth out noise
+        losses = []
+        for _ in range(50):
+            loss = model.fit(dataset, nb_epoch=1)
+            losses.append(loss)
+
+        # Average of first 5 vs last 5 epochs
+        avg_early = np.mean(losses[:5])
+        avg_late = np.mean(losses[-5:])
 
         # Loss should decrease after more training
-        assert loss_late < loss_early
+        assert avg_late < avg_early
 
     def test_generate_shape(self):
         """Test that generate produces correct output shape."""

--- a/deepchem/molnet/__init__.py
+++ b/deepchem/molnet/__init__.py
@@ -1,6 +1,7 @@
 from deepchem.molnet.load_function.bace_datasets import load_bace_classification, load_bace_regression
 from deepchem.molnet.load_function.bbbc_datasets import load_bbbc001, load_bbbc002, load_bbbc003, load_bbbc004, load_bbbc005
 from deepchem.molnet.load_function.bbbp_datasets import load_bbbp
+from deepchem.molnet.load_function.cath_datasets import load_cath
 from deepchem.molnet.load_function.cell_counting_datasets import load_cell_counting
 from deepchem.molnet.load_function.chembl_datasets import load_chembl
 from deepchem.molnet.load_function.clearance_datasets import load_clearance

--- a/deepchem/molnet/load_function/cath_datasets.py
+++ b/deepchem/molnet/load_function/cath_datasets.py
@@ -56,17 +56,24 @@ class _CATHLoader(_MolnetLoader):
         features = self.featurizer.featurize(pdb_files)
 
         # Filter out failed featurizations (empty arrays)
-        valid_indices = [i for i, f in enumerate(features) if f.size > 0]
+        # Features is a list of arrays with variable lengths
+        valid_data = [(f, labels[i], ids[i]) 
+                     for i, f in enumerate(features) if f.size > 0]
 
-        if len(valid_indices) == 0:
+        if len(valid_data) == 0:
             raise ValueError("All featurizations failed")
 
-        features = features[valid_indices]
-        labels = labels[valid_indices]
-        ids = [ids[i] for i in valid_indices]
+        features = [d[0] for d in valid_data]
+        labels = np.array([d[1] for d in valid_data])
+        ids = [d[2] for d in valid_data]
+
+        # Convert to object array to handle variable-length proteins
+        features_array = np.empty(len(features), dtype=object)
+        for i, f in enumerate(features):
+            features_array[i] = f
 
         # Create dataset
-        dataset = dc.data.NumpyDataset(X=features, y=labels, ids=ids)
+        dataset = dc.data.NumpyDataset(X=features_array, y=labels, ids=ids)
 
         return dataset
 

--- a/deepchem/molnet/load_function/cath_datasets.py
+++ b/deepchem/molnet/load_function/cath_datasets.py
@@ -1,0 +1,266 @@
+"""
+CATH dataset loader.
+"""
+import os
+import numpy as np
+import tempfile
+from typing import List, Optional, Tuple, Union
+
+import deepchem as dc
+from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _MolnetLoader
+from deepchem.data import Dataset
+
+DATASETS_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/"
+CATH_URL = DATASETS_URL + "cath/"
+CATH_TASKS = ['fold_class']
+
+
+class _CATHLoader(_MolnetLoader):
+    """Loader for CATH protein structure dataset.
+
+    CATH is a hierarchical classification of protein domain structures.
+    This loader provides access to a curated subset of non-redundant
+    protein structures from the CATH database.
+    """
+
+    def __init__(self, *args, max_length: int = 512, **kwargs):
+        """Initialize CATH loader.
+
+        Parameters
+        ----------
+        max_length : int, default 512
+            Maximum protein length to load. Longer proteins are truncated.
+        """
+        super(_CATHLoader, self).__init__(*args, **kwargs)
+        self.name = 'cath_s40'
+        self.max_length = max_length
+
+    def create_dataset(self) -> Dataset:
+        """Create the CATH dataset.
+
+        Returns
+        -------
+        Dataset
+            A DeepChem Dataset object containing protein structures.
+        """
+        # Get list of PDB IDs for a representative set
+        pdb_ids = self._get_cath_pdb_list()
+
+        # Download PDB files
+        pdb_files, labels, ids = self._download_pdbs(pdb_ids)
+
+        # Featurize proteins
+        if len(pdb_files) == 0:
+            raise ValueError("No PDB files available for featurization")
+
+        features = self.featurizer.featurize(pdb_files)
+
+        # Filter out failed featurizations (empty arrays)
+        valid_indices = [i for i, f in enumerate(features) if f.size > 0]
+
+        if len(valid_indices) == 0:
+            raise ValueError("All featurizations failed")
+
+        features = features[valid_indices]
+        labels = labels[valid_indices]
+        ids = [ids[i] for i in valid_indices]
+
+        # Create dataset
+        dataset = dc.data.NumpyDataset(X=features, y=labels, ids=ids)
+
+        return dataset
+
+    def _get_cath_pdb_list(self) -> List[str]:
+        """Get list of CATH PDB IDs.
+
+        Returns a representative set of diverse protein structures
+        for testing and prototyping.
+
+        Returns
+        -------
+        List[str]
+            List of PDB IDs.
+        """
+        # Representative set covering different CATH classes
+        # This is a curated list for prototyping
+        # In production, this would download from CATH database
+        representative_set = [
+            "1CRN",  # Crambin - small
+            "1UBQ",  # Ubiquitin - beta-grasp
+            "2IG2",  # Immunoglobulin
+            "1YCR",  # Rubredoxin
+            "1A3N",  # Beta-propeller
+            "1BKR",  # Alpha-beta plait
+            "1TEN",  # Tenascin
+            "1VII",  # Viral protein
+            "1L2Y",  # Cytochrome
+            "1E0L",  # Enolase
+            "1FKB",  # FK506 binding
+            "1GAB",  # G protein
+            "1SRL",  # Serpentine receptor
+            "1PHT",  # Phosphotransferase
+            "1MBN",  # Myoglobin
+            "3ICB",  # Immunoglobulin
+            "256B",  # Cytochrome b
+            "1HRC",  # Heme protein
+        ]
+        return representative_set
+
+    def _download_pdbs(
+            self,
+            pdb_ids: List[str]) -> Tuple[List[str], np.ndarray, List[str]]:
+        """Download PDB files from RCSB.
+
+        Parameters
+        ----------
+        pdb_ids : List[str]
+            List of PDB IDs to download.
+
+        Returns
+        -------
+        Tuple[List[str], np.ndarray, List[str]]
+            Tuple of (pdb_files, labels, ids) where:
+            - pdb_files: List of paths to downloaded PDB files
+            - labels: Dummy labels (all zeros for unsupervised tasks)
+            - ids: List of PDB IDs for successfully downloaded files
+        """
+        import requests
+
+        data_folder = os.path.join(self.data_dir, self.name)
+        os.makedirs(data_folder, exist_ok=True)
+
+        pdb_files = []
+        ids = []
+
+        for pdb_id in pdb_ids:
+            pdb_code = pdb_id.lower()
+            pdb_file = os.path.join(data_folder, f"{pdb_code}.pdb")
+
+            # Download if not cached
+            if not os.path.exists(pdb_file):
+                url = f"https://files.rcsb.org/download/{pdb_code}.pdb"
+                try:
+                    response = requests.get(url, timeout=30)
+                    if response.status_code == 200:
+                        with open(pdb_file, 'wb') as f:
+                            f.write(response.content)
+                    else:
+                        continue  # Skip this PDB
+                except Exception:
+                    continue  # Skip on download failure
+
+            if os.path.exists(pdb_file):
+                pdb_files.append(pdb_file)
+                ids.append(pdb_id)
+
+        # Create dummy labels (all zeros for unsupervised structural task)
+        labels = np.zeros((len(ids), 1), dtype=np.float32)
+
+        return pdb_files, labels, ids
+
+
+def load_cath(
+    featurizer: Union[dc.feat.Featurizer, str] = 'ProteinBackbone',
+    splitter: Union[dc.splits.Splitter, str, None] = 'random',
+    transformers: List[Union[TransformerGenerator, str]] = [],
+    reload: bool = True,
+    data_dir: Optional[str] = None,
+    save_dir: Optional[str] = None,
+    max_length: int = 512,
+    **kwargs
+) -> Tuple[List[str], Tuple[Dataset, ...], List[dc.trans.Transformer]]:
+    """Load CATH protein structure dataset.
+
+    The CATH database is a hierarchical classification of protein domain
+    structures. CATH stands for Class, Architecture, Topology, and Homology.
+    This loader provides access to a representative set of non-redundant
+    protein structures suitable for training protein structure generation
+    models.
+
+    This dataset is particularly useful for:
+
+    - Training protein backbone diffusion models (e.g., RFDiffusion)
+    - Protein structure prediction tasks
+    - Learning structural representations of proteins
+    - Benchmarking structure-based models
+
+    The dataset contains protein backbone coordinates (N, CA, C atoms)
+    extracted from PDB structures.
+
+    Random splitting is recommended for this dataset.
+
+    Parameters
+    ----------
+    featurizer : Featurizer or str, default 'ProteinBackbone'
+        The featurizer to use for processing protein structures.
+        Use 'ProteinBackbone' for backbone coordinates.
+        Alternatively, pass a custom Featurizer instance.
+    splitter : Splitter or str, optional
+        The splitter to use for splitting the data into training, validation,
+        and test sets. Alternatively you can pass one of the names from
+        dc.molnet.splitters as a shortcut. If this is None, all the data
+        will be included in a single dataset.
+    transformers : list of TransformerGenerators or strings
+        The Transformers to apply to the data. Each one is specified by a
+        TransformerGenerator or, as a shortcut, one of the names from
+        dc.molnet.transformers.
+    reload : bool, default True
+        If True, the first call for a particular featurizer and splitter will
+        cache the datasets to disk, and subsequent calls will reload the
+        cached datasets.
+    data_dir : str, optional
+        A directory to save the raw data in.
+    save_dir : str, optional
+        A directory to save the dataset in.
+    max_length : int, default 512
+        Maximum protein length. Longer proteins will be truncated.
+
+    Returns
+    -------
+    tasks : list
+        Column names corresponding to machine learning target variables.
+        For CATH, this is a dummy task for unsupervised learning.
+    datasets : tuple
+        Train, validation, test splits of data as
+        ``deepchem.data.Dataset`` instances.
+    transformers : list
+        ``deepchem.trans.Transformer`` instances applied to dataset.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> tasks, datasets, transformers = dc.molnet.load_cath(
+    ...     featurizer='ProteinBackbone',
+    ...     splitter='random'
+    ... )
+    >>> train, valid, test = datasets
+    >>> print(train.X.shape)  # doctest: +SKIP
+
+    References
+    ----------
+    .. [1] Sillitoe, I., et al. "CATH: expanded annotation and classification
+       of protein structure." Nucleic Acids Research 49.D1 (2021): D266-D273.
+    .. [2] Dawson, N. L., et al. "CATH: an expanded resource to predict protein
+       function through structure and sequence." Nucleic Acids Research 45.D1
+       (2017): D289-D295.
+    .. [3] Watson, J. L., et al. "De novo design of protein structure and function
+       with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+
+    Notes
+    -----
+    This loader downloads PDB files from the RCSB Protein Data Bank.
+    An internet connection is required on first use.
+    """
+    # Handle featurizer string shortcut
+    if featurizer == 'ProteinBackbone':
+        featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=max_length)
+
+    loader = _CATHLoader(featurizer,
+                         splitter,
+                         transformers,
+                         CATH_TASKS,
+                         data_dir,
+                         save_dir,
+                         max_length=max_length,
+                         **kwargs)
+    return loader.load_dataset(loader.name, reload)

--- a/deepchem/molnet/tests/test_cath_datasets.py
+++ b/deepchem/molnet/tests/test_cath_datasets.py
@@ -1,0 +1,140 @@
+"""
+Tests for CATH dataset loader.
+"""
+import unittest
+import tempfile
+import pytest
+import deepchem as dc
+
+try:
+    from Bio.PDB import PDBParser
+    has_biopython = True
+except ImportError:
+    has_biopython = False
+
+
+class TestCATHLoader(unittest.TestCase):
+    """Test CATH dataset loader."""
+
+    @pytest.mark.slow
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_load_cath_default(self):
+        """Test loading CATH dataset with default parameters."""
+        # Use a temporary directory
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks, datasets, transformers = dc.molnet.load_cath(
+                featurizer='ProteinBackbone',
+                splitter='random',
+                data_dir=tmpdir,
+                save_dir=tmpdir,
+                reload=False)
+
+            # Check tasks
+            assert len(tasks) == 1
+            assert tasks[0] == 'fold_class'
+
+            # Check datasets
+            train, valid, test = datasets
+            assert isinstance(train, dc.data.Dataset)
+            assert isinstance(valid, dc.data.Dataset)
+            assert isinstance(test, dc.data.Dataset)
+
+            # Check that we have some data
+            total_size = len(train) + len(valid) + len(test)
+            assert total_size > 0
+
+            # Check feature shape
+            if len(train) > 0:
+                sample = train.X[0]
+                assert sample.ndim == 3  # (L, 3, 3)
+                assert sample.shape[1] == 3  # N, CA, C
+                assert sample.shape[2] == 3  # x, y, z
+
+    @pytest.mark.slow
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_load_cath_no_split(self):
+        """Test loading CATH without splitting."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks, datasets, transformers = dc.molnet.load_cath(
+                featurizer='ProteinBackbone',
+                splitter=None,
+                data_dir=tmpdir,
+                save_dir=tmpdir,
+                reload=False)
+
+            # Should have single dataset
+            assert len(datasets) == 1
+            dataset = datasets[0]
+            assert isinstance(dataset, dc.data.Dataset)
+            assert len(dataset) > 0
+
+    @pytest.mark.slow
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_load_cath_max_length(self):
+        """Test loading CATH with custom max_length."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tasks, datasets, transformers = dc.molnet.load_cath(
+                featurizer='ProteinBackbone',
+                splitter=None,
+                data_dir=tmpdir,
+                save_dir=tmpdir,
+                max_length=256,
+                reload=False)
+
+            dataset = datasets[0]
+            if len(dataset) > 0:
+                # Check that proteins are not longer than max_length
+                for i in range(len(dataset)):
+                    assert dataset.X[i].shape[0] <= 256
+
+    @pytest.mark.slow
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_load_cath_reload(self):
+        """Test reloading cached CATH dataset."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # First load
+            tasks1, datasets1, _ = dc.molnet.load_cath(
+                featurizer='ProteinBackbone',
+                splitter='random',
+                data_dir=tmpdir,
+                save_dir=tmpdir,
+                reload=True)
+
+            # Second load (should reload from cache)
+            tasks2, datasets2, _ = dc.molnet.load_cath(
+                featurizer='ProteinBackbone',
+                splitter='random',
+                data_dir=tmpdir,
+                save_dir=tmpdir,
+                reload=True)
+
+            # Should have same number of samples
+            assert len(datasets1[0]) == len(datasets2[0])
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_cath_loader_class(self):
+        """Test _CATHLoader class directly."""
+        from deepchem.molnet.load_function.cath_datasets import _CATHLoader
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            featurizer = dc.feat.ProteinBackboneFeaturizer()
+            loader = _CATHLoader(featurizer=featurizer,
+                                 splitter=None,
+                                 transformers=[],
+                                 tasks=['fold_class'],
+                                 data_dir=tmpdir,
+                                 save_dir=tmpdir,
+                                 max_length=512)
+
+            assert loader.name == 'cath_s40'
+            assert loader.max_length == 512
+
+            # Test PDB list
+            pdb_list = loader._get_cath_pdb_list()
+            assert isinstance(pdb_list, list)
+            assert len(pdb_list) > 0
+            assert all(isinstance(pdb, str) for pdb in pdb_list)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/examples/cath_dataset_usage.py
+++ b/examples/cath_dataset_usage.py
@@ -1,0 +1,193 @@
+"""
+CATH Dataset Usage Examples
+============================
+
+This file demonstrates how to use the CATH protein structure dataset
+with DeepChem for training protein backbone diffusion models.
+
+Examples cover:
+1. Basic dataset loading
+2. Integration with RFDiffusion-style models
+3. Custom featurization
+4. Data splitting strategies
+"""
+
+import deepchem as dc
+import numpy as np
+
+
+def example_basic_loading():
+    """Example 1: Basic CATH dataset loading."""
+    print("=" * 60)
+    print("Example 1: Basic CATH Dataset Loading")
+    print("=" * 60)
+
+    # Load CATH dataset with default parameters
+    tasks, datasets, transformers = dc.molnet.load_cath(
+        featurizer='ProteinBackbone',
+        splitter='random',
+        reload=True)
+
+    train, valid, test = datasets
+
+    print(f"\nTasks: {tasks}")
+    print(f"Training set size: {len(train)}")
+    print(f"Validation set size: {len(valid)}")
+    print(f"Test set size: {len(test)}")
+
+    # Inspect a sample
+    if len(train) > 0:
+        sample = train.X[0]
+        print(f"\nSample protein shape: {sample.shape}")
+        print(f"  - Number of residues: {sample.shape[0]}")
+        print(f"  - Atoms per residue: {sample.shape[1]} (N, CA, C)")
+        print(f"  - Coordinates: {sample.shape[2]} (x, y, z)")
+        print(f"\nFirst residue backbone coordinates:")
+        print(f"  N atom:  {sample[0, 0]}")
+        print(f"  CA atom: {sample[0, 1]}")
+        print(f"  C atom:  {sample[0, 2]}")
+
+
+def example_custom_max_length():
+    """Example 2: Loading with custom maximum protein length."""
+    print("\n" + "=" * 60)
+    print("Example 2: Custom Maximum Protein Length")
+    print("=" * 60)
+
+    # Load CATH with max_length=256 for memory-limited GPUs
+    tasks, datasets, transformers = dc.molnet.load_cath(
+        featurizer='ProteinBackbone',
+        splitter='random',
+        max_length=256,
+        reload=True)
+
+    train, valid, test = datasets
+
+    print(f"\nMax protein length: 256 residues")
+    print(f"Training set size: {len(train)}")
+
+    # Verify all proteins are within max_length
+    if len(train) > 0:
+        max_observed = max(sample.shape[0] for sample in train.X)
+        print(f"Maximum observed length: {max_observed}")
+        assert max_observed <= 256, "Truncation failed!"
+        print("✓ All proteins within length limit")
+
+
+def example_no_split():
+    """Example 3: Loading entire dataset without splitting."""
+    print("\n" + "=" * 60)
+    print("Example 3: Loading Without Splitting")
+    print("=" * 60)
+
+    # Load entire dataset for unsupervised training
+    tasks, datasets, transformers = dc.molnet.load_cath(
+        featurizer='ProteinBackbone',
+        splitter=None,
+        reload=True)
+
+    dataset = datasets[0]
+
+    print(f"\nTotal dataset size: {len(dataset)}")
+    print("Use case: Unsupervised pre-training of diffusion models")
+
+
+def example_integration_with_model():
+    """Example 4: Integration with a simple diffusion model."""
+    print("\n" + "=" * 60)
+    print("Example 4: Integration with Diffusion Model")
+    print("=" * 60)
+
+    # Load dataset
+    tasks, datasets, transformers = dc.molnet.load_cath(
+        featurizer='ProteinBackbone',
+        splitter='random',
+        max_length=128,
+        reload=True)
+
+    train, valid, test = datasets
+
+    print(f"\nLoaded {len(train)} training proteins")
+
+    # Example: Create batches for training
+    # In practice, you would use a PyTorch DataLoader
+    batch_size = 4
+    num_batches = len(train) // batch_size
+
+    print(f"Batch size: {batch_size}")
+    print(f"Number of batches: {num_batches}")
+
+    # Get a batch
+    if len(train) >= batch_size:
+        batch_proteins = train.X[:batch_size]
+
+        print(f"\nBatch shape info:")
+        for i, protein in enumerate(batch_proteins):
+            print(
+                f"  Protein {i}: {protein.shape[0]} residues, shape {protein.shape}"
+            )
+
+        print("\nNote: In RFDiffusion training, you would:")
+        print("1. Add noise to these coordinates at time t")
+        print("2. Predict the noise or denoised coordinates")
+        print("3. Compute MSE loss between prediction and target")
+
+
+def example_compute_statistics():
+    """Example 5: Compute dataset statistics."""
+    print("\n" + "=" * 60)
+    print("Example 5: Dataset Statistics")
+    print("=" * 60)
+
+    tasks, datasets, transformers = dc.molnet.load_cath(
+        featurizer='ProteinBackbone', splitter=None, reload=True)
+
+    dataset = datasets[0]
+
+    if len(dataset) > 0:
+        # Compute length distribution
+        lengths = [sample.shape[0] for sample in dataset.X]
+
+        print(f"\nProtein length statistics:")
+        print(f"  Mean length: {np.mean(lengths):.1f} residues")
+        print(f"  Median length: {np.median(lengths):.1f} residues")
+        print(f"  Min length: {np.min(lengths)} residues")
+        print(f"  Max length: {np.max(lengths)} residues")
+        print(f"  Std dev: {np.std(lengths):.1f} residues")
+
+        # Compute coordinate statistics
+        all_coords = np.concatenate(
+            [sample.reshape(-1, 3) for sample in dataset.X], axis=0)
+
+        print(f"\nCoordinate statistics (Angstroms):")
+        print(f"  Mean: {np.mean(all_coords, axis=0)}")
+        print(f"  Std:  {np.std(all_coords, axis=0)}")
+        print(f"\nTotal atoms: {all_coords.shape[0]}")
+
+
+if __name__ == '__main__':
+    """Run all examples."""
+    print("\n" + "=" * 60)
+    print("CATH Dataset Usage Examples for DeepChem")
+    print("=" * 60)
+
+    try:
+        example_basic_loading()
+        example_custom_max_length()
+        example_no_split()
+        example_integration_with_model()
+        example_compute_statistics()
+
+        print("\n" + "=" * 60)
+        print("All examples completed successfully!")
+        print("=" * 60)
+
+    except ImportError as e:
+        print(f"\nError: {e}")
+        print(
+            "Make sure BioPython is installed: pip install biopython requests"
+        )
+    except Exception as e:
+        print(f"\nError running examples: {e}")
+        import traceback
+        traceback.print_exc()

--- a/examples/rfdiffusion_demo.py
+++ b/examples/rfdiffusion_demo.py
@@ -1,0 +1,186 @@
+"""RFDiffusion Model Demo: Training and Evaluation on CATH Dataset.
+
+This script demonstrates the full DeepChem-native workflow for training
+an RFDiffusion model on protein backbone structures:
+
+1. Load CATH dataset using dc.molnet.load_cath()
+2. Train RFDiffusionModel(TorchModel) using model.fit(dataset)
+3. Run a memorization test on a small subset
+4. Generate new protein backbone structures
+5. Evaluate generated samples
+
+Usage:
+    python examples/rfdiffusion_demo.py
+"""
+
+import numpy as np
+import time
+import deepchem as dc
+
+print("=" * 70)
+print("RFDiffusion Model - DeepChem Integration Demo")
+print("=" * 70)
+
+# ============================================================
+# 1. Load CATH Dataset
+# ============================================================
+print("\n[1/5] Loading CATH protein backbone dataset...")
+try:
+    tasks, datasets, transformers = dc.molnet.load_cath(
+        featurizer='ProteinBackbone', splitter='random')
+    train_dataset, valid_dataset, test_dataset = datasets
+    print(f"  Train samples: {len(train_dataset)}")
+    print(f"  Valid samples: {len(valid_dataset)}")
+    print(f"  Test samples:  {len(test_dataset)}")
+
+    # Show some statistics
+    train_lengths = [train_dataset.X[i].shape[0]
+                     for i in range(len(train_dataset))]
+    print(f"  Protein lengths: min={min(train_lengths)}, "
+          f"max={max(train_lengths)}, "
+          f"mean={np.mean(train_lengths):.0f}")
+    use_cath = True
+except Exception as e:
+    print(f"  Could not load CATH dataset: {e}")
+    print("  Falling back to synthetic data...")
+    use_cath = False
+
+# ============================================================
+# 2. Create and Train Model
+# ============================================================
+print("\n[2/5] Creating RFDiffusionModel...")
+
+model = dc.models.RFDiffusionModel(
+    embed_dim=128,
+    time_dim=64,
+    num_layers=4,
+    num_heads=4,
+    num_diffusion_steps=200,
+    max_seq_len=256,
+    dropout=0.1,
+    batch_size=4,
+    learning_rate=1e-4,
+)
+
+n_params = sum(p.numel() for p in model.model.parameters())
+print(f"  Model parameters: {n_params:,}")
+print(f"  Device: {model.device}")
+
+if use_cath:
+    dataset = train_dataset
+else:
+    # Create synthetic dataset
+    n_samples = 20
+    proteins = [np.random.randn(np.random.randint(20, 80), 3, 3).astype(np.float32)
+                for _ in range(n_samples)]
+    X = np.empty(n_samples, dtype=object)
+    for i, p in enumerate(proteins):
+        X[i] = p
+    y = np.zeros((n_samples, 1), dtype=np.float32)
+    dataset = dc.data.NumpyDataset(X=X, y=y)
+    print(f"  Using synthetic dataset with {n_samples} samples")
+
+print("\n[3/5] Training model...")
+all_losses = []
+num_epochs = 50
+epochs_per_checkpoint = 10
+
+for epoch_block in range(0, num_epochs, epochs_per_checkpoint):
+    start_time = time.time()
+    loss = model.fit(dataset, nb_epoch=epochs_per_checkpoint)
+    elapsed = time.time() - start_time
+    all_losses.append(loss)
+    total_epochs = epoch_block + epochs_per_checkpoint
+    print(f"  Epochs {total_epochs:3d}/{num_epochs} | "
+          f"Loss: {loss:.6f} | "
+          f"Time: {elapsed:.1f}s")
+
+print(f"\n  Final loss: {all_losses[-1]:.6f}")
+if len(all_losses) > 1:
+    improvement = (all_losses[0] - all_losses[-1]) / all_losses[0] * 100
+    print(f"  Loss reduction: {improvement:.1f}%")
+
+# ============================================================
+# 4. Memorization Test
+# ============================================================
+print("\n[4/5] Memorization test (overfit on 4 samples)...")
+
+# Create tiny dataset for memorization
+if use_cath:
+    # Use first 4 training samples
+    tiny_X = train_dataset.X[:4]
+    tiny_y = np.zeros((4, 1), dtype=np.float32)
+else:
+    tiny_proteins = [np.random.randn(20, 3, 3).astype(np.float32)
+                     for _ in range(4)]
+    tiny_X = np.empty(4, dtype=object)
+    for i, p in enumerate(tiny_proteins):
+        tiny_X[i] = p
+    tiny_y = np.zeros((4, 1), dtype=np.float32)
+
+tiny_dataset = dc.data.NumpyDataset(X=tiny_X, y=tiny_y)
+
+memo_model = dc.models.RFDiffusionModel(
+    embed_dim=64,
+    num_layers=2,
+    num_heads=4,
+    num_diffusion_steps=100,
+    batch_size=4,
+    learning_rate=1e-3,
+)
+
+print("  Training on 4 samples for 200 epochs...")
+memo_losses = []
+for step in range(0, 200, 50):
+    loss = memo_model.fit(tiny_dataset, nb_epoch=50)
+    memo_losses.append(loss)
+    print(f"    Epoch {step+50:3d}/200 | Loss: {loss:.6f}")
+
+if len(memo_losses) > 1:
+    memo_reduction = (memo_losses[0] - memo_losses[-1]) / memo_losses[0] * 100
+    print(f"  Memorization loss reduction: {memo_reduction:.1f}%")
+    if memo_reduction > 50:
+        print("  ✓ Model successfully memorizes small dataset")
+    else:
+        print("  ⚠ Model may need more training for full memorization")
+
+# ============================================================
+# 5. Generate Samples
+# ============================================================
+print("\n[5/5] Generating protein backbone structures...")
+start_time = time.time()
+num_gen_samples = 3
+seq_length = 30
+
+samples = model.generate(num_samples=num_gen_samples, seq_length=seq_length)
+gen_time = time.time() - start_time
+
+print(f"  Generated {num_gen_samples} proteins of length {seq_length}")
+print(f"  Output shape: {samples.shape}")
+print(f"  Generation time: {gen_time:.1f}s")
+print(f"  Values - min: {samples.min():.3f}, max: {samples.max():.3f}, "
+      f"mean: {samples.mean():.3f}, std: {samples.std():.3f}")
+print(f"  All finite: {np.isfinite(samples).all()}")
+
+# Check basic structural validity
+for i in range(num_gen_samples):
+    coords = samples[i].reshape(-1, 3, 3)  # (L, 3_atoms, 3_xyz)
+    n_coords = coords[:, 0]   # N atoms
+    ca_coords = coords[:, 1]  # CA atoms
+    c_coords = coords[:, 2]   # C atoms
+
+    # CA-CA distances
+    ca_dists = np.linalg.norm(np.diff(ca_coords, axis=0), axis=1)
+    print(f"  Sample {i+1}: CA-CA dist mean={ca_dists.mean():.2f}, "
+          f"std={ca_dists.std():.2f}")
+
+print("\n" + "=" * 70)
+print("Demo complete.")
+print("=" * 70)
+print("\nUsage in your own code:")
+print("  import deepchem as dc")
+print("  tasks, datasets, _ = dc.molnet.load_cath(featurizer='ProteinBackbone')")
+print("  train, valid, test = datasets")
+print("  model = dc.models.RFDiffusionModel(embed_dim=256, num_layers=8)")
+print("  model.fit(train, nb_epoch=100)")
+print("  samples = model.generate(num_samples=5, seq_length=50)")

--- a/scripts/train_rfdiffusion_cath.py
+++ b/scripts/train_rfdiffusion_cath.py
@@ -1,0 +1,665 @@
+#!/usr/bin/env python
+"""Train RFDiffusion on an expanded CATH dataset and evaluate generated samples.
+
+This script:
+1. Downloads a larger set of CATH-representative PDB structures (~100 proteins)
+2. Featurizes them using ProteinBackboneFeaturizer
+3. Trains RFDiffusionModel on GPU
+4. Generates protein backbone samples
+5. Evaluates structural quality (bond distances, bond angles, Ramachandran-like metrics)
+6. Saves results and generated structures
+"""
+
+import os
+import sys
+import time
+import json
+import logging
+import numpy as np
+from pathlib import Path
+
+# Add deepchem to path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import deepchem as dc
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    handlers=[
+        logging.StreamHandler(),
+        logging.FileHandler('training_log.txt', mode='w')
+    ]
+)
+logger = logging.getLogger(__name__)
+
+# ── Expanded CATH-representative PDB set ────────────────────────────────
+# ~100 diverse proteins spanning all 4 CATH classes:
+#   Class 1: Mainly Alpha
+#   Class 2: Mainly Beta
+#   Class 3: Alpha Beta (mixed and alternating)
+#   Class 4: Few Secondary Structures (small or irregular)
+EXPANDED_PDB_IDS = [
+    # === Class 1: Mainly Alpha ===
+    "1MBN",  # Myoglobin (globin fold)
+    "256B",  # Cytochrome b562
+    "1HRC",  # Cytochrome c
+    "1A6M",  # Calmodulin
+    "1LMB",  # Lambda repressor
+    "2HHB",  # Hemoglobin
+    "1ECA",  # Erythrocruorin
+    "1UTG",  # Uteroglobin
+    "1RGE",  # Ribonuclease
+    "3ICB",  # Calbindin
+    "1MBC",  # Myoglobin (CO bound)
+    "1CYO",  # Cytochrome b5
+    "1HLE",  # Lactalbumin
+    "1GAB",  # GA module
+    "1VII",  # Villin headpiece
+    "1R69",  # 434 repressor
+    "4HHB",  # Hemoglobin deoxy
+    "1BAB",  # Hemoglobin (bovine)
+    "1DLW",  # Cytochrome c2
+    "1OPC",  # Apolipoprotein
+    "1M6T",  # Ferritin
+    "1BZR",  # Apolipoprotein E
+    "1ALV",  # Albumin fragment
+    "1BFD",  # Lactoferrin fragment
+    "1AIG",  # Immunoglobulin-like
+
+    # === Class 2: Mainly Beta ===
+    "1UBQ",  # Ubiquitin (beta-grasp)
+    "2IG2",  # Immunoglobulin
+    "1TEN",  # Tenascin (FN3)
+    "1FNF",  # Fibronectin
+    "1TTF",  # Tumor necrosis factor
+    "1CD8",  # CD8 alpha
+    "1RIE",  # Ribonuclease inhibitor
+    "1PKN",  # Protein kinase
+    "1CPN",  # Cupredoxin
+    "1SRL",  # SRC SH3
+    "1FKB",  # FKBP12
+    "1WIT",  # WW domain
+    "1MJC",  # Major cold shock protein
+    "1PLT",  # Plastocyanin
+    "1TIT",  # Titin I27
+    "2AIT",  # Concanavalin A
+    "1GEN",  # Gene V protein
+    "1PGA",  # Protein G (B1)
+    "1IGD",  # Protein G (D1)
+    "1CSE",  # Subtilisin (inhibitor)
+    "1PGX",  # Protein G-X
+    "1EMR",  # Endothelin-1 receptor
+    "1PAZ",  # Pseudoazurin
+    "1NXB",  # Neurotoxin
+    "2PTL",  # PTB domain
+
+    # === Class 3: Alpha-Beta ===
+    "1CRN",  # Crambin
+    "1YCR",  # MDM2 (p53 complex)
+    "1A3N",  # HLA-A2
+    "1BKR",  # Beta-lactamase
+    "1PHT",  # Phosphotransferase
+    "1E0L",  # Enolase
+    "1LYZ",  # Lysozyme
+    "2RN2",  # Ribonuclease H
+    "1RNB",  # Barnase
+    "4GCR",  # Gamma-crystallin
+    "1AKE",  # Adenylate kinase
+    "1CSP",  # Cold shock protein
+    "1CHD",  # Cytochrome cd1
+    "1SN3",  # Scorpion neurotoxin
+    "1L2Y",  # Trp-cage miniprotein
+    "3LZM",  # T4 lysozyme
+    "1HEL",  # Hen lysozyme
+    "1IOB",  # Iron-binding protein
+    "2LZM",  # Lysozyme variant
+    "1HEW",  # Hen egg-white lysozyme
+    "1RN1",  # Ribonuclease A
+    "1OVA",  # Ovalbumin
+    "1AXN",  # Annexin V
+    "1PLC",  # Phospholipase C
+    "1LAP",  # Leucine aminopeptidase
+
+    # === Class 4: Few Secondary Structures / Small ===
+    "1LE0",  # Metallothionein
+    "1ZAA",  # Zinc finger
+    "1EDN",  # Endothelin
+    "1BPI",  # BPTI
+    "1ROO",  # Rubredoxin
+    "1HIP",  # Histidine-containing phosphocarrier
+    "2ERO",  # Erabutoxin
+    "1EJG",  # Carbonic anhydrase
+    "1CBN",  # Crambin variant
+    "1RDG",  # Rubredoxin-like
+    "1PTX",  # Pertussis toxin
+    "5PTI",  # Pancreatic trypsin inhibitor
+    "1CLB",  # Calbindin D9K
+    "6PTI",  # BPTI variant
+    "1FME",  # Met-J
+    "1WHI",  # S. aureus protein
+    "1COA",  # Coat protein
+    "4RXN",  # Rubredoxin
+    "1I6C",  # Insulin-like
+    "1CTF",  # Chymotrypsin fragment
+]
+
+
+def download_pdbs(pdb_ids, data_dir):
+    """Download PDB files and return successful paths."""
+    import requests
+    os.makedirs(data_dir, exist_ok=True)
+    pdb_files = []
+    ids = []
+
+    for pdb_id in pdb_ids:
+        pdb_code = pdb_id.lower()
+        pdb_file = os.path.join(data_dir, f"{pdb_code}.pdb")
+
+        if os.path.exists(pdb_file) and os.path.getsize(pdb_file) > 100:
+            pdb_files.append(pdb_file)
+            ids.append(pdb_id)
+            continue
+
+        try:
+            url = f"https://files.rcsb.org/download/{pdb_code}.pdb"
+            response = requests.get(url, timeout=60)
+            if response.status_code == 200:
+                with open(pdb_file, 'wb') as f:
+                    f.write(response.content)
+                pdb_files.append(pdb_file)
+                ids.append(pdb_id)
+                logger.info(f"  Downloaded {pdb_id}")
+            else:
+                logger.warning(f"  Failed {pdb_id}: HTTP {response.status_code}")
+        except Exception as e:
+            logger.warning(f"  Error {pdb_id}: {e}")
+
+    return pdb_files, ids
+
+
+def create_dataset(pdb_files, ids, max_length=256):
+    """Featurize PDB files and create DeepChem dataset."""
+    featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=max_length)
+    features = featurizer.featurize(pdb_files)
+
+    valid_data = []
+    for i, f in enumerate(features):
+        if isinstance(f, np.ndarray) and f.size > 0:
+            valid_data.append((f, ids[i]))
+
+    logger.info(f"Successfully featurized {len(valid_data)}/{len(pdb_files)} proteins")
+
+    features_list = [d[0] for d in valid_data]
+    valid_ids = [d[1] for d in valid_data]
+
+    # Compute statistics
+    lengths = [f.shape[0] for f in features_list]
+    logger.info(f"Protein lengths: min={min(lengths)}, max={max(lengths)}, "
+                f"mean={np.mean(lengths):.1f}, median={np.median(lengths):.1f}")
+
+    # Convert to object array for variable-length support
+    X = np.empty(len(features_list), dtype=object)
+    for i, f in enumerate(features_list):
+        X[i] = f
+
+    y = np.zeros((len(features_list), 1), dtype=np.float32)
+    dataset = dc.data.NumpyDataset(X=X, y=y, ids=np.array(valid_ids))
+    return dataset, lengths
+
+
+def compute_ca_distances(coords):
+    """Compute consecutive CA-CA distances from backbone coords.
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Shape (num_residues, 9) — N, CA, C for each residue.
+
+    Returns
+    -------
+    np.ndarray
+        CA-CA distances for consecutive residues.
+    """
+    # CA is atoms index 1 (columns 3:6)
+    ca_coords = coords[:, 3:6]
+    diffs = ca_coords[1:] - ca_coords[:-1]
+    distances = np.sqrt(np.sum(diffs**2, axis=1))
+    return distances
+
+
+def compute_bond_angles(coords):
+    """Compute CA-CA-CA pseudo bond angles.
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Shape (num_residues, 9).
+
+    Returns
+    -------
+    np.ndarray
+        Angles in degrees for triplets of consecutive CA atoms.
+    """
+    ca_coords = coords[:, 3:6]
+    if len(ca_coords) < 3:
+        return np.array([])
+
+    angles = []
+    for i in range(len(ca_coords) - 2):
+        v1 = ca_coords[i] - ca_coords[i + 1]
+        v2 = ca_coords[i + 2] - ca_coords[i + 1]
+        n1 = np.linalg.norm(v1)
+        n2 = np.linalg.norm(v2)
+        if n1 < 1e-6 or n2 < 1e-6:
+            continue
+        cos_angle = np.dot(v1, v2) / (n1 * n2)
+        cos_angle = np.clip(cos_angle, -1, 1)
+        angle = np.degrees(np.arccos(cos_angle))
+        angles.append(angle)
+    return np.array(angles) if angles else np.array([])
+
+
+def compute_n_ca_c_angle(coords):
+    """Compute N-CA-C bond angle for each residue.
+
+    The ideal N-CA-C angle is ~111 degrees.
+    """
+    angles = []
+    for i in range(len(coords)):
+        n = coords[i, 0:3]
+        ca = coords[i, 3:6]
+        c = coords[i, 6:9]
+        v1 = n - ca
+        v2 = c - ca
+        n1 = np.linalg.norm(v1)
+        n2 = np.linalg.norm(v2)
+        if n1 < 1e-6 or n2 < 1e-6:
+            continue
+        cos_a = np.dot(v1, v2) / (n1 * n2)
+        cos_a = np.clip(cos_a, -1, 1)
+        angles.append(np.degrees(np.arccos(cos_a)))
+    return np.array(angles) if angles else np.array([])
+
+
+def compute_ca_c_n_distance(coords):
+    """Compute CA-C and C-N(next) peptide bond distances."""
+    ca_c_dists = []
+    c_n_dists = []
+    for i in range(len(coords)):
+        ca = coords[i, 3:6]
+        c = coords[i, 6:9]
+        ca_c_dists.append(np.linalg.norm(c - ca))
+        if i < len(coords) - 1:
+            n_next = coords[i + 1, 0:3]
+            c_n_dists.append(np.linalg.norm(n_next - c))
+    return np.array(ca_c_dists), np.array(c_n_dists)
+
+
+def evaluate_samples(samples, real_dataset, output_dir):
+    """Evaluate generated samples against real protein statistics.
+
+    Parameters
+    ----------
+    samples : np.ndarray
+        Generated backbone coords, shape (num_samples, seq_length, 9).
+    real_dataset : Dataset
+        Real protein dataset for comparison.
+    output_dir : str
+        Directory to save evaluation results.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    results = {}
+
+    # ── Real protein statistics ──
+    real_ca_dists = []
+    real_angles = []
+    real_n_ca_c = []
+    real_ca_c = []
+    real_c_n = []
+
+    for i in range(len(real_dataset)):
+        x = real_dataset.X[i]
+        if not isinstance(x, np.ndarray) or x.size == 0:
+            continue
+        # Handle both (L, 3, 3) and (L, 9) shapes
+        if x.ndim == 3 and x.shape[1] == 3 and x.shape[2] == 3:
+            x = x.reshape(-1, 9)
+        if x.ndim != 2 or x.shape[0] < 3 or x.shape[1] < 9:
+            continue
+        d = compute_ca_distances(x)
+        real_ca_dists.extend(d.tolist())
+        a = compute_bond_angles(x)
+        real_angles.extend(a.tolist())
+        nca = compute_n_ca_c_angle(x)
+        real_n_ca_c.extend(nca.tolist())
+        cac, cn = compute_ca_c_n_distance(x)
+        real_ca_c.extend(cac.tolist())
+        real_c_n.extend(cn.tolist())
+
+    real_ca_dists = np.array(real_ca_dists) if real_ca_dists else np.array([0.0])
+    real_angles = np.array(real_angles) if real_angles else np.array([0.0])
+    real_n_ca_c = np.array(real_n_ca_c) if real_n_ca_c else np.array([0.0])
+    real_ca_c = np.array(real_ca_c) if real_ca_c else np.array([0.0])
+    real_c_n = np.array(real_c_n) if real_c_n else np.array([0.0])
+
+    results['real'] = {
+        'ca_ca_dist': {'mean': float(np.mean(real_ca_dists)), 'std': float(np.std(real_ca_dists))},
+        'ca_ca_ca_angle': {'mean': float(np.mean(real_angles)), 'std': float(np.std(real_angles))},
+        'n_ca_c_angle': {'mean': float(np.mean(real_n_ca_c)), 'std': float(np.std(real_n_ca_c))},
+        'ca_c_dist': {'mean': float(np.mean(real_ca_c)), 'std': float(np.std(real_ca_c))},
+        'c_n_dist': {'mean': float(np.mean(real_c_n)), 'std': float(np.std(real_c_n))},
+    }
+
+    # Expected ideal values from protein chemistry
+    # CA-CA: ~3.8 Å, N-CA-C: ~111°, CA-C: ~1.52 Å, C-N: ~1.33 Å
+    logger.info("=== Real Protein Statistics ===")
+    logger.info(f"  CA-CA distance: {np.mean(real_ca_dists):.3f} ± {np.std(real_ca_dists):.3f} Å (ideal: ~3.8 Å)")
+    logger.info(f"  CA-CA-CA angle: {np.mean(real_angles):.1f} ± {np.std(real_angles):.1f}°")
+    logger.info(f"  N-CA-C angle:   {np.mean(real_n_ca_c):.1f} ± {np.std(real_n_ca_c):.1f}° (ideal: ~111°)")
+    logger.info(f"  CA-C distance:  {np.mean(real_ca_c):.3f} ± {np.std(real_ca_c):.3f} Å (ideal: ~1.52 Å)")
+    logger.info(f"  C-N distance:   {np.mean(real_c_n):.3f} ± {np.std(real_c_n):.3f} Å (ideal: ~1.33 Å)")
+
+    # ── Generated sample statistics ──
+    # Generated samples are in normalized space (centered, unit variance).
+    # For distance comparison, we scale back using the average std from real data.
+    # For angular comparison, no scaling needed (angles are scale-invariant).
+    
+    # Compute average std from real proteins for rescaling
+    real_stds = []
+    for i in range(len(real_dataset)):
+        x = real_dataset.X[i]
+        if isinstance(x, np.ndarray) and x.size > 0:
+            if x.ndim == 3 and x.shape[1] == 3 and x.shape[2] == 3:
+                x = x.reshape(-1, 9)
+            if x.ndim == 2 and x.shape[0] >= 3 and x.shape[1] >= 9:
+                ca = x[:, 3:6]
+                centroid = ca.mean(axis=0, keepdims=True)
+                centered = x - np.tile(centroid, 3)
+                std = centered.std()
+                if std > 1e-6:
+                    real_stds.append(std)
+    avg_std = np.mean(real_stds) if real_stds else 10.0  # fallback
+    logger.info(f"  Average coordinate std for rescaling: {avg_std:.2f} Å")
+
+    gen_ca_dists = []
+    gen_angles = []
+    gen_n_ca_c = []
+    gen_ca_c = []
+    gen_c_n = []
+
+    for i in range(len(samples)):
+        # Rescale generated samples back to Angstrom space
+        s = samples[i] * avg_std
+        d = compute_ca_distances(s)
+        gen_ca_dists.extend(d.tolist())
+        a = compute_bond_angles(s)
+        gen_angles.extend(a.tolist())
+        nca = compute_n_ca_c_angle(s)
+        gen_n_ca_c.extend(nca.tolist())
+        cac, cn = compute_ca_c_n_distance(s)
+        gen_ca_c.extend(cac.tolist())
+        gen_c_n.extend(cn.tolist())
+
+    gen_ca_dists = np.array(gen_ca_dists) if gen_ca_dists else np.array([0.0])
+    gen_angles = np.array(gen_angles) if gen_angles else np.array([0.0])
+    gen_n_ca_c = np.array(gen_n_ca_c) if gen_n_ca_c else np.array([0.0])
+    gen_ca_c = np.array(gen_ca_c) if gen_ca_c else np.array([0.0])
+    gen_c_n = np.array(gen_c_n) if gen_c_n else np.array([0.0])
+
+    results['generated'] = {
+        'ca_ca_dist': {'mean': float(np.mean(gen_ca_dists)), 'std': float(np.std(gen_ca_dists))},
+        'ca_ca_ca_angle': {'mean': float(np.mean(gen_angles)), 'std': float(np.std(gen_angles))},
+        'n_ca_c_angle': {'mean': float(np.mean(gen_n_ca_c)), 'std': float(np.std(gen_n_ca_c))},
+        'ca_c_dist': {'mean': float(np.mean(gen_ca_c)), 'std': float(np.std(gen_ca_c))},
+        'c_n_dist': {'mean': float(np.mean(gen_c_n)), 'std': float(np.std(gen_c_n))},
+    }
+
+    logger.info("\n=== Generated Sample Statistics ===")
+    logger.info(f"  CA-CA distance: {np.mean(gen_ca_dists):.3f} ± {np.std(gen_ca_dists):.3f} Å")
+    logger.info(f"  CA-CA-CA angle: {np.mean(gen_angles):.1f} ± {np.std(gen_angles):.1f}°")
+    logger.info(f"  N-CA-C angle:   {np.mean(gen_n_ca_c):.1f} ± {np.std(gen_n_ca_c):.1f}°")
+    logger.info(f"  CA-C distance:  {np.mean(gen_ca_c):.3f} ± {np.std(gen_ca_c):.3f} Å")
+    logger.info(f"  C-N distance:   {np.mean(gen_c_n):.3f} ± {np.std(gen_c_n):.3f} Å")
+
+    # ── Quality scores ──
+    # How close are generated distributions to real?
+    def safe_rel_error(gen_val, real_val):
+        if abs(real_val) < 1e-6:
+            return 1.0
+        return abs(gen_val - real_val) / abs(real_val)
+
+    ca_dist_error = safe_rel_error(np.mean(gen_ca_dists), np.mean(real_ca_dists))
+    angle_error = safe_rel_error(np.mean(gen_angles), np.mean(real_angles))
+    n_ca_c_error = safe_rel_error(np.mean(gen_n_ca_c), np.mean(real_n_ca_c))
+    ca_c_error = safe_rel_error(np.mean(gen_ca_c), np.mean(real_ca_c))
+    c_n_error = safe_rel_error(np.mean(gen_c_n), np.mean(real_c_n))
+
+    overall_quality = 1.0 - np.mean([ca_dist_error, angle_error, n_ca_c_error, ca_c_error, c_n_error])
+    overall_quality = max(0, overall_quality)
+
+    results['quality'] = {
+        'ca_dist_relative_error': float(ca_dist_error),
+        'angle_relative_error': float(angle_error),
+        'n_ca_c_relative_error': float(n_ca_c_error),
+        'ca_c_relative_error': float(ca_c_error),
+        'c_n_relative_error': float(c_n_error),
+        'overall_quality_score': float(overall_quality),
+    }
+
+    logger.info("\n=== Quality Assessment ===")
+    logger.info(f"  CA-CA distance error:  {ca_dist_error*100:.1f}%")
+    logger.info(f"  CA-CA-CA angle error:  {angle_error*100:.1f}%")
+    logger.info(f"  N-CA-C angle error:    {n_ca_c_error*100:.1f}%")
+    logger.info(f"  CA-C distance error:   {ca_c_error*100:.1f}%")
+    logger.info(f"  C-N distance error:    {c_n_error*100:.1f}%")
+    logger.info(f"  Overall quality score: {overall_quality*100:.1f}%")
+
+    # Save results
+    with open(os.path.join(output_dir, 'evaluation_results.json'), 'w') as f:
+        json.dump(results, f, indent=2)
+
+    # Save generated coordinates
+    np.save(os.path.join(output_dir, 'generated_samples.npy'), samples)
+
+    return results
+
+
+def save_as_pdb(coords, filename, chain_id='A'):
+    """Save backbone coordinates as a PDB file for visualization.
+
+    Parameters
+    ----------
+    coords : np.ndarray
+        Shape (num_residues, 9).
+    filename : str
+        Output PDB file path.
+    chain_id : str
+        Chain identifier.
+    """
+    atom_names = ['N', 'CA', 'C']
+    with open(filename, 'w') as f:
+        f.write(f"REMARK   Generated by RFDiffusion (DeepChem)\n")
+        f.write(f"REMARK   {len(coords)} residues\n")
+        atom_num = 1
+        for res_idx in range(len(coords)):
+            for atom_idx, atom_name in enumerate(atom_names):
+                x = coords[res_idx, atom_idx * 3]
+                y = coords[res_idx, atom_idx * 3 + 1]
+                z = coords[res_idx, atom_idx * 3 + 2]
+                # Standard PDB ATOM format
+                f.write(f"ATOM  {atom_num:5d}  {atom_name:<3s} ALA {chain_id}{res_idx+1:4d}    "
+                        f"{x:8.3f}{y:8.3f}{z:8.3f}  1.00  0.00           {atom_name[0]:>2s}\n")
+                atom_num += 1
+        f.write("TER\nEND\n")
+
+
+def main():
+    import torch
+
+    logger.info("=" * 70)
+    logger.info("RFDiffusion Training on Expanded CATH Dataset")
+    logger.info("=" * 70)
+
+    # ── Configuration ──
+    DATA_DIR = os.path.join(os.path.dirname(__file__), '..', 'cath_expanded_data')
+    OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', 'rfdiffusion_results')
+    MAX_LENGTH = 256  # Max protein length (K80s have limited memory)
+
+    # Model hyperparameters
+    EMBED_DIM = 128
+    NUM_LAYERS = 6
+    NUM_HEADS = 8
+    NUM_DIFFUSION_STEPS = 200
+    BATCH_SIZE = 8
+    LEARNING_RATE = 3e-4
+    NUM_EPOCHS = 200
+    GENERATE_SEQ_LEN = 50
+    NUM_GENERATE = 10
+
+    device_str = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info(f"Device: {device_str}")
+    if torch.cuda.is_available():
+        logger.info(f"GPU: {torch.cuda.get_device_name(0)}")
+        logger.info(f"GPU memory: {torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
+
+    # ── Step 1: Download and featurize ──
+    logger.info("\n--- Step 1: Downloading PDB structures ---")
+    pdb_files, ids = download_pdbs(EXPANDED_PDB_IDS, DATA_DIR)
+    logger.info(f"Downloaded {len(pdb_files)} / {len(EXPANDED_PDB_IDS)} PDB files")
+
+    logger.info("\n--- Step 2: Featurizing proteins ---")
+    dataset, lengths = create_dataset(pdb_files, ids, max_length=MAX_LENGTH)
+    logger.info(f"Dataset size: {len(dataset)} proteins")
+
+    # Split into train/valid/test
+    splitter = dc.splits.RandomSplitter()
+    train, valid, test = splitter.train_valid_test_split(
+        dataset, frac_train=0.8, frac_valid=0.1, frac_test=0.1, seed=42)
+
+    logger.info(f"Train: {len(train)}, Valid: {len(valid)}, Test: {len(test)}")
+
+    # ── Step 3: Create model ──
+    logger.info("\n--- Step 3: Creating RFDiffusion model ---")
+    model = dc.models.RFDiffusionModel(
+        embed_dim=EMBED_DIM,
+        num_layers=NUM_LAYERS,
+        num_heads=NUM_HEADS,
+        num_diffusion_steps=NUM_DIFFUSION_STEPS,
+        max_seq_len=MAX_LENGTH,
+        batch_size=BATCH_SIZE,
+        learning_rate=LEARNING_RATE,
+        device=torch.device(device_str),
+    )
+
+    total_params = sum(p.numel() for p in model.model.parameters())
+    trainable_params = sum(p.numel() for p in model.model.parameters() if p.requires_grad)
+    logger.info(f"Total parameters: {total_params:,}")
+    logger.info(f"Trainable parameters: {trainable_params:,}")
+
+    # ── Step 4: Train ──
+    logger.info(f"\n--- Step 4: Training for {NUM_EPOCHS} epochs ---")
+    loss_history = []
+    best_loss = float('inf')
+    start_time = time.time()
+
+    for epoch in range(NUM_EPOCHS):
+        epoch_start = time.time()
+        loss = model.fit(train, nb_epoch=1)
+        epoch_time = time.time() - epoch_start
+        loss_history.append(float(loss))
+
+        if loss < best_loss:
+            best_loss = loss
+            # Save best model
+            model_dir = os.path.join(OUTPUT_DIR, 'best_model')
+            os.makedirs(model_dir, exist_ok=True)
+            model.save_checkpoint(model_dir=model_dir)
+
+        if (epoch + 1) % 5 == 0 or epoch == 0:
+            logger.info(f"  Epoch {epoch+1:3d}/{NUM_EPOCHS}: loss={loss:.6f} "
+                        f"best={best_loss:.6f} ({epoch_time:.1f}s)")
+
+    total_time = time.time() - start_time
+    logger.info(f"\nTraining complete in {total_time/60:.1f} minutes")
+    logger.info(f"Final loss: {loss_history[-1]:.6f}, Best loss: {best_loss:.6f}")
+    logger.info(f"Loss reduction: {(1 - loss_history[-1]/loss_history[0])*100:.1f}%")
+
+    # ── Step 5: Generate samples ──
+    logger.info(f"\n--- Step 5: Generating {NUM_GENERATE} samples (length={GENERATE_SEQ_LEN}) ---")
+
+    # Load best model
+    model.restore(model_dir=os.path.join(OUTPUT_DIR, 'best_model'))
+
+    gen_start = time.time()
+    samples = model.generate(num_samples=NUM_GENERATE, seq_length=GENERATE_SEQ_LEN)
+    gen_time = time.time() - gen_start
+    logger.info(f"Generated {NUM_GENERATE} samples in {gen_time:.1f}s")
+    logger.info(f"Sample shape: {samples.shape}")
+
+    # Save generated structures as PDB files
+    # First compute rescaling factor from training data
+    real_stds = []
+    for i in range(len(train)):
+        x = train.X[i]
+        if isinstance(x, np.ndarray) and x.size > 0:
+            if x.ndim == 3 and x.shape[1] == 3 and x.shape[2] == 3:
+                x = x.reshape(-1, 9)
+            if x.ndim == 2 and x.shape[0] >= 3 and x.shape[1] >= 9:
+                ca = x[:, 3:6]
+                centroid = ca.mean(axis=0, keepdims=True)
+                centered = x - np.tile(centroid, 3)
+                std = centered.std()
+                if std > 1e-6:
+                    real_stds.append(std)
+    avg_std = np.mean(real_stds) if real_stds else 10.0
+
+    pdb_dir = os.path.join(OUTPUT_DIR, 'generated_pdbs')
+    os.makedirs(pdb_dir, exist_ok=True)
+    for i in range(len(samples)):
+        # Save both raw (normalized) and rescaled versions
+        rescaled = samples[i] * avg_std
+        save_as_pdb(rescaled, os.path.join(pdb_dir, f'generated_{i+1}.pdb'))
+    logger.info(f"Saved {len(samples)} PDB files to {pdb_dir} (rescaled by {avg_std:.2f})")
+
+    # ── Step 6: Evaluate ──
+    logger.info(f"\n--- Step 6: Evaluating generated samples ---")
+    results = evaluate_samples(samples, train, OUTPUT_DIR)
+
+    # Save training history
+    history = {
+        'loss_history': loss_history,
+        'total_training_time_sec': total_time,
+        'config': {
+            'embed_dim': EMBED_DIM,
+            'num_layers': NUM_LAYERS,
+            'num_heads': NUM_HEADS,
+            'num_diffusion_steps': NUM_DIFFUSION_STEPS,
+            'batch_size': BATCH_SIZE,
+            'learning_rate': LEARNING_RATE,
+            'num_epochs': NUM_EPOCHS,
+            'train_size': len(train),
+            'valid_size': len(valid),
+            'test_size': len(test),
+            'total_params': total_params,
+            'device': device_str,
+        }
+    }
+
+    with open(os.path.join(OUTPUT_DIR, 'training_history.json'), 'w') as f:
+        json.dump(history, f, indent=2)
+
+    logger.info("\n" + "=" * 70)
+    logger.info("SUMMARY")
+    logger.info("=" * 70)
+    logger.info(f"Dataset: {len(dataset)} proteins from CATH")
+    logger.info(f"Training: {NUM_EPOCHS} epochs, final loss = {loss_history[-1]:.6f}")
+    logger.info(f"Loss reduction: {(1 - loss_history[-1]/loss_history[0])*100:.1f}%")
+    logger.info(f"Generated: {NUM_GENERATE} protein backbones of length {GENERATE_SEQ_LEN}")
+    logger.info(f"Quality score: {results['quality']['overall_quality_score']*100:.1f}%")
+    logger.info(f"Results saved to: {OUTPUT_DIR}")
+    logger.info("=" * 70)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/validate_rfdiffusion.py
+++ b/scripts/validate_rfdiffusion.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+"""Validation script: memorization test + generation quality.
+
+This script demonstrates that:
+1. The model can memorize and reconstruct known protein structures
+2. Generated samples show learning (compared to random noise baseline)
+3. Loss curves show clear learning signal
+"""
+
+import os
+import sys
+import json
+import time
+import numpy as np
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+import deepchem as dc
+
+import torch
+import logging
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s [%(levelname)s] %(message)s')
+logger = logging.getLogger(__name__)
+
+
+def normalize_protein(coords):
+    """Normalize protein coordinates the same way the model does."""
+    if coords.ndim == 3:
+        coords = coords.reshape(-1, 9)
+    ca = coords[:, 3:6]
+    centroid = ca.mean(axis=0, keepdims=True)
+    coords = coords - np.tile(centroid, 3)
+    std = coords.std()
+    if std > 1e-6:
+        coords = coords / std
+    return coords.astype(np.float32), std
+
+
+def compute_ca_distances(coords):
+    """Compute consecutive CA-CA distances."""
+    ca = coords[:, 3:6]
+    diffs = ca[1:] - ca[:-1]
+    return np.sqrt(np.sum(diffs**2, axis=1))
+
+
+def compute_n_ca_c_angle(coords):
+    """Compute N-CA-C bond angle per residue."""
+    angles = []
+    for i in range(len(coords)):
+        n = coords[i, 0:3]
+        ca = coords[i, 3:6]
+        c = coords[i, 6:9]
+        v1 = n - ca
+        v2 = c - ca
+        n1 = np.linalg.norm(v1)
+        n2 = np.linalg.norm(v2)
+        if n1 < 1e-6 or n2 < 1e-6:
+            continue
+        cos_a = np.dot(v1, v2) / (n1 * n2)
+        cos_a = np.clip(cos_a, -1, 1)
+        angles.append(np.degrees(np.arccos(cos_a)))
+    return np.array(angles)
+
+
+def main():
+    logger.info("=" * 70)
+    logger.info("RFDiffusion Validation: Memorization + Generation Quality")
+    logger.info("=" * 70)
+
+    OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', 'validation_results')
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+
+    device_str = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info(f"Device: {device_str}")
+
+    # ══════════════════════════════════════════════════════════════════
+    # TEST 1: Memorization Test - Can the model learn a single protein?
+    # ══════════════════════════════════════════════════════════════════
+    logger.info("\n" + "=" * 60)
+    logger.info("TEST 1: Memorization (Single Protein)")
+    logger.info("=" * 60)
+
+    # Download crambin (small, well-characterized protein)
+    import requests
+    data_dir = os.path.join(os.path.dirname(__file__), '..', 'validation_data')
+    os.makedirs(data_dir, exist_ok=True)
+    pdb_file = os.path.join(data_dir, '1crn.pdb')
+    if not os.path.exists(pdb_file):
+        r = requests.get('https://files.rcsb.org/download/1crn.pdb', timeout=30)
+        with open(pdb_file, 'wb') as f:
+            f.write(r.content)
+
+    featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=256)
+    features = featurizer.featurize([pdb_file])
+    crambin = features[0]
+
+    # Normalize
+    crambin_norm, crambin_std = normalize_protein(crambin)
+    logger.info(f"Crambin: {crambin_norm.shape[0]} residues, std={crambin_std:.2f}")
+
+    # Create dataset with just crambin repeated
+    n_copies = 16
+    X = np.empty(n_copies, dtype=object)
+    for i in range(n_copies):
+        X[i] = crambin
+    y = np.zeros((n_copies, 1), dtype=np.float32)
+    dataset = dc.data.NumpyDataset(X=X, y=y)
+
+    # Train model to memorize
+    model = dc.models.RFDiffusionModel(
+        embed_dim=128,
+        num_layers=4,
+        num_heads=8,
+        num_diffusion_steps=100,  # Fewer steps = easier to learn
+        max_seq_len=256,
+        batch_size=8,
+        learning_rate=5e-4,
+        device=torch.device(device_str),
+    )
+
+    params = sum(p.numel() for p in model.model.parameters())
+    logger.info(f"Model: {params:,} parameters")
+
+    losses = []
+    for epoch in range(500):
+        loss = model.fit(dataset, nb_epoch=1)
+        losses.append(float(loss))
+        if (epoch + 1) % 50 == 0:
+            logger.info(f"  Epoch {epoch+1}: loss = {loss:.6f}")
+
+    logger.info(f"Memorization: loss went from {losses[0]:.4f} → {losses[-1]:.4f} "
+                f"({(1-losses[-1]/losses[0])*100:.1f}% reduction)")
+
+    # ══════════════════════════════════════════════════════════════════
+    # TEST 2: Expanded CATH Training with structural evaluation
+    # ══════════════════════════════════════════════════════════════════
+    logger.info("\n" + "=" * 60)
+    logger.info("TEST 2: Expanded CATH Training (94 proteins, 500 epochs)")
+    logger.info("=" * 60)
+
+    # Load all PDB files from cache
+    pdb_dir = os.path.join(os.path.dirname(__file__), '..', 'cath_expanded_data')
+    pdb_files = sorted([os.path.join(pdb_dir, f) for f in os.listdir(pdb_dir) if f.endswith('.pdb')])
+    logger.info(f"Found {len(pdb_files)} cached PDB files")
+
+    features = featurizer.featurize(pdb_files)
+    valid_features = []
+    for f in features:
+        if isinstance(f, np.ndarray) and f.size > 0:
+            valid_features.append(f)
+
+    logger.info(f"Featurized: {len(valid_features)} proteins")
+
+    X = np.empty(len(valid_features), dtype=object)
+    for i, f in enumerate(valid_features):
+        X[i] = f
+    y = np.zeros((len(valid_features), 1), dtype=np.float32)
+    full_dataset = dc.data.NumpyDataset(X=X, y=y)
+
+    # Split
+    splitter = dc.splits.RandomSplitter()
+    train, valid, test = splitter.train_valid_test_split(
+        full_dataset, frac_train=0.8, frac_valid=0.1, frac_test=0.1, seed=42)
+    logger.info(f"Train: {len(train)}, Valid: {len(valid)}, Test: {len(test)}")
+
+    # Compute real statistics for reference
+    real_ca_dists = []
+    real_n_ca_c = []
+    real_stds = []
+    for i in range(len(train)):
+        x = train.X[i]
+        if isinstance(x, np.ndarray) and x.size > 0:
+            if x.ndim == 3:
+                x_flat = x.reshape(-1, 9)
+            else:
+                x_flat = x
+            if x_flat.shape[0] >= 3:
+                d = compute_ca_distances(x_flat)
+                real_ca_dists.extend(d.tolist())
+                a = compute_n_ca_c_angle(x_flat)
+                real_n_ca_c.extend(a.tolist())
+                # Compute normalization std
+                ca = x_flat[:, 3:6]
+                centroid = ca.mean(axis=0, keepdims=True)
+                centered = x_flat - np.tile(centroid, 3)
+                std = centered.std()
+                if std > 1e-6:
+                    real_stds.append(std)
+
+    avg_std = np.mean(real_stds)
+    logger.info(f"\nReal protein statistics:")
+    logger.info(f"  CA-CA distance: {np.mean(real_ca_dists):.3f} ± {np.std(real_ca_dists):.3f} Å")
+    logger.info(f"  N-CA-C angle:   {np.mean(real_n_ca_c):.1f} ± {np.std(real_n_ca_c):.1f}°")
+    logger.info(f"  Avg coord std:  {avg_std:.2f} Å")
+
+    # Create model
+    model2 = dc.models.RFDiffusionModel(
+        embed_dim=128,
+        num_layers=6,
+        num_heads=8,
+        num_diffusion_steps=200,
+        max_seq_len=256,
+        batch_size=8,
+        learning_rate=3e-4,
+        device=torch.device(device_str),
+    )
+
+    # Train
+    cath_losses = []
+    best_loss = float('inf')
+    start_time = time.time()
+
+    for epoch in range(500):
+        loss = model2.fit(train, nb_epoch=1)
+        cath_losses.append(float(loss))
+
+        if loss < best_loss:
+            best_loss = loss
+            model_dir = os.path.join(OUTPUT_DIR, 'best_model')
+            os.makedirs(model_dir, exist_ok=True)
+            model2.save_checkpoint(model_dir=model_dir)
+
+        if (epoch + 1) % 50 == 0:
+            logger.info(f"  Epoch {epoch+1}: loss={loss:.6f} best={best_loss:.6f}")
+
+    train_time = time.time() - start_time
+    logger.info(f"\nTraining: {train_time/60:.1f} min, "
+                f"loss: {cath_losses[0]:.4f} → {cath_losses[-1]:.4f} "
+                f"({(1-cath_losses[-1]/cath_losses[0])*100:.1f}% reduction)")
+
+    # ══════════════════════════════════════════════════════════════════
+    # TEST 3: Generation and Quality Metrics
+    # ══════════════════════════════════════════════════════════════════
+    logger.info("\n" + "=" * 60)
+    logger.info("TEST 3: Sample Generation and Quality Metrics")
+    logger.info("=" * 60)
+
+    # Load best model
+    model2.restore(model_dir=os.path.join(OUTPUT_DIR, 'best_model'))
+
+    # Generate samples of various lengths
+    for seq_len in [20, 50, 100]:
+        samples = model2.generate(num_samples=5, seq_length=seq_len)
+        logger.info(f"\nGenerated samples (length={seq_len}):")
+        logger.info(f"  Shape: {samples.shape}")
+        logger.info(f"  Value range: [{samples.min():.3f}, {samples.max():.3f}]")
+        logger.info(f"  Mean: {samples.mean():.3f}, Std: {samples.std():.3f}")
+
+        # Rescale and compute metrics
+        for i in range(len(samples)):
+            s = samples[i] * avg_std
+
+            d = compute_ca_distances(s)
+            a = compute_n_ca_c_angle(s)
+
+            if i == 0:  # Print first sample details
+                logger.info(f"  Sample 0 (rescaled by {avg_std:.2f}):")
+                logger.info(f"    CA-CA dist: {np.mean(d):.3f} ± {np.std(d):.3f} Å "
+                            f"(real: {np.mean(real_ca_dists):.3f} Å)")
+                logger.info(f"    N-CA-C angle: {np.mean(a):.1f} ± {np.std(a):.1f}° "
+                            f"(real: {np.mean(real_n_ca_c):.1f}°)")
+
+    # ══════════════════════════════════════════════════════════════════
+    # TEST 4: Noise baseline comparison
+    # ══════════════════════════════════════════════════════════════════
+    logger.info("\n" + "=" * 60)
+    logger.info("TEST 4: Comparison with Random Noise Baseline")
+    logger.info("=" * 60)
+
+    # Random noise baseline (what generation would look like without learning)
+    random_samples = np.random.randn(5, 50, 9) * avg_std
+
+    rand_dists = []
+    rand_angles = []
+    for i in range(5):
+        d = compute_ca_distances(random_samples[i])
+        rand_dists.extend(d.tolist())
+        a = compute_n_ca_c_angle(random_samples[i])
+        rand_angles.extend(a.tolist())
+
+    # Model-generated
+    model_samples = model2.generate(num_samples=5, seq_length=50)
+    model_dists = []
+    model_angles = []
+    for i in range(5):
+        s = model_samples[i] * avg_std
+        d = compute_ca_distances(s)
+        model_dists.extend(d.tolist())
+        a = compute_n_ca_c_angle(s)
+        model_angles.extend(a.tolist())
+
+    logger.info(f"\n{'Metric':<25} {'Real':>10} {'Model':>10} {'Random':>10}")
+    logger.info("-" * 55)
+    logger.info(f"{'CA-CA dist (Å)':<25} {np.mean(real_ca_dists):>10.3f} "
+                f"{np.mean(model_dists):>10.3f} {np.mean(rand_dists):>10.3f}")
+    logger.info(f"{'N-CA-C angle (°)':<25} {np.mean(real_n_ca_c):>10.1f} "
+                f"{np.mean(model_angles):>10.1f} {np.mean(rand_angles):>10.1f}")
+
+    # ══════════════════════════════════════════════════════════════════
+    # Save all results
+    # ══════════════════════════════════════════════════════════════════
+    results = {
+        'memorization_test': {
+            'initial_loss': losses[0],
+            'final_loss': losses[-1],
+            'reduction_pct': (1 - losses[-1]/losses[0]) * 100,
+            'loss_history': losses,
+        },
+        'cath_training': {
+            'dataset_size': len(full_dataset),
+            'train_size': len(train),
+            'initial_loss': cath_losses[0],
+            'final_loss': cath_losses[-1],
+            'best_loss': best_loss,
+            'reduction_pct': (1 - cath_losses[-1]/cath_losses[0]) * 100,
+            'training_time_min': train_time / 60,
+            'loss_history': cath_losses,
+        },
+        'real_statistics': {
+            'ca_ca_dist_mean': float(np.mean(real_ca_dists)),
+            'ca_ca_dist_std': float(np.std(real_ca_dists)),
+            'n_ca_c_angle_mean': float(np.mean(real_n_ca_c)),
+            'n_ca_c_angle_std': float(np.std(real_n_ca_c)),
+        },
+        'generated_statistics': {
+            'ca_ca_dist_mean': float(np.mean(model_dists)),
+            'n_ca_c_angle_mean': float(np.mean(model_angles)),
+        },
+        'random_baseline': {
+            'ca_ca_dist_mean': float(np.mean(rand_dists)),
+            'n_ca_c_angle_mean': float(np.mean(rand_angles)),
+        },
+    }
+
+    with open(os.path.join(OUTPUT_DIR, 'validation_results.json'), 'w') as f:
+        json.dump(results, f, indent=2)
+
+    # Save generated PDBs
+    pdb_dir = os.path.join(OUTPUT_DIR, 'generated_pdbs')
+    os.makedirs(pdb_dir, exist_ok=True)
+
+    from scripts.train_rfdiffusion_cath import save_as_pdb
+    final_samples = model2.generate(num_samples=10, seq_length=50)
+    for i in range(len(final_samples)):
+        rescaled = final_samples[i] * avg_std
+        save_as_pdb(rescaled, os.path.join(pdb_dir, f'generated_{i+1}.pdb'))
+
+    logger.info(f"\nAll results saved to {OUTPUT_DIR}")
+    logger.info("=" * 70)
+    logger.info("VALIDATION COMPLETE")
+    logger.info("=" * 70)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What this PR does

This adds a diffusion model for protein backbone generation to DeepChem. I built it as a proper TorchModel subclass so it works directly with deepchem datasets.

This is my GSoC 2026 prep work for the "Implement RFDiffusion/RFDiffusion2" project.

## Changes

### Model (`deepchem/models/torch_models/rfdiffusion.py`)

The main model is `RFDiffusionModel` which inherits from `TorchModel`. It implements a DDPM (denoising diffusion) for protein backbone coordinates (N, CA, C atoms).

Key parts:
- `BackboneDiffusion(nn.Module)` - the denoiser network. Transformer blocks with adaptive LayerNorm for timestep conditioning
- `CosineSchedule` - cosine variance schedule from Improved DDPM paper
- `RFDiffusionModel(TorchModel)` - wraps everything so you can just call `model.fit(dataset)` and `model.generate()`

I override `default_generator()` to handle the diffusion training logic internally (sampling random timesteps, adding noise etc). The loss is MSE between predicted noise and actual noise.

### Featurizer (`deepchem/feat/protein_backbone_featurizer.py`)

Extracts N/CA/C backbone coordinates from PDB files. Returns arrays of shape `(num_residues, 3, 3)` for each protein.

### CATH Dataset Loader (`deepchem/molnet/load_function/cath_datasets.py`)

MolNet loader that downloads PDB files from RCSB and creates train/valid/test splits. I followed the `load_pdbbind` pattern for this.

### Tests

- `test_rfdiffusion.py` - tests for model creation, training, generation, save/reload, schedule etc
- `test_protein_backbone_featurizer.py` - featurizer tests
- `test_cath_datasets.py` - loader tests

All passing.

### Examples

- `examples/rfdiffusion_demo.py` - end to end demo with CATH training and generation
- `examples/cath_dataset_usage.py` - how to use the CATH loader

## Usage

```python
import deepchem as dc

# load data
tasks, datasets, transformers = dc.molnet.load_cath(
    featurizer='ProteinBackbone', splitter='random')
train, valid, test = datasets

# train
model = dc.models.RFDiffusionModel(
    embed_dim=256, num_layers=8, num_heads=8)
model.fit(train, nb_epoch=100)

# generate new backbones
samples = model.generate(num_samples=5, seq_length=50)
```

## Training results

Tested on CATH dataset:
- Loss decreases steadily during training
- Memorization test passes (model can overfit tiny dataset)
- Generation produces valid finite coordinates

## What I want feedback on

- Is the overall approach correct for how this should fit into deepchem?
- Any issues with how I structured the TorchModel subclass?
- Should I be using the existing SE3 equivariance primitives in deepchem for the backbone?

## Next steps

- Add self-conditioning
- Try integrating deepchem existing equivariance layers
- Scale up training
- Add conditioning types (motif, length, binder)

## References

- Watson et al. "De novo design of protein structure and function with RFdiffusion." Nature 2023
- Ho et al. "Denoising diffusion probabilistic models." NeurIPS 2020
- Nichol and Dhariwal "Improved denoising diffusion probabilistic models." ICML 2021