### PR TITLE
Add PyTorch Model summary utility (#2820)

### DIFF
--- a/deepchem/models/tests/test_torch_model.py
+++ b/deepchem/models/tests/test_torch_model.py
@@ -530,10 +530,13 @@ def test_torch_compile():
 
     assert np.all(model_output == y)
 
+
 @pytest.mark.torch
 def test_torch_model_summary():
     """Test generating a summary for a TorchModel."""
+
     class SimpleTorchModel(torch.nn.Module):
+
         def __init__(self):
             super(SimpleTorchModel, self).__init__()
             self.fc = torch.nn.Linear(10, 5)
@@ -543,8 +546,8 @@ def test_torch_model_summary():
 
     pytorch_model = SimpleTorchModel()
     model = dc.models.TorchModel(pytorch_model, dc.models.losses.L2Loss())
-    
+
     # We should be able to call it without throwing an error if torchinfo is installed
     summary_output = model.summary(input_size=(1, 10))
     assert summary_output is not None
-    assert summary_output.total_params == 55 # 10 * 5 + 5 bias = 55
+    assert summary_output.total_params == 55  # 10 * 5 + 5 bias = 55

--- a/deepchem/models/tests/test_torch_model.py
+++ b/deepchem/models/tests/test_torch_model.py
@@ -529,3 +529,22 @@ def test_torch_compile():
     model_output = np.argmax(model_output, axis=2)
 
     assert np.all(model_output == y)
+
+@pytest.mark.torch
+def test_torch_model_summary():
+    """Test generating a summary for a TorchModel."""
+    class SimpleTorchModel(torch.nn.Module):
+        def __init__(self):
+            super(SimpleTorchModel, self).__init__()
+            self.fc = torch.nn.Linear(10, 5)
+
+        def forward(self, x):
+            return self.fc(x)
+
+    pytorch_model = SimpleTorchModel()
+    model = dc.models.TorchModel(pytorch_model, dc.models.losses.L2Loss())
+    
+    # We should be able to call it without throwing an error if torchinfo is installed
+    summary_output = model.summary(input_size=(1, 10))
+    assert summary_output is not None
+    assert summary_output.total_params == 55 # 10 * 5 + 5 bias = 55

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -1165,8 +1165,7 @@ class TorchModel(Model):
         except ImportError:
             raise ImportError(
                 "The `torchinfo` library is required to use the `summary()` method. "
-                "Please install it using: pip install torchinfo"
-            )
+                "Please install it using: pip install torchinfo")
 
         # We pass self.model to torchinfo.summary
         return torchinfo.summary(self.model, **kwargs)

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -1137,6 +1137,40 @@ class TorchModel(Model):
         """Get the number of steps of fitting that have been performed."""
         return self._global_step
 
+    def summary(self, **kwargs):
+        """
+        Print a summary of the model.
+
+        This method uses the `torchinfo` library to display a summary of the
+        underlying PyTorch model, including layer names, output shapes, and the
+        number of parameters.
+
+        It requires `torchinfo` to be installed. (`pip install torchinfo`)
+
+        Parameters
+        ----------
+        **kwargs: dict
+            Additional keyword arguments to pass to `torchinfo.summary`.
+            For example, you can pass `input_size`, `input_data`, or `depth`.
+            If neither `input_size` nor `input_data` is provided, it will attempt
+            to use `torchinfo` without them, which may not work for all models.
+
+        Returns
+        -------
+        None or torchinfo.ModelStatistics
+            Returns the model statistics object if `verbose` is 0, else None.
+        """
+        try:
+            import torchinfo
+        except ImportError:
+            raise ImportError(
+                "The `torchinfo` library is required to use the `summary()` method. "
+                "Please install it using: pip install torchinfo"
+            )
+
+        # We pass self.model to torchinfo.summary
+        return torchinfo.summary(self.model, **kwargs)
+
     def _log_scalar_to_tensorboard(self, name: str, value: Any, step: int):
         """Log a scalar value to Tensorboard."""
         self._summary_writer.add_scalar(name, value, step)


### PR DESCRIPTION
## Description

Fixes #2820

Added a `summary()` method to `TorchModel` that utilizes the `torchinfo` library (as an optional dependency) to print a Keras-style layer summary of the underlying PyTorch architecture. I also added a unit test `test_torch_model_summary` to verify that it correctly counts the parameters.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
