### PR TITLE
Fix DiskDataset select() IndexError when y or w metadata arrays are e…

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2500,11 +2500,11 @@ class DiskDataset(Dataset):
                     # Handle empty case where no data from this shard needed
                     X_sel = X[shard_inds]
                     # Handle the case of datasets with y/w missing
-                    if y is not None:
+                    if y is not None and len(y) > 0:
                         y_sel = y[shard_inds]
                     else:
                         y_sel = np.array([])
-                    if w is not None:
+                    if w is not None and len(w) > 0:
                         w_sel = w[shard_inds]
                     else:
                         w_sel = np.array([])

--- a/deepchem/data/tests/test_select.py
+++ b/deepchem/data/tests/test_select.py
@@ -128,3 +128,24 @@ def test_select_to_numpy():
     np.testing.assert_array_equal(y[indices], y_sel)
     np.testing.assert_array_equal(w[indices], w_sel)
     np.testing.assert_array_equal(ids[indices], ids_sel)
+
+
+def test_select_empty_y_w():
+    """Test that dataset select handles empty y and w appropriately."""
+    num_datapoints = 10
+    num_features = 10
+    X = np.random.rand(num_datapoints, num_features)
+    y = np.zeros(0)
+    w = np.zeros(0)
+    ids = np.array(["id"] * num_datapoints)
+    dataset = dc.data.DiskDataset.from_numpy(X, y, w, ids)
+
+    indices = [0, 4, 5, 8]
+    select_dataset = dataset.select(indices)
+    assert isinstance(select_dataset, dc.data.DiskDataset)
+    X_sel, y_sel, w_sel, ids_sel = (select_dataset.X, select_dataset.y,
+                                    select_dataset.w, select_dataset.ids)
+    np.testing.assert_array_equal(X[indices], X_sel)
+    np.testing.assert_array_equal(y, y_sel)
+    np.testing.assert_array_equal(w, w_sel)
+    np.testing.assert_array_equal(ids[indices], ids_sel)


### PR DESCRIPTION
## Description

Fixes #4059

When creating a `DiskDataset` with missing `y` or `w` labels (e.g., when inferring from an unlabeled test set using `DiskDataset.from_numpy()`), the underlying implementation instantiated empty arrays. Calling `dataset.select()` then resulted in an `IndexError: index is out of bounds for axis 0 with size 0` at lines `2504` and `2508` in `datasets.py` because it assumed the existence of elements to pick from `y` and `w`.

This patch adds a short validity length check directly inside `DiskDataset.select()` for `y` and `w` before slicing it. A unit test `test_select_empty_y_w` is also included to prevent regressions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
