### PR TITLE
Renamed predict_embedding to predict_embeddings in PyTorch SeqToSeqModel

### DIFF
--- a/deepchem/models/torch_models/seqtoseq.py
+++ b/deepchem/models/torch_models/seqtoseq.py
@@ -456,7 +456,7 @@ class SeqToSeqModel(TorchModel):
                 result.append(self._beam_search(probs[i], beam_width))
         return result
 
-    def predict_embedding(self, sequences: List[str]):  # type: ignore[override]
+    def predict_embeddings(self, sequences: List[str]):  # type: ignore[override]
         """Given a set of input sequences, compute the embedding vectors.
 
         Parameters


### PR DESCRIPTION
## Description

Fix #4245

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Summary of Changes: 
This PR fixes a backward compatibility bug in the PyTorch SeqToSeqModel. I renamed the predict_embedding method to predict_embeddings inside deepchem/models/torch_models/seqtoseq.py to properly match the original API.

I noticed this bug was also blocking a tutorial update over in PR #4207, so hopefully, this helps unblock that work as well! Please let me know if there are any other internal references I missed that need to be updated.

## Type of change

Please check the option that is related to your PR.

- [ \/] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ \/] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [\/ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ \/] I have checked my code and corrected any misspellings
