### PR TITLE
Renamed predict_embedding to predict_embeddings in PyTorch SeqToSeqModel

### DIFF
--- a/deepchem/models/tests/test_seqtoseq_model.py
+++ b/deepchem/models/tests/test_seqtoseq_model.py
@@ -90,9 +90,9 @@ class TestSeqToSeq(unittest.TestCase):
         tests = [seq for seq, target in generate_sequences(sequence_length, 50)]
         pred1 = model.predict_from_sequences(tests, beam_width=1)
         pred4 = model.predict_from_sequences(tests, beam_width=4)
-        embeddings = model.predict_embedding(tests)
-        pred1e = model.predict_from_embedding(embeddings, beam_width=1)
-        pred4e = model.predict_from_embedding(embeddings, beam_width=4)
+        embeddings = model.predict_embeddings(tests)
+        pred1e = model.predict_from_embeddings(embeddings, beam_width=1)
+        pred4e = model.predict_from_embeddings(embeddings, beam_width=4)
         count1 = 0
         count4 = 0
         for i in range(len(tests)):
@@ -124,8 +124,8 @@ class TestSeqToSeq(unittest.TestCase):
         count_special = 0
         for sequence, target in generate_sequences(sequence_length, 100):
             pred1 = model.predict_from_sequences([sequence], beam_width=5)
-            embedding = model.predict_embedding([sequence])
-            pred2 = model.predict_from_embedding(embedding, beam_width=5)
+            embedding = model.predict_embeddings([sequence])
+            pred2 = model.predict_from_embeddings(embedding, beam_width=5)
             if ''.join(pred1[0]) == sequence:
                 count_normal += 1
             if ''.join(pred2[0]) == sequence:

--- a/deepchem/models/torch_models/prot_bert.py
+++ b/deepchem/models/torch_models/prot_bert.py
@@ -98,7 +98,7 @@ class ProtBERT(HuggingFaceModel):
            The task defines the type of learning task in the model. The supported tasks are
            - `mlm` - masked language modeling commonly used in pretraining
            - `classification` - use it for classification tasks
-           - `feature_extractor` - use it along side the predict_embedding() method to extract features from a protein sequence
+           - `feature_extractor` - use it along side the predict_embeddings() method to extract features from a protein sequence
        model_path: str
            Path to the HuggingFace model
            - 'Rostlab/prot_bert' - Pretrained on Uniref100 dataset

--- a/deepchem/models/torch_models/seqtoseq.py
+++ b/deepchem/models/torch_models/seqtoseq.py
@@ -456,7 +456,7 @@ class SeqToSeqModel(TorchModel):
                 result.append(self._beam_search(probs[i], beam_width))
         return result
 
-    def predict_embedding(self, sequences: List[str]):  # type: ignore[override]
+    def predict_embeddings(self, sequences: List[str]):  # type: ignore[override]
         """Given a set of input sequences, compute the embedding vectors.
 
         Parameters
@@ -478,7 +478,7 @@ class SeqToSeqModel(TorchModel):
                 result.append(probs[i])
         return result
 
-    def predict_from_embedding(self,
+    def predict_from_embeddings(self,
                                embeddings: List[np.ndarray],
                                beam_width=5):
         """Given a set of embedding vectors, predict the output sequences.


### PR DESCRIPTION
## Description

Fix #4245

This PR ensures API consistency for the [SeqToSeqModel](cci:2://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/torch_models/seqtoseq.py:194:0-602:78) in PyTorch by renaming [predict_embedding](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/keras_model.py:861:4-880:71) and [predict_from_embedding](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/seqtoseq.py:274:4-296:21) to their plural versions ([predict_embeddings](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/torch_models/seqtoseq.py:458:4-478:21), [predict_from_embeddings](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/seqtoseq.py:274:4-296:21)). This aligns the PyTorch implementation with the Keras implementation and fixes a backward compatibility issue that was breaking tests and downstream tutorials.

**Summary of Changes:**
- Renamed [predict_embedding](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/keras_model.py:861:4-880:71) -> [predict_embeddings](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/torch_models/seqtoseq.py:458:4-478:21) in [deepchem/models/torch_models/seqtoseq.py](cci:7://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/torch_models/seqtoseq.py:0:0-0:0).
- Renamed [predict_from_embedding](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/seqtoseq.py:274:4-296:21) -> [predict_from_embeddings](cci:1://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/seqtoseq.py:274:4-296:21) in [deepchem/models/torch_models/seqtoseq.py](cci:7://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/torch_models/seqtoseq.py:0:0-0:0) for API symmetry.
- Updated [deepchem/models/tests/test_seqtoseq_model.py](cci:7://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/tests/test_seqtoseq_model.py:0:0-0:0) to match the new plural method names, fixing the regressions identified in PR #4757.
- Updated docstring references in [deepchem/models/torch_models/prot_bert.py](cci:7://file:///c:/Users/Priyank/Documents/CODE/gsoc-26/deepchem/deepchem/models/torch_models/prot_bert.py:0:0-0:0).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
