### PR TITLE
Fix AttributeError in molnet.run_benchmark (#4224)

### DIFF
--- a/deepchem/molnet/__init__.py
+++ b/deepchem/molnet/__init__.py
@@ -46,3 +46,4 @@ from deepchem.molnet.dnasim import simulate_motif_counting
 from deepchem.molnet.dnasim import simple_motif_embedding
 from deepchem.molnet.dnasim import motif_density
 from deepchem.molnet.dnasim import simulate_single_motif_detection
+from deepchem.molnet.run_benchmark import run_benchmark


### PR DESCRIPTION
Description
This PR fixes the AttributeError: module 'deepchem.molnet' has no attribute 'run_benchmark' reported in Issue #4224.

The run_benchmark function was defined in deepchem/molnet/run_benchmark.py but was not exposed in the molnet namespace via __init__.py. This prevented scripts like examples/benchmark.py from properly resolving the function call.

Changes
Exported run_benchmark in deepchem/molnet/__init__.py.

Testing
Verified locally using examples/benchmark.py. The script now successfully resolves and calls dc.molnet.run_benchmark without throwing an AttributeError.

Fixes #4224