### PR TITLE
docs: fix docstring indentation and SyntaxWarnings in torch_models (#4740)

### DIFF
--- a/deepchem/models/torch_models/attention.py
+++ b/deepchem/models/torch_models/attention.py
@@ -59,7 +59,7 @@ class ScaledDotProductAttention(nn.Module):
 
 
 class SelfAttention(nn.Module):
-    """SelfAttention Layer
+    r"""SelfAttention Layer
 
     Given $X\in \mathbb{R}^{n \times in_feature}$, the attention is calculated by: $a=softmax(W_2tanh(W_1X))$, where
     $W_1 \in \mathbb{R}^{hidden \times in_feature}$, $W_2 \in \mathbb{R}^{out_feature \times hidden}$.
@@ -88,7 +88,7 @@ class SelfAttention(nn.Module):
         nn.init.xavier_normal_(self.w2)
 
     def forward(self, X):
-        """The forward function.
+        r"""The forward function.
 
         Parameters
         ----------

--- a/deepchem/models/torch_models/ferminet.py
+++ b/deepchem/models/torch_models/ferminet.py
@@ -236,7 +236,7 @@ class Ferminet(torch.nn.Module):
         return potential.detach()
 
     def calculate_kinetic_energy(self,):
-        """
+        r"""
         Function to calculate the expected kinetic energy term per batch
         It is calculated via:
         \sum_{ri}^{}[(\pdv[]{log|\Psi|}{(ri)})^2 + \pdv[2]{log|\Psi|}{(ri)}]

--- a/deepchem/models/torch_models/fno.py
+++ b/deepchem/models/torch_models/fno.py
@@ -16,6 +16,7 @@ class FNOBlock(nn.Module):
     It leverages the Fourier transform to perform convolution in the frequency
     domain, which allows it to capture global, long-range dependencies in the
     input data efficiently. The operation consists of three steps:
+
     1. Transform the input to the frequency domain using the Fast Fourier Transform (FFT).
     2. Apply a linear transformation to a truncated set of lower-frequency modes.
     3. Transform the result back to the spatial domain using the Inverse FFT.
@@ -33,8 +34,8 @@ class FNOBlock(nn.Module):
     The forward pass computes:
     FNO_block(x) = ReLU(SpectralConv(x) + Conv(x))
 
-    Example
-    -------------
+    Examples
+    --------
     >>> import torch
     >>> from deepchem.models.torch_models.fno import FNOBlock
     >>> block = FNOBlock(width=128, modes=8, dims=2)
@@ -103,8 +104,8 @@ class FNO(nn.Module):
     ----------
     This technique was introduced in Li, Zongyi, et al. "Fourier neural operator for parametric partial differential equations." arXiv preprint arXiv:2010.08895 (2020).
 
-    Example
-    -------------
+    Examples
+    --------
     >>> import torch
     >>> from deepchem.models.torch_models.fno import FNO
     >>> model = FNO(in_channels=1, out_channels=1, modes=8, width=32, dims=2)
@@ -262,8 +263,8 @@ class FNOModel(TorchModel):
     ----------
     This technique was introduced in Li, Zongyi, et al. "Fourier neural operator for parametric partial differential equations." arXiv preprint arXiv:2010.08895 (2020).
 
-    Example
-    -------------
+    Examples
+    --------
     >>> import torch
     >>> import deepchem as dc
     >>> from deepchem.models.torch_models.fno import FNOModel
@@ -285,6 +286,7 @@ class FNOModel(TorchModel):
                  loss: nn.Module = nn.MSELoss(),
                  **kwargs) -> None:
         """Initialize the FNO model.
+
         Parameters
         ----------
         in_channels: int
@@ -302,7 +304,7 @@ class FNOModel(TorchModel):
             Number of FNO blocks to stack. More blocks can learn more complex mappings
         positional_encoding: bool, default False
             When enabled, uses meshgrids as positional encodings
-        loss: Union[Loss, LossFn], default nn.MSELoss()
+        loss: nn.Module, default nn.MSELoss()
             Loss function to use for training
         **kwargs: dict
             Additional arguments passed to TorchModel constructor

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -1201,7 +1201,7 @@ class GraphNetwork(torch.nn.Module):
             edge_features: Tensor,
             global_features: Tensor,
             batch: Optional[Tensor] = None) -> Tuple[Tensor, Tensor, Tensor]:
-        """Output computation for a GraphNetwork
+        r"""Output computation for a GraphNetwork
         
         Parameters
         ----------
@@ -7722,7 +7722,7 @@ class SE3PairwiseConv(nn.Module):
 
 
 class SE3Sum(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Residual Sum Function (SE3Sum).
 
     This layer performs element-wise summation of SE(3)-equivariant
@@ -7819,7 +7819,7 @@ class SE3Sum(nn.Module):
 
 
 class SE3Cat(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Feature Concatenation (SE3Cat).
 
     This layer concatenates features from two SE(3)-equivariant fiber representations.
@@ -7909,7 +7909,7 @@ class SE3Cat(nn.Module):
 
 
 class SE3AvgPooling(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Average Pooling Module (SE3AvgPooling).
 
     This layer **performs average pooling over graph nodes while preserving SE(3) equivariance.
@@ -8013,7 +8013,7 @@ class SE3AvgPooling(nn.Module):
 
 
 class SE3MaxPooling(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Max Pooling Module (SE3MaxPooling).
 
     This layer performs max pooling over graph nodes while preserving SE(3) equivariance.
@@ -8119,7 +8119,7 @@ class SE3MaxPooling(nn.Module):
 
 
 class SE3MultiHeadAttention(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Multi-Headed Self-Attention for Graph Neural Networks.
     This layer extends multi-head self-attention (MHA) to SE(3)-equivariant
     representations. Instead of using dot-product attention in standard Transformers,
@@ -8186,7 +8186,7 @@ class SE3MultiHeadAttention(nn.Module):
     """
 
     def __init__(self, f_value: Fiber, f_key: Fiber, n_heads: int) -> None:
-        """
+        r"""
         Initialize the SE(3)-equivariant multi-head self-attention layer.
 
         Parameters


### PR DESCRIPTION
Description
Overview
This PR addresses a critical slice of the documentation build warnings reported in #4740. It focuses on the deepchem/models/torch_models/ directory, resolving both Sphinx structural errors and Python 3.13 SyntaxWarnings.

Changes Made
Resolved SyntaxWarnings: Converted docstrings containing LaTeX math (using \mathcal, \sum, \left, etc.) to raw strings (r""") in layers.py, attention.py, and ferminet.py. This fixes the "invalid escape sequence" errors triggered by modern Python compilers.

Fixed Docstring Formatting: * Standardized the Parameters and Examples sections in fno.py to follow the numpydoc standard.

Corrected "Unexpected indentation" errors in FNOBlock and FNOModel by ensuring proper blank line spacing and 4-space indentation for parameter descriptions.

Audit Verification: Performed a full directory audit using python -m compileall to ensure no remaining syntax warnings exist in the Torch-based model files.

Impact
Fixing these warnings is a step toward a "clean build" for the DeepChem documentation. Specifically, it ensures that the NLP and Fourier Neural Operator (FNO) documentation renders correctly and remains compatible with the latest Python versions.

Closes: #4740 (Partially)