### PR TITLE
fix: remove invalid escape sequence warnings in differentiation utils docs

### DIFF
--- a/deepchem/utils/differentiation_utils/optimize/jacobian.py
+++ b/deepchem/utils/differentiation_utils/optimize/jacobian.py
@@ -328,7 +328,7 @@ class LinearMixing(Jacobian):
 
 
 class LowRankMatrix(object):
-    """represents a matrix of `\alpha * I + \sum_n c_n d_n^T`
+    r"""represents a matrix of `\alpha * I + \sum_n c_n d_n^T`
 
     Examples
     --------
@@ -451,7 +451,7 @@ class LowRankMatrix(object):
 
 
 class FullRankMatrix(object):
-    """represents a full rank matrix of `\alpha * I + \sum_n c_n d_n^T`
+    r"""represents a full rank matrix of `\alpha * I + \sum_n c_n d_n^T`
 
     Examples
     --------

--- a/deepchem/utils/differentiation_utils/solve.py
+++ b/deepchem/utils/differentiation_utils/solve.py
@@ -129,7 +129,7 @@ class solve_torchfcn(torch.autograd.Function):
     @staticmethod
     def forward(ctx, A, B, E, M, method, fwd_options, bck_options, na,
                 *all_params):
-        """Forward calculation of the solve function.
+        r"""Forward calculation of the solve function.
 
         Parameters
         ----------


### PR DESCRIPTION
## Summary
This keeps scope small and addresses invalid escape sequence warnings by making affected docstrings raw strings.

### Changes
- `deepchem/utils/differentiation_utils/optimize/jacobian.py`
  - made `LowRankMatrix` docstring raw (`r"""..."""`)
  - made `FullRankMatrix` docstring raw (`r"""..."""`)
- `deepchem/utils/differentiation_utils/solve.py`
  - made `solve_torchfcn.forward` docstring raw to avoid `\m` warning in math expression

No functional code changes, only docstring literal handling.

Fixes #2007

## Validation
- `python3 -Wall -m py_compile deepchem/utils/differentiation_utils/optimize/jacobian.py deepchem/utils/differentiation_utils/solve.py`

Note: running local pytest subset in this environment failed at collection because `scipy` is not installed.
