### PR TITLE
Add HuggingFaceModel.generate() API for text generation

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -51,6 +51,7 @@ class HuggingFaceModel(TorchModel):
          - `mtr` - multitask regression - a task used for both pretraining base models and finetuning
          - `regression` - use it for regression tasks, like property prediction
          - `classification` - use it for classification tasks
+         - `generation` - text generation using autoregressive models
 
         When the task is not specified or None, the wrapper returns raw output of the HuggingFaceModel.
         In cases where the HuggingFaceModel is a model without a task specific head, this output will be
@@ -562,6 +563,58 @@ class HuggingFaceModel(TorchModel):
             return final_results[0]
         else:
             return np.array(final_results)
+
+    def generate(self, inputs: Union[str, List[str]],
+                 **generate_kwargs) -> Union[str, List[str]]:
+        """Generate text for one or more input prompts.
+
+        This provides a task-specific generation API and keeps supervised
+        prediction paths unchanged.
+
+        Parameters
+        ----------
+        inputs: Union[str, List[str]]
+            Input prompt(s) for generation.
+        generate_kwargs: dict
+            Additional keyword arguments forwarded to
+            ``transformers.PreTrainedModel.generate``.
+
+        Returns
+        -------
+        Union[str, List[str]]
+            Generated text for a single input string or a list of generated
+            texts for multiple input strings.
+        """
+        if self.tokenizer is None:
+            raise ValueError('Tokenizer must be provided for generation.')
+        if not hasattr(self.model, 'generate'):
+            raise ValueError('The wrapped model does not support generate().')
+
+        self._ensure_built()
+        self.model.eval()
+
+        single_input = isinstance(inputs, str)
+        if single_input:
+            prompt_list = [inputs]
+        else:
+            prompt_list = list(inputs)
+            if len(prompt_list) == 0:
+                return []
+
+        tokenized_inputs = self.tokenizer(prompt_list,
+                                          padding=True,
+                                          return_tensors='pt')
+        tokenized_inputs = {
+            key: value.to(self.device)
+            for key, value in tokenized_inputs.items()
+        }
+
+        with torch.no_grad():
+            generated_tokens = self.model.generate(**tokenized_inputs,
+                                                   **generate_kwargs)
+        generated_texts = self.tokenizer.batch_decode(generated_tokens,
+                                                      skip_special_tokens=True)
+        return generated_texts[0] if single_input else generated_texts
 
     def fill_mask(self,
                   inputs: Union[str, List[str]],

--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -204,6 +204,35 @@ def test_load_from_hf_checkpoint():
 
 
 @pytest.mark.hf
+def test_generate_api(hf_tokenizer):
+    from transformers.models.gpt2 import GPT2Config, GPT2LMHeadModel
+
+    config = GPT2Config(vocab_size=hf_tokenizer.vocab_size,
+                        n_layer=1,
+                        n_head=1,
+                        n_embd=32,
+                        bos_token_id=hf_tokenizer.bos_token_id,
+                        eos_token_id=hf_tokenizer.eos_token_id,
+                        pad_token_id=hf_tokenizer.pad_token_id)
+    model = GPT2LMHeadModel(config)
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=hf_tokenizer,
+                                task='generation',
+                                device=torch.device('cpu'))
+
+    single_output = hf_model.generate("CCO", max_new_tokens=2, do_sample=False)
+    assert isinstance(single_output, str)
+    assert len(single_output) > 0
+
+    batch_output = hf_model.generate(["CCO", "CCN"],
+                                     max_new_tokens=2,
+                                     do_sample=False)
+    assert isinstance(batch_output, list)
+    assert len(batch_output) == 2
+    assert all(isinstance(text, str) and len(text) > 0 for text in batch_output)
+
+
+@pytest.mark.hf
 def test_fill_mask_IO(tmpdir, hf_tokenizer):
     from transformers import (RobertaConfig, RobertaForMaskedLM)
 


### PR DESCRIPTION
Fix #4724
  Adds a dedicated generate() API to HuggingFaceModel for text-generation workflows, as discussed in the issue thread.
  This keeps generation separate from supervised predict() logic and avoids introducing generation-specific behavior into _predict().

  ### Summary of changes

  - Added HuggingFaceModel.generate(inputs, **generate_kwargs) in deepchem/models/torch_models/hf_models.py.
      - Validates tokenizer/model generation capability.
  - Updated HuggingFaceModel task documentation to include generation.
  - Added focused test test_generate_api in deepchem/models/torch_models/tests/test_hf_models.py using a tiny local GPT2 config (no external     


  Issue #4724 points out that generation is semantically different from supervised prediction.
  This PR follows the suggested direction from the issue discussion by introducing a dedicated generate() API instead of modifying _predict()    
  assumptions.

  ### Dependencies

  No new project dependencies added.


  Please check the option that is related to your PR.

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
      - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
  - [ ] Documentations (modification for documents)

  ## Checklist

  - [x] My code follows the style guidelines of this project (https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)           
      - [x] Run yapf -i <modified file> and check no errors (yapf version must be  0.32.0)                                                       
      - [ ] Run mypy -p deepchem and check no errors                                                                                             
      - [x] Run flake8 <modified file> --count and check no errors                                                                               
      - [ ] Run python -m doctest <modified file> and check no errors                                                                            
  - [x] I have performed a self-review of my own code                                                                                            
  - [ ] I have commented my code, particularly in hard-to-understand areas                                                                       
  - [x] I have made corresponding changes to the documentation                                                                                   
  - [x] I have added tests that prove my fix is effective or that my feature works                                                               
  - [x] New unit tests pass locally with my changes                                                                                              
  - [x] I have checked my code and corrected any misspellings                                                                                    
                                                                                                                                                 
  > Note: In this Windows environment, the pre-commit mypy hook fails due a typed-ast build/toolchain issue (not related to this PR’s code changes).      