### PR TITLE
Add Open in Colab badge to ESMFold tutorial

### DIFF
--- a/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb
+++ b/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb
@@ -6,7 +6,9 @@
         "id": "sET1U_ldbl8K"
       },
       "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb)\n",
         "# **Protein Structure Prediction with ESMFold**\n",
+        "\n",
         "\n",
         "Author: Anamika Yadav"
       ]

--- a/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb
+++ b/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb
@@ -6,11 +6,13 @@
         "id": "sET1U_ldbl8K"
       },
       "source": [
-        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb)\n",
+        "\n",
         "# **Protein Structure Prediction with ESMFold**\n",
         "\n",
         "\n",
-        "Author: Anamika Yadav"
+        "Author: Anamika Yadav\n",
+        "\n",
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb)"
       ]
     },
     {


### PR DESCRIPTION
This PR adds a clickable 'Open in Colab' badge to the ESMFold protein structure prediction tutorial.

Fixes #4364
