### PR TITLE
Add tutorial: Computational Toxicity Prediction with Tox21/ToxCast

### DIFF
--- a/examples/tutorials/Computational_Toxicity_Prediction.ipynb
+++ b/examples/tutorials/Computational_Toxicity_Prediction.ipynb
@@ -1,0 +1,336 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Computational Toxicity Prediction with Tox21 and ToxCast\n",
+    "\n",
+    "Toxicity testing has traditionally relied on animal experiments, but large-scale in-vitro screening programs like [Tox21](https://tripod.nih.gov/tox21/challenge/) and [ToxCast](https://www.epa.gov/comptox-tools/toxicity-forecasting-toxcast) have generated thousands of high-throughput assay measurements that can be used to train computational models instead. These datasets are part of a broader shift toward **New Approach Methodologies (NAMs)** -- computational and in-vitro techniques that can predict toxicity without animal testing [1].\n",
+    "\n",
+    "In this tutorial, we'll use DeepChem to build machine learning models that predict toxicity directly from molecular structure. We'll work with two MoleculeNet datasets:\n",
+    "\n",
+    "- **Tox21**: 8,014 compounds tested across 12 nuclear receptor and stress response pathway assays\n",
+    "- **ToxCast**: 8,597 compounds tested across 617 high-throughput assays\n",
+    "\n",
+    "We'll compare fingerprint-based and graph-based models, evaluate per-task performance, and see how multitask learning helps when data is sparse.\n",
+    "\n",
+    "[1] Parish, S.T., et al. \"An evaluation framework for new approach methodologies (NAMs) for human safety assessment.\" *Regulatory Toxicology and Pharmacology* 112 (2020): 104592.\n",
+    "\n",
+    "## Colab\n",
+    "\n",
+    "This tutorial and the rest in this sequence can be done in Google colab. If you'd like to open this notebook in colab, you can use the following link.\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Computational_Toxicity_Prediction.ipynb)\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "To run DeepChem within Colab, you'll need to run the following installation commands. You can of course run this tutorial locally if you prefer. In that case, don't run these cells since they will download and install DeepChem again on your local machine."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --pre deepchem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import deepchem as dc\n",
+    "import numpy as np\n",
+    "dc.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The Tox21 Dataset\n",
+    "\n",
+    "The Toxicology in the 21st Century (Tox21) initiative is a collaboration between the NIH, EPA, and FDA that screens compounds against panels of biological targets related to toxicity. The Tox21 dataset in MoleculeNet contains 8,014 compounds measured on 12 assay endpoints:\n",
+    "\n",
+    "- **Nuclear Receptor (NR) assays**: AR, AR-LBD, AhR, Aromatase, ER, ER-LBD, PPAR-gamma\n",
+    "- **Stress Response (SR) assays**: ARE, ATAD5, HSE, MMP, p53\n",
+    "\n",
+    "Each endpoint is a binary classification task (active/inactive). A compound that is \"active\" in an assay is interacting with that biological pathway in a way that could indicate toxicity.\n",
+    "\n",
+    "All of this data was generated entirely from automated in-vitro cell-based and biochemical assays -- no animal testing required. Let's load it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tox21_tasks, tox21_datasets, tox21_transformers = dc.molnet.load_tox21(\n",
+    "    featurizer='ECFP', splitter='scaffold'\n",
+    ")\n",
+    "train_dataset, valid_dataset, test_dataset = tox21_datasets\n",
+    "\n",
+    "print(f\"Tasks: {len(tox21_tasks)}\")\n",
+    "print(f\"Training compounds: {len(train_dataset)}\")\n",
+    "print(f\"Validation compounds: {len(valid_dataset)}\")\n",
+    "print(f\"Test compounds: {len(test_dataset)}\")\n",
+    "print(f\"\\nAssay endpoints:\")\n",
+    "for task in tox21_tasks:\n",
+    "    print(f\"  {task}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We used Extended-Connectivity Fingerprints (ECFP) as the featurizer. ECFPs encode the presence of molecular substructures as a fixed-length binary vector -- a compact representation of what chemical \"fragments\" appear in each molecule.\n",
+    "\n",
+    "We also used scaffold splitting, which ensures train/test molecules come from different chemical scaffolds. This is a harder but more realistic evaluation than random splitting, because in practice you want to predict toxicity for novel chemical structures.\n",
+    "\n",
+    "## Training a Multitask Model\n",
+    "\n",
+    "A key advantage of datasets like Tox21 is that they measure many endpoints simultaneously. A **multitask model** predicts all 12 endpoints from a single shared representation. This is valuable because:\n",
+    "\n",
+    "1. Tasks that share biological mechanisms can learn from each other\n",
+    "2. Sparse labels in one task get supplemented by data from other tasks\n",
+    "3. The shared representation learns more general chemical features\n",
+    "\n",
+    "Let's train a `MultitaskClassifier` -- a stack of fully connected layers with shared hidden representations and per-task output heads."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n_tasks = len(tox21_tasks)\n",
+    "n_features = train_dataset.get_data_shape()[0]\n",
+    "\n",
+    "model = dc.models.MultitaskClassifier(\n",
+    "    n_tasks,\n",
+    "    n_features,\n",
+    "    layer_sizes=[1024, 512],\n",
+    "    dropouts=0.2,\n",
+    "    learning_rate=0.001,\n",
+    "    batch_size=128,\n",
+    ")\n",
+    "model.fit(train_dataset, nb_epoch=15)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Evaluating Per-Task Performance\n",
+    "\n",
+    "Since each task has very different class balance (some targets have very few active compounds), we use **ROC-AUC** as the evaluation metric. An AUC of 0.5 means random guessing, while 1.0 is perfect prediction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "metric = dc.metrics.Metric(dc.metrics.roc_auc_score)\n",
+    "\n",
+    "print(\"Training set performance:\")\n",
+    "train_scores = model.evaluate(train_dataset, [metric], tox21_transformers)\n",
+    "\n",
+    "print(\"\\nTest set performance:\")\n",
+    "test_scores = model.evaluate(test_dataset, [metric], tox21_transformers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Graph Convolutional Model\n",
+    "\n",
+    "Fingerprint-based models treat molecules as fixed-length vectors. An alternative approach is to work with the molecular graph directly, where atoms are nodes and bonds are edges. **Graph convolutional models** learn features directly from this graph structure, which can capture spatial and topological patterns that fingerprints miss.\n",
+    "\n",
+    "Let's reload Tox21 with the `GraphConv` featurizer and train a `GraphConvModel`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gc_tasks, gc_datasets, gc_transformers = dc.molnet.load_tox21(\n",
+    "    featurizer='GraphConv', splitter='scaffold'\n",
+    ")\n",
+    "gc_train, gc_valid, gc_test = gc_datasets\n",
+    "\n",
+    "gc_model = dc.models.GraphConvModel(\n",
+    "    n_tasks=len(gc_tasks),\n",
+    "    mode='classification',\n",
+    "    batch_size=128,\n",
+    "    learning_rate=0.001,\n",
+    "    dropout=0.2,\n",
+    ")\n",
+    "gc_model.fit(gc_train, nb_epoch=15)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"GraphConvModel - Training set:\")\n",
+    "gc_train_scores = gc_model.evaluate(gc_train, [metric], gc_transformers)\n",
+    "\n",
+    "print(\"\\nGraphConvModel - Test set:\")\n",
+    "gc_test_scores = gc_model.evaluate(gc_test, [metric], gc_transformers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Scaling Up: ToxCast\n",
+    "\n",
+    "While Tox21 has 12 endpoints, the EPA's ToxCast program measured compounds across **617 assays** spanning a much broader range of biological targets. This makes it one of the largest public toxicity datasets available.\n",
+    "\n",
+    "The sheer number of tasks makes multitask learning particularly valuable here -- many individual assays have very sparse data, but the shared representation across hundreds of tasks helps compensate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tc_tasks, tc_datasets, tc_transformers = dc.molnet.load_toxcast(\n",
+    "    featurizer='ECFP', splitter='scaffold'\n",
+    ")\n",
+    "tc_train, tc_valid, tc_test = tc_datasets\n",
+    "\n",
+    "print(f\"ToxCast tasks: {len(tc_tasks)}\")\n",
+    "print(f\"Training compounds: {len(tc_train)}\")\n",
+    "print(f\"Test compounds: {len(tc_test)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tc_model = dc.models.MultitaskClassifier(\n",
+    "    len(tc_tasks),\n",
+    "    tc_train.get_data_shape()[0],\n",
+    "    layer_sizes=[1024, 512],\n",
+    "    dropouts=0.2,\n",
+    "    learning_rate=0.001,\n",
+    "    batch_size=128,\n",
+    ")\n",
+    "tc_model.fit(tc_train, nb_epoch=10)\n",
+    "\n",
+    "print(\"ToxCast - Test set:\")\n",
+    "tc_test_scores = tc_model.evaluate(tc_test, [metric], tc_transformers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## From In-Vitro Data to Clinical Toxicity: ClinTox\n",
+    "\n",
+    "Can models trained on in-vitro assay data generalize to predicting clinical toxicity outcomes? The **ClinTox** dataset contains 1,491 compounds with two labels: FDA approval status and clinical trial toxicity. Let's train a model on ClinTox and compare with the earlier Tox21 results.\n",
+    "\n",
+    "ClinTox bridges the gap between high-throughput in-vitro screening (like Tox21) and real-world drug safety outcomes, demonstrating how computational approaches can inform decisions that previously required animal studies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ct_tasks, ct_datasets, ct_transformers = dc.molnet.load_clintox(\n",
+    "    featurizer='ECFP', splitter='scaffold'\n",
+    ")\n",
+    "ct_train, ct_valid, ct_test = ct_datasets\n",
+    "\n",
+    "print(f\"ClinTox tasks: {ct_tasks}\")\n",
+    "print(f\"Training compounds: {len(ct_train)}\")\n",
+    "print(f\"Test compounds: {len(ct_test)}\")\n",
+    "\n",
+    "ct_model = dc.models.MultitaskClassifier(\n",
+    "    len(ct_tasks),\n",
+    "    ct_train.get_data_shape()[0],\n",
+    "    layer_sizes=[512, 256],\n",
+    "    dropouts=0.2,\n",
+    "    learning_rate=0.001,\n",
+    "    batch_size=64,\n",
+    ")\n",
+    "ct_model.fit(ct_train, nb_epoch=20)\n",
+    "\n",
+    "print(\"\\nClinTox - Test set:\")\n",
+    "ct_test_scores = ct_model.evaluate(ct_test, [metric], ct_transformers)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The Bigger Picture\n",
+    "\n",
+    "The models we built in this tutorial are examples of **Quantitative Structure-Activity Relationship (QSAR)** models -- they predict biological activity from molecular structure. QSAR models are one of several computational approaches that collectively form New Approach Methodologies:\n",
+    "\n",
+    "- **QSAR/QSPR models**: Predict activity or properties from chemical structure (what we did here)\n",
+    "- **Read-across**: Predict toxicity of untested chemicals based on similar compounds with known toxicity\n",
+    "- **PBPK models**: Physiologically-based pharmacokinetic models that simulate how chemicals move through the body\n",
+    "- **In-vitro assays**: Cell-based experiments like those in Tox21 and ToxCast (the data source for our models)\n",
+    "- **Organ-on-chip**: Microfluidic devices that mimic organ function for toxicity testing\n",
+    "\n",
+    "These approaches are increasingly recognized by regulatory agencies. The EPA committed in 2019 to [reducing animal testing requests](https://www.epa.gov/research/epa-new-approach-methods-work-plan-reducing-use-vertebrate-animals-chemical-testing) by 2035, with NAMs playing a central role. The 2023 FDA Modernization Act 2.0 eliminated the requirement for animal testing in drug approval, opening the door for computational and in-vitro alternatives.\n",
+    "\n",
+    "Datasets like Tox21 and ToxCast -- and the computational models built from them -- are building blocks for a future where toxicity assessment relies on data and algorithms rather than animal experiments.\n",
+    "\n",
+    "## Further Reading\n",
+    "\n",
+    "- Wu, Z., et al. \"MoleculeNet: a benchmark for molecular machine learning.\" *Chemical Science* 9.2 (2018): 513-530.\n",
+    "- Mayr, A., et al. \"DeepTox: Toxicity Prediction using Deep Learning.\" *Frontiers in Environmental Science* 3 (2016): 80.\n",
+    "- Thomas, R.S., et al. \"The Next Generation Blueprint of Computational Toxicology at the U.S. Environmental Protection Agency.\" *Toxicological Sciences* 169.2 (2019): 317-332."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Congratulations! Time to join the Community!\n",
+    "\n",
+    "Congratulations on completing this tutorial notebook! If you enjoyed working through the tutorial, and want to continue working with DeepChem, we encourage you to finish the rest of the tutorials in this series. You can also help the DeepChem community in the following ways:\n",
+    "\n",
+    "## Star DeepChem on [GitHub](https://github.com/deepchem/deepchem)\n",
+    "This helps build awareness of the DeepChem project and the tools for open source drug discovery that we're trying to build.\n",
+    "\n",
+    "## Join the DeepChem Discord\n",
+    "The DeepChem [Discord](https://discord.gg/cGzwCdrUqS) hosts a number of scientists, developers, and enthusiasts interested in deep learning for the life sciences. Join the conversation!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.9.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
Adds a new tutorial notebook demonstrating computational toxicity prediction using DeepChem's MoleculeNet toxicity datasets. This addresses the [tutorial wishlist](https://github.com/deepchem/deepchem/issues/2907) by covering an important application area that doesn't yet have a dedicated tutorial.

## What the tutorial covers
- **Tox21 dataset**: Loading and exploring the 12-endpoint nuclear receptor and stress response assay data
- **MultitaskClassifier with ECFP**: Training a fingerprint-based multitask model, evaluating per-task ROC-AUC
- **GraphConvModel**: Comparing graph convolutional approach on the same data
- **ToxCast**: Scaling to 617 assay endpoints with multitask learning
- **ClinTox**: Bridging in-vitro screening to clinical toxicity outcomes
- **Context on NAMs**: How these computational approaches fit into the broader landscape of New Approach Methodologies for toxicity assessment

## Design choices
- Follows the established tutorial format (Colab badge, pip install, community closing section)
- Uses scaffold splitting throughout for realistic evaluation
- Progresses from simple (Tox21, 12 tasks) to complex (ToxCast, 617 tasks)
- Contextualizes the datasets as part of the shift toward computational alternatives to animal testing, referencing EPA and FDA policy developments
- All code uses existing DeepChem APIs -- no new dependencies

## References
- Relates to #2907 (Tutorial Wishlist)
- Wu et al., "MoleculeNet: a benchmark for molecular machine learning" (2018)
- Parish et al., "An evaluation framework for new approach methodologies" (2020)
- Thomas et al., "The Next Generation Blueprint of Computational Toxicology at the U.S. EPA" (2019)