### PR TITLE
Add environment version checks to Basic Tools tutorial

### DIFF
--- a/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
+++ b/examples/tutorials/The_Basic_Tools_of_the_Deep_Life_Sciences.ipynb
@@ -64,6 +64,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import deepchem as dc\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "print(\"DeepChem version:\", dc.__version__)\n",
+    "print(\"NumPy version:\", np.__version__)\n",
+    "print(\"Pandas version:\", pd.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "id": "CMWAv-Z46nCc",
     "pycharm": {
@@ -128,23 +143,7 @@
     "id": "PDiY03h35zF_",
     "outputId": "e3b7af38-f298-4161-db16-afbd3d4078c9"
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.google.colaboratory.intrinsic+json": {
-       "type": "string"
-      },
-      "text/plain": [
-       "'2.5.0.dev'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {
-      "tags": []
-     },
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import deepchem as dc\n",
     "dc.__version__"
@@ -246,16 +245,7 @@
     "id": "LJc90fs_5zGs",
     "outputId": "770a8b76-1a7c-48a1-952e-1ae0343541c4"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Training set score: {'pearson_r2_score': 0.9323622956442351}\n",
-      "Test set score: {'pearson_r2_score': 0.6898768897014962}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "metric = dc.metrics.Metric(dc.metrics.pearson_r2_score)\n",
     "print(\"Training set score:\", model.evaluate(train_dataset, [metric], transformers))\n",
@@ -286,24 +276,7 @@
     "id": "HSVqeYox5zGx",
     "outputId": "f2218dfc-e100-4950-9b09-5ff0be493cfa"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[-1.8629359] [-1.60114461] c1cc2ccc3cccc4ccc(c1)c2c34\n",
-      "[0.6617248] [0.20848251] Cc1cc(=O)[nH]c(=S)[nH]1\n",
-      "[-0.5705674] [-0.01602738] Oc1ccc(cc1)C2(OC(=O)c3ccccc23)c4ccc(O)cc4 \n",
-      "[-2.0929456] [-2.82191713] c1ccc2c(c1)cc3ccc4cccc5ccc2c3c45\n",
-      "[-1.4962314] [-0.52891635] C1=Cc2cccc3cccc1c23\n",
-      "[1.8620405] [1.10168349] CC1CO1\n",
-      "[-0.5858227] [-0.88987406] CCN2c1ccccc1N(C)C(=S)c3cccnc23 \n",
-      "[-0.9799993] [-0.52649706] CC12CCC3C(CCc4cc(O)ccc34)C2CCC1=O\n",
-      "[-1.0176951] [-0.76358725] Cn2cc(c1ccccc1)c(=O)c(c2)c3cccc(c3)C(F)(F)F\n",
-      "[0.05622783] [-0.64020358] ClC(Cl)(Cl)C(NC=O)N1C=CN(C=C1)C(NC=O)C(Cl)(Cl)Cl \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "solubilities = model.predict_on_batch(test_dataset.X[:10])\n",
     "for molecule, solubility, test_solubility in zip(test_dataset.ids, solubilities, test_dataset.y):\n",
@@ -361,7 +334,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "deepchem",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -375,7 +348,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.20"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds a standard environment and version check cell to the "Basic Tools of the Deep Life Sciences" tutorial. >
Adding __version__ printouts for DeepChem, NumPy, and Pandas at the top of the notebook helps improve reproducibility and allows future users to easily debug environment mismatches.
