### PR TITLE
Fix logging format for missing dependency warnings (#4772)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
+.venv/
+env/
 build/
 develop-eggs/
 dist/

--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -29,7 +29,9 @@ try:
     from deepchem.models.chemnet_models import Smiles2Vec, ChemCeption
 except ModuleNotFoundError as e:
     logger.warning(
-        f'Skipped loading some Tensorflow models, missing a dependency. {e}')
+        "Skipped loading some TensorFlow models due to missing dependency: %s",
+        e,
+    )
 
 # scikit-learn model
 from deepchem.models.sklearn_models import SklearnModel
@@ -52,7 +54,9 @@ try:
     from deepchem.models.torch_models import WeaveModel, DTNNModel
 except ModuleNotFoundError as e:
     logger.warning(
-        f'Skipped loading some PyTorch models, missing a dependency. {e}')
+        "Skipped loading some PyTorch models due to missing dependency: %s",
+        e,
+    )
 
 try:
     from deepchem.models.torch_models import HuggingFaceModel
@@ -60,7 +64,10 @@ try:
     from deepchem.models.torch_models import MoLFormer
     from deepchem.models.torch_models import OneFormer
 except ImportError as e:
-    logger.warning(e)
+    logger.warning(
+        "Skipped loading HuggingFace-related models due to missing dependency: %s",
+        e,
+    )
 
 # Pytorch models with torch-geometric dependency
 try:
@@ -69,7 +76,8 @@ try:
     from deepchem.models.torch_models import DMPNN, DMPNNModel, GNNModular, MXMNet
 except ImportError as e:
     logger.warning(
-        f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}'
+        "Skipped loading PyTorch-Geometric dependent modules due to missing dependency: %s",
+        e,
     )
 
 # Pytorch-lightning modules import
@@ -78,7 +86,8 @@ try:
     from deepchem.models.trainer import DistributedTrainer
 except ModuleNotFoundError as e:
     logger.warning(
-        f'Skipped loading modules with pytorch-lightning dependency, missing a dependency. {e}'
+        "Skipped loading PyTorch-Lightning modules due to missing dependency: %s",
+        e,
     )
 
 # Jax models
@@ -87,7 +96,9 @@ try:
     from deepchem.models.jax_models import PINNModel
 except ModuleNotFoundError as e:
     logger.warning(
-        f'Skipped loading some Jax models, missing a dependency. {e}')
+        "Skipped loading some JAX models due to missing dependency: %s",
+        e,
+    )
 
 #####################################################################################
 # Compatibility imports for renamed XGBoost models. Remove below with DeepChem 3.0.


### PR DESCRIPTION
This PR addresses issue #4772.

I have updated the logging statements in deepchem/models/__init__.py to use proper logger formatting instead of f-strings. This ensures consistent logging style across the codebase and avoids unnecessary string formatting when the log level is disabled.
The changes only affect the logging message format and do not modify any functionality.
Kindly review the changes and let me know if any improvements are needed.

Before vs After Code:

Before:
```
logger.warning(
    f"Skipped loading some TensorFlow models due to missing dependency: {e}"
)

```
After:
```
logger.warning(
    "Skipped loading some TensorFlow models due to missing dependency: %s",
    e,
)

```
Github:- @vinitjain2005
