### PR TITLE
Fix invalid escape sequence warnings in attention docstrings

### DIFF
--- a/deepchem/models/torch_models/attention.py
+++ b/deepchem/models/torch_models/attention.py
@@ -59,7 +59,7 @@ class ScaledDotProductAttention(nn.Module):
 
 
 class SelfAttention(nn.Module):
-    """SelfAttention Layer
+    r"""SelfAttention Layer
 
     Given $X\in \mathbb{R}^{n \times in_feature}$, the attention is calculated by: $a=softmax(W_2tanh(W_1X))$, where
     $W_1 \in \mathbb{R}^{hidden \times in_feature}$, $W_2 \in \mathbb{R}^{out_feature \times hidden}$.
@@ -88,7 +88,7 @@ class SelfAttention(nn.Module):
         nn.init.xavier_normal_(self.w2)
 
     def forward(self, X):
-        """The forward function.
+        r"""The forward function.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description

Fixes `DeprecationWarning: invalid escape sequence` in `attention.py`.

Hi! I'm a PhD student preparing my proposal for the GSoC 2026 (the topic on Symbolic ML). While running `pytest deepchem/models/tests/test_torch_model.py` to get familiar with the TorchModel codebase i noticed a couple of `DeprecationWarning: invalid escape sequence` in the `attention.py` docstrings. 

I just added the `r` prefix to make them raw strings. 


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
