### PR TITLE
Fix invalid escape sequence warning in Ferminet docstring (#2007)

### DIFF
--- a/deepchem/models/torch_models/ferminet.py
+++ b/deepchem/models/torch_models/ferminet.py
@@ -183,6 +183,7 @@ class Ferminet(torch.nn.Module):
             return energy.detach()
 
     def calculate_nuclear_nuclear(self,) -> torch.Tensor:
+
         """
         Function to calculate where only the nucleus terms are involved and does not change when new electrons are sampled.
         atom-atom potential term = Zi*Zj/|Ri-Rj|, where Zi, Zj are the nuclear charges and Ri, Rj are nuclear coordinates
@@ -236,7 +237,7 @@ class Ferminet(torch.nn.Module):
         return potential.detach()
 
     def calculate_kinetic_energy(self,):
-        """
+        r"""
         Function to calculate the expected kinetic energy term per batch
         It is calculated via:
         \sum_{ri}^{}[(\pdv[]{log|\Psi|}{(ri)})^2 + \pdv[2]{log|\Psi|}{(ri)}]


### PR DESCRIPTION
## Description

Fix #2007 

This PR fixes a DeprecationWarning caused by invalid escape sequences in the
`calculate_kinetic_energy` docstring in `deepchem/models/torch_models/ferminet.py`.

The issue was caused by LaTeX-style backslash expressions (e.g., \sum, \pdv)
being interpreted as escape sequences by Python.

Resolved by converting the affected docstring to a raw string (r""" ... """).

No functional code changes were made.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
