### PR TITLE
Fix Colab environment and add badge to Atomic Contributions tutorial

### DIFF
--- a/examples/tutorials/Atomic_Contributions_for_Molecules.ipynb
+++ b/examples/tutorials/Atomic_Contributions_for_Molecules.ipynb
@@ -1,6 +1,22 @@
 {
   "cells": [
     {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install --pre deepchem"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Atomic_Contributions_for_Molecules.ipynb)"
+      ]
+    },
+    {
       "cell_type": "markdown",
       "metadata": {
         "id": "-1lrRjjKPlGi"


### PR DESCRIPTION
This PR adds the missing DeepChem installation cell to the top of the notebook and includes an Open in Colab badge to improve usability.

Fixes #2785