### PR TITLE
Replace bare except with except Exception in datasets module (#3137)

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -525,9 +525,8 @@ class Dataset(object):
         """
         try:
             import tensorflow as tf
-        except:
-            raise ImportError(
-                "This method requires TensorFlow to be installed.")
+        except Exception:
+            raise ImportError("This method requires TensorFlow to be installed.")
 
         # Retrieve the first sample so we can determine the dtypes.
         X, y, w, ids = next(self.itersamples())
@@ -998,7 +997,7 @@ class NumpyDataset(Dataset):
         """
         try:
             from deepchem.data.pytorch_datasets import _TorchNumpyDataset
-        except:
+        except Exception:
             raise ImportError("This method requires PyTorch to be installed.")
 
         pytorch_ds = _TorchNumpyDataset(numpy_dataset=self,
@@ -1922,7 +1921,7 @@ class DiskDataset(Dataset):
         """
         try:
             from deepchem.data.pytorch_datasets import _TorchDiskDataset
-        except:
+        except Exception:
             raise ImportError("This method requires PyTorch to be installed.")
 
         pytorch_ds = _TorchDiskDataset(disk_dataset=self,
@@ -3011,7 +3010,7 @@ class ImageDataset(Dataset):
         """
         try:
             from deepchem.data.pytorch_datasets import _TorchImageDataset
-        except:
+        except Exception:
             raise ValueError("This method requires PyTorch to be installed.")
 
         pytorch_ds = _TorchImageDataset(image_dataset=self,


### PR DESCRIPTION
## Description

This PR replaces bare `except:` statements with `except Exception:` in
`deepchem/data/datasets.py` to follow Python best practices for error handling.

Bare except clauses can hide unexpected errors such as `KeyboardInterrupt`
or `SystemExit`. Replacing them with `except Exception:` ensures only
standard exceptions are caught.

Fixes #3137


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
- [ ] Run `mypy -p deepchem` and check no errors
- [ ] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings