### PR TITLE
Add shuffle() method to NumpyDataset

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -965,6 +965,23 @@ class NumpyDataset(Dataset):
         w = self.w[indices]
         ids = self.ids[indices]
         return NumpyDataset(X, y, w, ids)
+    def shuffle(self, seed: Optional[int] = None) -> None:
+        """Shuffle dataset samples while preserving alignment of X, y, w, and ids.
+
+    Parameters
+    ----------
+    seed: int, optional
+        Random seed for reproducibility.
+    """
+
+        if seed is not None:
+            np.random.seed(seed)
+        perm = np.random.permutation(len(self._X))
+        X = self._X[perm]
+        y = self._y[perm]
+        w = self._w[perm]
+        ids = self._ids[perm]
+        return NumpyDataset(X, y, w, ids)
 
     def make_pytorch_dataset(self,
                              epochs: int = 1,

--- a/deepchem/data/tests/test_numpy_dataset_shuffle.py
+++ b/deepchem/data/tests/test_numpy_dataset_shuffle.py
@@ -1,0 +1,27 @@
+import numpy as np
+import deepchem as dc
+
+
+def test_numpy_dataset_shuffle_changes_order():
+
+    X = np.arange(10).reshape(10,1)
+    y = np.arange(10)
+
+    dataset = dc.data.NumpyDataset(X, y)
+
+    shuffled = dataset.shuffle(seed=42)
+
+    assert not np.array_equal(dataset.X, shuffled.X)
+
+
+def test_numpy_dataset_shuffle_alignment():
+
+    X = np.arange(10).reshape(10,1)
+    y = np.arange(10)
+
+    dataset = dc.data.NumpyDataset(X, y)
+
+    shuffled = dataset.shuffle(seed=42)
+
+    for i in range(len(shuffled.X)):
+        assert shuffled.X[i][0] == shuffled.y[i]


### PR DESCRIPTION
## Description

This PR adds a `shuffle()` method to `NumpyDataset`.

The method returns a shuffled copy of the dataset while preserving
alignment between `X`, `y`, `w`, and `ids`.

Motivation:
Currently, `NumpyDataset` does not provide a built-in method to shuffle
samples. Users must manually shuffle arrays using NumPy, which is less
convenient and can lead to mistakes if feature/label alignment is not
maintained.

Example usage:

dataset = dc.data.NumpyDataset(X, y)
shuffled = dataset.shuffle(seed=42)

Features:
- Returns a shuffled copy of the dataset
- Preserves alignment between X, y, w, and ids
- Supports optional random seed for reproducibility

Tests:
Added `test_numpy_dataset_shuffle.py` which verifies:
- Dataset order changes after shuffling
- Feature and label alignment is preserved


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)


## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
- [ ] Run `mypy -p deepchem` and check no errors
- [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings