### PR TITLE
Add train_test_split method to NumpyDataset with tests

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -966,6 +966,55 @@ class NumpyDataset(Dataset):
         ids = self.ids[indices]
         return NumpyDataset(X, y, w, ids)
 
+    def train_test_split(
+        self,
+        test_size: float = 0.2,
+        seed: Optional[int] = None
+        ) -> Tuple["NumpyDataset", "NumpyDataset"]:
+        """Split the dataset into train and test datasets.
+
+        Parameters
+        ----------
+        test_size: float, default 0.2
+        Fraction of the dataset to include in the test split.
+        seed: int, optional
+        Random seed for reproducibility.
+
+        Returns
+        -------
+        Tuple[NumpyDataset, NumpyDataset]
+        train_dataset, test_dataset
+        """
+
+        if not 0 < test_size < 1:
+            raise ValueError("test_size must be between 0 and 1")
+
+        if seed is not None:
+            np.random.seed(seed)
+
+        n_samples = len(self)
+        indices = np.random.permutation(n_samples)
+
+        split_index = int(n_samples * (1 - test_size))
+
+        train_indices = indices[:split_index]
+        test_indices = indices[split_index:]
+
+        train_dataset = NumpyDataset(
+            self._X[train_indices],
+            self._y[train_indices] if self._y is not None else None,
+            self._w[train_indices] if self._w is not None else None,
+            self._ids[train_indices] if self._ids is not None else None
+        )
+
+        test_dataset = NumpyDataset(
+            self._X[test_indices],
+            self._y[test_indices] if self._y is not None else None,
+            self._w[test_indices] if self._w is not None else None,
+            self._ids[test_indices] if self._ids is not None else None
+        )
+
+        return train_dataset, test_dataset
     def make_pytorch_dataset(self,
                              epochs: int = 1,
                              deterministic: bool = False,

--- a/deepchem/data/tests/test_numpy_dataset_split.py
+++ b/deepchem/data/tests/test_numpy_dataset_split.py
@@ -1,0 +1,28 @@
+import numpy as np
+import deepchem as dc
+
+
+def test_train_test_split_basic():
+
+    X = np.random.rand(10, 3)
+    y = np.random.rand(10, 1)
+
+    dataset = dc.data.NumpyDataset(X, y)
+
+    train, test = dataset.train_test_split(test_size=0.3)
+
+    assert len(train) == 7
+    assert len(test) == 3
+
+
+def test_train_test_split_alignment():
+
+    X = np.arange(10).reshape(10, 1)
+    y = np.arange(10)
+
+    dataset = dc.data.NumpyDataset(X, y)
+
+    train, test = dataset.train_test_split(seed=42)
+
+    for i in range(len(train)):
+        assert train.X[i][0] == train.y[i]


### PR DESCRIPTION
## Description

This PR adds a `train_test_split()` method to the `NumpyDataset` class.

The method allows users to split a dataset into training and testing subsets based on a specified `test_size`. It preserves the alignment between features (`X`), labels (`y`), weights (`w`), and identifiers (`ids`).

An optional random seed is supported to ensure reproducible splits.

Unit tests have been added to validate:
- Correct dataset sizes after splitting
- Proper alignment between dataset fields

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] Run `yapf -i <modified file>` and check no errors
- [x] Run `mypy -p deepchem` and check no errors
- [x] Run `flake8 <modified file> --count` and check no errors
- [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings