### PR TITLE
Avoid unintended task-dimension removal in SklearnModel.fit

### DIFF
--- a/deepchem/models/sklearn_models/sklearn_model.py
+++ b/deepchem/models/sklearn_models/sklearn_model.py
@@ -100,11 +100,19 @@ class SklearnModel(Model):
             The `Dataset` to train this model on.
         """
         X = dataset.X
-        y = np.squeeze(dataset.y)
-        w = np.squeeze(dataset.w)
+        y = dataset.y
+        w = dataset.w
+
+        # Avoid using np.squeeze since it may remove task dimensions
+        # unintentionally for single-task datasets with shape (n_samples, 1)
+        if isinstance(y, np.ndarray) and y.ndim == 2 and y.shape[1] == 1:
+         y = y[:, 0]
+         
+        if isinstance(w, np.ndarray) and w.ndim == 2 and w.shape[1] == 1:
+         w = w[:, 0]
         # Some scikit-learn models don't use weights.
         if self.use_weights:
-            self.model.fit(X, y, w)
+            self.model.fit(X, y, sample_weight=w)
             return
         self.model.fit(X, y)
 
@@ -146,6 +154,11 @@ class SklearnModel(Model):
     def save(self):
         """Saves scikit-learn model to disk using joblib."""
         save_to_disk(self.model, self.get_model_filename(self.model_dir))
+
+    def reload(self):
+        """Loads scikit-learn model from joblib file on disk."""
+        self.model = load_from_disk(self.get_model_filename(self.model_dir))
+
 
     def reload(self):
         """Loads scikit-learn model from joblib file on disk."""


### PR DESCRIPTION
## Description

This PR fixes a potential issue in `SklearnModel.fit()` where `np.squeeze()` was previously applied to `dataset.y` and `dataset.w`.

Using `np.squeeze()` can unintentionally remove the task dimension when datasets have shape `(n_samples, 1)`. Since DeepChem datasets support multi-task learning, this behavior can cause inconsistent shapes between single-task and multi-task datasets.

This PR replaces `np.squeeze()` with explicit dimension checks to ensure that the task dimension is preserved unless it is explicitly safe to remove.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
- [ ] Run `mypy -p deepchem` and check no errors
- [ ] Run `flake8 <modified file> --count` and check no errors
- [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
