### PR TITLE
fix: standardize logger.warning format in models/__init__.py

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -60,7 +60,8 @@ try:
     from deepchem.models.torch_models import MoLFormer
     from deepchem.models.torch_models import OneFormer
 except ImportError as e:
-    logger.warning(e)
+    logger.warning(
+        f'Skipped loading some HuggingFace models, missing a dependency. {e}')
 
 # Pytorch models with torch-geometric dependency
 try:


### PR DESCRIPTION
## What This PR Does

Standardizes the `logger.warning` call in the HuggingFace optional-dependency import block of `deepchem/models/__init__.py` to match the format used by every other block in the file.

## Why I Made This Change

While reading through the codebase, I noticed all optional-dependency import blocks use a descriptive f-string format:
```python
logger.warning(f'Skipped loading some X models, missing a dependency. {e}')
```

The HuggingFace block was the only exception, using a bare:
```python
logger.warning(e)
```

This means if a user is missing a HuggingFace dependency, the log message gives them far less context than any other missing-dependency warning in the same file.

## Research / Trace

I traced the inconsistency to L62-63 of `deepchem/models/__init__.py`. All other `except` blocks in this file use the descriptive f-string pattern. The bare `logger.warning(e)` was likely introduced when the HuggingFace block was added separately from the original blocks.

**Before:**
```python
except ImportError as e:
    logger.warning(e)
```

**After:**
```python
except ImportError as e:
    logger.warning(
        f'Skipped loading some HuggingFace models, missing a dependency. {e}')
```

## Changes

- `deepchem/models/__init__.py`: Standardized the HuggingFace import warning message to match the format used by all other optional-dependency blocks.

## Testing

No functional behavior changed. This is a pure logging consistency fix. Existing tests pass unchanged.

Closes #4772