### PR TITLE
fix: correct grammatical errors in Introduction_to_Equivariance tutorial

### DIFF
--- a/examples/tutorials/Introduction_to_Equivariance.ipynb
+++ b/examples/tutorials/Introduction_to_Equivariance.ipynb
@@ -191,7 +191,7 @@
    "id": "173d1fd8-4506-49f1-ac01-bcff95c524b6",
    "metadata": {},
    "source": [
-    "Although our model is not trained, we are not concerned about. Since, we only want see if our model is affected by permutations, translations and rotations"
+    "Although our model is not trained, we are not concerned about that. Since we only want to see if our model is affected by permutations, translations and rotations"
    ]
   },
   {


### PR DESCRIPTION
## What This PR Does

Fixes two grammatical issues in the prose of the `Introduction_to_Equivariance.ipynb` tutorial notebook.

## Why I Made This Change

I was reading through the equivariance tutorial to understand how DeepChem handles SE(3)-equivariant models, and noticed a broken sentence in one of the explanatory cells. The sentence reads:

> *"Although our model is not trained, we are not concerned about. Since, we only want see if our model is affected"*

This has a missing word ('that'), a missing word ('to'), and an unnecessary comma after 'Since'. It reads as unfinished, which is confusing for new readers.

## Changes

- `examples/tutorials/Introduction_to_Equivariance.ipynb`: Fixed sentence in explanatory markdown cell

**Before:**
> Although our model is not trained, we are not concerned about. Since, we only want see if our model is affected

**After:**
> Although our model is not trained, we are not concerned about that. Since we only want to see if our model is affected

## Testing

Documentation-only change. No code cells modified.

Closes #4543