### PR TITLE
docs: add Sphinx label to Delaney (ESOL) dataset section in moleculenet.rst

### DIFF
--- a/docs/source/api_reference/moleculenet.rst
+++ b/docs/source/api_reference/moleculenet.rst
@@ -103,6 +103,8 @@ Clintox Datasets
 
 .. autofunction:: deepchem.molnet.load_clintox
 
+.. _delaney-datasets:
+
 Delaney Datasets
 ----------------
 


### PR DESCRIPTION
## What This PR Does

Adds a Sphinx cross-reference label `.. _delaney-datasets:` to the Delaney (ESOL) section in `moleculenet.rst`, so the section can be linked directly rather than resolving to the top of the page.

## Why I Made This Change

The Delaney (ESOL) examples in `examples.rst` link to `./moleculenet.html`, which only takes users to the top of the MoleculeNet page. There's no anchor to navigate them directly to the Delaney section, so users have to scroll to find it.

I checked the Sphinx documentation on [cross-referencing arbitrary locations](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref). Adding a `.. _label:` directive above a section heading makes it linkable via `:ref:`label`` from any other document.

**Before:** clicking the Delaney link in examples → lands at top of MoleculeNet page
**After:** `:ref:`delaney-datasets`` → jumps directly to the Delaney section

## Changes

- `docs/source/api_reference/moleculenet.rst`: Added `.. _delaney-datasets:` label above the Delaney Datasets heading (line 106)

## Testing

Documentation-only change. No code modified.

Closes #4627