### PR TITLE
Added text generation example using HuggingFaceModel.generate() on examples/olmo_generate_example.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.mypy_cache/
+model-dir/
 
 # C extensions
 *.so

--- a/deepchem/models/tests/test_hf.py
+++ b/deepchem/models/tests/test_hf.py
@@ -1,0 +1,15 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import deepchem as dc
+def test_huggingface_generate():
+    model = AutoModelForCausalLM.from_pretrained("distilgpt2")
+    tokenizer = AutoTokenizer.from_pretrained("distilgpt2")
+
+    hf_model = dc.models.torch_models.HuggingFaceModel(
+        model=model,
+        tokenizer=tokenizer,
+        task="text_generation"
+    )
+
+    result = hf_model.generate("DeepChem is", max_length=20)
+    assert isinstance(result, list)
+    assert isinstance(result[0], str)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -650,3 +650,29 @@ class HuggingFaceModel(TorchModel):
             results.append(text_results)
 
         return results[0] if len(results) == 1 else results
+
+    def generate(self, inputs: Union[str, List[str]], **kwargs) -> List[str]:
+        """Generate text using HuggingFace's text generation pipeline."""
+        self._ensure_built()
+        self.model.eval()
+        if not hasattr(self.model, 'generate'):
+            raise ValueError("This HuggingFace model doesn't support text generation.")
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        if self.tokenizer.pad_token is None:
+            self.tokenizer.pad_token = self.tokenizer.eos_token
+            self.model.config.pad_token_id = self.model.config.eos_token_id
+        encoded = self.tokenizer(inputs, return_tensors='pt', padding=True, truncation=True)
+        device = self.device
+        if torch.cuda.is_available():
+            device = torch.device('cuda')
+        elif device.type == 'mps':
+            # HuggingFace's generate method does not currently support MPS. Move model and inputs to CPU.
+            logger.warning("HuggingFace's generate method does not currently support MPS. Moving model and inputs to CPU for generation.")
+            self.model.to('cpu')
+            device = torch.device('cpu')
+        self.model.to(device)
+        encoded = {key: value.to(device) for key, value in encoded.items()}
+        with torch.no_grad():
+            outputs = self.model.generate(**encoded, **kwargs)
+        return self.tokenizer.batch_decode(outputs, skip_special_tokens=True)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -635,7 +635,7 @@ class HuggingFaceModel(TorchModel):
 
             # Decode the sequence with each of the top_k tokens inserted
             # Calculate the score as the probability of that token in the sequence.
-            text_results = []
+            text_results: List[HuggingFaceModel.FillMaskOutput] = []
             probs = torch.softmax(mask_token_logits, dim=1)
             for token in top_k_tokens:
                 token_str = self.tokenizer.decode([token])
@@ -656,19 +656,25 @@ class HuggingFaceModel(TorchModel):
         self._ensure_built()
         self.model.eval()
         if not hasattr(self.model, 'generate'):
-            raise ValueError("This HuggingFace model doesn't support text generation.")
+            raise ValueError(
+                "This HuggingFace model doesn't support text generation.")
         if isinstance(inputs, str):
             inputs = [inputs]
         if self.tokenizer.pad_token is None:
             self.tokenizer.pad_token = self.tokenizer.eos_token
             self.model.config.pad_token_id = self.model.config.eos_token_id
-        encoded = self.tokenizer(inputs, return_tensors='pt', padding=True, truncation=True)
+        encoded = self.tokenizer(inputs,
+                                 return_tensors='pt',
+                                 padding=True,
+                                 truncation=True)
         device = self.device
         if torch.cuda.is_available():
             device = torch.device('cuda')
         elif device.type == 'mps':
             # HuggingFace's generate method does not currently support MPS. Move model and inputs to CPU.
-            logger.warning("HuggingFace's generate method does not currently support MPS. Moving model and inputs to CPU for generation.")
+            logger.warning(
+                "HuggingFace's generate method does not currently support MPS. Moving model and inputs to CPU for generation."
+            )
             self.model.to('cpu')
             device = torch.device('cpu')
         self.model.to(device)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -610,8 +610,11 @@ class HuggingFaceModel(TorchModel):
             mask_token_index = torch.where(
                 encoded_input["input_ids"] == self.tokenizer.mask_token_id)[1]
             # Ensure that the masked token index appears EXACTLY once.
-            assert mask_token_index.numel(
-            ) == 1, f"Sequence has masked indices at: {list(mask_token_index)}. Please ensure that only one position is masked in the sequence."
+            if mask_token_index.numel() != 1:
+                raise ValueError(
+                    f"Sequence has masked indices at: {list(mask_token_index)}."
+                    "Please ensure that only one position is masked in the sequence."
+                )
 
             with torch.no_grad():
                 output = self.model(**encoded_input)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -568,12 +568,17 @@ class HuggingFaceModel(TorchModel):
         score: float
         token: int
         token_str: str
-    def fill_mask(self, inputs: Union[str, List[str]], top_k: int = 5) -> Union[List[FillMaskOutput], List[List[FillMaskOutput]]]:
+
+    def fill_mask(
+        self,
+        inputs: Union[str, List[str]],
+        top_k: int = 5
+    ) -> Union[List[FillMaskOutput], List[List[FillMaskOutput]]]:
         """Implements the HuggingFace 'fill_mask' pipeline from HuggingFace.
         https://huggingface.co/docs/transformers/main_classes/pipelines
 
         Takes as input a sequence or list of sequences where each sequence
-        containts a single masked position and returns a list of dictionaries per sequence
+        contains a single masked position and returns a list of dictionaries per sequence
         containing the filled sequence, the token, and the score for that token.
 
         Parameters
@@ -585,7 +590,7 @@ class HuggingFaceModel(TorchModel):
 
         Returns
         -------
-        Union[List[Dict], List[List[Dict]]]
+        Union[List[FillMaskOutput], List[List[FillMaskOutput]]]
             A list or a list of list of dictionaries with the following keys:
             - sequence (str): The corresponding input with the mask token prediction.
             - score (float): The corresponding probability.
@@ -594,6 +599,8 @@ class HuggingFaceModel(TorchModel):
         """
 
         # First make sure tha the model is successfully loaded, then set to eval mode.
+        if top_k <= 0:
+            raise ValueError("top_k must be a positive integer.")
         self._ensure_built()
         self.model.eval()
 
@@ -629,10 +636,11 @@ class HuggingFaceModel(TorchModel):
             # Decode the sequence with each of the top_k tokens inserted
             # Calculate the score as the probability of that token in the sequence.
             text_results = []
+            probs = torch.softmax(mask_token_logits, dim=1)
             for token in top_k_tokens:
                 token_str = self.tokenizer.decode([token])
                 filled_text = text.replace(self.tokenizer.mask_token, token_str)
-                score = torch.softmax(mask_token_logits, dim=1)[0, token].item()
+                score = probs[0, token].item()
                 text_results.append({
                     'sequence': filled_text,
                     'score': score,

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -2,7 +2,7 @@ import logging
 import time
 from collections.abc import Sequence as SequenceCollection
 from typing import (TYPE_CHECKING, Any, Callable, Iterable, List, Optional,
-                    Tuple, Union, Dict)
+                    Tuple, Union, Dict, TypedDict)
 
 import numpy as np
 import torch
@@ -563,9 +563,12 @@ class HuggingFaceModel(TorchModel):
         else:
             return np.array(final_results)
 
-    def fill_mask(self,
-                  inputs: Union[str, List[str]],
-                  top_k: int = 5) -> Union[List[Dict], List[List[Dict]]]:
+    class FillMaskOutput(TypedDict):
+        sequence: str
+        score: float
+        token: int
+        token_str: str
+    def fill_mask(self, inputs: Union[str, List[str]], top_k: int = 5) -> Union[List[FillMaskOutput], List[List[FillMaskOutput]]]:
         """Implements the HuggingFace 'fill_mask' pipeline from HuggingFace.
         https://huggingface.co/docs/transformers/main_classes/pipelines
 

--- a/examples/olmo_generate_example.py
+++ b/examples/olmo_generate_example.py
@@ -1,0 +1,20 @@
+import deepchem as dc
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def main():
+    "I used a small model as running allenai/OLMo-7B-hf and even running allenai/OLMo-1B-hf takes a long time on CPU. You can change the model to one of those if you have a GPU and want to test out the larger models."
+    "However, the smaller distilgpt2 model is still able to generate reasonable text based on the prompt, so it should be sufficient for testing out the HuggingFaceModel's generate function."
+    MODEL_NAME = "distilgpt2"
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    model = AutoModelForCausalLM.from_pretrained(MODEL_NAME)
+    hf_model = dc.models.torch_models.HuggingFaceModel(model=model,
+                                                       tokenizer=tokenizer,
+                                                       task="text_generation")
+    prompt = "The molecule has a molecular weight of 300 and a logP of 2.5. It is likely to be"
+    answer = hf_model.generate(prompt, max_length=50)
+    print(answer[0])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
I created an example script in examples/olmo_generate_example.py using the dstillgpt2 Hugging Face model because when I tried using allenai/OLMo-7B-hf and even allenai/OLMo-1B-hf, it filled up my disk. However, my code shows how to use the HuggingFaceModel.generate() function for text generation. This helps demonstrate how DeepChem can support text generation with HuggingFace models.

## Type of change 
Please check the option that is related to your PR.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ X] Documentations (modification for documents)

## Checklist

- [X ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ X] Run `mypy -p deepchem` and check no errors
  - [ X] Run `flake8 <modified file> --count` and check no errors
  - [ X] Run `python -m doctest <modified file>` and check no errors
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [X ] I have checked my code and corrected any misspellings
