### PR TITLE
Add OLMo model support in DeepChem via HuggingFaceModel wrapper

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -75,3 +75,5 @@ try:
 
 except ModuleNotFoundError as e:
     logger.warning(f'Skipped loading modules with transformers dependency. {e}')
+
+from .olmo_model import OLMoModel

--- a/deepchem/models/torch_models/olmo_model.py
+++ b/deepchem/models/torch_models/olmo_model.py
@@ -1,0 +1,28 @@
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from deepchem.models.torch_models.hf_models import HuggingFaceModel
+
+
+class OLMoModel(HuggingFaceModel):
+
+    def __init__(self, model_name="allenai/OLMo-1B"):
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            model_name,
+            trust_remote_code=True
+        )
+
+        
+        model = AutoModelForCausalLM.from_pretrained(
+            model_name,
+            trust_remote_code=True
+        )
+
+       
+
+        super().__init__(
+            model=model,
+            tokenizer=tokenizer,
+            task=None
+        )
+
+       

--- a/examples/olmo_example.py
+++ b/examples/olmo_example.py
@@ -1,0 +1,7 @@
+from deepchem.models.torch_models.olmo_model import OLMoModel
+
+print("Creating DeepChem OLMo model...")
+
+model = OLMoModel()
+
+print("Model created successfully!")


### PR DESCRIPTION
## Description

This PR adds initial support for OLMo models in DeepChem using the existing HuggingFaceModel wrapper.

The change introduces an `OLMoModel` wrapper that allows loading OLMo language models from HuggingFace and using them inside DeepChem workflows.

Key changes:

* Added `OLMoModel` wrapper in `deepchem/models/torch_models/olmo_model.py`
* Integrated the model through the existing `HuggingFaceModel` abstraction
* Added the import in `deepchem/models/torch_models/__init__.py`
* Added a small example script demonstrating how to initialize the model

For testing and compatibility, the implementation was verified using **OLMo-1B** from HuggingFace. Using the smaller model helps validate the integration without requiring extremely large downloads during development.

This PR is intended as an initial step toward supporting larger OLMo models (such as 7B) within DeepChem.

## Type of change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentations (modification for documents)

## Checklist

* [x] I have performed a self-review of my own code
* [x] I have commented my code where necessary
* [x] I have checked my code and corrected any misspellings
