### PR TITLE
Validate HuggingFaceModel task and tokenizer inputs

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -148,6 +148,19 @@ class HuggingFaceModel(TorchModel):
             task: Optional[str] = None,
             config: Optional[Dict] = None,
             **kwargs):
+        supported_tasks = {
+            None, 'mlm', 'mtr', 'regression', 'classification',
+            'universal_segmentation'
+        }
+        if task not in supported_tasks:
+            raise ValueError(
+                f"Unsupported task '{task}'. Supported tasks are: "
+                "'mlm', 'mtr', 'regression', 'classification', "
+                "'universal_segmentation', or None.")
+        tokenizer_required_tasks = {'mlm', 'mtr', 'regression', 'classification'}
+        if task in tokenizer_required_tasks and tokenizer is None:
+            raise ValueError(
+                f"`tokenizer` must be provided for task '{task}'.")
         self.task = task
         self.tokenizer = tokenizer
         if self.task == 'mlm':

--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -269,6 +269,37 @@ def test_fill_mask_fidelity(tmpdir, hf_tokenizer):
 
 
 @pytest.mark.hf
+def test_invalid_hf_task_raises():
+    from transformers.models.roberta import RobertaConfig, RobertaForMaskedLM
+
+    config = RobertaConfig(vocab_size=100)
+    model = RobertaForMaskedLM(config)
+
+    with pytest.raises(ValueError, match="Unsupported task"):
+        HuggingFaceModel(model=model,
+                         tokenizer=None,
+                         task='invalid_task',
+                         device=torch.device('cpu'))
+
+
+@pytest.mark.hf
+def test_missing_tokenizer_for_regression_raises():
+    from transformers.models.roberta import (RobertaConfig,
+                                             RobertaForSequenceClassification)
+
+    config = RobertaConfig(vocab_size=100,
+                           problem_type='regression',
+                           num_labels=1)
+    model = RobertaForSequenceClassification(config)
+
+    with pytest.raises(ValueError, match="tokenizer"):
+        HuggingFaceModel(model=model,
+                         tokenizer=None,
+                         task='regression',
+                         device=torch.device('cpu'))
+
+
+@pytest.mark.hf
 def test_load_from_pretrained_with_diff_task(tmpdir):
     # Tests loading a pretrained model where the weight shape in last layer
     # (the final projection layer) of the pretrained model does not match


### PR DESCRIPTION
## Description

This PR improves input validation in `deepchem.models.torch_models.hf_models.HuggingFaceModel`.

The current wrapper accepts task configurations that may only fail later in the execution path, for example during batch preparation or model usage. This PR adds early validation in the constructor so that misconfigured models fail immediately with clearer error messages.

Specifically, this change:
- validates supported `task` values at initialization time
- raises an explicit error when `tokenizer=None` is provided for tokenization-dependent tasks such as `mlm`, `mtr`, `regression`, and `classification`

In addition, this PR adds targeted unit tests covering:
- invalid task values
- missing tokenizer for regression mode

This keeps the behavior unchanged for valid inputs while making configuration errors easier to diagnose and safer to extend in future HuggingFace-related work.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

