### PR TITLE
Fix Colab installation issue by resolving typeguard dependency conflict

### DIFF
--- a/docs/source/get_started/installation.rst
+++ b/docs/source/get_started/installation.rst
@@ -33,7 +33,8 @@ For using models with tensorflow dependencies, you install using
 
 .. code-block:: bash
 
-    pip install --pre deepchem[tensorflow]
+    pip install typeguard==2.13.3
+    pip install deepchem[tensorflow]
 
 For using models with Pytorch dependencies, you install using
 


### PR DESCRIPTION
## Description

Fixes installation issue in Google Colab caused by typeguard dependency conflict.

## Changes

- Added explicit typeguard==2.13.3 installation before deepchem[tensorflow]
- Ensures compatibility with Python 3.12 environments (Colab)

## Type of change

- [x] Documentations

## Notes

This improves reproducibility of DeepChem tutorials in Colab environments.