### PR TITLE
Add HuggingFaceModel batch preparation tests

### DIFF
--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -11,6 +11,16 @@ except ModuleNotFoundError:
     pass
 
 
+class DummyTokenizer:
+
+    def __call__(self, smiles, padding=True, return_tensors="pt"):
+        batch_size = len(smiles)
+        return {
+            "input_ids": torch.ones((batch_size, 4), dtype=torch.long),
+            "attention_mask": torch.ones((batch_size, 4), dtype=torch.long)
+        }
+
+
 @pytest.fixture
 def hf_tokenizer(tmpdir):
     filepath = os.path.join(tmpdir, 'smiles.txt')
@@ -266,6 +276,69 @@ def test_fill_mask_fidelity(tmpdir, hf_tokenizer):
 
             # Test 3. Check that the infilling went to the right spot
             assert filled['sequence'].startswith(f'<s>{filled["token_str"]}')
+
+@pytest.mark.hf
+def test_prepare_batch_regression_labels_are_float():
+    from transformers.models.roberta import (RobertaConfig,
+                                             RobertaForSequenceClassification)
+
+    config = RobertaConfig(vocab_size=100, problem_type='regression', num_labels=1)
+    model = RobertaForSequenceClassification(config)
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=DummyTokenizer(),
+                                task='regression',
+                                device=torch.device('cpu'))
+
+    batch = ((np.array(["CCO", "CCC"], dtype=object),),
+             (np.array([[1.5], [2.5]], dtype=np.float32),), np.ones((2, 1)))
+    inputs, labels, _ = hf_model._prepare_batch(batch)
+
+    assert labels is not None
+    assert labels.dtype == torch.float32
+    assert inputs["labels"] is not None
+    assert inputs["labels"].dtype == torch.float32
+
+
+@pytest.mark.hf
+def test_prepare_batch_classification_labels_are_long():
+    from transformers.models.roberta import (RobertaConfig,
+                                             RobertaForSequenceClassification)
+
+    config = RobertaConfig(vocab_size=100, num_labels=2)
+    model = RobertaForSequenceClassification(config)
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=DummyTokenizer(),
+                                task='classification',
+                                device=torch.device('cpu'))
+
+    batch = ((np.array(["CCO", "CCC"], dtype=object),),
+             (np.array([[1], [0]], dtype=np.int64),), np.ones((2, 1)))
+    inputs, labels, _ = hf_model._prepare_batch(batch)
+
+    assert labels is not None
+    assert labels.dtype == torch.int64
+    assert inputs["labels"] is not None
+    assert inputs["labels"].dtype == torch.int64
+
+
+@pytest.mark.hf
+def test_prepare_batch_prediction_allows_none_labels():
+    from transformers.models.roberta import (RobertaConfig,
+                                             RobertaForSequenceClassification)
+
+    config = RobertaConfig(vocab_size=100, problem_type='regression', num_labels=1)
+    model = RobertaForSequenceClassification(config)
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=DummyTokenizer(),
+                                task='regression',
+                                device=torch.device('cpu'))
+
+    batch = ((np.array(["CCO", "CCC"], dtype=object),), None, np.ones((2, 1)))
+    inputs, labels, _ = hf_model._prepare_batch(batch)
+
+    assert labels is None
+    assert inputs["labels"] is None
+    assert torch.equal(inputs["input_ids"], torch.ones((2, 4), dtype=torch.long))
 
 
 @pytest.mark.hf


### PR DESCRIPTION
## Description

This PR adds focused unit tests for task-specific batch preparation behavior in `deepchem.models.torch_models.hf_models.HuggingFaceModel`.

Specifically, the new tests verify that:
- regression labels are converted to float tensors
- classification labels are converted to long tensors
- prediction-style batch preparation works when `y=None`

To keep the tests isolated and lightweight, they use a small tokenizer stub instead of relying on external tokenizer loading.

These tests improve coverage of `HuggingFaceModel._prepare_batch()` and make task-specific tensor handling easier to validate and maintain.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
