### PR TITLE
Clarify HuggingFaceModel task support and tokenizer requirements

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -40,6 +40,9 @@ class HuggingFaceModel(TorchModel):
     tokenization algorithms and other utilities like data collation, random masking of tokens
     for masked language model training etc.
 
+    Supported tasks are validated at initialization time to make invalid model
+    configurations fail early with clearer errors.
+
 
     Parameters
     ----------
@@ -51,12 +54,19 @@ class HuggingFaceModel(TorchModel):
          - `mtr` - multitask regression - a task used for both pretraining base models and finetuning
          - `regression` - use it for regression tasks, like property prediction
          - `classification` - use it for classification tasks
+         - `universal_segmentation` - use it for segmentation models supported by
+           HuggingFace's `AutoModelForUniversalSegmentation`
+         - `None` - return raw model outputs without applying task-specific handling
 
         When the task is not specified or None, the wrapper returns raw output of the HuggingFaceModel.
         In cases where the HuggingFaceModel is a model without a task specific head, this output will be
         the last hidden states.
-    tokenizer: transformers.tokenization_utils.PreTrainedTokenizer
-        Tokenizer
+    tokenizer: transformers.tokenization_utils.PreTrainedTokenizer, optional
+        Tokenizer used to convert raw inputs into model tokens. This is required
+        for tokenization-dependent tasks such as `mlm`, `mtr`, `regression`, and
+        `classification`. It may be omitted when `task=None` and raw model outputs
+        are used directly, or when task-specific preprocessing does not require a
+        tokenizer.
     config: dict, (optional, default None)
         A dictionary of model configuration parameters that will be passed to the Hugging Face
         `AutoModel` classes via `**kwargs` when loading from the hf_checkpoint. These parameters


### PR DESCRIPTION
## Description

This PR improves the `HuggingFaceModel` documentation to better reflect the current API and initialization behavior.

Specifically, it:
- clarifies the full set of supported `task` values
- documents that `tokenizer` is required for tokenization-dependent tasks such as `mlm`, `mtr`, `regression`, and `classification`
- clarifies the meaning of `task=None`
- notes that task configurations are validated during initialization for earlier and clearer error reporting

This makes the wrapper easier to use correctly and keeps the documentation aligned with the current implementation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
