### PR TITLE
Added 'Open in Colab button' to ESMFold tutorial

### DIFF
--- a/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb
+++ b/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb
@@ -13,6 +13,13 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/deepchem/deepchem/blob/master/examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
       "metadata": {
         "id": "6zwZZeBedXOx"
       },


### PR DESCRIPTION
## Description
Added "Open in Colab" button to the `Protein_Structure_Prediction_with_ESMFold.ipynb` 
notebook.

## Related Issue
Fix #4364


##  Motivation and Changes 
All other DeepChem tutorials have the Colab button but this notebook was missing it.
This makes it easier for beginners to run the notebook without any local setup.
- Added Colab badge markdown cell at the top of 'examples/tutorials/Protein_Structure_Prediction_with_ESMFold.ipynb'

## Type of change
- [ ✓] New feature (non-breaking change which adds functionality)


## Checklist
- [✓ ] My code follows [the style guidelines of this project]
- [✓ ] I have che
<img width="1147" height="376" alt="Screenshot 2026-03-18 140014" src="https://github.com/user-attachments/assets/de8aeb86-274f-4ada-9ea1-63cd104ed49e" />