### PR TITLE
fix: update outdated Gitter reference to Discord in Large_Scale_Chemical_Screens tutorial

### DIFF
--- a/examples/tutorials/Large_Scale_Chemical_Screens.ipynb
+++ b/examples/tutorials/Large_Scale_Chemical_Screens.ipynb
@@ -776,8 +776,8 @@
     "## Star DeepChem on [GitHub](https://github.com/deepchem/deepchem)\n",
     "This helps build awareness of the DeepChem project and the tools for open source drug discovery that we're trying to build.\n",
     "\n",
-    "## Join the DeepChem Gitter\n",
-    "The DeepChem [Gitter](https://gitter.im/deepchem/Lobby) hosts a number of scientists, developers, and enthusiasts interested in deep learning for the life sciences. Join the conversation!"
+    "## Join the DeepChem Discord\n",
+    "The DeepChem [Discord](https://discord.com/invite/SxSzjRRDMA) hosts a number of scientists, developers, and enthusiasts interested in deep learning for the life sciences. Join the conversation!"
    ]
   }
  ],


### PR DESCRIPTION
…cal_Screens tutorial

## Description

Fix #(issue)

Updated outdated community link from Gitter to Discord in Large_Scale_Chemical_Screens.ipynb tutorial, as DeepChem has migrated from Gitter to Discord.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ x ] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
