### PR TITLE
Fix typo: ddeepchem -> deepchem in layers.rst

### DIFF
--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -487,7 +487,7 @@ InceptionV3 Layers
 .. autoclass:: deepchem.models.torch_models.inception_v3.InceptionA
    :members:
 
-.. autoclass:: ddeepchem.models.torch_models.inception_v3.InceptionB
+.. autoclass:: deepchem.models.torch_models.inception_v3.InceptionB
    :members:
 
 .. autoclass:: deepchem.models.torch_models.inception_v3.InceptionC


### PR DESCRIPTION
## Summary
Fixed a typo in `docs/source/api_reference/layers.rst` where 
`ddeepchem` was incorrectly written instead of `deepchem` in 
the InceptionV3 Layers section.

## Changes
- Line 488: `ddeepchem` → `deepchem`

## Related Issue
Fixes part of #2989 (Fixing warnings, errors in docs build)