### PR TITLE
fix: standardize dependency warning messages in models/__init__.py

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -1,7 +1,9 @@
 """
 Gathers all models in one place for convenient imports
 """
+
 # flake8: noqa
+
 import logging
 
 from deepchem.models.models import Model
@@ -14,20 +16,18 @@ logger = logging.getLogger(__name__)
 # Tensorflow Dependency Models
 try:
     from deepchem.models.keras_model import KerasModel
-
     from deepchem.models.IRV import MultitaskIRVClassifier
     from deepchem.models.robust_multitask import RobustMultitaskClassifier
     from deepchem.models.robust_multitask import RobustMultitaskRegressor
     from deepchem.models.progressive_multitask import ProgressiveMultitaskRegressor, ProgressiveMultitaskClassifier
     from deepchem.models.graph_models import DAGModel, MPNNModel, GraphConvModel
     from deepchem.models.scscore import ScScoreModel
-
     from deepchem.models.seqtoseq import SeqToSeq
     from deepchem.models.gan import GAN, WGAN
     from deepchem.models.molgan import BasicMolGANModel
     from deepchem.models.text_cnn import TextCNNModel
     from deepchem.models.chemnet_models import Smiles2Vec, ChemCeption
-except ModuleNotFoundError as e:
+except (ModuleNotFoundError, ImportError) as e:
     logger.warning(
         f'Skipped loading some Tensorflow models, missing a dependency. {e}')
 
@@ -50,42 +50,42 @@ try:
     from deepchem.models.torch_models import ScaledDotProductAttention, SelfAttention
     from deepchem.models.torch_models import GroverReadout
     from deepchem.models.torch_models import WeaveModel, DTNNModel
-except ModuleNotFoundError as e:
+except (ModuleNotFoundError, ImportError) as e:
     logger.warning(
         f'Skipped loading some PyTorch models, missing a dependency. {e}')
 
+# HuggingFace models
 try:
     from deepchem.models.torch_models import HuggingFaceModel
     from deepchem.models.torch_models import Chemberta
     from deepchem.models.torch_models import MoLFormer
     from deepchem.models.torch_models import OneFormer
-except ImportError as e:
-    logger.warning(e)
+except (ModuleNotFoundError, ImportError) as e:
+    logger.warning(
+        f'Skipped loading some HuggingFace models, missing a dependency. {e}')
 
 # Pytorch models with torch-geometric dependency
 try:
     # TODO We should clean up DMPNN and remove torch_geometric dependency during import
     from deepchem.models.torch_models import MEGNetModel
     from deepchem.models.torch_models import DMPNN, DMPNNModel, GNNModular, MXMNet
-except ImportError as e:
+except (ModuleNotFoundError, ImportError) as e:
     logger.warning(
-        f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}'
-    )
+        f'Skipped loading modules with pytorch-geometric dependency, missing a dependency. {e}')
 
 # Pytorch-lightning modules import
 try:
     from deepchem.models.lightning import DCLightningModule, DCLightningDatasetModule
     from deepchem.models.trainer import DistributedTrainer
-except ModuleNotFoundError as e:
+except (ModuleNotFoundError, ImportError) as e:
     logger.warning(
-        f'Skipped loading modules with pytorch-lightning dependency, missing a dependency. {e}'
-    )
+        f'Skipped loading modules with pytorch-lightning dependency, missing a dependency. {e}')
 
 # Jax models
 try:
     from deepchem.models.jax_models import JaxModel
     from deepchem.models.jax_models import PINNModel
-except ModuleNotFoundError as e:
+except (ModuleNotFoundError, ImportError) as e:
     logger.warning(
         f'Skipped loading some Jax models, missing a dependency. {e}')
 
@@ -98,9 +98,11 @@ from deepchem.models.gbdt_models.gbdt_model import XGBoostModel
 ########################################################################################
 # Compatibility imports for renamed TensorGraph models. Remove below with DeepChem 3.0.
 ########################################################################################
+
 try:
     from deepchem.models.text_cnn import TextCNNTensorGraph
     from deepchem.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvTensorGraph, MPNNTensorGraph
     from deepchem.models.IRV import TensorflowMultitaskIRVClassifier
-except ModuleNotFoundError:
-    pass
+except (ModuleNotFoundError, ImportError) as e:
+    logger.warning(
+        f'Skipped loading some legacy TensorGraph models, missing a dependency. {e}')


### PR DESCRIPTION
## Description
This PR standardizes all dependency warning messages in `deepchem/models/__init__.py`.

Fixes #4772

**Problem:**
The warning messages shown when an optional dependency (like PyTorch, TensorFlow, etc.)
is missing were inconsistent across different sections of the file:
- The HuggingFace block used `logger.warning(e)` — just printed the raw error with no explanation
- The legacy TensorGraph block used `pass` — completely silent, no warning at all
- Some blocks caught only `ModuleNotFoundError`, others caught only `ImportError`

This means users could get confusing or missing messages when a dependency is not installed.
**Fix:**
All `except` blocks now follow the same standard format:
```python
except (ModuleNotFoundError, ImportError) as e:
    logger.warning(
        f'Skipped loading some X models, missing a dependency. {e}')
```

**Changes made in `deepchem/models/__init__.py`:**
 Block  : Before --> After 
 TensorFlow : `except ModuleNotFoundError` --> `except (ModuleNotFoundError, ImportError)`
 PyTorch : `except ModuleNotFoundError` --> `except (ModuleNotFoundError, ImportError)` 
 HuggingFace : `logger.warning(e)` only --> Full descriptive warning message 
 PyTorch-geometric : `except ImportError` --> `except (ModuleNotFoundError, ImportError)` 
 PyTorch Lightning : `except ModuleNotFoundError` --> `except (ModuleNotFoundError, ImportError)` 
 Jax : `except ModuleNotFoundError` --> `except (ModuleNotFoundError, ImportError)` 
 Legacy TensorGraph : `pass`  --> Full descriptive warning message 

## Type of change
- [ ✓] New feature (non-breaking change which adds functionality)

## Checklist
- [✓] My code follows the style guidelines of this project
- [✓] Run `yapf -i deepchem/models/__init__.py` and check no errors (yapf version 0.22.0)
- [✓] Run `mypy -p deepchem` and check no errors
- [✓] Run `flake8 deepchem/models/__init__.py --count` and check no errors
- [✓] Run `python -m doctest deepchem/models/__init__.py` and check no errors
- [✓] I have performed a self-review of my own code


<img width="861" height="559" alt="Screenshot 2026-03-18 180341" src="https://github.com/user-attachments/assets/bf4571d8-89e7-4e63-bbc2-d08690d173da" />
