### PR TITLE
[feat] Support custom tokenizer arguments in HuggingFaceModel

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -112,11 +112,12 @@ class HuggingFaceModel(TorchModel):
     >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='mlm', model_dir='model-dir')
     >>> training_loss = hf_model.fit(dataset, nb_epoch=1)
 
-    >>> # finetuning a regression model
+    >>> # finetuning a regression model with custom tokenizer kwargs
     >>> from transformers.models.roberta import RobertaForSequenceClassification
     >>> config = RobertaConfig(vocab_size=tokenizer.vocab_size, problem_type='regression', num_labels=1)
     >>> model = RobertaForSequenceClassification(config)
-    >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='regression', model_dir='model-dir')
+    >>> tokenizer_kwargs = {'max_length': 512, 'truncation': True}
+    >>> hf_model = HuggingFaceModel(model=model, tokenizer=tokenizer, task='regression', tokenizer_kwargs=tokenizer_kwargs, model_dir='model-dir')
     >>> hf_model.load_from_pretrained()
     >>> training_loss = hf_model.fit(dataset, nb_epoch=1)
     >>> prediction = hf_model.predict(dataset)  # prediction
@@ -147,6 +148,7 @@ class HuggingFaceModel(TorchModel):
             tokenizer: 'transformers.tokenization_utils.PreTrainedTokenizer',
             task: Optional[str] = None,
             config: Optional[Dict] = None,
+            tokenizer_kwargs: Optional[Dict] = None,
             **kwargs):
         self.task = task
         self.tokenizer = tokenizer
@@ -161,6 +163,12 @@ class HuggingFaceModel(TorchModel):
             self.config = config
         else:
             self.config = {}
+
+        if tokenizer_kwargs:
+            self.tokenizer_kwargs = tokenizer_kwargs
+        else:
+            self.tokenizer_kwargs = {}
+
         super(HuggingFaceModel, self).__init__(
             model=model,
             loss=None,  # type: ignore
@@ -277,9 +285,13 @@ class HuggingFaceModel(TorchModel):
 
     def _prepare_batch(self, batch: Tuple[Any, Any, Any]):
         smiles_batch, y, w = batch
-        tokens = self.tokenizer(smiles_batch[0].tolist(),
-                                padding=True,
-                                return_tensors="pt")
+        # Merge default padding and return_tensors with user provided tokenizer_kwargs
+        tokenizer_kwargs = {
+            'padding': True,
+            'return_tensors': "pt",
+            **self.tokenizer_kwargs
+        }
+        tokens = self.tokenizer(smiles_batch[0].tolist(), **tokenizer_kwargs)
 
         if self.task == 'mlm':
             inputs, labels = self.data_collator.torch_mask_tokens(

--- a/deepchem/models/torch_models/tests/test_hf_models.py
+++ b/deepchem/models/torch_models/tests/test_hf_models.py
@@ -364,3 +364,26 @@ def test_load_molformer_model_from_hf_checkpoint(tmpdir):
                                         from_hf_checkpoint=True)
     assert finetune_model.model.config.problem_type == 'regression'
     assert finetune_model.model.config.num_labels == 1
+
+
+@pytest.mark.hf
+def test_tokenizer_kwargs(hf_tokenizer):
+    """Test that tokenizer_kwargs are correctly passed and respected."""
+    from transformers.models.roberta import RobertaConfig, RobertaForSequenceClassification
+    config = RobertaConfig(vocab_size=hf_tokenizer.vocab_size)
+    model = RobertaForSequenceClassification(config)
+
+    # Test with max_length and truncation
+    tokenizer_kwargs = {'max_length': 5, 'truncation': True}
+    hf_model = HuggingFaceModel(model=model,
+                                tokenizer=hf_tokenizer,
+                                task='classification',
+                                tokenizer_kwargs=tokenizer_kwargs,
+                                device=torch.device('cpu'))
+
+    smiles = ["CN(c1ccccc1)c1ccccc1C(=O)NCC1(O)CCOCC1"]
+    batch = (np.array(smiles), None, None)
+    inputs, _, _ = hf_model._prepare_batch(batch)
+
+    # The input_ids should be truncated to max_length (5)
+    assert inputs['input_ids'].shape[1] == 5


### PR DESCRIPTION
## Description

Feat - Support custom tokenizer arguments in HuggingFaceModel

This PR introduces a `tokenizer_kwargs` parameter to the `HuggingFaceModel` class, allowing users to pass custom configuration options (such as `max_length`, `truncation`, and padding strategies) directly to the underlying HuggingFace tokenizer.

Previously, these parameters were either hardcoded or relied on default values, limiting flexibility for different model architectures and dataset requirements.

### Key changes:
- Updated `HuggingFaceModel.__init__` to accept and store `tokenizer_kwargs`.
- Modified `_prepare_batch` to merge and apply these custom arguments during tokenization.
- Added a unit test `test_tokenizer_kwargs` in `test_hf_models.py` to verify correct handling of arguments like `max_length` and `truncation`.
- Updated class documentation with examples demonstrating the new functionality.

---

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)  
- [x] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
  - In this case, we recommend discussing your modification on GitHub issues before creating the PR  
- [x] Documentations (modification for documents)  

---

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i deepchem/models/torch_models/hf_models.py` and check no errors (**yapf version must be 0.32.0**)  
  - [x] Run `mypy -p deepchem` and check no errors  
  - [x] Run `flake8 deepchem/models/torch_models/hf_models.py --count` and check no errors  
  - [x] Run `python -m doctest deepchem/models/torch_models/hf_models.py` and check no errors  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code, particularly in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] I have added tests that prove my fix is effective or that my feature works  
- [x] New unit tests pass locally with my changes  
- [x] I have checked my code and corrected any misspellings  