### PR TITLE
Add docstring to HuggingFaceModel._prepare_batch

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -276,6 +276,26 @@ class HuggingFaceModel(TorchModel):
                                            strict=False)
 
     def _prepare_batch(self, batch: Tuple[Any, Any, Any]):
+        """Prepares a batch of data for training or prediction.
+
+    Tokenizes raw SMILES strings and prepares input tensors for the
+    underlying HuggingFace model based on the current task type.
+
+    Parameters
+    ----------
+    batch: Tuple[Any, Any, Any]
+        A tuple of (X, y, w) where X contains SMILES strings,
+        y contains labels, and w contains sample weights.
+
+    Returns
+    -------
+    Tuple[Dict[str, torch.Tensor], Optional[torch.Tensor], Any]
+        A tuple of (inputs, labels, weights) where inputs is a
+        dictionary of tensors ready for the HuggingFace model.
+        For 'mlm' tasks, labels are None as they are embedded in inputs.
+        For 'regression', 'classification', and 'mtr' tasks, labels
+        are returned as a separate tensor.
+    """
         smiles_batch, y, w = batch
         tokens = self.tokenizer(smiles_batch[0].tolist(),
                                 padding=True,


### PR DESCRIPTION
## Summary
`_prepare_batch` was the only method in `HuggingFaceModel` without a docstring, unlike all other methods in the class (`load_from_pretrained`, `fit_generator`, `_predict`, `fill_mask`).

## Changes
- Added NumPy-style docstring to `_prepare_batch` documenting parameters, return type, and behavior for each task type (`mlm`, `regression`, `classification`, `mtr`)

## Related
Getting familiar with the `hf_models.py` module as part of GSoC 2026 OLMo integration proposal work.