### PR TITLE
Created a differentiable molecular dynamics integration routine

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -52,6 +52,7 @@ from deepchem.models.torch_models.hnn import HNN, HNNModel
 from deepchem.models.torch_models.chemception import ChemCeptionLayer, ChemCeption
 from deepchem.models.torch_models.fno import FNO, FNOModel
 from deepchem.models.torch_models.lnn import LNN, LNNModel
+from deepchem.models.torch_models.differentiable_molecular_dynamics import MolecularDynamics
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel

--- a/deepchem/models/torch_models/differentiable_molecular_dynamics.py
+++ b/deepchem/models/torch_models/differentiable_molecular_dynamics.py
@@ -1,0 +1,106 @@
+import torch
+import torch.nn as nn
+from deepchem.models.torch_models.torch_model import TorchModel
+
+
+class VelocityVerlet(nn.Module):
+  """
+    Implements Velocity Verlet integration for molecular dynamics.
+
+    This module performs a single step or multiple steps of Velocity Verlet integration.
+
+    Parameters
+    ----------
+    time_step: float
+        The time step for the integration.
+    mass: float
+        The mass of the particles.
+    force_fn: callable
+        A function that takes positions `r` and returns forces `F`.
+        The function should take a tensor of shape (batch_size, n_particles, n_dimensions)
+        and return a tensor of the same shape.
+    """
+
+  def __init__(self, time_step=0.001, mass=1.0, force_fn=None):
+    super(VelocityVerlet, self).__init__()
+    self.time_step = time_step
+    self.mass = mass
+    self.force_fn = force_fn
+
+  def forward(self, r, v, steps=1, force_fn=None):
+    """
+        Performs MD simulation.
+
+        Parameters
+        ----------
+        r: torch.Tensor
+            Initial positions. Shape (Batch, N_atoms, 3)
+        v: torch.Tensor
+            Initial velocities. Shape (Batch, N_atoms, 3)
+        steps: int
+            Number of integration steps.
+        force_fn: Callable
+            Function that takes (r) and returns forces (F).
+            If not provided, uses the one from __init__.
+
+        Returns
+        -------
+        r_final: torch.Tensor
+        v_final: torch.Tensor
+        """
+    if force_fn is None:
+      if self.force_fn is None:
+        raise ValueError("force_fn must be provided.")
+      force_fn = self.force_fn
+
+    dt = self.time_step
+    m = self.mass
+
+    # If inputs are not tensors, convert them
+    if not isinstance(r, torch.Tensor):
+      r = torch.tensor(r)
+    if not isinstance(v, torch.Tensor):
+      v = torch.tensor(v)
+
+    # Initial force computation
+    f = force_fn(r)
+    a = f / m
+
+    for _ in range(steps):
+      # v(t + 0.5*dt) = v(t) + 0.5 * a(t) * dt
+      v_half = v + 0.5 * a * dt
+
+      # r(t + dt) = r(t) + v(t + 0.5*dt) * dt
+      r_next = r + v_half * dt
+
+      # a(t + dt) = F(r(t + dt)) / m
+      f_next = force_fn(r_next)
+      a_next = f_next / m
+
+      # v(t + dt) = v(t + 0.5*dt) + 0.5 * a(t + dt) * dt
+      v_next = v_half + 0.5 * a_next * dt
+
+      r = r_next
+      v = v_next
+      a = a_next
+
+    return r, v
+
+
+class MolecularDynamics(TorchModel):
+  """
+    Differentiable Molecular Dynamics wrapper.
+
+    This class wraps the VelocityVerlet module in a TorchModel.
+    """
+
+  def __init__(self,
+               time_step=0.001,
+               mass=1.0,
+               force_fn=None,
+               loss=None,
+               **kwargs):
+    model = VelocityVerlet(time_step=time_step, mass=mass, force_fn=force_fn)
+    # loss is optional for simulation
+    super(MolecularDynamics, self).__init__(model, loss=loss, **kwargs)
+

--- a/deepchem/models/torch_models/tests/test_differentiable_md.py
+++ b/deepchem/models/torch_models/tests/test_differentiable_md.py
@@ -1,0 +1,91 @@
+import pytest
+import numpy as np
+import torch
+import sys
+from unittest.mock import MagicMock
+
+# Mock transformers if it is not installed
+try:
+    import transformers
+except ImportError:
+    transformers = MagicMock()
+    transformers.__path__ = []
+    sys.modules["transformers"] = transformers
+    sys.modules["transformers.models.auto"] = MagicMock()
+    sys.modules["transformers.data"] = MagicMock()
+    sys.modules["transformers.data.data_collator"] = MagicMock()
+
+try:
+    from deepchem.models.torch_models.differentiable_molecular_dynamics import MolecularDynamics
+except ImportError:
+    # This might happen if torch is not installed, but we should let pytest handle it via markers or just fail
+    pass
+
+@pytest.mark.torch
+def test_molecular_dynamics_harmonic_oscillator():
+    """
+    Test velocity verlet integration with a harmonic oscillator.
+    """
+    # 1D harmonic oscillator: F = -k * x
+    # Mass m = 1
+    # k = 1
+    # Angular frequency omega = sqrt(k/m) = 1
+    # Expected solution: x(t) = x(0) * cos(omega*t) + v(0)/omega * sin(omega*t)
+    
+    k = 1.0
+    m = 1.0
+    
+    def harmonic_force(r):
+        return -k * r
+        
+    md = MolecularDynamics(time_step=0.01, mass=m, force_fn=harmonic_force)
+    
+    # Initial conditions
+    # Batch size 1, 1 particle, 1 dimension
+    r0 = torch.tensor([[[1.0]]], requires_grad=True)
+    v0 = torch.tensor([[[0.0]]], requires_grad=True)
+    
+    # Run for 100 steps -> t = 1.0
+    steps = 100
+    
+    # We call the internal model directly to pass steps, 
+    # as fitting the TorchModel interface to this test is unnecessary complexity
+    r_final, v_final = md.model(r0, v0, steps=steps)
+    
+    t_final = 0.01 * steps
+    
+    # Analytical solution
+    x_expected = 1.0 * np.cos(t_final)
+    v_expected = -1.0 * np.sin(t_final)
+    
+    # Check close. Velocity Verlet is 2nd order accurate.
+    assert np.allclose(r_final.detach().numpy(), x_expected, atol=1e-2)
+    assert np.allclose(v_final.detach().numpy(), v_expected, atol=1e-2)
+    
+    # Test differentiability
+    # If we compute a loss on final state, gradients should flow back to initial state
+    loss = (r_final - torch.tensor([[[0.0]]])).sum()
+    loss.backward()
+    
+    assert r0.grad is not None
+    assert v0.grad is not None
+
+@pytest.mark.torch
+def test_molecular_dynamics_shape():
+    """Test that shapes are preserved."""
+    def zero_force(r):
+        return torch.zeros_like(r)
+        
+    md = MolecularDynamics(time_step=0.1, mass=1.0, force_fn=zero_force)
+    
+    batch_size = 5
+    n_particles = 10
+    n_dims = 3
+    
+    r0 = torch.randn(batch_size, n_particles, n_dims)
+    v0 = torch.randn(batch_size, n_particles, n_dims)
+    
+    r_final, v_final = md.model(r0, v0, steps=5)
+    
+    assert r_final.shape == r0.shape
+    assert v_final.shape == v0.shape


### PR DESCRIPTION
## Description

Fix #4704 

Created differentiable_molecular_dynamics.py under torch_models, added the relevant test file and changes to __init__.py accordingly
The newly created differentiable molecular dynamics integration routine implements a simple velocity verlet integration method. This is a simple implementation, facilitating future additions to this functionality.
No new dependencies are required for this change.


## Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have added tests that prove my fix is effective or that my feature works
- New unit tests pass locally with my changes
- I have checked my code and corrected any misspellings
