### PR TITLE
Add constrained Gibbs-style molecular sampler

### DIFF
--- a/deepchem/utils/smiles_sampling.py
+++ b/deepchem/utils/smiles_sampling.py
@@ -14,6 +14,7 @@ model for molecular generation (e.g., ChemBERTa-style models).
 
 import random
 import torch
+from typing import Callable, List
 from rdkit import Chem
 from rdkit.Chem import QED, AllChem, DataStructs
 
@@ -61,6 +62,9 @@ def gibbs_step(
     This function is model-agnostic and works with any masked language model
     that supports token masking and logits prediction (e.g., ChemBERTa-style models).
 
+    Note:
+        This uses top-k candidate filtering with validity checks, not exact Gibbs sampling.
+
     Args:
         smiles (str): Input SMILES string.
         model: Masked language model.
@@ -82,7 +86,9 @@ def gibbs_step(
     pos = random.choice(safe_positions)
 
     inputs = tokenizer(smiles, return_tensors="pt")
-    inputs = {k: v.to(next(model.parameters()).device) for k, v in inputs.items()}
+
+    device = next(model.parameters()).device
+    inputs = {key: val.to(device) for key, val in inputs.items()}
 
     inputs["input_ids"][0][pos] = tokenizer.mask_token_id
 
@@ -111,11 +117,11 @@ def gibbs_step(
 
 def run_chain(
     seed: str,
-    gibbs_step_fn,
+    gibbs_step_fn: Callable[[str], str],
     steps: int = 50,
     min_sim: float = 0.3,
     min_qed: float = 0.4
-) -> list:
+) -> List[str]:
     """
     Run constrained Gibbs-style sampling.
 
@@ -130,7 +136,7 @@ def run_chain(
         min_qed (float): Minimum QED threshold.
 
     Returns:
-        list: Trajectory of SMILES strings.
+        List[str]: Trajectory of SMILES strings.
     """
 
     current = seed

--- a/deepchem/utils/smiles_sampling.py
+++ b/deepchem/utils/smiles_sampling.py
@@ -1,9 +1,24 @@
+"""
+Utilities for constrained molecular generation using Gibbs-style sampling.
+
+This module provides:
+- SMILES validation
+- Similarity computation (Tanimoto)
+- QED scoring
+- Gibbs-style mutation step using masked language models
+- Sampling chains with simple constraints
+
+The implementation is model-agnostic and can be used with any masked language
+model for molecular generation (e.g., ChemBERTa-style models).
+"""
 
 import random
+import torch
 from rdkit import Chem
 from rdkit.Chem import QED, AllChem, DataStructs
 
 
+#Validation
 def is_valid_smiles(smiles):
     try:
         return Chem.MolFromSmiles(smiles) is not None
@@ -11,6 +26,7 @@ def is_valid_smiles(smiles):
         return False
 
 
+# Metrics
 def tanimoto(s1, s2):
     m1 = Chem.MolFromSmiles(s1)
     m2 = Chem.MolFromSmiles(s2)
@@ -31,9 +47,23 @@ def qed_score(smiles):
     return QED.qed(mol)
 
 
+# Sampling 
 def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
     """
     Perform one Gibbs-style mutation step using a masked language model.
+
+    This function is model-agnostic and works with any masked language model
+    that supports token masking and logits prediction (e.g., ChemBERTa-style models).
+
+    Args:
+        smiles (str): Input SMILES string.
+        model: Masked language model.
+        tokenizer: Corresponding tokenizer.
+        allowed_tokens (set): Tokens allowed for mutation.
+        k (int): Top-k sampling size.
+
+    Returns:
+        str: Mutated SMILES string (or original if no valid mutation found).
     """
 
     tokens = tokenizer.tokenize(smiles)
@@ -48,13 +78,13 @@ def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
     inputs = tokenizer(smiles, return_tensors="pt")
     inputs["input_ids"][0][pos] = tokenizer.mask_token_id
 
-    outputs = model(**inputs)
-    logits = outputs.logits[0, pos]
+    with torch.no_grad():
+        outputs = model(**inputs)
 
+    logits = outputs.logits[0, pos]
     topk_indices = logits.topk(k).indices
 
     for idx in topk_indices:
-
         token = tokenizer.decode([idx])
 
         if token not in allowed_tokens:

--- a/deepchem/utils/smiles_sampling.py
+++ b/deepchem/utils/smiles_sampling.py
@@ -1,0 +1,98 @@
+
+import random
+from rdkit import Chem
+from rdkit.Chem import QED, AllChem, DataStructs
+
+
+def is_valid_smiles(smiles):
+    try:
+        return Chem.MolFromSmiles(smiles) is not None
+    except Exception:
+        return False
+
+
+def tanimoto(s1, s2):
+    m1 = Chem.MolFromSmiles(s1)
+    m2 = Chem.MolFromSmiles(s2)
+
+    if m1 is None or m2 is None:
+        return 0.0
+
+    fp1 = AllChem.GetMorganFingerprintAsBitVect(m1, 2)
+    fp2 = AllChem.GetMorganFingerprintAsBitVect(m2, 2)
+
+    return DataStructs.TanimotoSimilarity(fp1, fp2)
+
+
+def qed_score(smiles):
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return 0.0
+    return QED.qed(mol)
+
+
+def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
+    """
+    Perform one Gibbs-style mutation step using a masked language model.
+    """
+
+    tokens = tokenizer.tokenize(smiles)
+
+    safe_positions = [i for i, t in enumerate(tokens) if t in allowed_tokens]
+
+    if not safe_positions:
+        return smiles
+
+    pos = random.choice(safe_positions)
+
+    inputs = tokenizer(smiles, return_tensors="pt")
+    inputs["input_ids"][0][pos] = tokenizer.mask_token_id
+
+    outputs = model(**inputs)
+    logits = outputs.logits[0, pos]
+
+    topk_indices = logits.topk(k).indices
+
+    for idx in topk_indices:
+
+        token = tokenizer.decode([idx])
+
+        if token not in allowed_tokens:
+            continue
+
+        new_tokens = tokens.copy()
+        new_tokens[pos] = token
+
+        new_smiles = tokenizer.convert_tokens_to_string(new_tokens).replace(" ", "")
+
+        if is_valid_smiles(new_smiles):
+            return new_smiles
+
+    return smiles
+
+
+def run_chain(seed, gibbs_step_fn, steps=50, min_sim=0.3, min_qed=0.4):
+    """
+    Run constrained Gibbs-style sampling.
+    """
+
+    current = seed
+    trajectory = [seed]
+
+    for _ in range(steps):
+
+        proposal = gibbs_step_fn(current)
+
+        if proposal is None or proposal == current:
+            trajectory.append(current)
+            continue
+
+        sim = tanimoto(seed, proposal)
+        q = qed_score(proposal)
+
+        if sim >= min_sim and q >= min_qed:
+            current = proposal
+
+        trajectory.append(current)
+
+    return trajectory

--- a/deepchem/utils/smiles_sampling.py
+++ b/deepchem/utils/smiles_sampling.py
@@ -18,16 +18,16 @@ from rdkit import Chem
 from rdkit.Chem import QED, AllChem, DataStructs
 
 
-#Validation
-def is_valid_smiles(smiles):
+# --- Validation ---
+def is_valid_smiles(smiles: str) -> bool:
     try:
         return Chem.MolFromSmiles(smiles) is not None
     except Exception:
         return False
 
 
-# Metrics
-def tanimoto(s1, s2):
+# --- Metrics ---
+def tanimoto(s1: str, s2: str) -> float:
     m1 = Chem.MolFromSmiles(s1)
     m2 = Chem.MolFromSmiles(s2)
 
@@ -40,15 +40,21 @@ def tanimoto(s1, s2):
     return DataStructs.TanimotoSimilarity(fp1, fp2)
 
 
-def qed_score(smiles):
+def qed_score(smiles: str) -> float:
     mol = Chem.MolFromSmiles(smiles)
     if mol is None:
         return 0.0
     return QED.qed(mol)
 
 
-# Sampling 
-def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
+# --- Sampling ---
+def gibbs_step(
+    smiles: str,
+    model,
+    tokenizer,
+    allowed_tokens: set,
+    k: int = 50
+) -> str:
     """
     Perform one Gibbs-style mutation step using a masked language model.
 
@@ -76,6 +82,8 @@ def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
     pos = random.choice(safe_positions)
 
     inputs = tokenizer(smiles, return_tensors="pt")
+    inputs = {k: v.to(next(model.parameters()).device) for k, v in inputs.items()}
+
     inputs["input_ids"][0][pos] = tokenizer.mask_token_id
 
     with torch.no_grad():
@@ -85,7 +93,7 @@ def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
     topk_indices = logits.topk(k).indices
 
     for idx in topk_indices:
-        token = tokenizer.decode([idx])
+        token = tokenizer.convert_ids_to_tokens(int(idx))
 
         if token not in allowed_tokens:
             continue
@@ -101,9 +109,28 @@ def gibbs_step(smiles, model, tokenizer, allowed_tokens, k=50):
     return smiles
 
 
-def run_chain(seed, gibbs_step_fn, steps=50, min_sim=0.3, min_qed=0.4):
+def run_chain(
+    seed: str,
+    gibbs_step_fn,
+    steps: int = 50,
+    min_sim: float = 0.3,
+    min_qed: float = 0.4
+) -> list:
     """
     Run constrained Gibbs-style sampling.
+
+    Applies iterative local mutations using a Gibbs-style proposal function,
+    while enforcing similarity and QED constraints.
+
+    Args:
+        seed (str): Initial SMILES string.
+        gibbs_step_fn (Callable): Function that proposes mutations.
+        steps (int): Number of sampling steps.
+        min_sim (float): Minimum Tanimoto similarity threshold.
+        min_qed (float): Minimum QED threshold.
+
+    Returns:
+        list: Trajectory of SMILES strings.
     """
 
     current = seed


### PR DESCRIPTION
Hi,

This PR introduces a constrained Gibbs-style sampler for molecular generation.

The implementation includes:
- A Gibbs sampling step using masked token prediction
- A sampling chain utility (run_chain)
- Basic constraints using Tanimoto similarity and QED

The design is modular and allows custom proposal functions and models to be used.

This provides a lightweight and extensible baseline for constrained molecular generation in DeepChem.

Happy to extend with benchmarks or examples if needed.