### PR TITLE
Fix formatting and improve example for SMILES Gibbs sampler

### DIFF
--- a/deepchem/utils/examples/smiles_sampling_example.py
+++ b/deepchem/utils/examples/smiles_sampling_example.py
@@ -1,0 +1,38 @@
+"""
+Example usage of Gibbs-style SMILES sampler.
+
+This demonstrates how to use the run_chain API with a custom step function.
+
+NOTE:
+In practice, `gibbs_step_fn` should be implemented using a masked language model.
+For example, using HuggingFace Transformers:
+
+    from transformers import AutoTokenizer, AutoModelForMaskedLM
+
+    model_name = "DeepChem/MoLFormer-c3-1.1B"
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    model = AutoModelForMaskedLM.from_pretrained(model_name, trust_remote_code=True)
+
+    def step_fn(smiles):
+        return gibbs_step(smiles, model, tokenizer, allowed_tokens)
+"""
+
+from deepchem.utils.smiles_sampling import run_chain
+
+
+def dummy_step(smiles: str) -> str:
+    """Identity step (no mutation)."""
+    return smiles
+
+
+seed = "CCO"
+
+trajectory = run_chain(
+    seed=seed,
+    gibbs_step_fn=dummy_step,
+    steps=5
+)
+
+print("Generated trajectory:")
+for smi in trajectory:
+    print(smi)

--- a/deepchem/utils/examples/smiles_sampling_example.py
+++ b/deepchem/utils/examples/smiles_sampling_example.py
@@ -37,7 +37,7 @@ for smi in trajectory:
 print("\nUnique molecules:", len(set(trajectory)))
 
 
-# ---- Advanced usage (commented) ----
+# ---- Advanced usage ----
 # Example with a masked language model:
 #
 # from transformers import AutoTokenizer, AutoModelForMaskedLM

--- a/deepchem/utils/examples/smiles_sampling_example.py
+++ b/deepchem/utils/examples/smiles_sampling_example.py
@@ -1,27 +1,22 @@
 """
 Example usage of Gibbs-style SMILES sampler.
 
-This demonstrates how to use the run_chain API with a custom step function.
+This demonstrates how to run constrained sampling and observe
+trajectory behavior such as stability and diversity.
 
 NOTE:
 In practice, `gibbs_step_fn` should be implemented using a masked language model.
-For example, using HuggingFace Transformers:
-
-    from transformers import AutoTokenizer, AutoModelForMaskedLM
-
-    model_name = "DeepChem/MoLFormer-c3-1.1B"
-    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-    model = AutoModelForMaskedLM.from_pretrained(model_name, trust_remote_code=True)
-
-    def step_fn(smiles):
-        return gibbs_step(smiles, model, tokenizer, allowed_tokens)
+See comments below for integration with models like MoLFormer.
 """
 
 from deepchem.utils.smiles_sampling import run_chain
 
 
 def dummy_step(smiles: str) -> str:
-    """Identity step (no mutation)."""
+    """
+    Simple mutation: returns the same molecule.
+    Replace this with a model-based step function.
+    """
     return smiles
 
 
@@ -30,9 +25,28 @@ seed = "CCO"
 trajectory = run_chain(
     seed=seed,
     gibbs_step_fn=dummy_step,
-    steps=5
+    steps=10
 )
 
 print("Generated trajectory:")
 for smi in trajectory:
     print(smi)
+
+print("\nUnique molecules:", len(set(trajectory)))
+
+
+# ---- Advanced usage (commented) ----
+# Example with a masked language model:
+#
+# from transformers import AutoTokenizer, AutoModelForMaskedLM
+#
+# model_name = "DeepChem/MoLFormer-c3-1.1B"
+# tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+# model = AutoModelForMaskedLM.from_pretrained(model_name, trust_remote_code=True)
+#
+# allowed_tokens = set(tokenizer.get_vocab().keys())
+#
+# def step_fn(smiles):
+#     return gibbs_step(smiles, model, tokenizer, allowed_tokens)
+#
+# trajectory = run_chain("CCO", step_fn, steps=20)

--- a/deepchem/utils/examples/smiles_sampling_example.py
+++ b/deepchem/utils/examples/smiles_sampling_example.py
@@ -1,12 +1,13 @@
 """
 Example usage of Gibbs-style SMILES sampler.
 
-This demonstrates how to run constrained sampling and observe
+This demonstrates how to run constrained sampling and inspect
 trajectory behavior such as stability and diversity.
 
 NOTE:
-In practice, `gibbs_step_fn` should be implemented using a masked language model.
-See comments below for integration with models like MoLFormer.
+In practice, `gibbs_step_fn` should be implemented using a masked
+language model. See the commented section below for integration
+with models like MoLFormer.
 """
 
 from deepchem.utils.smiles_sampling import run_chain
@@ -14,7 +15,8 @@ from deepchem.utils.smiles_sampling import run_chain
 
 def dummy_step(smiles: str) -> str:
     """
-    Simple mutation: returns the same molecule.
+    Identity step (no mutation).
+
     Replace this with a model-based step function.
     """
     return smiles
@@ -39,6 +41,7 @@ print("\nUnique molecules:", len(set(trajectory)))
 # Example with a masked language model:
 #
 # from transformers import AutoTokenizer, AutoModelForMaskedLM
+# from deepchem.utils.smiles_sampling import gibbs_step
 #
 # model_name = "DeepChem/MoLFormer-c3-1.1B"
 # tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)


### PR DESCRIPTION
This PR fixes formatting issues in the SMILES Gibbs sampling example and improves readability.

Changes:
- Added proper PEP8 spacing
- Improved structure of example script
- Included clear separation between basic and advanced usage

This ensures the example is clean, readable, and consistent with DeepChem style guidelines.