### PR TITLE
fix: update Chemberta imports for transformers 5.x compat

### DIFF
--- a/deepchem/models/torch_models/chemberta.py
+++ b/deepchem/models/torch_models/chemberta.py
@@ -1,9 +1,8 @@
 from typing import Dict, Any, Tuple
 from deepchem.models.torch_models.hf_models import HuggingFaceModel
-from transformers.models.roberta.modeling_roberta import (
-    RobertaConfig, RobertaForMaskedLM, RobertaForSequenceClassification)
-from transformers.models.roberta.tokenization_roberta_fast import \
-    RobertaTokenizerFast
+from transformers import (RobertaConfig, RobertaForMaskedLM,
+                          RobertaForSequenceClassification,
+                          RobertaTokenizerFast)
 from transformers.modeling_utils import PreTrainedModel
 try:
     import torch


### PR DESCRIPTION
Fixes the import-time crash from #4912.

`transformers.models.roberta.tokenization_roberta_fast` was removed in transformers 5.x (renamed to `tokenization_roberta_old`), so `from deepchem.models.torch_models.chemberta import Chemberta` throws a `ModuleNotFoundError`.

This switches to the top-level `from transformers import RobertaTokenizerFast` which works across 4.x and 5.x. Also updated the modeling imports for consistency.

There's a separate runtime issue with `RobertaTokenizerFast` in 5.x where old-format tokenizer files don't load — tracked in #4912.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have performed a self-review of my own code
- [x] New and existing imports work with transformers 4.x and 5.x
- [x] No breaking changes to existing functionality