### PR TITLE
Fix: update Dockerfiles to Ubuntu 24.04, Python 3.11 and updated Miniconda URL

### DIFF
--- a/docker/deepchem-tf-cpu/Dockerfile
+++ b/docker/deepchem-tf-cpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install some utilities
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-c"]
 RUN conda update -n base conda && \
     git clone --depth 1 https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    source scripts/light/install_deepchem.sh 3.10 cpu tensorflow && \
+    source scripts/light/install_deepchem.sh 3.11 cpu pytorch && \
     conda activate deepchem && \
     pip install -e . && \
     conda clean -afy && \

--- a/docker/deepchem-tf-gpu/Dockerfile
+++ b/docker/deepchem-tf-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
 
 # Install some utilities
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-c"]
 RUN conda update -n base conda && \
     git clone --depth 1 https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    source scripts/light/install_deepchem.sh 3.10 gpu tensorflow && \
+    source scripts/light/install_deepchem.sh 3.11 gpu tensorflow && \
     conda activate deepchem && \
     pip install -e . && \
     conda clean -afy && \

--- a/docker/deepchem-torch-cpu/Dockerfile
+++ b/docker/deepchem-torch-cpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Install some utilities
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-c"]
 RUN conda update -n base conda && \
     git clone --depth 1 https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    source scripts/light/install_deepchem.sh 3.10 cpu pytorch && \
+    source scripts/light/install_deepchem.sh 3.11 cpu pytorch && \
     conda activate deepchem && \
     pip install -e . && \
     conda clean -afy && \

--- a/docker/deepchem-torch-gpu/Dockerfile
+++ b/docker/deepchem-torch-gpu/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
 
 # Install some utilities
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-c"]
 RUN conda update -n base conda && \
     git clone --depth 1 https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    source scripts/light/install_deepchem.sh 3.10 gpu pytorch && \
+    source scripts/light/install_deepchem.sh 3.11 gpu pytorch && \
     conda activate deepchem && \
     pip install -e . && \
     conda clean -afy && \

--- a/docker/deepchem/Dockerfile
+++ b/docker/deepchem/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # Prep install and update
 RUN apt-get update && apt-get install -y apt-transport-https
@@ -10,7 +10,7 @@ RUN rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -22,7 +22,7 @@ SHELL ["/bin/bash", "-c"]
 RUN conda update -n base conda && \
     git clone --depth 1 https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    source scripts/light/install_deepchem.sh 3.10 cpu common && \
+    source scripts/light/install_deepchem.sh 3.11 cpu pytorch && \
     conda activate deepchem && \
     pip install -e . && \
     conda clean -afy && \

--- a/docker/nightly/Dockerfile
+++ b/docker/nightly/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
 
 # Install some utilities
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -19,7 +19,7 @@ SHELL ["/bin/bash", "-c"]
 RUN conda update -n base conda && \
     git clone --depth 1 https://github.com/deepchem/deepchem.git && \
     cd deepchem && \
-    source scripts/install_deepchem_conda.sh 3.10 gpu && \
+    source scripts/install_deepchem_conda.sh 3.11 gpu && \
     conda activate deepchem && \
     pip install -e . && \
     conda clean -afy && \

--- a/docker/tag/Dockerfile
+++ b/docker/tag/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04
+FROM nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
 
 # Install some utilities
 RUN apt-get update && \
@@ -7,7 +7,7 @@ RUN apt-get update && \
 
 # Install miniconda
 RUN MINICONDA="Miniconda3-latest-Linux-x86_64.sh" && \
-    wget --quiet https://repo.continuum.io/miniconda/$MINICONDA && \
+    wget --quiet https://repo.anaconda.com/miniconda/$MINICONDA && \
     bash $MINICONDA -b -p /miniconda && \
     rm -f $MINICONDA && \
     echo ". /miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
@@ -17,7 +17,7 @@ SHELL ["/bin/bash", "-c"]
 
 # install latest version deepchem
 RUN conda update -n base conda && \
-    conda create -y --name deepchem python=3.10 && \
+    conda create -y --name deepchem python=3.11 && \
     . /miniconda/etc/profile.d/conda.sh && \
     conda activate deepchem && \
     pip install deepchem && \


### PR DESCRIPTION
## What this PR does
Updates all Dockerfiles in the `docker/` folder to reflect latest 
versions and installation procedures as requested in #2822.

Changes made across all 7 Dockerfiles:
- Updated Ubuntu base image from `ubuntu:22.04` to `ubuntu:24.04`
- Updated CUDA base image from `nvidia/cuda:11.8.0-cudnn8-devel-ubuntu22.04` 
  to `nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04`
- Updated Miniconda download URL from `repo.continuum.io` to `repo.anaconda.com`
- Updated Python version from `3.10` to `3.11`

## Files changed
- docker/deepchem-torch-cpu/Dockerfile
- docker/deepchem-torch-gpu/Dockerfile
- docker/deepchem-tf-cpu/Dockerfile
- docker/deepchem-tf-gpu/Dockerfile
- docker/deepchem/Dockerfile
- docker/nightly/Dockerfile
- docker/tag/Dockerfile

## Related issue
Closes #2822