### PR TITLE
Add word level IUPAC tokenizer utility with tests

### DIFF
--- a/deepchem/feat/iupac_tokenizer.py
+++ b/deepchem/feat/iupac_tokenizer.py
@@ -1,0 +1,10 @@
+import re
+from deepchem.feat.base_classes import Featurizer
+
+
+class IUPACTokenizer(Featurizer):
+    """Word-level tokenizer for IUPAC chemical names."""
+
+    def _featurize(self, iupac_name):
+        tokens = re.findall(r"[A-Za-z]+|\d+|[-(),]", iupac_name)
+        return tokens

--- a/deepchem/feat/tests/test_iupac_tokenizer.py
+++ b/deepchem/feat/tests/test_iupac_tokenizer.py
@@ -1,0 +1,7 @@
+from deepchem.feat.iupac_tokenizer import IUPACTokenizer
+
+
+def test_simple_iupac():
+    tokenizer = IUPACTokenizer()
+    tokens = tokenizer.featurize(["2-methylpropane"])
+    assert list(tokens[0]) == ['2', '-', 'methylpropane']


### PR DESCRIPTION
## Summary

This PR adds a simple word-level IUPAC tokenizer utility for chemical nomenclature strings.

## Changes

* Added `IUPACTokenizer` under `deepchem/feat`
* Implemented regex-based tokenization for IUPAC names
* Added unit tests for a sample molecule name

## Motivation

This contribution supports sequence-based molecular representation workflows and can serve as a useful utility for SMILES ↔ IUPAC translation models and tokenizer baselines.
