### PR TITLE
docs: fix broken Delaney (ESOL) dataset link (#4627)

### DIFF
--- a/docs/source/get_started/examples.rst
+++ b/docs/source/get_started/examples.rst
@@ -42,7 +42,7 @@ Before jumping in to examples, we'll import our libraries and ensure our doctest
 Delaney (ESOL)
 ----------------
 
-Examples of training models on the Delaney (ESOL) dataset included in `MoleculeNet <./moleculenet.html>`_.
+Examples of training models on the Delaney (ESOL) dataset included in `MoleculeNet <https://deepchem.readthedocs.io/en/latest/api_reference/moleculenet.html#delaney-datasets>`_.
 
 We'll be using its :code:`smiles` field to train models to predict its experimentally measured solvation energy (:code:`expt`).
 


### PR DESCRIPTION
## Description

Fix #4627 

The link on line 50 was using a relative path (<./moleculenet.html>) which caused a 404 routing error on the live documentation site. I updated it to the absolute ReadTheDocs URL (https://deepchem.readthedocs.io/en/latest/api_reference/moleculenet.html#delaney-datasets) so users can correctly navigate to the dataset's API reference.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
- [ ] Run yapf -i <modified file> and check no errors (yapf version must be  0.32.0) (N/A - Documentation only)
- [ ] Run mypy -p deepchem and check no errors (N/A - Documentation only)
- [ ] Run flake8 <modified file> --count and check no errors (N/A - Documentation only)
- [ ] Run python -m doctest <modified file> and check no errors (N/A - Documentation only)

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas 
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings