### PR TITLE
docs(hf_models): add missing docstring for HuggingFaceModel._prepare_batch

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -276,6 +276,27 @@ class HuggingFaceModel(TorchModel):
                                            strict=False)
 
     def _prepare_batch(self, batch: Tuple[Any, Any, Any]):
+        """Prepare a batch of data for model input.
+
+        Tokenizes SMILES strings and formats inputs based on the task type.
+        For masked language modeling, applies random token masking via the
+        data collator. For regression, classification, and multitask regression,
+        converts labels to the appropriate tensor dtype and moves all tensors
+        to the model device.
+
+        Parameters
+        ----------
+        batch: Tuple[Any, Any, Any]
+            A tuple of (X, y, w) where X contains SMILES strings, y contains
+            labels, and w contains sample weights.
+
+        Returns
+        -------
+        Tuple[Dict[str, torch.Tensor], Optional[torch.Tensor], Any]
+            A tuple of (inputs, labels, weights) where inputs is a dictionary
+            of tokenized tensors ready for the model. For mlm tasks, labels
+            are embedded in inputs and returned as None separately.
+        """
         smiles_batch, y, w = batch
         tokens = self.tokenizer(smiles_batch[0].tolist(),
                                 padding=True,

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -288,14 +288,26 @@ class HuggingFaceModel(TorchModel):
         ----------
         batch: Tuple[Any, Any, Any]
             A tuple of (X, y, w) where X contains SMILES strings, y contains
-            labels, and w contains sample weights.
+            labels, and w contains sample weights. During prediction, ``y``
+            may be ``None``.
 
         Returns
         -------
         Tuple[Dict[str, torch.Tensor], Optional[torch.Tensor], Any]
-            A tuple of (inputs, labels, weights) where inputs is a dictionary
-            of tokenized tensors ready for the model. For mlm tasks, labels
-            are embedded in inputs and returned as None separately.
+            A tuple of ``(inputs, labels, weights)`` where ``inputs`` is a
+            dictionary of tokenized tensors ready for the model.
+
+            For ``mlm`` tasks, random masking is applied and the masked
+            language modeling labels are stored in ``inputs["labels"]``.
+            In this case, the second return value ``labels`` is always
+            ``None``.
+
+            For ``regression``, ``classification``, and ``mtr`` tasks, the
+            labels from ``y`` (when provided) are converted to tensors,
+            stored in ``inputs["labels"]``, and also returned as the second
+            element of the tuple. During prediction, ``y`` can be ``None``,
+            in which case both the returned ``labels`` and
+            ``inputs["labels"]`` will be ``None``.
         """
         smiles_batch, y, w = batch
         tokens = self.tokenizer(smiles_batch[0].tolist(),


### PR DESCRIPTION
The `_prepare_batch` method in `HuggingFaceModel` was missing a numpydoc-style 
docstring, inconsistent with all other methods in the class. This PR adds a 
complete docstring describing the parameters, return values, and behavior 
for each task type (mlm, regression, classification, mtr).