### PR TITLE
fix: standardize dependency warning messages in models/__init__.py

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -60,7 +60,8 @@ try:
     from deepchem.models.torch_models import MoLFormer
     from deepchem.models.torch_models import OneFormer
 except ImportError as e:
-    logger.warning(e)
+    logger.warning(
+        f'Skipped loading some HuggingFace models, missing a dependency. {e}')
 
 # Pytorch models with torch-geometric dependency
 try:
@@ -102,5 +103,7 @@ try:
     from deepchem.models.text_cnn import TextCNNTensorGraph
     from deepchem.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvTensorGraph, MPNNTensorGraph
     from deepchem.models.IRV import TensorflowMultitaskIRVClassifier
-except ModuleNotFoundError:
-    pass
+except ModuleNotFoundError as e:
+    logger.warning(
+        f'Skipped loading some TensorGraph compatibility models, missing a dependency. {e}'
+    )


### PR DESCRIPTION
## Summary

Fixes #4772

- HuggingFace except block now logs a descriptive message instead of just the raw exception `e.`
- TensorGraph compat except block now logs a warning instead of silently passing, consistent with all other blocks in the file

## Description

`deepchem/models/__init__.py` uses a consistent pattern across all dependency import blocks:
```python
logger.warning(f'Skipped loading some X models, missing a dependency. {e}')
```

Two blocks deviated from this pattern:

1. The HuggingFace block used `logger.warning(e)` — no context about which models were skipped
2. The TensorGraph compatibility block silently `passed ' — no warning at all

This PR makes both blocks consistent with the rest of the file. No functional logic has changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)