### PR TITLE
Remove duplicate compute_charges function from fragment_utils

### DIFF
--- a/deepchem/utils/fragment_utils.py
+++ b/deepchem/utils/fragment_utils.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Sequence, Set, Tuple, Union
 import logging
 from deepchem.utils.typing import RDKitAtom, RDKitMol
 from deepchem.utils.geometry_utils import compute_pairwise_distances
+from deepchem.utils.rdkit_utils import compute_charges
 
 logger = logging.getLogger(__name__)
 
@@ -376,31 +377,3 @@ def reduce_molecular_complex_to_contacts(
         contact_frag = get_mol_subset(frag[0], frag[1], keep)
         reduced_complex.append(contact_frag)
     return reduced_complex
-
-
-# TODO: This is duplicated! Clean up
-def compute_charges(mol):
-    """Attempt to compute Gasteiger Charges on Mol
-
-    This also has the side effect of calculating charges on mol.  The
-    mol passed into this function has to already have been sanitized
-
-    Parameters
-    ----------
-    mol: rdkit molecule
-
-    Returns
-    -------
-    No return since updates in place.
-
-    Note
-    ----
-    This function requires RDKit to be installed.
-    """
-    from rdkit.Chem import AllChem
-    try:
-        # Updates charges in place
-        AllChem.ComputeGasteigerCharges(mol)
-    except Exception as e:
-        logger.exception("Unable to compute charges for mol")
-        raise MoleculeLoadException(e)


### PR DESCRIPTION
## Description

Fix #Remove duplicate compute_charges function from fragment_utils

  The `compute_charges()` function was duplicated in two files:      
  - `deepchem/utils/rdkit_utils.py` (line 155)                       
  - `deepchem/utils/fragment_utils.py` (line 382)   which may cause inconsistency issue in the future.


## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [ x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ x] Run `mypy -p deepchem` and check no errors
  - [ x] Run `flake8 <modified file> --count` and check no errors
  - [ x] Run `python -m doctest <modified file>` and check no errors
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New unit tests pass locally with my changes
- [ x] I have checked my code and corrected any misspellings
