### PR TITLE
Fix #3402: Add overwrite param to create_dataset to prevent silent da…

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1244,7 +1244,8 @@ class DiskDataset(Dataset):
     @staticmethod
     def create_dataset(shard_generator: Iterable[Batch],
                        data_dir: Optional[str] = None,
-                       tasks: Optional[ArrayLike] = None) -> "DiskDataset":
+                       tasks: Optional[ArrayLike] = None,
+                       overwrite: bool = False) -> "DiskDataset":
         """Creates a new DiskDataset
 
         Parameters
@@ -1256,16 +1257,33 @@ class DiskDataset(Dataset):
             Filename for data directory. Creates a temp directory if none specified.
         tasks: Sequence, optional (default [])
             List of tasks for this dataset.
+        overwrite: bool, optional (default False)
+            If False and data_dir already contains files, raises a ValueError
+            to prevent accidental data loss. Set to True to allow overwriting.
 
         Returns
         -------
         DiskDataset
             A new `DiskDataset` constructed from the given data
+
+        Raises
+        ------
+        ValueError
+            If data_dir contains existing files and overwrite is False.
         """
         if data_dir is None:
             data_dir = tempfile.mkdtemp()
         elif not os.path.exists(data_dir):
             os.makedirs(data_dir)
+        else:
+            # data_dir exists — check for existing files
+            if not overwrite:
+                existing_files = os.listdir(data_dir)
+                if existing_files:
+                    raise ValueError(
+                        f"Directory '{data_dir}' already contains files: "
+                        f"{existing_files}. To overwrite existing data, "
+                        f"set overwrite=True.")
 
         metadata_rows = []
         time1 = time.time()

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -863,6 +863,37 @@ def test_to_str():
                                    ids=np.arange(50))
     ref_str = '<NumpyDataset X.shape: (50, 3), y.shape: (50,), w.shape: (50,), task_names: [0]>'
     assert str(dataset) == ref_str
+    
+
+def test_create_dataset_overwrite_protection():
+    """Test that create_dataset raises ValueError on non-empty dir without overwrite=True.
+
+    Regression test for https://github.com/deepchem/deepchem/issues/3402
+    """
+    X = np.random.rand(5, 3)
+    dataset = dc.data.DiskDataset.from_numpy(X)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        target = os.path.join(tmpdir, "mydata")
+
+        # First save to empty dir — should succeed
+        dc.data.DiskDataset.create_dataset(
+            [(dataset.X, dataset.y, dataset.w, dataset.ids)],
+            data_dir=target,
+            overwrite=False)
+
+        # Second save to same non-empty dir — should raise
+        with pytest.raises(ValueError, match="already contains files"):
+            dc.data.DiskDataset.create_dataset(
+                [(dataset.X, dataset.y, dataset.w, dataset.ids)],
+                data_dir=target,
+                overwrite=False)
+
+        # With overwrite=True — should succeed silently
+        dc.data.DiskDataset.create_dataset(
+            [(dataset.X, dataset.y, dataset.w, dataset.ids)],
+            data_dir=target,
+            overwrite=True)
 
 
 class TestDatasets(unittest.TestCase):


### PR DESCRIPTION
## Title:
Fix #3402: Add overwrite param to create_dataset to prevent silent data loss

## Description
Fixes #3402

When `DiskDataset.create_dataset()` was called with a `data_dir` that already
contained files, it would silently overwrite them — a destructive action with no
warning. This PR adds an `overwrite` parameter (default `False`) that raises a
clear `ValueError` if the directory is non-empty, preventing accidental data loss.

**Usage:**
```python
# Raises ValueError if dir already has files
dc.data.DiskDataset.create_dataset(shards, data_dir="my_dir")

# Explicitly allow overwriting
dc.data.DiskDataset.create_dataset(shards, data_dir="my_dir", overwrite=True)
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings