### PR TITLE
Fix/cnnmodule mode duplicate

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -60,7 +60,8 @@ try:
     from deepchem.models.torch_models import MoLFormer
     from deepchem.models.torch_models import OneFormer
 except ImportError as e:
-    logger.warning(e)
+    logger.warning(
+        f'Skipped loading some HuggingFace models, missing a dependency. {e}')
 
 # Pytorch models with torch-geometric dependency
 try:
@@ -102,5 +103,7 @@ try:
     from deepchem.models.text_cnn import TextCNNTensorGraph
     from deepchem.models.graph_models import WeaveTensorGraph, DTNNTensorGraph, DAGTensorGraph, GraphConvTensorGraph, MPNNTensorGraph
     from deepchem.models.IRV import TensorflowMultitaskIRVClassifier
-except ModuleNotFoundError:
-    pass
+except ModuleNotFoundError as e:
+    logger.warning(
+        f'Skipped loading some TensorGraph compatibility models, missing a dependency. {e}'
+    )

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -235,7 +235,6 @@ class CNNModule(nn.Module):
         self.mode = mode
         self.n_classes = n_classes
         self.uncertainty = uncertainty
-        self.mode = mode
         self.layer_filters = layer_filters
         self.residual = residual
 


### PR DESCRIPTION
## Description

Fixes #4938

Removes a redundant duplicate assignment of `self.mode` in
`CNNModule.__init__` located in `deepchem/models/torch_models/layers.py`.

The attribute `self.mode` was assigned twice with the same value.
This change removes the duplicate assignment to improve code clarity
and maintainability.



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
  - [x] Run `flake8 deepchem/models/torch_models/layers.py --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings