### PR TITLE
Remove redundant self.mode assignment in CNNModule

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -235,7 +235,6 @@ class CNNModule(nn.Module):
         self.mode = mode
         self.n_classes = n_classes
         self.uncertainty = uncertainty
-        self.mode = mode
         self.layer_filters = layer_filters
         self.residual = residual
 


### PR DESCRIPTION
## Description

Fix  #4938

Removes a redundant duplicate assignment of `self.mode` in
`CNNModule.__init__` located in `deepchem/models/torch_models/layers.py`.

The attribute `self.mode` was assigned twice with the same value.
This change removes the duplicate assignment to improve code clarity
and maintainability.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
  - [x] Run `flake8 deepchem/models/torch_models/layers.py --count` and found no errors.
- [x] I have performed a self-review of my own code
- [x] I have checked my code and corrected any misspellings
