### PR TITLE
docs: fix parameter mismatches in data/supports.py

### DIFF
--- a/deepchem/data/supports.py
+++ b/deepchem/data/supports.py
@@ -116,6 +116,8 @@ def get_task_test(dataset, n_episodes, n_test, task, log_every_n=50):
         Number of episodes to sample test sets for.
     n_test: int
         Number of compounds per test set.
+    task: int
+        Index of the task to select.
     log_every_n: int, optional
         Prints every log_every_n supports sampled.
     """
@@ -169,7 +171,7 @@ def get_single_task_support(dataset, n_pos, n_neg, task, replace=True):
 
     Parameters
     ----------
-    datasets: dc.data.Dataset
+    dataset: dc.data.Dataset
         Dataset from which supports are sampled.
     n_pos: int
         Number of positive samples in support.
@@ -193,7 +195,7 @@ def get_task_support(dataset, n_episodes, n_pos, n_neg, task, log_every_n=50):
 
     Parameters
     ----------
-    datasets: dc.data.Dataset
+    dataset: dc.data.Dataset
         Dataset from which supports are sampled.
     n_episodes: int
         Number of episodes for which supports have to be sampled from this task.
@@ -264,8 +266,6 @@ class EpisodeGenerator(object):
             Number of samples in test set.
         n_episodes_per_task: int
             Number of (support, task) pairs to sample per task.
-        replace: bool
-            Whether to use sampling with or without replacement.
         """
         time_start = time.time()
         self.tasks = range(len(dataset.get_task_names()))


### PR DESCRIPTION
## Description
This PR fixes several structural docstring errors in `deepchem/data/supports.py` that cause Sphinx autodoc warnings. 

Specifically, this PR:
- Adds the missing `task` parameter documentation to `get_task_test`
- Fixes the `datasets` typo (changed to `dataset`) in `get_single_task_support` and `get_task_support` to match the function signatures
- Removes the ghost parameter `replace` from the `EpisodeGenerator` docstring as it does not exist in the `__init__` signature.

Addresses **Issue #4740**.

## Type of change
- [x] Documentations (modification for documents)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation