### PR TITLE
test: cover non-DiskDataset transform out_dir behavior

### DIFF
--- a/deepchem/trans/tests/test_balancing.py
+++ b/deepchem/trans/tests/test_balancing.py
@@ -1,5 +1,6 @@
 import itertools
 import tempfile
+from unittest import mock
 
 import numpy as np
 
@@ -174,6 +175,40 @@ def test_transform_to_directory():
                                np.zeros_like(w_task[w_orig_task == 0]))
     # Check that sum of 0s equals sum of 1s in transformed for each task
     assert np.isclose(np.sum(w_task[y_task == 0]), np.sum(w_task[y_task == 1]))
+
+
+def test_transform_to_directory_keeps_temporary_source_separate():
+    """Test that non-DiskDataset inputs do not reuse out_dir as the temp source."""
+    n_samples = 6
+    n_features = 3
+    n_classes = 2
+    np.random.seed(123)
+    X = np.random.rand(n_samples, n_features)
+    y = np.random.randint(n_classes, size=(n_samples,))
+    w = np.ones((n_samples,))
+    dataset = dc.data.NumpyDataset(X, y, w)
+
+    balancing_transformer = dc.trans.BalancingTransformer(dataset=dataset)
+    temp_source = mock.MagicMock()
+    temp_source.get_shape.return_value = (
+        dataset.X.shape,
+        dataset.y.shape,
+        dataset.w.shape,
+        dataset.ids.shape,
+    )
+    temp_source.transform.return_value = "transformed"
+
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        with mock.patch.object(dc.data.DiskDataset, "from_numpy", return_value=temp_source) as from_numpy:
+            result = balancing_transformer.transform(dataset, out_dir=tmpdirname)
+
+    assert result == "transformed"
+    from_numpy.assert_called_once_with(dataset.X, dataset.y, dataset.w, dataset.ids)
+    temp_source.transform.assert_called_once_with(
+        balancing_transformer,
+        out_dir=tmpdirname,
+        parallel=False,
+    )
 
 
 def test_array_shapes():

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -193,7 +193,8 @@ class Transformer(object):
         if out_dir is not None:
             if not isinstance(dataset, dc.data.DiskDataset):
                 dataset = dc.data.DiskDataset.from_numpy(
-                    dataset.X, dataset.y, dataset.w, dataset.ids)
+                    dataset.X, dataset.y, dataset.w, dataset.ids,
+                    data_dir=out_dir)
         _, y_shape, w_shape, _ = dataset.get_shape()
         if y_shape == tuple() and self.transform_y:
             raise ValueError("Cannot transform y when y_values are not present")

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -193,8 +193,7 @@ class Transformer(object):
         if out_dir is not None:
             if not isinstance(dataset, dc.data.DiskDataset):
                 dataset = dc.data.DiskDataset.from_numpy(
-                    dataset.X, dataset.y, dataset.w, dataset.ids,
-                    data_dir=out_dir)
+                    dataset.X, dataset.y, dataset.w, dataset.ids)
         _, y_shape, w_shape, _ = dataset.get_shape()
         if y_shape == tuple() and self.transform_y:
             raise ValueError("Cannot transform y when y_values are not present")


### PR DESCRIPTION
This adds coverage around `Transformer.transform(..., out_dir=...)` for non-`DiskDataset` inputs.

The important behavior here is that `out_dir` should be used for the final transformed dataset, while the temporary `DiskDataset` created from a `NumpyDataset` should stay separate. Reusing `out_dir` as the temporary source directory makes the transform path read from and write to the same location, which is not the intended flow.

This PR adds a regression test for that case using the balancing transformer path, so future changes do not accidentally alias the temporary source dataset and the requested output directory.

Related to #1956
