### PR TITLE
docs: fix Sphinx build warnings in layers.rst and jacobian.py

### DIFF
--- a/deepchem/utils/differentiation_utils/optimize/jacobian.py
+++ b/deepchem/utils/differentiation_utils/optimize/jacobian.py
@@ -328,7 +328,7 @@ class LinearMixing(Jacobian):
 
 
 class LowRankMatrix(object):
-    """represents a matrix of `\alpha * I + \sum_n c_n d_n^T`
+    r"""represents a matrix of `\alpha * I + \sum_n c_n d_n^T`
 
     Examples
     --------
@@ -451,7 +451,7 @@ class LowRankMatrix(object):
 
 
 class FullRankMatrix(object):
-    """represents a full rank matrix of `\alpha * I + \sum_n c_n d_n^T`
+    r"""represents a full rank matrix of `\alpha * I + \sum_n c_n d_n^T`
 
     Examples
     --------

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -355,7 +355,7 @@ Flow Layers
 Grover Layers
 ^^^^^^^^^^^^^
 
-The following layers are used for implementing GROVER model as described in the paper `<Self-Supervised  Graph Transformer on Large-Scale Molecular Data <https://drug.ai.tencent.com/publications/GROVER.pdf>_`
+The following layers are used for implementing GROVER model as described in the paper `Self-Supervised Graph Transformer on Large-Scale Molecular Data <https://drug.ai.tencent.com/publications/GROVER.pdf>`_
 
 .. autoclass:: deepchem.models.torch_models.grover_layers.GroverMPNEncoder
   :members:
@@ -487,7 +487,7 @@ InceptionV3 Layers
 .. autoclass:: deepchem.models.torch_models.inception_v3.InceptionA
    :members:
 
-.. autoclass:: ddeepchem.models.torch_models.inception_v3.InceptionB
+.. autoclass:: deepchem.models.torch_models.inception_v3.InceptionB
    :members:
 
 .. autoclass:: deepchem.models.torch_models.inception_v3.InceptionC


### PR DESCRIPTION
## Description

Fix several Sphinx documentation build warnings:

### layers.rst
- **Typo**: `ddeepchem.models.torch_models.inception_v3.InceptionB` → `deepchem.models...` (line 490) — caused autodoc to fail silently
- **Malformed RST link**: GROVER paper reference had incorrect link syntax (`\`<Title <URL>_\``) instead of the correct `` `Title <URL>`_ `` format

### jacobian.py  
- **Invalid escape sequences**: `LowRankMatrix` and `FullRankMatrix` class docstrings contain LaTeX notation (`\alpha`, `\sum`) but were not declared as raw strings, triggering `DeprecationWarning: invalid escape sequence` in Python 3.12+

Ref #2989

## Type of change

- [x] Documentation fix