### PR TITLE
Fix: Correct type hint for conformer pruning indices in conformers.py

### DIFF
--- a/deepchem/utils/conformers.py
+++ b/deepchem/utils/conformers.py
@@ -240,7 +240,7 @@ class ConformerGenerator(object):
         rmsd = self.get_conformer_rmsd(mol)
 
         sort = np.argsort(energies)  # sort by increasing energy
-        keep: List[float] = []  # always keep lowest-energy conformer
+        keep: List[int] = []  # always keep lowest-energy conformer
         discard = []
         for i in sort:
             # always keep lowest-energy conformer


### PR DESCRIPTION
## Description

hey! just fixing a small mypy type hint error i ran into in `deepchem/utils/conformers.py`.

**Motivation and Context:**
so on line 243, the `keep` list is currently annotated as `List[float]`. but it's actually storing the sorted indices from `np.argsort(energies)`, which are ints. coz of this, mypy throws an error on line 271 (`conf_ids[i]`) since we can't use a float to index a list.

the code wasn't actually broken at runtime since python dynamically ignores the type hint and just uses the ints anyway (you can see the code natively treating it as ints on line 261: `np.asarray(keep, dtype=int)`). but the static mypy checker was getting tripped up by the incorrect sticky note. 

this PR just changes the type hint to `List[int]` so the linter is happy and future devs don't get confused reading it!

*(note: i'm just getting familiar with the codebase architecture and CI/CD pipeline rn, so starting with something tiny)*

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings