### PR TITLE
Add minimal differentiable molecular dynamics implementation (Velocity Verlet)

### DIFF
--- a/deepchem/models/tests/test_differentiable_md.py
+++ b/deepchem/models/tests/test_differentiable_md.py
@@ -1,0 +1,70 @@
+import pytest
+import torch
+from deepchem.models.torch_models.differentiable_md import DifferentiableMD
+
+
+class TestDifferentiableMD:
+    """Test the DifferentiableMD class."""
+
+    def test_step_shapes(self):
+        """Test that step returns correct shapes."""
+        md = DifferentiableMD(dt=0.01)
+
+        batch_size = 2
+        n_atoms = 3
+        positions = torch.randn(batch_size, n_atoms, 3)
+        velocities = torch.randn(batch_size, n_atoms, 3)
+        forces = torch.randn(batch_size, n_atoms, 3)
+        mass = torch.ones(n_atoms)
+
+        new_pos, new_vel = md.step(positions, velocities, forces, mass)
+
+        assert new_pos.shape == positions.shape
+        assert new_vel.shape == velocities.shape
+
+    def test_autograd(self):
+        """Test that gradients flow through the step."""
+        md = DifferentiableMD(dt=0.01)
+
+        positions = torch.randn(2, 3, 3, requires_grad=True)
+        velocities = torch.randn(2, 3, 3, requires_grad=True)
+        forces = torch.randn(2, 3, 3, requires_grad=True)
+        mass = torch.ones(3)
+
+        new_pos, new_vel = md.step(positions, velocities, forces, mass)
+
+        # Compute some loss
+        loss = (new_pos ** 2).sum() + (new_vel ** 2).sum()
+        loss.backward()
+
+        assert positions.grad is not None
+        assert velocities.grad is not None
+        assert forces.grad is not None
+
+    def test_scalar_mass(self):
+        """Test with scalar mass."""
+        md = DifferentiableMD(dt=0.01)
+
+        positions = torch.randn(2, 3, 3)
+        velocities = torch.randn(2, 3, 3)
+        forces = torch.randn(2, 3, 3)
+        mass = torch.tensor(1.0)
+
+        new_pos, new_vel = md.step(positions, velocities, forces, mass)
+
+        assert new_pos.shape == positions.shape
+        assert new_vel.shape == velocities.shape
+
+    def test_no_batch(self):
+        """Test with single molecule (no batch dimension)."""
+        md = DifferentiableMD(dt=0.01)
+
+        positions = torch.randn(3, 3)
+        velocities = torch.randn(3, 3)
+        forces = torch.randn(3, 3)
+        mass = torch.ones(3)
+
+        new_pos, new_vel = md.step(positions, velocities, forces, mass)
+
+        assert new_pos.shape == positions.shape
+        assert new_vel.shape == velocities.shape

--- a/deepchem/models/torch_models/differentiable_md.py
+++ b/deepchem/models/torch_models/differentiable_md.py
@@ -1,0 +1,68 @@
+import torch
+from typing import Optional
+
+
+class DifferentiableMD:
+    """A differentiable molecular dynamics simulator using Velocity Verlet integration.
+
+    This class implements a single time step of molecular dynamics simulation
+    that is compatible with PyTorch's autograd for gradient computation.
+    """
+
+    def __init__(self, dt: float = 0.01):
+        """Initialize the MD simulator.
+
+        Parameters
+        ----------
+        dt : float
+            Time step for integration.
+        """
+        self.dt = dt
+
+    def step(self, positions: torch.Tensor, velocities: torch.Tensor,
+             forces: torch.Tensor, mass: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Perform one step of Velocity Verlet integration.
+
+        Parameters
+        ----------
+        positions : torch.Tensor
+            Current positions, shape (batch_size, n_atoms, 3) or (n_atoms, 3)
+        velocities : torch.Tensor
+            Current velocities, same shape as positions
+        forces : torch.Tensor
+            Current forces, same shape as positions
+        mass : torch.Tensor
+            Masses, shape (n_atoms,) or scalar
+
+        Returns
+        -------
+        new_positions : torch.Tensor
+            Updated positions
+        new_velocities : torch.Tensor
+            Updated velocities
+        """
+        dt = self.dt
+
+        # Ensure mass has correct shape for broadcasting
+        if mass.dim() == 0:  # scalar
+            mass = mass.expand_as(positions)
+        elif mass.shape[-1] == positions.shape[-2]:  # (n_atoms,)
+            mass = mass.unsqueeze(-1).expand_as(positions)
+        else:
+            raise ValueError("Mass shape incompatible with positions")
+
+        # Half step velocity
+        v_half = velocities + 0.5 * dt * forces / mass
+
+        # Update positions
+        new_positions = positions + dt * v_half
+
+        # Note: In a full MD simulation, forces would be recomputed here
+        # based on the new positions. For this prototype, we assume
+        # forces are provided and constant for the step.
+        new_forces = forces
+
+        # Full step velocity
+        new_velocities = v_half + 0.5 * dt * new_forces / mass
+
+        return new_positions, new_velocities


### PR DESCRIPTION
This PR adds a minimal differentiable molecular dynamics (MD) module using the Velocity Verlet integration method in PyTorch. The implementation is designed to be fully compatible with PyTorch's autograd system, allowing gradients to flow through positions, velocities, and forces.

## What is implemented

- `DifferentiableMD` class in `deepchem/models/torch_models/differentiable_md.py`
- Velocity Verlet integration step
- Support for batched operations
- Autograd compatibility
- Unit tests in `deepchem/models/tests/test_differentiable_md.py`

## Why it is useful

This module enables differentiable molecular dynamics simulations, which can be used for:
- Training neural network potentials
- Optimizing molecular structures with gradient-based methods
- Integrating MD with machine learning pipelines

## Autograd compatibility

The implementation ensures that gradients can be computed with respect to positions, velocities, and forces, making it suitable for end-to-end differentiable simulations.

References issue #4704.