### PR TITLE
fix: use `is None` instead of `== None` (PEP 8 E711)

### DIFF
--- a/deepchem/molnet/run_benchmark_low_data.py
+++ b/deepchem/molnet/run_benchmark_low_data.py
@@ -58,7 +58,7 @@ def run_benchmark_low_data(datasets,
   for dataset in datasets:
     if dataset in ['muv', 'sider', 'tox21']:
       mode = 'classification'
-      if metric == None:
+      if metric is None:
         metric = str('auc')
     else:
       raise ValueError('Dataset not supported')
@@ -70,7 +70,7 @@ def run_benchmark_low_data(datasets,
     if isinstance(metric, str):
       metric = metric_all[metric]
 
-    if featurizer == None and isinstance(model, str):
+    if featurizer is None and isinstance(model, str):
       # Assigning featurizer if not user defined
       pair = (dataset, model)
       if pair in CheckFeaturizer:


### PR DESCRIPTION
## Description

Use identity check `is None` instead of equality check `== None` in `deepchem/molnet/run_benchmark_low_data.py`, as recommended by PEP 8 (E711).

Singletons like `None` should be compared using `is` or `is not`, never equality operators. The `is` operator checks identity, which is both more correct and slightly faster.

**Changes:**
- Line 61: `if metric == None:` -> `if metric is None:`
- - Line 73: `if featurizer == None and isinstance(model, str):` -> `if featurizer is None and isinstance(model, str):`
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
## Testing

No behavior change — this is a correctness/style fix only. `None` is a singleton, so `is None` and `== None` produce identical results.