### PR TITLE
feat(utils): add AlphaFold DB structure retrieval

### DIFF
--- a/deepchem/utils/__init__.py
+++ b/deepchem/utils/__init__.py
@@ -129,6 +129,10 @@ from deepchem.utils.voxel_utils import voxelize
 
 from deepchem.utils.sequence_utils import hhblits
 from deepchem.utils.sequence_utils import hhsearch
+from deepchem.utils.alphafold_utils import AlphaFoldStructure
+from deepchem.utils.alphafold_utils import AlphaFoldStructureMetadata
+from deepchem.utils.alphafold_utils import download_alphafold_structure
+from deepchem.utils.alphafold_utils import get_alphafold_structure_metadata
 
 from deepchem.utils.poly_wd_graph_utils import handle_hydrogen
 from deepchem.utils.poly_wd_graph_utils import make_polymer_mol

--- a/deepchem/utils/alphafold_utils.py
+++ b/deepchem/utils/alphafold_utils.py
@@ -1,0 +1,244 @@
+"""Utilities for retrieving AlphaFold Protein Structure Database models.
+
+The AlphaFold Protein Structure Database provides precomputed protein
+structure predictions for UniProt accessions. These helpers intentionally do
+not depend on the original AlphaFold, OpenFold, ColabFold, JAX, PyTorch, model
+weights, or sequence databases. They provide a lightweight integration point so
+DeepChem workflows can retrieve predicted structures and pass the resulting PDB
+or mmCIF files to existing featurizers and docking tools.
+
+Examples
+--------
+>>> from deepchem.utils.alphafold_utils import download_alphafold_structure
+>>> # Downloads AF-P69905-F1.pdb into the current directory.
+>>> # result = download_alphafold_structure("P69905", ".")
+>>> # result.path
+>>> # './AF-P69905-F1.pdb'
+"""
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib import error, request
+
+ALPHAFOLD_DB_API_URL = "https://alphafold.ebi.ac.uk/api/prediction/{uniprot_id}"
+ALPHAFOLD_DB_LICENSE = "CC BY 4.0"
+
+
+@dataclass(frozen=True)
+class AlphaFoldStructureMetadata:
+    """Metadata for a prediction in the AlphaFold Protein Structure Database.
+
+    Parameters
+    ----------
+    entry_id: str
+        AlphaFold DB entry identifier, for example ``"AF-P69905-F1"``.
+    uniprot_accession: str
+        UniProt accession used by the AlphaFold DB prediction.
+    uniprot_id: str, optional
+        UniProt mnemonic identifier if returned by the API.
+    pdb_url: str, optional
+        URL for the predicted structure in PDB format.
+    cif_url: str, optional
+        URL for the predicted structure in mmCIF format.
+    bcif_url: str, optional
+        URL for the predicted structure in binary CIF format.
+    pae_doc_url: str, optional
+        URL for predicted aligned error JSON metadata.
+    version: int, optional
+        Latest AlphaFold DB model version.
+    license: str
+        License for AlphaFold DB structures. AlphaFold DB structures are
+        provided under CC BY 4.0.
+    raw_metadata: dict, optional
+        Unmodified JSON object returned by the AlphaFold DB API.
+    """
+    entry_id: str
+    uniprot_accession: str
+    uniprot_id: Optional[str] = None
+    pdb_url: Optional[str] = None
+    cif_url: Optional[str] = None
+    bcif_url: Optional[str] = None
+    pae_doc_url: Optional[str] = None
+    version: Optional[int] = None
+    license: str = ALPHAFOLD_DB_LICENSE
+    raw_metadata: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class AlphaFoldStructure:
+    """A downloaded AlphaFold DB structure file and its metadata.
+
+    Parameters
+    ----------
+    path: str
+        Path to the downloaded structure file.
+    format: str
+        File format written to ``path``. Supported values are ``"pdb"`` and
+        ``"mmcif"``.
+    metadata: AlphaFoldStructureMetadata
+        Metadata returned by the AlphaFold DB API.
+    """
+    path: str
+    format: str
+    metadata: AlphaFoldStructureMetadata
+
+
+def _normalize_uniprot_id(uniprot_id: str) -> str:
+    """Normalize and validate a UniProt accession for AlphaFold DB queries."""
+    normalized = uniprot_id.strip().upper()
+    if not normalized:
+        raise ValueError("uniprot_id must be a non-empty string")
+    return normalized
+
+
+def _read_url(url: str, timeout: float) -> bytes:
+    """Read bytes from a URL using only the Python standard library."""
+    req = request.Request(url, headers={"User-Agent": "deepchem-alphafold-utils"})
+    with request.urlopen(req, timeout=timeout) as response:
+        return response.read()
+
+
+def _metadata_from_api_record(record: Dict[str, Any]) -> AlphaFoldStructureMetadata:
+    """Convert an AlphaFold DB API record into a metadata dataclass."""
+    entry_id = record.get("entryId")
+    uniprot_accession = record.get("uniprotAccession")
+    if not entry_id or not uniprot_accession:
+        raise ValueError("AlphaFold DB response is missing required metadata")
+
+    return AlphaFoldStructureMetadata(
+        entry_id=entry_id,
+        uniprot_accession=uniprot_accession,
+        uniprot_id=record.get("uniprotId"),
+        pdb_url=record.get("pdbUrl"),
+        cif_url=record.get("cifUrl"),
+        bcif_url=record.get("bcifUrl"),
+        pae_doc_url=record.get("paeDocUrl"),
+        version=record.get("latestVersion"),
+        raw_metadata=record,
+    )
+
+
+def get_alphafold_structure_metadata(
+        uniprot_id: str,
+        timeout: float = 10.0) -> AlphaFoldStructureMetadata:
+    """Get metadata for an AlphaFold DB prediction by UniProt accession.
+
+    Parameters
+    ----------
+    uniprot_id: str
+        UniProt accession, for example ``"P69905"``.
+    timeout: float, default 10.0
+        Network timeout in seconds.
+
+    Returns
+    -------
+    AlphaFoldStructureMetadata
+        Metadata for the first AlphaFold DB prediction matching ``uniprot_id``.
+
+    Raises
+    ------
+    ValueError
+        If no AlphaFold DB prediction exists for the accession, the API returns
+        malformed data, or the request fails.
+    """
+    normalized_uniprot_id = _normalize_uniprot_id(uniprot_id)
+    url = ALPHAFOLD_DB_API_URL.format(uniprot_id=normalized_uniprot_id)
+
+    try:
+        payload = _read_url(url, timeout)
+    except error.HTTPError as exc:
+        if exc.code == 404:
+            raise ValueError(
+                f"No AlphaFold DB prediction found for {normalized_uniprot_id}"
+            ) from exc
+        raise ValueError(
+            f"Failed to query AlphaFold DB for {normalized_uniprot_id}: {exc}"
+        ) from exc
+    except error.URLError as exc:
+        raise ValueError(
+            f"Failed to query AlphaFold DB for {normalized_uniprot_id}: {exc}"
+        ) from exc
+
+    try:
+        records = json.loads(payload.decode("utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError("AlphaFold DB returned invalid JSON") from exc
+
+    if not isinstance(records, list) or len(records) == 0:
+        raise ValueError(
+            f"No AlphaFold DB prediction found for {normalized_uniprot_id}")
+    if not isinstance(records[0], dict):
+        raise ValueError("AlphaFold DB response has an unexpected format")
+
+    return _metadata_from_api_record(records[0])
+
+
+def download_alphafold_structure(uniprot_id: str,
+                                 output_dir: str,
+                                 file_format: str = "pdb",
+                                 timeout: float = 10.0,
+                                 filename: Optional[str] = None
+                                 ) -> AlphaFoldStructure:
+    """Download a predicted AlphaFold DB structure by UniProt accession.
+
+    Parameters
+    ----------
+    uniprot_id: str
+        UniProt accession, for example ``"P69905"``.
+    output_dir: str
+        Directory where the structure file should be written. The directory is
+        created if it does not already exist.
+    file_format: str, default "pdb"
+        Structure format to download. Supported values are ``"pdb"`` and
+        ``"mmcif"``. ``"cif"`` is accepted as an alias for ``"mmcif"``.
+    timeout: float, default 10.0
+        Network timeout in seconds for both metadata and file download.
+    filename: str, optional
+        Output filename. If omitted, a filename derived from the AlphaFold DB
+        entry identifier is used.
+
+    Returns
+    -------
+    AlphaFoldStructure
+        Path, format, and metadata for the downloaded structure.
+
+    Raises
+    ------
+    ValueError
+        If ``file_format`` is unsupported, metadata is unavailable, the selected
+        format is unavailable for the entry, or a network request fails.
+    """
+    normalized_format = file_format.lower()
+    if normalized_format == "cif":
+        normalized_format = "mmcif"
+    if normalized_format not in {"pdb", "mmcif"}:
+        raise ValueError("file_format must be one of 'pdb', 'mmcif', or 'cif'")
+
+    metadata = get_alphafold_structure_metadata(uniprot_id, timeout=timeout)
+    structure_url = metadata.pdb_url if normalized_format == "pdb" else metadata.cif_url
+    if structure_url is None:
+        raise ValueError(
+            f"AlphaFold DB entry {metadata.entry_id} does not provide {normalized_format} data"
+        )
+
+    suffix = ".pdb" if normalized_format == "pdb" else ".cif"
+    if filename is None:
+        filename = f"{metadata.entry_id}{suffix}"
+
+    output_path = Path(output_dir) / filename
+    os.makedirs(output_path.parent, exist_ok=True)
+
+    try:
+        structure_bytes = _read_url(structure_url, timeout)
+    except error.URLError as exc:
+        raise ValueError(
+            f"Failed to download AlphaFold DB structure {metadata.entry_id}: {exc}"
+        ) from exc
+
+    output_path.write_bytes(structure_bytes)
+    return AlphaFoldStructure(path=str(output_path),
+                              format=normalized_format,
+                              metadata=metadata)

--- a/deepchem/utils/test/test_alphafold_utils.py
+++ b/deepchem/utils/test/test_alphafold_utils.py
@@ -1,0 +1,142 @@
+import json
+from pathlib import Path
+from urllib.error import HTTPError
+
+import pytest
+
+from deepchem.utils import alphafold_utils
+
+
+class MockResponse:
+
+    def __init__(self, payload, status=200):
+        self.payload = payload
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+    def read(self):
+        if isinstance(self.payload, str):
+            return self.payload.encode("utf-8")
+        return self.payload
+
+
+def test_get_alphafold_structure_metadata_queries_api(monkeypatch):
+    response = [{
+        "entryId": "AF-P69905-F1",
+        "uniprotAccession": "P69905",
+        "uniprotId": "HBA_HUMAN",
+        "pdbUrl": "https://example.org/AF-P69905-F1-model_v4.pdb",
+        "cifUrl": "https://example.org/AF-P69905-F1-model_v4.cif",
+        "bcifUrl": "https://example.org/AF-P69905-F1-model_v4.bcif",
+        "paeDocUrl": "https://example.org/AF-P69905-F1-predicted_aligned_error_v4.json",
+        "latestVersion": 4,
+    }]
+    opened_urls = []
+
+    def mock_urlopen(request, timeout=10):
+        opened_urls.append(request.full_url)
+        return MockResponse(json.dumps(response))
+
+    monkeypatch.setattr(alphafold_utils.request, "urlopen", mock_urlopen)
+
+    metadata = alphafold_utils.get_alphafold_structure_metadata("p69905")
+
+    assert opened_urls == [
+        "https://alphafold.ebi.ac.uk/api/prediction/P69905"
+    ]
+    assert metadata.entry_id == "AF-P69905-F1"
+    assert metadata.uniprot_accession == "P69905"
+    assert metadata.uniprot_id == "HBA_HUMAN"
+    assert metadata.pdb_url == "https://example.org/AF-P69905-F1-model_v4.pdb"
+    assert metadata.version == 4
+    assert metadata.license == "CC BY 4.0"
+
+
+def test_get_alphafold_structure_metadata_rejects_empty_response(monkeypatch):
+
+    def mock_urlopen(request, timeout=10):
+        return MockResponse("[]")
+
+    monkeypatch.setattr(alphafold_utils.request, "urlopen", mock_urlopen)
+
+    with pytest.raises(ValueError, match="No AlphaFold DB prediction"):
+        alphafold_utils.get_alphafold_structure_metadata("P00000")
+
+
+def test_get_alphafold_structure_metadata_wraps_http_errors(monkeypatch):
+
+    def mock_urlopen(request, timeout=10):
+        raise HTTPError(request.full_url, 404, "Not Found", None, None)
+
+    monkeypatch.setattr(alphafold_utils.request, "urlopen", mock_urlopen)
+
+    with pytest.raises(ValueError, match="No AlphaFold DB prediction"):
+        alphafold_utils.get_alphafold_structure_metadata("P00000")
+
+
+def test_download_alphafold_structure_writes_pdb(monkeypatch, tmp_path):
+    metadata_response = [{
+        "entryId": "AF-P69905-F1",
+        "uniprotAccession": "P69905",
+        "pdbUrl": "https://example.org/AF-P69905-F1-model_v4.pdb",
+        "cifUrl": "https://example.org/AF-P69905-F1-model_v4.cif",
+        "latestVersion": 4,
+    }]
+    pdb_text = "HEADER    ALPHAFOLD MODEL\nATOM      1  N   MET A   1\n"
+    opened_urls = []
+
+    def mock_urlopen(request, timeout=10):
+        opened_urls.append(request.full_url)
+        if request.full_url.endswith("/P69905"):
+            return MockResponse(json.dumps(metadata_response))
+        return MockResponse(pdb_text)
+
+    monkeypatch.setattr(alphafold_utils.request, "urlopen", mock_urlopen)
+
+    result = alphafold_utils.download_alphafold_structure("P69905", tmp_path)
+
+    assert result.path == str(tmp_path / "AF-P69905-F1.pdb")
+    assert Path(result.path).read_text() == pdb_text
+    assert result.format == "pdb"
+    assert result.metadata.entry_id == "AF-P69905-F1"
+    assert opened_urls == [
+        "https://alphafold.ebi.ac.uk/api/prediction/P69905",
+        "https://example.org/AF-P69905-F1-model_v4.pdb",
+    ]
+
+
+def test_download_alphafold_structure_supports_mmcif(monkeypatch, tmp_path):
+    metadata_response = [{
+        "entryId": "AF-P69905-F1",
+        "uniprotAccession": "P69905",
+        "pdbUrl": "https://example.org/AF-P69905-F1-model_v4.pdb",
+        "cifUrl": "https://example.org/AF-P69905-F1-model_v4.cif",
+        "latestVersion": 4,
+    }]
+
+    def mock_urlopen(request, timeout=10):
+        if request.full_url.endswith("/P69905"):
+            return MockResponse(json.dumps(metadata_response))
+        return MockResponse("data_AF-P69905-F1\n#\n")
+
+    monkeypatch.setattr(alphafold_utils.request, "urlopen", mock_urlopen)
+
+    result = alphafold_utils.download_alphafold_structure("P69905",
+                                                          tmp_path,
+                                                          file_format="mmcif")
+
+    assert result.path == str(tmp_path / "AF-P69905-F1.cif")
+    assert Path(result.path).read_text() == "data_AF-P69905-F1\n#\n"
+    assert result.format == "mmcif"
+
+
+def test_download_alphafold_structure_rejects_unknown_format(tmp_path):
+    with pytest.raises(ValueError, match="file_format must be"):
+        alphafold_utils.download_alphafold_structure("P69905",
+                                                     tmp_path,
+                                                     file_format="pdbqt")

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -125,6 +125,19 @@ Genomic Utilities
 
 .. autofunction:: deepchem.utils.sequence_utils.MSA_to_dataset
 
+Protein Structure Utilities
+---------------------------
+
+.. autoclass:: deepchem.utils.alphafold_utils.AlphaFoldStructureMetadata
+  :members:
+
+.. autoclass:: deepchem.utils.alphafold_utils.AlphaFoldStructure
+  :members:
+
+.. autofunction:: deepchem.utils.alphafold_utils.get_alphafold_structure_metadata
+
+.. autofunction:: deepchem.utils.alphafold_utils.download_alphafold_structure
+
 
 Geometry Utilities
 ------------------


### PR DESCRIPTION
## Description

Adds a lightweight AlphaFold Protein Structure Database integration for retrieving precomputed protein structure predictions by UniProt accession.

This provides an immediate DeepChem integration point for AlphaFold-predicted structures without adding heavyweight runtime dependencies such as AlphaFold, OpenFold, ColabFold, JAX, PyTorch, model weights, or sequence databases.

## Changes

- Add `deepchem.utils.alphafold_utils` with:
  - `AlphaFoldStructureMetadata`
  - `AlphaFoldStructure`
  - `get_alphafold_structure_metadata()`
  - `download_alphafold_structure()`
- Export the new helpers from `deepchem.utils`
- Add API reference docs under Protein Structure Utilities
- Add unit tests using mocked AlphaFold DB API/file responses so CI does not require network access

Fixes #4965

## Tests

- `python -m pytest deepchem/utils/test/test_alphafold_utils.py -q`
- `python -m pytest --doctest-modules deepchem/utils/alphafold_utils.py -q`
- `python -m compileall -q deepchem/utils/alphafold_utils.py deepchem/utils/test/test_alphafold_utils.py`
- `git diff --check`