### PR TITLE
Add ProteinBackboneFeaturizer for PDB backbone extraction

### DIFF
--- a/deepchem/feat/__init__.py
+++ b/deepchem/feat/__init__.py
@@ -78,6 +78,8 @@ from deepchem.feat.atomic_conformation import AtomicConformationFeaturizer
 
 from deepchem.feat.huggingface_featurizer import HuggingFaceFeaturizer
 
+from deepchem.feat.protein_backbone_featurizer import ProteinBackboneFeaturizer
+
 # biological sequence featurizers
 try:
     from deepchem.feat.bio_seq_featurizer import SAMFeaturizer

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -2,7 +2,7 @@
 Protein Backbone Featurizer for structural diffusion models.
 """
 import logging
-from typing import Iterable
+from typing import Dict, Iterable, Optional
 import numpy as np
 from deepchem.feat.base_classes import Featurizer
 
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 class ProteinBackboneFeaturizer(Featurizer):
     """Featurizes protein structures by extracting backbone atom coordinates.
 
-    This featurizer extracts the N, CA (Cα), and C backbone atom coordinates
+    This featurizer extracts the N, CA, and C backbone atom coordinates
     from PDB structures. It is designed for use with protein structure generation
     models like RFDiffusion that operate on backbone geometry.
 
@@ -30,14 +30,16 @@ class ProteinBackboneFeaturizer(Featurizer):
 
     Since proteins have variable lengths, calling ``featurize()`` returns
     a numpy object array where each element is an ``(L, 3, 3)`` array.
+    For multi-model PDB files only the first model is featurized. Standard
+    amino-acid residues missing any of N, CA, or C are skipped.
 
     This class requires BioPython to be installed.
 
     Parameters
     ----------
-    max_length : int, default 512
+    max_length : int or None, default 512
         Maximum number of residues to extract. Longer proteins will be
-        truncated from the center.
+        center-cropped with a warning. If None, no length limit is applied.
 
     Examples
     --------
@@ -64,19 +66,39 @@ class ProteinBackboneFeaturizer(Featurizer):
        function with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
     """
 
-    def __init__(self, max_length: int = 512):
+    def __init__(self, max_length: Optional[int] = 512):
         """Initialize the ProteinBackboneFeaturizer.
 
         Parameters
         ----------
-        max_length : int, default 512
+        max_length : int or None, default 512
             Maximum number of residues to extract. Longer proteins will be
-            truncated from the center.
+            center-cropped with a warning. If None, no length limit is applied.
         """
         if not has_biopython:
             raise ImportError("ProteinBackboneFeaturizer requires BioPython. "
                               "Install it with: pip install biopython")
+        if max_length is not None and max_length <= 0:
+            raise ValueError("max_length must be positive or None")
         self.max_length = max_length
+        self._last_metadata: Dict[str, Dict[str, object]] = {}
+
+    def get_metadata(self, datapoint: str) -> Dict[str, object]:
+        """Return metadata recorded during the most recent featurization.
+
+        Parameters
+        ----------
+        datapoint : str
+            Path to a PDB file that was previously featurized.
+
+        Returns
+        -------
+        dict
+            Metadata including original length, skipped residues, chains,
+            model id, and truncation details. Returns an empty dict if the
+            datapoint has not been featurized by this instance.
+        """
+        return dict(self._last_metadata.get(datapoint, {}))
 
     def featurize(self,
                   datapoints: Iterable[str],
@@ -134,8 +156,19 @@ class ProteinBackboneFeaturizer(Featurizer):
         structure = parser.get_structure('protein', datapoint)
 
         coords_list = []
+        metadata: Dict[str, object] = {
+            'model_id': None,
+            'chain_ids': [],
+            'original_length': 0,
+            'returned_length': 0,
+            'skipped_residues': 0,
+            'truncated': False,
+            'crop_start': None,
+        }
         for model in structure:
+            metadata['model_id'] = model.id
             for chain in model:
+                metadata['chain_ids'].append(chain.id)
                 for residue in chain:
                     if not is_aa(residue, standard=True):
                         continue
@@ -149,21 +182,30 @@ class ProteinBackboneFeaturizer(Featurizer):
                                             dtype=np.float32)
                         coords_list.append(backbone)
                     except KeyError:
-                        # Skip residues missing backbone atoms
+                        metadata['skipped_residues'] += 1
                         continue
 
             # Only use first model
             break
 
         if len(coords_list) == 0:
+            self._last_metadata[datapoint] = metadata
             return np.array([])
 
         coords = np.stack(coords_list, axis=0)  # (L, 3, 3)
+        metadata['original_length'] = int(coords.shape[0])
 
         # Center crop if too long
         L = coords.shape[0]
-        if L > self.max_length:
+        if self.max_length is not None and L > self.max_length:
             start = (L - self.max_length) // 2
             coords = coords[start:start + self.max_length]
+            metadata['truncated'] = True
+            metadata['crop_start'] = int(start)
+            logger.warning(
+                "Protein %s has %d residues; center-cropped to max_length=%d",
+                datapoint, L, self.max_length)
 
+        metadata['returned_length'] = int(coords.shape[0])
+        self._last_metadata[datapoint] = metadata
         return coords

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -45,7 +45,11 @@ class ProteinBackboneFeaturizer(Featurizer):
     ----------
     max_length : int or None, default 512
         Maximum number of residues to extract. Longer proteins will be
-        center-cropped with a warning. If None, no length limit is applied.
+        center-cropped with a warning, which means the middle
+        ``max_length`` residues are kept and residues from both ends are
+        dropped. This is useful for RFDiffusion-style models that need a
+        fixed upper bound on sequence length while still keeping the
+        central part of the fold.
 
     Examples
     --------
@@ -79,7 +83,11 @@ class ProteinBackboneFeaturizer(Featurizer):
         ----------
         max_length : int or None, default 512
             Maximum number of residues to extract. Longer proteins will be
-            center-cropped with a warning. If None, no length limit is applied.
+            center-cropped with a warning, which means the middle
+            ``max_length`` residues are kept and residues from both ends are
+            dropped. This keeps a consistent maximum size for diffusion
+            training without always biasing the crop toward the N-terminus
+            or C-terminus. If None, no length limit is applied.
         """
         if not has_biopython:
             raise ImportError("ProteinBackboneFeaturizer requires BioPython. "
@@ -103,6 +111,25 @@ class ProteinBackboneFeaturizer(Featurizer):
             Metadata including original length, skipped residues, chains,
             model id, and truncation details. Returns an empty dict if the
             datapoint has not been featurized by this instance.
+
+        Examples
+        --------
+        >>> import deepchem as dc
+        >>> import tempfile
+        >>> import os
+        >>> pdb_content = '''ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
+        ... ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
+        ... ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
+        ... END'''
+        >>> with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as f:
+        ...     _ = f.write(pdb_content)
+        ...     pdb_file = f.name
+        >>> featurizer = dc.feat.ProteinBackboneFeaturizer()
+        >>> _ = featurizer.featurize([pdb_file])
+        >>> meta = featurizer.get_metadata(pdb_file)
+        >>> meta['returned_length']
+        1
+        >>> os.unlink(pdb_file)
         """
         return copy.deepcopy(self._last_metadata.get(datapoint, {}))
 

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -54,21 +54,16 @@ class ProteinBackboneFeaturizer(Featurizer):
     Examples
     --------
     >>> import deepchem as dc
-    >>> import tempfile
     >>> import os
-    >>> # Create a minimal PDB file for testing
-    >>> pdb_content = '''ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
-    ... ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
-    ... ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
-    ... END'''
-    >>> with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as f:
-    ...     _ = f.write(pdb_content)
-    ...     pdb_file = f.name
+    >>> current_dir = os.path.dirname(os.path.abspath(dc.feat.__file__))
+    >>> pdb_file = os.path.join(current_dir, 'tests', 'data',
+    ...                         '3zso_protein_noH.pdb')
     >>> featurizer = dc.feat.ProteinBackboneFeaturizer()
     >>> features = featurizer.featurize([pdb_file])
-    >>> features[0].shape
-    (1, 3, 3)
-    >>> os.unlink(pdb_file)
+    >>> features.shape[0]
+    1
+    >>> features[0].shape[-2:]
+    (3, 3)
 
     References
     ----------
@@ -115,21 +110,15 @@ class ProteinBackboneFeaturizer(Featurizer):
         Examples
         --------
         >>> import deepchem as dc
-        >>> import tempfile
         >>> import os
-        >>> pdb_content = '''ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
-        ... ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
-        ... ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
-        ... END'''
-        >>> with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as f:
-        ...     _ = f.write(pdb_content)
-        ...     pdb_file = f.name
+        >>> current_dir = os.path.dirname(os.path.abspath(dc.feat.__file__))
+        >>> pdb_file = os.path.join(current_dir, 'tests', 'data',
+        ...                         '3zso_protein_noH.pdb')
         >>> featurizer = dc.feat.ProteinBackboneFeaturizer()
         >>> _ = featurizer.featurize([pdb_file])
         >>> meta = featurizer.get_metadata(pdb_file)
-        >>> meta['returned_length']
-        1
-        >>> os.unlink(pdb_file)
+        >>> meta['returned_length'] > 0
+        True
         """
         return copy.deepcopy(self._last_metadata.get(datapoint, {}))
 

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -3,7 +3,7 @@ Protein Backbone Featurizer for structural diffusion models.
 """
 import copy
 import logging
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Any
 import numpy as np
 from deepchem.feat.base_classes import Featurizer
 
@@ -95,9 +95,9 @@ class ProteinBackboneFeaturizer(Featurizer):
         if max_length is not None and max_length <= 0:
             raise ValueError("max_length must be positive or None")
         self.max_length = max_length
-        self._last_metadata: Dict[str, Dict[str, object]] = {}
+        self._last_metadata: Dict[str, Dict[str, Any]] = {}
 
-    def get_metadata(self, datapoint: str) -> Dict[str, object]:
+    def get_metadata(self, datapoint: str) -> Dict[str, Any]:
         """Return metadata recorded during the most recent featurization.
 
         Parameters
@@ -173,8 +173,8 @@ class ProteinBackboneFeaturizer(Featurizer):
         parser = PDBParser(QUIET=True)
         structure = parser.get_structure('protein', datapoint)
 
-        coords_list = []
-        metadata: Dict[str, object] = {
+        coords_list: List[np.ndarray] = []
+        metadata: Dict[str, Any] = {
             'model_id': None,
             'chain_ids': [],
             'original_length': 0,

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -3,7 +3,7 @@ Protein Backbone Featurizer for structural diffusion models.
 """
 import copy
 import logging
-from typing import Dict, Iterable, Optional
+from typing import Dict, Optional
 import numpy as np
 from deepchem.feat.base_classes import Featurizer
 
@@ -106,48 +106,6 @@ class ProteinBackboneFeaturizer(Featurizer):
         """
         return copy.deepcopy(self._last_metadata.get(datapoint, {}))
 
-    def featurize(self,
-                  datapoints: Iterable[str],
-                  log_every_n: int = 1000,
-                  **kwargs) -> np.ndarray:
-        """Featurize a list of PDB file paths.
-
-        Overrides base ``Featurizer.featurize()`` to return an object-typed
-        numpy array, since proteins have variable-length backbones and
-        ``np.asarray`` would fail on inhomogeneous shapes.
-
-        Parameters
-        ----------
-        datapoints : Iterable[str]
-            Paths to PDB files to featurize.
-        log_every_n : int, default 1000
-            Log progress every ``log_every_n`` datapoints.
-
-        Returns
-        -------
-        np.ndarray
-            Object array where each element is an ``(L, 3, 3)``
-            float32 array of backbone coordinates.
-        """
-        datapoints = list(datapoints)
-        features = []
-        for i, point in enumerate(datapoints):
-            if i % log_every_n == 0:
-                logger.info("Featurizing datapoint %i" % i)
-            try:
-                features.append(self._featurize(point, **kwargs))
-            except Exception as exc:
-                self._last_metadata.pop(point, None)
-                logger.warning(
-                    "Failed to featurize datapoint %d (%s): %s. Appending empty array.",
-                    i, point, exc)
-                features.append(_empty_backbone_coords())
-
-        out = np.empty(len(features), dtype=object)
-        for i, feature in enumerate(features):
-            out[i] = feature
-        return out
-
     def _featurize(self, datapoint: str, **kwargs) -> np.ndarray:
         """Extract backbone coordinates from a PDB file.
 
@@ -162,6 +120,28 @@ class ProteinBackboneFeaturizer(Featurizer):
             Array of shape ``(L, 3, 3)`` containing backbone atom
             coordinates, where L is the number of residues, or an
             empty array on failure.
+        """
+        try:
+            return self._parse_backbone(datapoint)
+        except Exception as exc:
+            self._last_metadata.pop(datapoint, None)
+            logger.warning(
+                "Failed to featurize datapoint %s: %s. Appending empty array.",
+                datapoint, exc)
+            return _empty_backbone_coords()
+
+    def _parse_backbone(self, datapoint: str) -> np.ndarray:
+        """Parse backbone coordinates from a PDB file.
+
+        Parameters
+        ----------
+        datapoint : str
+            Path to a PDB file.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(L, 3, 3)`` of backbone atom coordinates.
         """
         parser = PDBParser(QUIET=True)
         structure = parser.get_structure('protein', datapoint)

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -1,6 +1,7 @@
 """
 Protein Backbone Featurizer for structural diffusion models.
 """
+import copy
 import logging
 from typing import Dict, Iterable, Optional
 import numpy as np
@@ -13,6 +14,11 @@ except ImportError:
     has_biopython = False
 
 logger = logging.getLogger(__name__)
+
+
+def _empty_backbone_coords() -> np.ndarray:
+    """Return an empty backbone tensor with the documented shape."""
+    return np.zeros((0, 3, 3), dtype=np.float32)
 
 
 class ProteinBackboneFeaturizer(Featurizer):
@@ -98,7 +104,7 @@ class ProteinBackboneFeaturizer(Featurizer):
             model id, and truncation details. Returns an empty dict if the
             datapoint has not been featurized by this instance.
         """
-        return dict(self._last_metadata.get(datapoint, {}))
+        return copy.deepcopy(self._last_metadata.get(datapoint, {}))
 
     def featurize(self,
                   datapoints: Iterable[str],
@@ -130,12 +136,17 @@ class ProteinBackboneFeaturizer(Featurizer):
                 logger.info("Featurizing datapoint %i" % i)
             try:
                 features.append(self._featurize(point, **kwargs))
-            except Exception:
-                logger.warning("Failed to featurize datapoint %d. "
-                               "Appending empty array." % i)
-                features.append(np.array([]))
+            except Exception as exc:
+                self._last_metadata.pop(point, None)
+                logger.warning(
+                    "Failed to featurize datapoint %d (%s): %s. Appending empty array.",
+                    i, point, exc)
+                features.append(_empty_backbone_coords())
 
-        return np.asarray(features, dtype=object)
+        out = np.empty(len(features), dtype=object)
+        for i, feature in enumerate(features):
+            out[i] = feature
+        return out
 
     def _featurize(self, datapoint: str, **kwargs) -> np.ndarray:
         """Extract backbone coordinates from a PDB file.
@@ -190,7 +201,7 @@ class ProteinBackboneFeaturizer(Featurizer):
 
         if len(coords_list) == 0:
             self._last_metadata[datapoint] = metadata
-            return np.array([])
+            return _empty_backbone_coords()
 
         coords = np.stack(coords_list, axis=0)  # (L, 3, 3)
         metadata['original_length'] = int(coords.shape[0])

--- a/deepchem/feat/protein_backbone_featurizer.py
+++ b/deepchem/feat/protein_backbone_featurizer.py
@@ -1,0 +1,169 @@
+"""
+Protein Backbone Featurizer for structural diffusion models.
+"""
+import logging
+from typing import Iterable
+import numpy as np
+from deepchem.feat.base_classes import Featurizer
+
+try:
+    from Bio.PDB import PDBParser, is_aa
+    has_biopython = True
+except ImportError:
+    has_biopython = False
+
+logger = logging.getLogger(__name__)
+
+
+class ProteinBackboneFeaturizer(Featurizer):
+    """Featurizes protein structures by extracting backbone atom coordinates.
+
+    This featurizer extracts the N, CA (Cα), and C backbone atom coordinates
+    from PDB structures. It is designed for use with protein structure generation
+    models like RFDiffusion that operate on backbone geometry.
+
+    Each protein is featurized as an array of shape ``(L, 3, 3)`` where:
+
+    - L is the number of residues
+    - The second dimension corresponds to [N, CA, C] atoms
+    - The third dimension contains [x, y, z] coordinates in Angstroms
+
+    Since proteins have variable lengths, calling ``featurize()`` returns
+    a numpy object array where each element is an ``(L, 3, 3)`` array.
+
+    This class requires BioPython to be installed.
+
+    Parameters
+    ----------
+    max_length : int, default 512
+        Maximum number of residues to extract. Longer proteins will be
+        truncated from the center.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> import tempfile
+    >>> import os
+    >>> # Create a minimal PDB file for testing
+    >>> pdb_content = '''ATOM      1  N   ALA A   1       0.000   0.000   0.000  1.00  0.00           N
+    ... ATOM      2  CA  ALA A   1       1.458   0.000   0.000  1.00  0.00           C
+    ... ATOM      3  C   ALA A   1       2.009   1.420   0.000  1.00  0.00           C
+    ... END'''
+    >>> with tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False) as f:
+    ...     _ = f.write(pdb_content)
+    ...     pdb_file = f.name
+    >>> featurizer = dc.feat.ProteinBackboneFeaturizer()
+    >>> features = featurizer.featurize([pdb_file])
+    >>> features[0].shape
+    (1, 3, 3)
+    >>> os.unlink(pdb_file)
+
+    References
+    ----------
+    .. [1] Watson, J. L., et al. "De novo design of protein structure and
+       function with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+    """
+
+    def __init__(self, max_length: int = 512):
+        """Initialize the ProteinBackboneFeaturizer.
+
+        Parameters
+        ----------
+        max_length : int, default 512
+            Maximum number of residues to extract. Longer proteins will be
+            truncated from the center.
+        """
+        if not has_biopython:
+            raise ImportError("ProteinBackboneFeaturizer requires BioPython. "
+                              "Install it with: pip install biopython")
+        self.max_length = max_length
+
+    def featurize(self,
+                  datapoints: Iterable[str],
+                  log_every_n: int = 1000,
+                  **kwargs) -> np.ndarray:
+        """Featurize a list of PDB file paths.
+
+        Overrides base ``Featurizer.featurize()`` to return an object-typed
+        numpy array, since proteins have variable-length backbones and
+        ``np.asarray`` would fail on inhomogeneous shapes.
+
+        Parameters
+        ----------
+        datapoints : Iterable[str]
+            Paths to PDB files to featurize.
+        log_every_n : int, default 1000
+            Log progress every ``log_every_n`` datapoints.
+
+        Returns
+        -------
+        np.ndarray
+            Object array where each element is an ``(L, 3, 3)``
+            float32 array of backbone coordinates.
+        """
+        datapoints = list(datapoints)
+        features = []
+        for i, point in enumerate(datapoints):
+            if i % log_every_n == 0:
+                logger.info("Featurizing datapoint %i" % i)
+            try:
+                features.append(self._featurize(point, **kwargs))
+            except Exception:
+                logger.warning("Failed to featurize datapoint %d. "
+                               "Appending empty array." % i)
+                features.append(np.array([]))
+
+        return np.asarray(features, dtype=object)
+
+    def _featurize(self, datapoint: str, **kwargs) -> np.ndarray:
+        """Extract backbone coordinates from a PDB file.
+
+        Parameters
+        ----------
+        datapoint : str
+            Path to a PDB file.
+
+        Returns
+        -------
+        np.ndarray
+            Array of shape ``(L, 3, 3)`` containing backbone atom
+            coordinates, where L is the number of residues, or an
+            empty array on failure.
+        """
+        parser = PDBParser(QUIET=True)
+        structure = parser.get_structure('protein', datapoint)
+
+        coords_list = []
+        for model in structure:
+            for chain in model:
+                for residue in chain:
+                    if not is_aa(residue, standard=True):
+                        continue
+
+                    try:
+                        n_coord = residue['N'].get_coord()
+                        ca_coord = residue['CA'].get_coord()
+                        c_coord = residue['C'].get_coord()
+
+                        backbone = np.array([n_coord, ca_coord, c_coord],
+                                            dtype=np.float32)
+                        coords_list.append(backbone)
+                    except KeyError:
+                        # Skip residues missing backbone atoms
+                        continue
+
+            # Only use first model
+            break
+
+        if len(coords_list) == 0:
+            return np.array([])
+
+        coords = np.stack(coords_list, axis=0)  # (L, 3, 3)
+
+        # Center crop if too long
+        L = coords.shape[0]
+        if L > self.max_length:
+            start = (L - self.max_length) // 2
+            coords = coords[start:start + self.max_length]
+
+        return coords

--- a/deepchem/feat/tests/test_protein_backbone_featurizer.py
+++ b/deepchem/feat/tests/test_protein_backbone_featurizer.py
@@ -167,6 +167,18 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
             os.unlink(missing_pdb.name)
 
     @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_get_metadata_returns_safe_copy(self):
+        """Test metadata access does not expose internal mutable state."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer()
+        featurizer.featurize([self.pdb_file.name])
+
+        metadata = featurizer.get_metadata(self.pdb_file.name)
+        metadata['chain_ids'].append('B')
+
+        fresh_metadata = featurizer.get_metadata(self.pdb_file.name)
+        assert fresh_metadata['chain_ids'] == ['A']
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
     def test_invalid_pdb(self):
         """Test handling of invalid PDB files."""
         invalid_pdb = tempfile.NamedTemporaryFile(mode='w',
@@ -181,8 +193,35 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
 
             # Should return empty array for failed featurization
             assert features[0].size == 0
+            assert features[0].shape == (0, 3, 3)
+            assert features[0].dtype == np.float32
+            metadata = featurizer.get_metadata(invalid_pdb.name)
+            assert metadata['original_length'] == 0
+            assert metadata['returned_length'] == 0
+            assert metadata['skipped_residues'] == 0
         finally:
             os.unlink(invalid_pdb.name)
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_exception_clears_stale_metadata(self):
+        """Test exception path clears metadata for the failing datapoint."""
+        missing_path = self.pdb_file.name
+        featurizer = dc.feat.ProteinBackboneFeaturizer()
+        featurizer.featurize([missing_path])
+        assert featurizer.get_metadata(missing_path)['returned_length'] == 3
+
+        os.unlink(missing_path)
+        with self.assertLogs('deepchem.feat.protein_backbone_featurizer',
+                             level='WARNING'):
+            features = featurizer.featurize([missing_path])
+
+        assert features[0].shape == (0, 3, 3)
+        assert featurizer.get_metadata(missing_path) == {}
+        self.pdb_file = tempfile.NamedTemporaryFile(mode='w',
+                                                    suffix='.pdb',
+                                                    delete=False)
+        self.pdb_file.write(self.pdb_content)
+        self.pdb_file.close()
 
     def test_requires_biopython(self):
         """Test that error is raised if BioPython is not installed."""

--- a/deepchem/feat/tests/test_protein_backbone_featurizer.py
+++ b/deepchem/feat/tests/test_protein_backbone_featurizer.py
@@ -39,10 +39,10 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
             "       0.500   4.000   4.000  1.00  0.00           C\n"
             "ATOM      9  C   VAL A   3"
             "       1.000   5.400   4.000  1.00  0.00           C\n"
-            "END\n"
-        )
-        self.pdb_file = tempfile.NamedTemporaryFile(
-            mode='w', suffix='.pdb', delete=False)
+            "END\n")
+        self.pdb_file = tempfile.NamedTemporaryFile(mode='w',
+                                                    suffix='.pdb',
+                                                    delete=False)
         self.pdb_file.write(self.pdb_content)
         self.pdb_file.close()
 
@@ -56,6 +56,12 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
         """Test featurizer initialization."""
         featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=128)
         assert featurizer.max_length == 128
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_invalid_max_length(self):
+        """Test invalid max_length fails clearly."""
+        with self.assertRaises(ValueError):
+            dc.feat.ProteinBackboneFeaturizer(max_length=0)
 
     @unittest.skipIf(not has_biopython, "BioPython not installed")
     def test_featurize_single_pdb(self):
@@ -80,12 +86,10 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
         coords = features[0]  # (L, 3, 3)
 
         # Check first residue N atom coordinates
-        np.testing.assert_array_almost_equal(
-            coords[0, 0], [0.0, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(coords[0, 0], [0.0, 0.0, 0.0])
 
         # Check first residue CA atom coordinates
-        np.testing.assert_array_almost_equal(
-            coords[0, 1], [1.458, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(coords[0, 1], [1.458, 0.0, 0.0])
 
     @unittest.skipIf(not has_biopython, "BioPython not installed")
     def test_truncation(self):
@@ -100,35 +104,74 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
         for res_i in range(20):
             for atom_name, element in atoms:
                 x = float(res_i) * 3.8
-                line = (
-                    f"ATOM  {serial:5d} {atom_name:^4s}"
-                    f" ALA A{res_i + 1:4d}    "
-                    f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
-                    f"  1.00  0.00           {element}\n")
+                line = (f"ATOM  {serial:5d} {atom_name:^4s}"
+                        f" ALA A{res_i + 1:4d}    "
+                        f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
+                        f"  1.00  0.00           {element}\n")
                 lines.append(line)
                 serial += 1
         lines.append("END\n")
         long_pdb_content = "".join(lines)
 
-        pdb_file2 = tempfile.NamedTemporaryFile(
-            mode='w', suffix='.pdb', delete=False)
+        pdb_file2 = tempfile.NamedTemporaryFile(mode='w',
+                                                suffix='.pdb',
+                                                delete=False)
         pdb_file2.write(long_pdb_content)
         pdb_file2.close()
 
         try:
             featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=10)
-            features = featurizer.featurize([pdb_file2.name])
+            with self.assertLogs('deepchem.feat.protein_backbone_featurizer',
+                                 level='WARNING'):
+                features = featurizer.featurize([pdb_file2.name])
 
             # Should be truncated to max_length
             assert features[0].shape[0] == 10
+            metadata = featurizer.get_metadata(pdb_file2.name)
+            assert metadata['original_length'] == 20
+            assert metadata['returned_length'] == 10
+            assert metadata['truncated'] is True
+            assert metadata['crop_start'] == 5
         finally:
             os.unlink(pdb_file2.name)
 
     @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_missing_backbone_atoms_are_recorded(self):
+        """Test residues missing backbone atoms are skipped and recorded."""
+        pdb_content = ("ATOM      1  N   ALA A   1"
+                       "       0.000   0.000   0.000  1.00  0.00           N\n"
+                       "ATOM      2  CA  ALA A   1"
+                       "       1.458   0.000   0.000  1.00  0.00           C\n"
+                       "ATOM      3  C   ALA A   1"
+                       "       2.009   1.420   0.000  1.00  0.00           C\n"
+                       "ATOM      4  N   GLY A   2"
+                       "       1.500   2.000   1.000  1.00  0.00           N\n"
+                       "ATOM      5  CA  GLY A   2"
+                       "       2.000   3.350   1.000  1.00  0.00           C\n"
+                       "END\n")
+        missing_pdb = tempfile.NamedTemporaryFile(mode='w',
+                                                  suffix='.pdb',
+                                                  delete=False)
+        missing_pdb.write(pdb_content)
+        missing_pdb.close()
+
+        try:
+            featurizer = dc.feat.ProteinBackboneFeaturizer()
+            features = featurizer.featurize([missing_pdb.name])
+            assert features[0].shape == (1, 3, 3)
+            metadata = featurizer.get_metadata(missing_pdb.name)
+            assert metadata['skipped_residues'] == 1
+            assert metadata['chain_ids'] == ['A']
+            assert metadata['model_id'] == 0
+        finally:
+            os.unlink(missing_pdb.name)
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
     def test_invalid_pdb(self):
         """Test handling of invalid PDB files."""
-        invalid_pdb = tempfile.NamedTemporaryFile(
-            mode='w', suffix='.pdb', delete=False)
+        invalid_pdb = tempfile.NamedTemporaryFile(mode='w',
+                                                  suffix='.pdb',
+                                                  delete=False)
         invalid_pdb.write("This is not a valid PDB file\n")
         invalid_pdb.close()
 

--- a/deepchem/feat/tests/test_protein_backbone_featurizer.py
+++ b/deepchem/feat/tests/test_protein_backbone_featurizer.py
@@ -1,0 +1,154 @@
+"""
+Tests for ProteinBackboneFeaturizer.
+"""
+import unittest
+import tempfile
+import os
+import numpy as np
+import deepchem as dc
+
+try:
+    from Bio.PDB import PDBParser  # noqa: F401
+    has_biopython = True
+except ImportError:
+    has_biopython = False
+
+
+class TestProteinBackboneFeaturizer(unittest.TestCase):
+    """Test ProteinBackboneFeaturizer class."""
+
+    def setUp(self):
+        """Create minimal PDB file for testing."""
+        # Minimal PDB with 3 residues
+        self.pdb_content = (
+            "ATOM      1  N   ALA A   1"
+            "       0.000   0.000   0.000  1.00  0.00           N\n"
+            "ATOM      2  CA  ALA A   1"
+            "       1.458   0.000   0.000  1.00  0.00           C\n"
+            "ATOM      3  C   ALA A   1"
+            "       2.009   1.420   0.000  1.00  0.00           C\n"
+            "ATOM      4  N   GLY A   2"
+            "       1.500   2.000   1.000  1.00  0.00           N\n"
+            "ATOM      5  CA  GLY A   2"
+            "       2.000   3.350   1.000  1.00  0.00           C\n"
+            "ATOM      6  C   GLY A   2"
+            "       1.500   4.000   2.000  1.00  0.00           C\n"
+            "ATOM      7  N   VAL A   3"
+            "       1.000   3.500   3.000  1.00  0.00           N\n"
+            "ATOM      8  CA  VAL A   3"
+            "       0.500   4.000   4.000  1.00  0.00           C\n"
+            "ATOM      9  C   VAL A   3"
+            "       1.000   5.400   4.000  1.00  0.00           C\n"
+            "END\n"
+        )
+        self.pdb_file = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.pdb', delete=False)
+        self.pdb_file.write(self.pdb_content)
+        self.pdb_file.close()
+
+    def tearDown(self):
+        """Clean up temporary file."""
+        if os.path.exists(self.pdb_file.name):
+            os.unlink(self.pdb_file.name)
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_featurizer_init(self):
+        """Test featurizer initialization."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=128)
+        assert featurizer.max_length == 128
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_featurize_single_pdb(self):
+        """Test featurizing a single PDB file."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer()
+        features = featurizer.featurize([self.pdb_file.name])
+
+        # Base class featurize returns np.ndarray
+        assert isinstance(features, np.ndarray)
+        assert len(features) == 1  # One protein
+
+        # Each element is an (L, 3, 3) array
+        coords = features[0]
+        assert coords.shape == (3, 3, 3)  # 3 residues, 3 atoms, 3 xyz
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_backbone_coordinates(self):
+        """Test that backbone coordinates are correctly extracted."""
+        featurizer = dc.feat.ProteinBackboneFeaturizer()
+        features = featurizer.featurize([self.pdb_file.name])
+
+        coords = features[0]  # (L, 3, 3)
+
+        # Check first residue N atom coordinates
+        np.testing.assert_array_almost_equal(
+            coords[0, 0], [0.0, 0.0, 0.0])
+
+        # Check first residue CA atom coordinates
+        np.testing.assert_array_almost_equal(
+            coords[0, 1], [1.458, 0.0, 0.0])
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_truncation(self):
+        """Test that long proteins are truncated."""
+        # PDB format has strict column positions:
+        # cols 1-6: record, 7-11: serial, 13-16: name,
+        # 17: altLoc, 18-20: resName, 22: chainID, 23-26: resSeq,
+        # 31-38: x, 39-46: y, 47-54: z
+        lines = []
+        atoms = [("N", "N"), ("CA", "C"), ("C", "C")]
+        serial = 1
+        for res_i in range(20):
+            for atom_name, element in atoms:
+                x = float(res_i) * 3.8
+                line = (
+                    f"ATOM  {serial:5d} {atom_name:^4s}"
+                    f" ALA A{res_i + 1:4d}    "
+                    f"{x:8.3f}{0.0:8.3f}{0.0:8.3f}"
+                    f"  1.00  0.00           {element}\n")
+                lines.append(line)
+                serial += 1
+        lines.append("END\n")
+        long_pdb_content = "".join(lines)
+
+        pdb_file2 = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.pdb', delete=False)
+        pdb_file2.write(long_pdb_content)
+        pdb_file2.close()
+
+        try:
+            featurizer = dc.feat.ProteinBackboneFeaturizer(max_length=10)
+            features = featurizer.featurize([pdb_file2.name])
+
+            # Should be truncated to max_length
+            assert features[0].shape[0] == 10
+        finally:
+            os.unlink(pdb_file2.name)
+
+    @unittest.skipIf(not has_biopython, "BioPython not installed")
+    def test_invalid_pdb(self):
+        """Test handling of invalid PDB files."""
+        invalid_pdb = tempfile.NamedTemporaryFile(
+            mode='w', suffix='.pdb', delete=False)
+        invalid_pdb.write("This is not a valid PDB file\n")
+        invalid_pdb.close()
+
+        try:
+            featurizer = dc.feat.ProteinBackboneFeaturizer()
+            features = featurizer.featurize([invalid_pdb.name])
+
+            # Should return empty array for failed featurization
+            assert features[0].size == 0
+        finally:
+            os.unlink(invalid_pdb.name)
+
+    def test_requires_biopython(self):
+        """Test that error is raised if BioPython is not installed."""
+        if has_biopython:
+            self.skipTest("BioPython is installed")
+
+        with self.assertRaises(ImportError):
+            dc.feat.ProteinBackboneFeaturizer()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/docs/source/api_reference/featurizers.rst
+++ b/docs/source/api_reference/featurizers.rst
@@ -570,6 +570,10 @@ BindingPocketFeaturizer
 ProteinBackboneFeaturizer
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+This featurizer reads only the first model from a multi-model PDB,
+skips standard residues missing any of N, CA, or C, and center-crops
+overlength proteins with a warning when ``max_length`` is set.
+
 .. autoclass:: deepchem.feat.ProteinBackboneFeaturizer
   :members:
   :inherited-members:

--- a/docs/source/api_reference/featurizers.rst
+++ b/docs/source/api_reference/featurizers.rst
@@ -567,6 +567,13 @@ BindingPocketFeaturizer
   :members:
   :inherited-members:
 
+ProteinBackboneFeaturizer
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autoclass:: deepchem.feat.ProteinBackboneFeaturizer
+  :members:
+  :inherited-members:
+
 UserDefinedFeaturizer
 ^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Description

Fix #4747

Adds `ProteinBackboneFeaturizer`, a DeepChem featurizer for extracting protein backbone coordinates from PDB files. The featurizer returns one variable-length `(L, 3, 3)` array per protein, where the atom axis is ordered as N, CA, C.

This PR is the first part of the RFDiffusion integration work. It only adds the backbone featurizer and its API documentation/tests.

Implementation details:

- uses BioPython `PDBParser` and standard amino-acid filtering
- reads the first model from multi-model PDB files
- skips residues missing any of N, CA, or C
- validates `max_length`
- center-crops overlength proteins with a warning
- records metadata for returned length, original length, skipped residues, model id, chains, and truncation
- returns empty backbone arrays with shape `(0, 3, 3)` and dtype `float32` for empty/failure cases

Validation run locally:

```bash
/home/chidwipak/Gsoc2026/deepchem/venv/bin/python -m pytest deepchem/feat/tests/test_protein_backbone_featurizer.py -q
# 9 passed, 1 skipped
```

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
