### PR TITLE
docs: fix broken github ribbon image link in index.rst [skip ci]

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,9 +4,11 @@ The DeepChem Project
 .. raw:: html
 
   <embed>
-    <a href="https://github.com/deepchem/deepchem">
-      <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://camo.githubusercontent.com/365986a132ccd6a44c23a9169022c0b5c890c387/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_right_red_aa0000.png">
-    </a>
+   <a href="https://github.com/deepchem/deepchem">
+       <img style="position: absolute; top: 0; right: 0; border: 0;" 
+            src="https://github.blog/wp-content/uploads/2008/12/forkme_right_red_aa0000.png" 
+            alt="Fork me on GitHub">
+   </a>
   </embed>
 
 


### PR DESCRIPTION
## Description
I noticed the "Fork me on GitHub" ribbon on the [main documentation page](https://deepchem.readthedocs.io/en/latest/index.html) was broken and displaying alt text instead of the image.

The previous image source pointed to an outdated/unavailable asset, causing the ribbon image to fail loading.

## Changes 
- Fixed the broken “Fork me on GitHub” ribbon image in the documentation site.
- Replaced the outdated S3-hosted asset with a working GitHub-hosted image.


## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X] Documentations (modification for documents)

## Checklist

- [ ] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
