### PR TITLE
Fixed the incorrect class name in RobertaTokenizer docstring

### DIFF
--- a/deepchem/feat/roberta_tokenizer.py
+++ b/deepchem/feat/roberta_tokenizer.py
@@ -35,7 +35,7 @@ class RobertaFeaturizer(RobertaTokenizerFast, Featurizer):
     -----
     This class requires transformers to be installed.
     RobertaFeaturizer uses dual inheritance with RobertaTokenizerFast in Huggingface for rapid tokenization,
-    as well as DeepChem's Featurizrer class.
+    as well as DeepChem's Featurizer class.
     """
 
     def __init__(self, **kwargs):

--- a/deepchem/feat/roberta_tokenizer.py
+++ b/deepchem/feat/roberta_tokenizer.py
@@ -35,7 +35,7 @@ class RobertaFeaturizer(RobertaTokenizerFast, Featurizer):
     -----
     This class requires transformers to be installed.
     RobertaFeaturizer uses dual inheritance with RobertaTokenizerFast in Huggingface for rapid tokenization,
-    as well as DeepChem's MolecularFeaturizer class.
+    as well as DeepChem's Featurizrer class.
     """
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
## Description

Fixed an incorrect class name in the [RobertaFeaturizer]
The Note section incorrectly referred to `MolecularFeaturizer` when the class actually inherits from DeepChem's `Featurizer` base class.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings