### PR TITLE
Add RFDiffusion frame math utilities

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -1,0 +1,310 @@
+"""SE(3) rigid-frame math utilities for RFDiffusion.
+
+This module contains the non-learned geometric primitives used by the
+RFDiffusion stack:
+
+* residue-local frame construction from backbone atoms `(N, CA, C)`
+* rigid transform apply / inverse / invert / compose helpers
+* Rodrigues exp/log maps between so(3) vectors and SO(3) rotations
+
+The module is intentionally self-contained and depends only on PyTorch.
+"""
+
+from typing import Optional, Sequence, Tuple
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError("rfdiffusion_frames requires PyTorch to be installed.")
+
+__all__ = [
+    "apply_inverse_rigid",
+    "apply_rigid",
+    "build_backbone_frames",
+    "compose_rigids",
+    "invert_rigid",
+    "make_identity_rigid",
+    "so3_exp_map",
+    "so3_log_map",
+]
+
+_SMALL_OMEGA: float = 1e-4
+
+
+def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
+    """Normalize vectors with epsilon stabilization.
+
+    Parameters
+    ----------
+    vector : torch.Tensor
+        Tensor of shape `(..., 3)`.
+    eps : float
+        Positive epsilon added to the norm.
+
+    Returns
+    -------
+    torch.Tensor
+        Normalized vectors.
+    """
+    norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
+    return vector / (norm + eps)
+
+
+def build_backbone_frames(
+        backbone: torch.Tensor,
+        eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build residue-local frames from `(N, CA, C)` backbone coordinates.
+
+    Parameters
+    ----------
+    backbone : torch.Tensor
+        Backbone coordinates of shape `(..., 3, 3)` ordered as
+        `(N, CA, C)`.
+    eps : float, default 1e-8
+        Positive stabilization constant.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Frame origins of shape `(..., 3)`.
+    """
+    if backbone.shape[-2:] != (3, 3):
+        raise ValueError("backbone must have shape (..., 3, 3).")
+    if eps <= 0:
+        raise ValueError("eps must be positive.")
+
+    n_atom = backbone[..., 0, :]
+    ca_atom = backbone[..., 1, :]
+    c_atom = backbone[..., 2, :]
+
+    x_axis = _normalize(c_atom - ca_atom, eps)
+    n_direction = n_atom - ca_atom
+    y_axis = n_direction - (n_direction * x_axis).sum(dim=-1,
+                                                      keepdim=True) * x_axis
+    y_axis = _normalize(y_axis, eps)
+    z_axis = torch.linalg.cross(x_axis, y_axis, dim=-1)
+
+    rotations = torch.stack((x_axis, y_axis, z_axis), dim=-1)
+    return rotations, ca_atom
+
+
+def make_identity_rigid(
+        shape: Sequence[int],
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create identity rigid transforms `(I, 0)`.
+
+    Parameters
+    ----------
+    shape : sequence of int
+        Batch shape.
+    device : torch.device, optional
+        Device for returned tensors.
+    dtype : torch.dtype, optional
+        Tensor dtype.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Identity rotations of shape `(*shape, 3, 3)`.
+    translations : torch.Tensor
+        Zero translations of shape `(*shape, 3)`.
+    """
+    shape = tuple(shape)
+    rotation = torch.eye(3, device=device, dtype=dtype)
+    rotation = rotation.expand(*shape, 3, 3).contiguous().clone()
+    translation = torch.zeros(*shape, 3, device=device, dtype=dtype)
+    return rotation, translation
+
+
+def _expand_rigid_to_points(
+        rotations: torch.Tensor, translations: torch.Tensor,
+        points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Broadcast rigid transforms across extra point dimensions."""
+    extra_dims = points.dim() - translations.dim()
+    if extra_dims < 0:
+        raise ValueError(
+            "points must have at least the transform batch dimensions.")
+    for _ in range(extra_dims):
+        rotations = rotations.unsqueeze(-3)
+        translations = translations.unsqueeze(-2)
+    return rotations, translations
+
+
+def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                points: torch.Tensor) -> torch.Tensor:
+    """Apply rigid transforms `x -> x @ R.T + t`.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points of shape `(..., 3)` or with extra point axes.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points.
+    """
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    rotated = torch.matmul(points.unsqueeze(-2),
+                           rotations.transpose(-1, -2)).squeeze(-2)
+    return rotated + translations
+
+
+def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                        points: torch.Tensor) -> torch.Tensor:
+    """Apply inverse rigid transforms `y -> (y - t) @ R`."""
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    centered = points - translations
+    return torch.matmul(centered.unsqueeze(-2), rotations).squeeze(-2)
+
+
+def invert_rigid(
+        rotations: torch.Tensor,
+        translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Invert rigid transforms.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    inv_rotations : torch.Tensor
+        Transposed rotations.
+    inv_translations : torch.Tensor
+        Inverse translations.
+    """
+    inv_rotations = rotations.transpose(-1, -2)
+    inv_translations = -torch.matmul(translations.unsqueeze(-2),
+                                     rotations).squeeze(-2)
+    return inv_rotations, inv_translations
+
+
+def compose_rigids(
+        rotations_a: torch.Tensor, translations_a: torch.Tensor,
+        rotations_b: torch.Tensor,
+        translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compose two rigid transforms `T_a o T_b`.
+
+    Parameters
+    ----------
+    rotations_a, rotations_b : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations_a, translations_b : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Composite rotations.
+    translations : torch.Tensor
+        Composite translations.
+    """
+    rotations = torch.matmul(rotations_a, rotations_b)
+    translations = apply_rigid(rotations_a, translations_a, translations_b)
+    return rotations, translations
+
+
+def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
+    """Return `sin(x) / x` with a stable Taylor branch near zero."""
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
+
+
+def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
+    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch."""
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)
+    series = 0.5 - x * x / 24.0
+    return torch.where(small, series, closed)
+
+
+def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
+    """Map tangent vectors in so(3) to rotation matrices.
+
+    Parameters
+    ----------
+    tangent : torch.Tensor
+        Tangent vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    """
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)
+    zeros = torch.zeros_like(tangent[..., 0])
+    tx, ty, tz = tangent[..., 0], tangent[..., 1], tangent[..., 2]
+    skew = torch.stack([
+        torch.stack([zeros, -tz, ty], dim=-1),
+        torch.stack([tz, zeros, -tx], dim=-1),
+        torch.stack([-ty, tx, zeros], dim=-1),
+    ],
+                       dim=-2)
+    eye = torch.eye(3, dtype=tangent.dtype, device=tangent.device)
+    sin_coeff = _safe_sin_div_x(omega).unsqueeze(-1)
+    cos_coeff = _safe_one_minus_cos_div_x_sq(omega).unsqueeze(-1)
+    skew_sq = torch.matmul(skew, skew)
+    return eye + sin_coeff * skew + cos_coeff * skew_sq
+
+
+def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
+    """Map rotation matrices to tangent vectors on the principal branch.
+
+    The rotation is converted to a unit quaternion first and then to an
+    axis-angle vector. Routing through the quaternion keeps the result stable
+    for rotations near ``pi``, where reading the angle straight from the trace
+    loses accuracy because ``sin(omega)`` goes to zero.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Tangent vectors of shape `(..., 3)` whose norm lies in ``[0, pi]``.
+    """
+    m00 = rotations[..., 0, 0]
+    m11 = rotations[..., 1, 1]
+    m22 = rotations[..., 2, 2]
+    trace = m00 + m11 + m22
+
+    # Read the unit quaternion from the rotation matrix. Each component
+    # magnitude comes from the diagonal and its sign from the skew part.
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
+    qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
+    qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
+
+    quat_vec = torch.stack([qx, qy, qz], dim=-1)
+    sin_half = quat_vec.norm(dim=-1)
+    cos_half = qw.clamp(-1.0, 1.0)
+    omega = 2.0 * torch.atan2(sin_half, cos_half)
+
+    small = sin_half < _SMALL_OMEGA
+    safe_sin_half = torch.where(small, torch.ones_like(sin_half), sin_half)
+    unit_axis = quat_vec / safe_sin_half.unsqueeze(-1)
+    # Near zero rotation the axis is ill-defined; there the tangent vector
+    # is approximately 2 * (qx, qy, qz).
+    return torch.where(small.unsqueeze(-1), 2.0 * quat_vec,
+                       omega.unsqueeze(-1) * unit_axis)

--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -1,11 +1,29 @@
 """SE(3) rigid-frame math utilities for RFDiffusion.
 
-This module contains the non-learned geometric primitives used by the
-RFDiffusion stack:
+RFDiffusion represents each residue as a rigid frame: a rotation matrix
+plus a translation, the same `(R, t)` convention AlphaFold2's structure
+module uses. `build_backbone_frames` builds one such frame per residue
+from its `(N, CA, C)` backbone atoms, and the rest of the module is the
+algebra needed to work with those frames:
 
-* residue-local frame construction from backbone atoms `(N, CA, C)`
-* rigid transform apply / inverse / invert / compose helpers
-* Rodrigues exp/log maps between so(3) vectors and SO(3) rotations
+* apply / inverse-apply / invert / compose helpers for moving points and
+  frames between global and residue-local coordinates
+* Rodrigues exp/log maps between so(3) tangent vectors and SO(3) rotations
+
+Downstream, the frames from `build_backbone_frames` feed the invariant
+point attention (IPA) block, and `so3_exp_map`/`so3_log_map` are what let
+the rotational diffusion process update and read back a residue's
+orientation at each denoising step.
+
+DeepChem's `equivariance_utils.py` already has SO(3)/SE(3) exp and log
+maps, but through a `LieGroup` class built for a different representation
+(homogeneous matrices and 6D Lie algebra vectors, used by the LieConv/TFN
+layers). Converting between that and the `(R, t)` frames used here on
+every call would add overhead without simplifying anything, so this
+module keeps its own copies tailored to the frame representation. The log
+map here also goes through a quaternion rather than the matrix trace,
+which stays accurate for rotations near pi where the trace-based form
+loses precision.
 
 The module is intentionally self-contained and depends only on PyTorch.
 """
@@ -42,6 +60,7 @@ def _normalize(vector: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import _normalize
     >>> v = torch.tensor([[3.0, 0.0, 0.0], [0.0, 4.0, 0.0]])
     >>> _normalize(v)
     tensor([[1., 0., 0.],
@@ -86,6 +105,7 @@ def build_backbone_frames(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import build_backbone_frames
     >>> n = torch.tensor([0.0, 1.0, 0.0])
     >>> ca = torch.tensor([0.0, 0.0, 0.0])
     >>> c = torch.tensor([1.0, 0.0, 0.0])
@@ -142,6 +162,7 @@ def make_identity_rigid(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
     >>> R, t = make_identity_rigid((2, 4))
     >>> R.shape
     torch.Size([2, 4, 3, 3])
@@ -175,6 +196,19 @@ def _expand_rigid_to_points(
         Rotations with unsqueezed singleton dimensions matching points.
     expanded_translations : torch.Tensor
         Translations with unsqueezed singleton dimensions matching points.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     make_identity_rigid, _expand_rigid_to_points)
+    >>> R, t = make_identity_rigid((2,))
+    >>> points = torch.randn(2, 5, 3)  # 5 atoms per residue
+    >>> R_exp, t_exp = _expand_rigid_to_points(R, t, points)
+    >>> R_exp.shape
+    torch.Size([2, 1, 3, 3])
+    >>> t_exp.shape
+    torch.Size([2, 1, 3])
     """
     extra_dims = points.dim() - translations.dim()
     if extra_dims < 0:
@@ -209,6 +243,8 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     apply_rigid, make_identity_rigid)
     >>> R, t = make_identity_rigid((2,))
     >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     >>> out = apply_rigid(R, t, pts)
@@ -245,6 +281,8 @@ def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     apply_inverse_rigid, make_identity_rigid)
     >>> R, t = make_identity_rigid((2,))
     >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     >>> out = apply_inverse_rigid(R, t, pts)
@@ -279,6 +317,7 @@ def invert_rigid(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import invert_rigid
     >>> R = torch.eye(3)
     >>> t = torch.tensor([1.0, 2.0, 3.0])
     >>> inv_R, inv_t = invert_rigid(R, t)
@@ -314,6 +353,8 @@ def compose_rigids(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     compose_rigids, make_identity_rigid)
     >>> R1, t1 = make_identity_rigid(())
     >>> R2, t2 = make_identity_rigid(())
     >>> R_comp, t_comp = compose_rigids(R1, t1, R2, t2)
@@ -326,14 +367,42 @@ def compose_rigids(
 
 
 def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
-    """Return `sin(x) / x` with a stable Taylor branch near zero."""
+    """Return `sin(x) / x` with a stable Taylor branch near zero.
+
+    Used by `so3_exp_map` as the coefficient on the skew-symmetric term of
+    Rodrigues' formula, where `x` is the rotation angle `omega`.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor, typically a batch of rotation angles.
+
+    Returns
+    -------
+    torch.Tensor
+        Elementwise `sin(x) / x`, same shape as `x`.
+    """
     small = x.abs() < _SMALL_OMEGA
     safe_x = torch.where(small, torch.ones_like(x), x)
     return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
 
 
 def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
-    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch."""
+    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch.
+
+    Used by `so3_exp_map` as the coefficient on the squared skew-symmetric
+    term of Rodrigues' formula, where `x` is the rotation angle `omega`.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor, typically a batch of rotation angles.
+
+    Returns
+    -------
+    torch.Tensor
+        Elementwise `(1 - cos(x)) / x^2`, same shape as `x`.
+    """
     small = x.abs() < _SMALL_OMEGA
     safe_x = torch.where(small, torch.ones_like(x), x)
     closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)

--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -17,34 +17,35 @@ try:
 except ModuleNotFoundError:
     raise ImportError("rfdiffusion_frames requires PyTorch to be installed.")
 
-__all__ = [
-    "apply_inverse_rigid",
-    "apply_rigid",
-    "build_backbone_frames",
-    "compose_rigids",
-    "invert_rigid",
-    "make_identity_rigid",
-    "so3_exp_map",
-    "so3_log_map",
-]
-
+# Threshold for small-angle Taylor expansions.
+# For rotation angles theta < 1e-4, sin(theta)/theta ~ 1 - theta^2/6 and
+# (1 - cos(theta))/theta^2 ~ 1/2 - theta^2/24. This avoids division-by-zero
+# and float32 precision loss near the identity (Grassia, 1998).
 _SMALL_OMEGA: float = 1e-4
 
 
-def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
-    """Normalize vectors with epsilon stabilization.
+def _normalize(vector: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Normalize 3D vectors along the last dimension with epsilon stabilization.
 
     Parameters
     ----------
     vector : torch.Tensor
         Tensor of shape `(..., 3)`.
-    eps : float
-        Positive epsilon added to the norm.
+    eps : float, default 1e-8
+        Small positive constant added to the norm denominator.
 
     Returns
     -------
     torch.Tensor
-        Normalized vectors.
+        Normalized vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> v = torch.tensor([[3.0, 0.0, 0.0], [0.0, 4.0, 0.0]])
+    >>> _normalize(v)
+    tensor([[1., 0., 0.],
+            [0., 1., 0.]])
     """
     norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
     return vector / (norm + eps)
@@ -53,22 +54,47 @@ def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
 def build_backbone_frames(
         backbone: torch.Tensor,
         eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Build residue-local frames from `(N, CA, C)` backbone coordinates.
+    """Construct residue-local coordinate frames from protein backbone coordinates.
+
+    Builds an orthonormal right-handed reference frame for each residue
+    from N, CA, and C atom positions using Gram-Schmidt orthogonalization:
+    - The x-axis points along the CA -> C bond.
+    - The xy-plane contains the N, CA, and C atoms (with N in the positive y-half).
+    - The z-axis is the cross product x x y.
+    - The frame origin is positioned at the CA atom.
 
     Parameters
     ----------
     backbone : torch.Tensor
-        Backbone coordinates of shape `(..., 3, 3)` ordered as
-        `(N, CA, C)`.
+        Backbone coordinates of shape `(..., 3, 3)` ordered as `(N, CA, C)`
+        along the second-to-last dimension.
     eps : float, default 1e-8
-        Positive stabilization constant.
+        Small positive constant to avoid division by zero during normalization.
 
     Returns
     -------
     rotations : torch.Tensor
-        Rotation matrices of shape `(..., 3, 3)`.
+        Rotation matrices of shape `(..., 3, 3)` representing local frame orientations.
     translations : torch.Tensor
-        Frame origins of shape `(..., 3)`.
+        Frame origins of shape `(..., 3)` corresponding to CA coordinates.
+
+    Raises
+    ------
+    ValueError
+        If backbone does not have shape `(..., 3, 3)` or `eps <= 0`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> n = torch.tensor([0.0, 1.0, 0.0])
+    >>> ca = torch.tensor([0.0, 0.0, 0.0])
+    >>> c = torch.tensor([1.0, 0.0, 0.0])
+    >>> backbone = torch.stack([n, ca, c], dim=0)
+    >>> R, t = build_backbone_frames(backbone)
+    >>> R.shape
+    torch.Size([3, 3])
+    >>> t.shape
+    torch.Size([3])
     """
     if backbone.shape[-2:] != (3, 3):
         raise ValueError("backbone must have shape (..., 3, 3).")
@@ -95,23 +121,32 @@ def make_identity_rigid(
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Create identity rigid transforms `(I, 0)`.
+    """Create identity rigid transforms (identity rotation and zero translation).
 
     Parameters
     ----------
     shape : sequence of int
-        Batch shape.
+        Batch shape for the generated transforms.
     device : torch.device, optional
-        Device for returned tensors.
+        Target device for the returned tensors.
     dtype : torch.dtype, optional
-        Tensor dtype.
+        Target data type for the returned tensors.
 
     Returns
     -------
     rotations : torch.Tensor
-        Identity rotations of shape `(*shape, 3, 3)`.
+        Identity rotation matrices of shape `(*shape, 3, 3)`.
     translations : torch.Tensor
-        Zero translations of shape `(*shape, 3)`.
+        Zero translation vectors of shape `(*shape, 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2, 4))
+    >>> R.shape
+    torch.Size([2, 4, 3, 3])
+    >>> t.shape
+    torch.Size([2, 4, 3])
     """
     shape = tuple(shape)
     rotation = torch.eye(3, device=device, dtype=dtype)
@@ -123,7 +158,24 @@ def make_identity_rigid(
 def _expand_rigid_to_points(
         rotations: torch.Tensor, translations: torch.Tensor,
         points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Broadcast rigid transforms across extra point dimensions."""
+    """Broadcast rigid transform batch dimensions across extra point dimensions.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points tensor of shape `(..., *extra_dims, 3)`.
+
+    Returns
+    -------
+    expanded_rotations : torch.Tensor
+        Rotations with unsqueezed singleton dimensions matching points.
+    expanded_translations : torch.Tensor
+        Translations with unsqueezed singleton dimensions matching points.
+    """
     extra_dims = points.dim() - translations.dim()
     if extra_dims < 0:
         raise ValueError(
@@ -136,7 +188,9 @@ def _expand_rigid_to_points(
 
 def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
                 points: torch.Tensor) -> torch.Tensor:
-    """Apply rigid transforms `x -> x @ R.T + t`.
+    """Apply rigid transforms to 3D points: `y = points @ R.T + t`.
+
+    Transforms points from local coordinates to global coordinates.
 
     Parameters
     ----------
@@ -145,12 +199,21 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     translations : torch.Tensor
         Translation vectors of shape `(..., 3)`.
     points : torch.Tensor
-        Points of shape `(..., 3)` or with extra point axes.
+        Points tensor of shape `(..., 3)` or with extra point axes.
 
     Returns
     -------
     torch.Tensor
-        Transformed points.
+        Transformed points of the same shape as `points`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2,))
+    >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> out = apply_rigid(R, t, pts)
+    >>> torch.allclose(out, pts)
+    True
     """
     rotations, translations = _expand_rigid_to_points(rotations, translations,
                                                       points)
@@ -161,7 +224,33 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
 
 def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
                         points: torch.Tensor) -> torch.Tensor:
-    """Apply inverse rigid transforms `y -> (y - t) @ R`."""
+    """Apply inverse rigid transforms to 3D points: `x = (points - t) @ R`.
+
+    Transforms points from global coordinates back to local residue coordinates.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points tensor of shape `(..., 3)` or with extra point axes.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points of the same shape as `points`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2,))
+    >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> out = apply_inverse_rigid(R, t, pts)
+    >>> torch.allclose(out, pts)
+    True
+    """
     rotations, translations = _expand_rigid_to_points(rotations, translations,
                                                       points)
     centered = points - translations
@@ -171,7 +260,7 @@ def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
 def invert_rigid(
         rotations: torch.Tensor,
         translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Invert rigid transforms.
+    """Compute the inverse of rigid transforms `(R, t)^(-1) = (R.T, -t @ R)`.
 
     Parameters
     ----------
@@ -183,9 +272,18 @@ def invert_rigid(
     Returns
     -------
     inv_rotations : torch.Tensor
-        Transposed rotations.
+        Inverted rotation matrices of shape `(..., 3, 3)`.
     inv_translations : torch.Tensor
-        Inverse translations.
+        Inverted translation vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R = torch.eye(3)
+    >>> t = torch.tensor([1.0, 2.0, 3.0])
+    >>> inv_R, inv_t = invert_rigid(R, t)
+    >>> inv_t
+    tensor([-1., -2., -3.])
     """
     inv_rotations = rotations.transpose(-1, -2)
     inv_translations = -torch.matmul(translations.unsqueeze(-2),
@@ -197,7 +295,7 @@ def compose_rigids(
         rotations_a: torch.Tensor, translations_a: torch.Tensor,
         rotations_b: torch.Tensor,
         translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Compose two rigid transforms `T_a o T_b`.
+    """Compose two rigid transforms `T_a o T_b = (R_a @ R_b, apply_rigid(T_a, t_b))`.
 
     Parameters
     ----------
@@ -209,9 +307,18 @@ def compose_rigids(
     Returns
     -------
     rotations : torch.Tensor
-        Composite rotations.
+        Composed rotation matrices of shape `(..., 3, 3)`.
     translations : torch.Tensor
-        Composite translations.
+        Composed translation vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R1, t1 = make_identity_rigid(())
+    >>> R2, t2 = make_identity_rigid(())
+    >>> R_comp, t_comp = compose_rigids(R1, t1, R2, t2)
+    >>> R_comp.shape
+    torch.Size([3, 3])
     """
     rotations = torch.matmul(rotations_a, rotations_b)
     translations = apply_rigid(rotations_a, translations_a, translations_b)
@@ -235,17 +342,26 @@ def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
 
 
 def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
-    """Map tangent vectors in so(3) to rotation matrices.
+    """Map so(3) tangent vectors (axis-angle) to SO(3) rotation matrices via Rodrigues' formula.
 
     Parameters
     ----------
     tangent : torch.Tensor
-        Tangent vectors of shape `(..., 3)`.
+        Tangent vectors of shape `(..., 3)` where direction specifies the
+        rotation axis and norm specifies the rotation angle in radians.
 
     Returns
     -------
     torch.Tensor
         Rotation matrices of shape `(..., 3, 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> w = torch.zeros(3)
+    >>> R = so3_exp_map(w)
+    >>> torch.allclose(R, torch.eye(3))
+    True
     """
     omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)
     zeros = torch.zeros_like(tangent[..., 0])
@@ -264,12 +380,12 @@ def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
 
 
 def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
-    """Map rotation matrices to tangent vectors on the principal branch.
+    """Map SO(3) rotation matrices to so(3) tangent vectors on the principal branch.
 
-    The rotation is converted to a unit quaternion first and then to an
+    The rotation matrix is converted to a unit quaternion first and then to an
     axis-angle vector. Routing through the quaternion keeps the result stable
-    for rotations near ``pi``, where reading the angle straight from the trace
-    loses accuracy because ``sin(omega)`` goes to zero.
+    for rotations near pi, where reading the angle from the matrix trace
+    loses accuracy because sin(omega) goes to zero.
 
     Parameters
     ----------
@@ -279,7 +395,15 @@ def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
     Returns
     -------
     torch.Tensor
-        Tangent vectors of shape `(..., 3)` whose norm lies in ``[0, pi]``.
+        Tangent vectors of shape `(..., 3)` whose norm lies in `[0, pi]`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R = torch.eye(3)
+    >>> w = so3_log_map(R)
+    >>> torch.allclose(w, torch.zeros(3))
+    True
     """
     m00 = rotations[..., 0, 0]
     m11 = rotations[..., 1, 1]

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
@@ -1,0 +1,269 @@
+"""Tests for RFDiffusion rigid-frame math utilities."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        apply_inverse_rigid,
+        apply_rigid,
+        build_backbone_frames,
+        compose_rigids,
+        invert_rigid,
+        make_identity_rigid,
+        so3_exp_map,
+        so3_log_map,
+    )
+
+
+def _random_rotation(device=None, dtype=torch.float32, generator=None):
+    matrix = torch.randn(3, 3, device=device, dtype=dtype, generator=generator)
+    q_matrix, r_matrix = torch.linalg.qr(matrix)
+    signs = torch.sign(torch.diagonal(r_matrix))
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    q_matrix = q_matrix @ torch.diag(signs)
+    if torch.det(q_matrix) < 0:
+        q_matrix[:, -1] = -q_matrix[:, -1]
+    return q_matrix
+
+
+def _make_backbone(batch_size=2, seq_len=5, dtype=torch.float32, seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    base = torch.tensor([[-1.2, 1.1, 0.0], [0.0, 0.0, 0.0], [1.5, 0.0, 0.0]],
+                        dtype=dtype)
+    offsets = torch.randn(batch_size,
+                          seq_len,
+                          1,
+                          3,
+                          dtype=dtype,
+                          generator=generator)
+    return base.view(1, 1, 3, 3) + offsets
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestRigidFrameUtilities:
+
+    def test_frames_are_orthonormal_and_right_handed(self):
+        backbone = _make_backbone(batch_size=3, seq_len=7)
+        rotations, translations = build_backbone_frames(backbone)
+        assert rotations.shape == (3, 7, 3, 3)
+        assert translations.shape == (3, 7, 3)
+        gram = rotations.transpose(-1, -2) @ rotations
+        identity = torch.eye(3).expand_as(gram)
+        assert torch.allclose(gram, identity, atol=1e-5)
+        det = torch.det(rotations)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+
+    def test_translation_is_alpha_carbon(self):
+        backbone = _make_backbone()
+        _, translations = build_backbone_frames(backbone)
+        assert torch.allclose(translations, backbone[..., 1, :], atol=0.0)
+
+    def test_frames_match_canonical_residue(self):
+        backbone = torch.tensor([[[-1.0, 1.0, 0.0], [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        rotations, translations = build_backbone_frames(backbone)
+        assert torch.allclose(rotations, torch.eye(3).unsqueeze(0), atol=1e-6)
+        assert torch.allclose(translations, torch.zeros(1, 3), atol=0.0)
+
+    def test_frames_match_upstream_epsilon_normalization(self):
+        backbone = torch.tensor(
+            [[[[-1.1, 0.9, 0.2], [0.2, -0.3, 0.4], [1.4, 0.1, -0.2]]]],
+            dtype=torch.float64)
+        rotations, translations = build_backbone_frames(backbone, eps=1e-8)
+        n_atom = backbone[..., 0, :]
+        ca_atom = backbone[..., 1, :]
+        c_atom = backbone[..., 2, :]
+        e1 = c_atom - ca_atom
+        e1 = e1 / (torch.linalg.norm(e1, dim=-1, keepdim=True) + 1e-8)
+        v2 = n_atom - ca_atom
+        u2 = v2 - (e1 * v2).sum(dim=-1, keepdim=True) * e1
+        e2 = u2 / (torch.linalg.norm(u2, dim=-1, keepdim=True) + 1e-8)
+        e3 = torch.cross(e1, e2, dim=-1)
+        expected = torch.stack([e1, e2, e3], dim=-1)
+        assert torch.allclose(rotations, expected, atol=0.0, rtol=0.0)
+        assert torch.allclose(translations, ca_atom, atol=0.0, rtol=0.0)
+
+    def test_frames_handle_small_n_ca_c_angle(self):
+        backbone = torch.tensor([[[1.0, 1e-3, 0.0], [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        rotations, _ = build_backbone_frames(backbone)
+        gram = rotations.transpose(-1, -2) @ rotations
+        assert torch.isfinite(rotations).all()
+        assert torch.allclose(gram, torch.eye(3).unsqueeze(0), atol=3e-5)
+
+    def test_frames_se3_equivariance(self):
+        backbone = _make_backbone(seed=11)
+        rotations, translations = build_backbone_frames(backbone)
+        global_rotation = _random_rotation()
+        global_translation = torch.randn(3)
+        moved = apply_rigid(global_rotation, global_translation, backbone)
+        rotations_moved, translations_moved = build_backbone_frames(moved)
+        assert torch.allclose(rotations_moved,
+                              global_rotation @ rotations,
+                              atol=1e-5)
+        expected_t = apply_rigid(global_rotation, global_translation,
+                                 translations)
+        assert torch.allclose(translations_moved, expected_t, atol=1e-5)
+
+    def test_frames_raise_on_bad_shape(self):
+        with pytest.raises(ValueError, match=r"\(\.\.\., 3, 3\)"):
+            build_backbone_frames(torch.zeros(2, 5, 3))
+
+    def test_frames_raise_on_nonpositive_eps(self):
+        backbone = _make_backbone()
+        with pytest.raises(ValueError, match="eps"):
+            build_backbone_frames(backbone, eps=0.0)
+
+    def test_make_identity_rigid_shape_and_values(self):
+        rotations, translations = make_identity_rigid((4, 3))
+        assert rotations.shape == (4, 3, 3, 3)
+        assert translations.shape == (4, 3, 3)
+        identity = torch.eye(3).expand_as(rotations)
+        assert torch.equal(rotations, identity)
+        assert torch.equal(translations, torch.zeros_like(translations))
+
+    def test_make_identity_rigid_returns_writable_tensor(self):
+        rotations, _ = make_identity_rigid((4, 3))
+        rotations[0, 0, 0, 0] = 99.0
+        assert rotations[0, 0, 0, 0].item() == 99.0
+        assert rotations[0, 1, 0, 0].item() == 1.0
+
+    def test_apply_rigid_inverse_roundtrip(self):
+        backbone = _make_backbone()
+        rotations, translations = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(rotations, translations, backbone)
+        recovered = apply_rigid(rotations, translations, local)
+        assert torch.allclose(recovered, backbone, atol=1e-5)
+
+    def test_apply_rigid_broadcasts_over_extra_dims(self):
+        rotations, translations = make_identity_rigid((2, 3))
+        rotations = rotations.clone()
+        for batch_idx in range(2):
+            for seq_idx in range(3):
+                rotations[batch_idx, seq_idx] = _random_rotation()
+        translations = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 4, 5, 3)
+        moved = apply_rigid(rotations, translations, points)
+        expected = torch.einsum("blij,blkmj->blkmi", rotations, points)
+        expected = expected + translations.view(2, 3, 1, 1, 3)
+        assert moved.shape == points.shape
+        assert torch.allclose(moved, expected, atol=1e-5)
+
+    def test_apply_rigid_translation_only(self):
+        rotations, _ = make_identity_rigid((2, 5))
+        translations = torch.randn(2, 5, 3)
+        points = torch.randn(2, 5, 3)
+        assert torch.allclose(apply_rigid(rotations, translations, points),
+                              points + translations,
+                              atol=1e-6)
+
+    def test_apply_rigid_raises_on_too_few_point_dims(self):
+        rotations, translations = make_identity_rigid((2, 3))
+        bad = torch.randn(3)
+        with pytest.raises(ValueError, match="at least"):
+            apply_rigid(rotations, translations, bad)
+
+    def test_invert_rigid_is_left_and_right_inverse(self):
+        backbone = _make_backbone()
+        rotations, translations = build_backbone_frames(backbone)
+        inv_rotations, inv_translations = invert_rigid(rotations, translations)
+        left_r, left_t = compose_rigids(inv_rotations, inv_translations,
+                                        rotations, translations)
+        right_r, right_t = compose_rigids(rotations, translations,
+                                          inv_rotations, inv_translations)
+        assert torch.allclose(left_r, torch.eye(3).expand_as(left_r), atol=1e-5)
+        assert torch.allclose(left_t, torch.zeros_like(left_t), atol=1e-5)
+        assert torch.allclose(right_r,
+                              torch.eye(3).expand_as(right_r),
+                              atol=1e-5)
+        assert torch.allclose(right_t, torch.zeros_like(right_t), atol=1e-5)
+
+    def test_compose_matches_sequential_application(self):
+        rotations_a = torch.stack([_random_rotation() for _ in range(6)])
+        rotations_a = rotations_a.view(2, 3, 3, 3)
+        rotations_b = torch.stack([_random_rotation() for _ in range(6)])
+        rotations_b = rotations_b.view(2, 3, 3, 3)
+        translations_a = torch.randn(2, 3, 3)
+        translations_b = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 7, 3)
+
+        sequential = apply_rigid(
+            rotations_a, translations_a,
+            apply_rigid(rotations_b, translations_b, points))
+        rotations, translations = compose_rigids(rotations_a, translations_a,
+                                                 rotations_b, translations_b)
+        composed = apply_rigid(rotations, translations, points)
+        assert torch.allclose(composed, sequential, atol=1e-5)
+
+    def test_compose_is_associative(self):
+        rotations = [_random_rotation() for _ in range(3)]
+        translations = [torch.randn(3) for _ in range(3)]
+        rotation_a, rotation_b, rotation_c = rotations
+        translation_a, translation_b, translation_c = translations
+        left_r, left_t = compose_rigids(
+            *compose_rigids(rotation_a, translation_a, rotation_b,
+                            translation_b), rotation_c, translation_c)
+        right_r, right_t = compose_rigids(
+            rotation_a, translation_a,
+            *compose_rigids(rotation_b, translation_b, rotation_c,
+                            translation_c))
+        assert torch.allclose(left_r, right_r, atol=1e-5)
+        assert torch.allclose(left_t, right_t, atol=1e-5)
+
+    def test_apply_rigid_supports_fp64_precision(self):
+        backbone = _make_backbone(dtype=torch.float64, seed=3)
+        rotations, translations = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(rotations, translations, backbone)
+        recovered = apply_rigid(rotations, translations, local)
+        assert torch.allclose(recovered, backbone, atol=1e-12)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3Maps:
+
+    def test_exp_returns_proper_rotation(self):
+        torch.manual_seed(0)
+        tangent = torch.randn(32, 3) * 0.5
+        rotations = so3_exp_map(tangent)
+        det = torch.det(rotations)
+        ortho_err = (rotations @ rotations.transpose(-1, -2) -
+                     torch.eye(3)).abs().max()
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+        assert ortho_err < 1e-5
+
+    def test_exp_zero_tangent_gives_identity(self):
+        rotations = so3_exp_map(torch.zeros(4, 3))
+        identity = torch.eye(3).expand(4, 3, 3)
+        assert torch.allclose(rotations, identity, atol=1e-7)
+
+    def test_log_exp_roundtrip_principal_branch(self):
+        torch.manual_seed(1)
+        axis = torch.randn(50, 3)
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        omega = torch.rand(50) * (math.pi - 1e-3) + 1e-4
+        tangent = omega.unsqueeze(-1) * axis
+        recovered = so3_log_map(so3_exp_map(tangent))
+        assert (tangent - recovered).norm(dim=-1).max() < 1e-3
+
+    def test_log_map_stable_near_pi(self):
+        axis = torch.tensor([[0.6, -0.2, 0.7745967]])
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        tangent = (math.pi - 1e-4) * axis
+        recovered = so3_log_map(so3_exp_map(tangent))
+        assert torch.allclose(recovered, tangent, atol=1e-3)
+
+    def test_small_omega_taylor_branch(self):
+        tangent = torch.tensor([[1e-7, 0.0, 0.0], [0.0, 1e-7, 0.0]])
+        rotations = so3_exp_map(tangent)
+        identity = torch.eye(3).expand_as(rotations)
+        assert (rotations - identity).abs().max() < 1e-6


### PR DESCRIPTION
## Description

Fix #4747

This PR adds the SE(3) frame math needed by the later RFDiffusion pieces. It keeps the scope small: just the rigid-frame utilities, Rodrigues SO(3) exp/log helpers, and focused tests for the frame operations.

The new code lives in `deepchem/models/torch_models/rfdiffusion_frames.py` and adds:

- `build_backbone_frames`
- `make_identity_rigid`
- `apply_rigid`
- `apply_inverse_rigid`
- `invert_rigid`
- `compose_rigids`
- `so3_exp_map`
- `so3_log_map`

This PR does not add the IPA block yet. That is planned for the next PR so this one stays easy to review.

Validation run locally:

```bash
python -m flake8 --max-line-length=100 deepchem/models/torch_models/rfdiffusion_frames.py deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
python -m pytest deepchem/models/torch_models/tests/test_rfdiffusion_frames.py -q
# 23 passed
```

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
