### PR TITLE
[WIP] RFDiffusion: IPA and Multi-Track Foundation

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion_se3.py
+++ b/deepchem/models/torch_models/rfdiffusion_se3.py
@@ -1,0 +1,702 @@
+"""SE(3) rigid-frame utilities and Invariant Point Attention.
+
+This module provides the geometric primitives used by the SE(3)-aware
+RFDiffusion denoiser. Two groups of objects are exposed:
+
+* Rigid-frame utilities — :func:`build_backbone_frames`,
+  :func:`apply_rigid`, :func:`apply_inverse_rigid`, :func:`invert_rigid`,
+  :func:`compose_rigids`, and :func:`make_identity_rigid`. They use the
+  row-vector convention: a rigid transform ``T = (R, t)`` maps a point
+  ``x ∈ ℝ³`` to ``x @ R.T + t``. Rotation matrices are right-handed
+  (``det(R) = +1``), and frames are constructed from N / Cα / C backbone
+  atoms following AlphaFold2 supplementary Algorithm 21 (Jumper et al.,
+  Nature 596, 583–589, 2021).
+
+* :class:`InvariantPointAttention` — the three-term Invariant Point
+  Attention layer from AlphaFold2 supplementary Algorithm 22 (Jumper et
+  al., 2021). The scalar output is SE(3)-invariant: every term that
+  depends on residue frames goes through point distances or a
+  frame-local round-trip, so a global rigid transform of the input
+  frames leaves the output unchanged.
+
+Developer-facing summary
+------------------------
+If another module needs residue geometry, call
+``build_backbone_frames(backbone)`` and use the returned
+``(rotations, translations)`` pair as the per-residue frame state.
+If another module needs the SE(3)-aware attention block, call
+``InvariantPointAttention(single_repr, rotations, translations,
+pair_repr=None, mask=None)`` and it will return updated single-residue
+features of the same shape as ``single_repr``.
+
+Only PyTorch is required — no external geometry library.
+
+References
+----------
+.. [Jumper2021] Jumper, J. et al. *Highly accurate protein structure
+   prediction with AlphaFold.* Nature 596, 583–589 (2021).
+   doi:10.1038/s41586-021-03819-2.
+.. [Watson2023] Watson, J. L. et al. *De novo design of protein structure
+   and function with RFdiffusion.* Nature 620, 1089–1100 (2023).
+   doi:10.1038/s41586-023-06415-8.
+.. [Yim2023] Yim, J. et al. *SE(3) diffusion model with application to
+   protein backbone generation.* Proceedings of the 40th International
+   Conference on Machine Learning, PMLR 202 (2023).
+"""
+
+import math
+from typing import Optional, Sequence, Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError('These classes require PyTorch to be installed.')
+
+
+# ---------------------------------------------------------------------------
+# Rigid-frame utilities
+# ---------------------------------------------------------------------------
+
+
+def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
+    """ε-stabilized vector normalization along the last dimension.
+
+    Parameters
+    ----------
+    vector : torch.Tensor
+        Tensor of shape ``(..., 3)``.
+    eps : float
+        Lower bound on the norm; vectors with norm below ``ε`` are scaled
+        as if their norm were ``ε``.
+
+    Returns
+    -------
+    torch.Tensor
+        Vector divided by ``max(‖v‖, ε)``.
+    """
+    norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
+    return vector / (norm + eps)
+
+
+def build_backbone_frames(
+        backbone: torch.Tensor,
+        eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Construct residue-local frames from N, Cα, C backbone coordinates.
+
+    Implements AlphaFold2 supplementary Algorithm 21
+    (``rigidFrom3Points``). Given backbone atoms ``(N, Cα, C)`` per
+    residue, the local frame has its origin at ``Cα`` and orthonormal
+    axes ``(ê₁, ê₂, ê₃)`` obtained by Gram–Schmidt orthogonalization with
+    an ε-stabilized normalization to guard against numerically degenerate
+    configurations:
+
+    .. math::
+
+        \\hat e_1 &= (C - C_\\alpha) / \\| C - C_\\alpha \\|, \\\\
+        u_2      &= (N - C_\\alpha)
+                    - \\hat e_1 \\big( \\hat e_1 \\cdot (N - C_\\alpha) \\big),
+                    \\\\
+        \\hat e_2 &= u_2 / \\| u_2 \\|, \\\\
+        \\hat e_3 &= \\hat e_1 \\times \\hat e_2.
+
+    The returned rotation has the orthonormal axes as its **columns**,
+    so a point ``x_{local}`` in the residue frame maps to
+    ``x_{global} = x_{local} @ R.T + t`` (row-vector convention).
+
+    Parameters
+    ----------
+    backbone : torch.Tensor
+        Backbone coordinates of shape ``(..., 3, 3)`` with atoms ordered
+        as ``(N, Cα, C)`` along the second-to-last dimension.
+    eps : float, default 1e-8
+        ε-stabilization threshold for normalization. Must be positive.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)`` with
+        ``det(R) = +1`` and ``Rᵀ R = I`` to within ``O(ε)``.
+    translations : torch.Tensor
+        Frame origins (Cα coordinates) of shape ``(..., 3)``.
+
+    Raises
+    ------
+    ValueError
+        If ``backbone`` does not have shape ``(..., 3, 3)`` or if
+        ``eps`` is non-positive.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_se3 import (
+    ...     build_backbone_frames)
+    >>> backbone = torch.tensor([[[-1.2, 1.1, 0.0],
+    ...                           [0.0, 0.0, 0.0],
+    ...                           [1.5, 0.0, 0.0]]])
+    >>> R, t = build_backbone_frames(backbone)
+    >>> tuple(R.shape), tuple(t.shape)
+    ((1, 3, 3), (1, 3))
+    >>> bool(torch.allclose(R.transpose(-1, -2) @ R, torch.eye(3),
+    ...                     atol=1e-6))
+    True
+
+    References
+    ----------
+    .. [1] Jumper, J. et al. *Highly accurate protein structure
+       prediction with AlphaFold.* Nature 596, 583–589 (2021).
+    """
+    if backbone.shape[-2:] != (3, 3):
+        raise ValueError('backbone must have shape (..., 3, 3).')
+    if eps <= 0:
+        raise ValueError('eps must be positive.')
+
+    n_atom = backbone[..., 0, :]
+    ca_atom = backbone[..., 1, :]
+    c_atom = backbone[..., 2, :]
+
+    x_axis = _normalize(c_atom - ca_atom, eps)
+    n_direction = n_atom - ca_atom
+    y_axis = n_direction - (n_direction * x_axis).sum(dim=-1,
+                                                      keepdim=True) * x_axis
+    y_axis = _normalize(y_axis, eps)
+    z_axis = torch.linalg.cross(x_axis, y_axis, dim=-1)
+
+    rotations = torch.stack((x_axis, y_axis, z_axis), dim=-1)
+    return rotations, ca_atom
+
+
+def make_identity_rigid(
+        shape: Sequence[int],
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create identity rigid transforms ``(I₃, 0)`` with a given batch shape.
+
+    Parameters
+    ----------
+    shape : sequence of int
+        Batch shape ``(..., )`` for the transforms. May be empty for a
+        single frame.
+    device : torch.device, optional
+        Device for the returned tensors. Defaults to the current default
+        device.
+    dtype : torch.dtype, optional
+        Data type for the returned tensors. Defaults to
+        ``torch.get_default_dtype()``.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Identity rotations of shape ``(*shape, 3, 3)``. Always a freshly
+        allocated tensor, safe to mutate.
+    translations : torch.Tensor
+        Zero translations of shape ``(*shape, 3)``.
+    """
+    shape = tuple(shape)
+    rotation = torch.eye(3, device=device, dtype=dtype)
+    rotation = rotation.expand(*shape, 3, 3).contiguous().clone()
+    translation = torch.zeros(*shape, 3, device=device, dtype=dtype)
+    return rotation, translation
+
+
+def _expand_rigid_to_points(
+        rotations: torch.Tensor, translations: torch.Tensor,
+        points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Broadcast rigid transforms over leading point dimensions.
+
+    ``rotations`` has shape ``(..., 3, 3)`` and ``translations`` has shape
+    ``(..., 3)``; the function inserts singleton axes so they align with
+    ``points`` having shape ``(..., extra, 3)`` for arbitrarily many
+    ``extra`` axes.
+    """
+    extra_dims = points.dim() - translations.dim()
+    if extra_dims < 0:
+        raise ValueError(
+            'points must have at least the transform batch dimensions.')
+    for _ in range(extra_dims):
+        rotations = rotations.unsqueeze(-3)
+        translations = translations.unsqueeze(-2)
+    return rotations, translations
+
+
+def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                points: torch.Tensor) -> torch.Tensor:
+    """Apply rigid transforms ``T = (R, t)`` to points: ``x ↦ x Rᵀ + t``.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``. The axes of the
+        local frame are the **columns** of ``R``.
+    translations : torch.Tensor
+        Translation vectors of shape ``(..., 3)``.
+    points : torch.Tensor
+        Points of shape ``(..., 3)`` or ``(..., n_extra_dims, 3)``.
+        Broadcasting against the transform batch shape is automatic.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points, same shape as ``points``.
+    """
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    rotated = torch.matmul(points.unsqueeze(-2),
+                           rotations.transpose(-1, -2)).squeeze(-2)
+    return rotated + translations
+
+
+def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                        points: torch.Tensor) -> torch.Tensor:
+    """Apply the inverse rigid transform ``T⁻¹``: ``y ↦ (y − t) R``.
+
+    Equivalent to ``apply_rigid(*invert_rigid(R, t), y)`` but avoids
+    constructing the inverse explicitly. The composition with
+    :func:`apply_rigid` reproduces the identity to machine precision.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+    translations : torch.Tensor
+        Translation vectors of shape ``(..., 3)``.
+    points : torch.Tensor
+        Points of shape ``(..., 3)`` or ``(..., n_extra_dims, 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Points expressed in the local frame.
+    """
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    centered = points - translations
+    return torch.matmul(centered.unsqueeze(-2), rotations).squeeze(-2)
+
+
+def invert_rigid(
+        rotations: torch.Tensor,
+        translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Invert rigid transforms.
+
+    Given ``T = (R, t)`` returns ``T⁻¹ = (Rᵀ, −t R)`` so that
+    ``compose_rigids(T, T⁻¹)`` is the identity transform.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+    translations : torch.Tensor
+        Translation vectors of shape ``(..., 3)``.
+
+    Returns
+    -------
+    inv_rotations : torch.Tensor
+        ``Rᵀ`` of shape ``(..., 3, 3)``.
+    inv_translations : torch.Tensor
+        ``−t R`` of shape ``(..., 3)``.
+    """
+    inv_rotations = rotations.transpose(-1, -2)
+    inv_translations = -torch.matmul(translations.unsqueeze(-2),
+                                     rotations).squeeze(-2)
+    return inv_rotations, inv_translations
+
+
+def compose_rigids(
+        rotations_a: torch.Tensor, translations_a: torch.Tensor,
+        rotations_b: torch.Tensor,
+        translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compose two rigid transforms: ``T_a ∘ T_b``.
+
+    The returned transform first applies ``T_b`` and then ``T_a``:
+
+    .. math::
+
+        (T_a \\circ T_b)(x) = T_a(T_b(x))
+                            = (x R_b^\\top + t_b) R_a^\\top + t_a.
+
+    Parameters
+    ----------
+    rotations_a, rotations_b : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+    translations_a, translations_b : torch.Tensor
+        Translation vectors of shape ``(..., 3)``.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Composite rotation ``R_a R_b`` of shape ``(..., 3, 3)``.
+    translations : torch.Tensor
+        Composite translation ``t_b R_a^\\top + t_a`` of shape
+        ``(..., 3)``.
+    """
+    rotations = torch.matmul(rotations_a, rotations_b)
+    translations = apply_rigid(rotations_a, translations_a, translations_b)
+    return rotations, translations
+
+
+# ---------------------------------------------------------------------------
+# Invariant Point Attention
+# ---------------------------------------------------------------------------
+
+
+class InvariantPointAttention(nn.Module):
+    """Invariant Point Attention (AlphaFold2 supplementary Algorithm 22).
+
+    The layer mixes residue-level scalar features with point features
+    that live in residue-local frames. Its scalar output is invariant
+    under any global rigid transform of all input frames because every
+    frame-dependent quantity enters through (a) Euclidean distances
+    between points or (b) a round-trip ``T⁻¹ ∘ T`` that cancels the
+    global motion exactly.
+
+    The attention logit decomposes into three additive terms — scalar
+    QK, point-distance, and pair-bias — combined with the AlphaFold2
+    weighting:
+
+    .. math::
+
+        a_{ij}^{h} \\propto \\exp \\Big( w_L \\big[ s_{ij}^{h}
+        - \\tfrac{1}{2} w_C\\, \\gamma^{h}
+              \\sum_p \\| T_i \\hat q_{ip}^{h}
+                       - T_j \\hat k_{jp}^{h} \\|^2
+        + b_{ij}^{h} \\big] \\Big),
+
+    where
+
+    * :math:`s_{ij}^{h} = \\langle q_i^{h}, k_j^{h} \\rangle /
+      \\sqrt{c}` is the scaled dot-product of the scalar Q/K heads of
+      width :math:`c = embed\\_dim / num\\_heads`,
+    * :math:`\\hat q^{h}_{ip}, \\hat k^{h}_{jp} \\in \\mathbb{R}^{3}`
+      are :math:`p = 1, \\dots, N_{qk}` query/key points per head,
+      expressed in their residue's local frame and lifted to the
+      global frame by the rigid transform :math:`T_i`,
+    * :math:`\\gamma^{h} = \\mathrm{softplus}(\\hat\\gamma^{h})` is a
+      learnable, strictly positive per-head gating scalar,
+    * :math:`w_C = \\sqrt{2/(9 N_{qk})}` is the canonical point-term
+      normalization constant from Algorithm 22,
+    * :math:`b_{ij}^{h}` is a per-head bias linearly projected from the
+      pair representation :math:`z_{ij} \\in \\mathbb{R}^{c_z}` if a
+      ``pair_dim`` is supplied; the term is omitted otherwise,
+    * :math:`w_L = \\sqrt{1/L}` with :math:`L = 3` when the pair-bias
+      term is active and :math:`L = 2` otherwise — a standard variance
+      stabilization over the number of additive logit sources.
+
+    Each token receives the concatenation of (i) the scalar attention
+    output ``Σⱼ aᵢⱼ vⱼ``, (ii) optionally the pair output
+    ``Σⱼ aᵢⱼ zᵢⱼ`` (only when ``pair_dim`` is given), and (iii) the
+    value-point output mapped back into the residue's own local frame
+    together with its per-point Euclidean norm. The concatenation is
+    passed through a final linear layer back to ``embed_dim``.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Scalar input / output channel count. Must be a positive multiple
+        of ``num_heads``.
+    num_heads : int, default 8
+        Number of attention heads.
+    num_qk_points : int, default 4
+        Query/key points per head.
+    num_v_points : int, default 8
+        Value points per head.
+    pair_dim : int, optional
+        Width :math:`c_z` of an optional pair representation
+        ``z_{ij} ∈ ℝ^{c_z}``. When ``None`` (default) both the pair-bias
+        logit and the pair attention output are disabled.
+    dropout : float, default 0.0
+        Dropout applied to the attention weights.
+    eps : float, default 1e-8
+        ε-stabilization for the point-norm features so their gradient
+        stays finite at zero.
+
+    Raises
+    ------
+    ValueError
+        If ``embed_dim``, ``num_heads``, ``num_qk_points``, or
+        ``num_v_points`` is non-positive, if ``embed_dim`` is not a
+        multiple of ``num_heads``, or if ``dropout`` is outside
+        ``[0, 1)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_se3 import (
+    ...     InvariantPointAttention, build_backbone_frames)
+    >>> _ = torch.manual_seed(0)
+    >>> backbone = torch.randn(2, 5, 3, 3)
+    >>> R, t = build_backbone_frames(backbone)
+    >>> layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+    >>> out = layer(torch.randn(2, 5, 16), R, t)
+    >>> tuple(out.shape)
+    (2, 5, 16)
+
+    References
+    ----------
+    .. [1] Jumper, J. et al. *Highly accurate protein structure
+       prediction with AlphaFold.* Nature 596, 583–589 (2021).
+       Supplementary Algorithm 22.
+    .. [2] Watson, J. L. et al. *De novo design of protein structure
+       and function with RFdiffusion.* Nature 620, 1089–1100 (2023).
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 num_heads: int = 8,
+                 num_qk_points: int = 4,
+                 num_v_points: int = 8,
+                 pair_dim: Optional[int] = None,
+                 dropout: float = 0.0,
+                 eps: float = 1e-8) -> None:
+        super().__init__()
+        if embed_dim <= 0:
+            raise ValueError('embed_dim must be positive.')
+        if num_heads <= 0:
+            raise ValueError('num_heads must be positive.')
+        if embed_dim % num_heads != 0:
+            raise ValueError('embed_dim must be divisible by num_heads.')
+        if num_qk_points <= 0:
+            raise ValueError('num_qk_points must be positive.')
+        if num_v_points <= 0:
+            raise ValueError('num_v_points must be positive.')
+        if pair_dim is not None and pair_dim <= 0:
+            raise ValueError('pair_dim must be positive when provided.')
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError('dropout must lie in [0, 1).')
+        if eps <= 0:
+            raise ValueError('eps must be positive.')
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.num_qk_points = num_qk_points
+        self.num_v_points = num_v_points
+        self.pair_dim = pair_dim
+        self.eps = eps
+
+        # Scalar projections (per AF2 Algorithm 22 line 1).
+        self.query_scalar = nn.Linear(embed_dim, embed_dim)
+        self.key_scalar = nn.Linear(embed_dim, embed_dim)
+        self.value_scalar = nn.Linear(embed_dim, embed_dim)
+
+        # Point projections (per Algorithm 22 line 2).
+        self.query_points = nn.Linear(embed_dim, num_heads * num_qk_points * 3)
+        self.key_points = nn.Linear(embed_dim, num_heads * num_qk_points * 3)
+        self.value_points = nn.Linear(embed_dim, num_heads * num_v_points * 3)
+
+        # Pair-bias projection b_{ij}^h = z_{ij} W_b (per Algorithm 22 line 3).
+        if pair_dim is not None:
+            self.pair_bias = nn.Linear(pair_dim, num_heads, bias=False)
+        else:
+            self.pair_bias = None
+
+        # Per-head softplus-gated scalar γ^h. Initialised so that
+        # softplus(γ̂) ≈ ln 2, which mirrors the AF2 reference init.
+        self.point_weights = nn.Parameter(
+            torch.full((num_heads,), math.log(math.exp(1.0) - 1.0)))
+
+        # Output projection: scalar concat + (pair concat if any) + point
+        # vectors + point norms.
+        point_features = num_heads * num_v_points * (3 + 1)
+        pair_features = num_heads * pair_dim if pair_dim is not None else 0
+        self.output = nn.Linear(embed_dim + pair_features + point_features,
+                                embed_dim)
+        self.dropout = nn.Dropout(dropout)
+
+        # AF2 weighting constants (registered as buffers so they move with
+        # the module under .to(device)).
+        w_c = math.sqrt(2.0 / (9.0 * num_qk_points))
+        num_sources = 3.0 if pair_dim is not None else 2.0
+        w_l = math.sqrt(1.0 / num_sources)
+        self.register_buffer('w_c',
+                             torch.tensor(w_c, dtype=torch.get_default_dtype()))
+        self.register_buffer('w_l',
+                             torch.tensor(w_l, dtype=torch.get_default_dtype()))
+
+    # ------------------------------------------------------------------ #
+    # Internal helpers                                                   #
+    # ------------------------------------------------------------------ #
+
+    def _reshape_scalar(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reshape ``(B, L, H·c)`` → ``(B, H, L, c)``."""
+        batch_size, seq_len, _ = tensor.shape
+        tensor = tensor.view(batch_size, seq_len, self.num_heads, self.head_dim)
+        return tensor.permute(0, 2, 1, 3)
+
+    def _reshape_points(self, tensor: torch.Tensor,
+                        num_points: int) -> torch.Tensor:
+        """Reshape ``(B, L, H·P·3)`` → ``(B, L, H, P, 3)``."""
+        batch_size, seq_len, _ = tensor.shape
+        return tensor.view(batch_size, seq_len, self.num_heads, num_points, 3)
+
+    # ------------------------------------------------------------------ #
+    # Forward pass                                                       #
+    # ------------------------------------------------------------------ #
+
+    def forward(self,
+                single_repr: torch.Tensor,
+                rotations: torch.Tensor,
+                translations: torch.Tensor,
+                pair_repr: Optional[torch.Tensor] = None,
+                mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Apply Invariant Point Attention.
+
+        Parameters
+        ----------
+        single_repr : torch.Tensor
+            Residue scalar features of shape
+            ``(batch, num_residues, embed_dim)``.
+        rotations : torch.Tensor
+            Residue frame rotations of shape
+            ``(batch, num_residues, 3, 3)``.
+        translations : torch.Tensor
+            Residue frame translations of shape
+            ``(batch, num_residues, 3)``.
+        pair_repr : torch.Tensor, optional
+            Pair representation ``z`` of shape
+            ``(batch, num_residues, num_residues, pair_dim)``. Required
+            iff the layer was constructed with ``pair_dim`` set.
+        mask : torch.Tensor, optional
+            Boolean (or ``{0,1}``) residue mask of shape
+            ``(batch, num_residues)``. Masked positions are excluded
+            from attention (as keys) and their output is set to zero
+            (as queries).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated scalar features of shape
+            ``(batch, num_residues, embed_dim)``.
+
+        Raises
+        ------
+        ValueError
+            If any input tensor has an inconsistent shape, if
+            ``pair_repr`` is missing while ``pair_dim`` is set, or if
+            ``pair_repr`` is supplied to a layer constructed without
+            ``pair_dim``.
+        """
+        if single_repr.dim() != 3:
+            raise ValueError(
+                'single_repr must have shape (batch, num_residues, embed_dim).')
+        if rotations.shape != single_repr.shape[:2] + (3, 3):
+            raise ValueError(
+                'rotations must have shape (batch, num_residues, 3, 3).')
+        if translations.shape != single_repr.shape[:2] + (3,):
+            raise ValueError(
+                'translations must have shape (batch, num_residues, 3).')
+
+        batch_size, seq_len, _ = single_repr.shape
+        device = single_repr.device
+        dtype = single_repr.dtype
+
+        if (pair_repr is None) != (self.pair_dim is None):
+            raise ValueError(
+                'pair_repr must be provided iff pair_dim was set at '
+                'construction.')
+        if pair_repr is not None:
+            expected_pair = (batch_size, seq_len, seq_len, self.pair_dim)
+            if pair_repr.shape != expected_pair:
+                raise ValueError(
+                    'pair_repr must have shape '
+                    '(batch, num_residues, num_residues, pair_dim).')
+
+        if mask is not None:
+            if mask.shape != (batch_size, seq_len):
+                raise ValueError('mask must have shape (batch, num_residues).')
+            mask = mask.to(dtype=torch.bool, device=device)
+
+        # ----------- Scalar projections (B, H, L, c) -----------------
+        query_scalar = self._reshape_scalar(self.query_scalar(single_repr))
+        key_scalar = self._reshape_scalar(self.key_scalar(single_repr))
+        value_scalar = self._reshape_scalar(self.value_scalar(single_repr))
+
+        # ----------- Point projections in the local frame -----------
+        query_points_local = self._reshape_points(
+            self.query_points(single_repr), self.num_qk_points)
+        key_points_local = self._reshape_points(self.key_points(single_repr),
+                                                self.num_qk_points)
+        value_points_local = self._reshape_points(
+            self.value_points(single_repr), self.num_v_points)
+
+        # Lift points from local to global frames T_i.
+        query_points = apply_rigid(rotations, translations, query_points_local)
+        key_points = apply_rigid(rotations, translations, key_points_local)
+        value_points = apply_rigid(rotations, translations, value_points_local)
+
+        # Reorder to (B, H, L, P, 3) so the head dimension precedes seq.
+        query_points = query_points.permute(0, 2, 1, 3, 4)
+        key_points = key_points.permute(0, 2, 1, 3, 4)
+        value_points = value_points.permute(0, 2, 1, 3, 4)
+
+        # ----------- Three logit terms ------------------------------
+        scalar_logits = torch.matmul(query_scalar, key_scalar.transpose(-1, -2))
+        scalar_logits = scalar_logits / math.sqrt(self.head_dim)
+
+        # Squared point distances summed over points p.
+        # query_points: (B, H, L_q, P, 3) -> (B, H, L_q, 1, P, 3)
+        # key_points:   (B, H, L_k, P, 3) -> (B, H, 1, L_k, P, 3)
+        point_diff = query_points.unsqueeze(3) - key_points.unsqueeze(2)
+        point_dist2 = point_diff.pow(2).sum(dim=(-1, -2))
+
+        gamma = F.softplus(self.point_weights).view(1, self.num_heads, 1, 1)
+        w_c = self.w_c.to(dtype=dtype)
+        point_logits = -0.5 * w_c * gamma * point_dist2
+
+        if self.pair_bias is not None:
+            assert pair_repr is not None  # for type checkers
+            bias = self.pair_bias(pair_repr)  # (B, L_q, L_k, H)
+            bias = bias.permute(0, 3, 1, 2)  # (B, H, L_q, L_k)
+        else:
+            bias = torch.zeros_like(scalar_logits)
+
+        w_l = self.w_l.to(dtype=dtype)
+        logits = w_l * (scalar_logits + point_logits + bias)
+
+        # ----------- Masking ---------------------------------------
+        if mask is not None:
+            key_mask = mask.view(batch_size, 1, 1, seq_len)
+            logits = logits.masked_fill(~key_mask,
+                                        torch.finfo(logits.dtype).min)
+
+        attention = torch.softmax(logits, dim=-1)
+        attention = self.dropout(attention)
+
+        # ----------- Outputs ---------------------------------------
+        # Scalar output (B, H, L, c) -> (B, L, H·c).
+        scalar_out = torch.matmul(attention, value_scalar)
+        scalar_out = scalar_out.permute(0, 2, 1,
+                                        3).reshape(batch_size, seq_len,
+                                                   self.embed_dim)
+
+        # Point output: weighted sum in the *global* frame then mapped
+        # back into the residue-local frame via T_i^{-1}.
+        # attention: (B, H, L_q, L_k); value_points: (B, H, L_k, P, 3).
+        point_out_global = torch.einsum('bhij,bhjpd->bhipd', attention,
+                                        value_points)
+        # Reorder to (B, L_q, H, P, 3) to match the rigid-transform
+        # broadcast convention used in apply_inverse_rigid.
+        point_out_global = point_out_global.permute(0, 2, 1, 3, 4)
+        point_out_local = apply_inverse_rigid(rotations, translations,
+                                              point_out_global)
+        point_norms = torch.sqrt(
+            point_out_local.pow(2).sum(dim=-1) + self.eps)
+        point_out_local = point_out_local.reshape(batch_size, seq_len, -1)
+        point_norms = point_norms.reshape(batch_size, seq_len, -1)
+
+        feature_list = [scalar_out]
+        if self.pair_bias is not None:
+            # Pair output: Σ_j a_{ij}^h z_{ij}^{c_z}  → (B, L_q, H, c_z).
+            assert pair_repr is not None
+            pair_out = torch.einsum('bhij,bijc->bihc', attention, pair_repr)
+            pair_out = pair_out.reshape(batch_size, seq_len, -1)
+            feature_list.append(pair_out)
+        feature_list.extend([point_out_local, point_norms])
+
+        output = self.output(torch.cat(feature_list, dim=-1))
+
+        if mask is not None:
+            output = output * mask.unsqueeze(-1).to(dtype=output.dtype)
+        return output

--- a/deepchem/models/torch_models/rfdiffusion_tracks.py
+++ b/deepchem/models/torch_models/rfdiffusion_tracks.py
@@ -1,0 +1,1185 @@
+"""RoseTTAFold-style multi-track architecture for RFDiffusion.
+
+This module implements the three-track network used by RFDiffusion to
+denoise protein backbones:
+
+* **1D track** — a single representation :math:`s_i \\in \\mathbb{R}^{L
+  \\times C_s}` updated by pair-biased self-attention and a residual
+  feed-forward block.
+* **2D track** — a pair representation :math:`z_{ij} \\in
+  \\mathbb{R}^{L \\times L \\times C_z}` updated by an outer-product
+  mean from the single track, triangular multiplicative updates
+  (outgoing and incoming), triangular self-attention (starting and
+  ending node), and a pair transition. Because every pair operation is
+  :math:`\\mathcal{O}(L^2)` (or :math:`\\mathcal{O}(L^3)` for the
+  triangular updates), each pair operation accepts a ``chunk_size``
+  argument that bounds the working-set size along the chunked axis.
+* **3D track** — rigid frames :math:`T_i = (R_i, t_i) \\in SE(3)`
+  updated by the verified Invariant Point Attention layer
+  (Algorithm 22 of [Jumper2021]_) followed by a backbone-update head
+  that predicts a per-residue translation :math:`\\Delta t_i \\in
+  \\mathbb{R}^3` (in the local frame) and a quaternion residual
+  :math:`(1, b, c, d)` from which a rotation update
+  :math:`R_{\\Delta}` is built. Frames are composed as
+  :math:`R_i^{\\text{new}} = R_i R_{\\Delta}` and
+  :math:`t_i^{\\text{new}} = R_i \\Delta t_i + t_i`.
+
+All pair updates are symmetrised so that the invariant
+:math:`z_{ij} = z_{ji}` is preserved across the full stack — a
+property exercised by the test suite.
+
+The public class :class:`RFDiffusionMultiTrackStack` exposes a forward
+signature identical to a stack of
+:class:`~deepchem.models.torch_models.rfdiffusion.DiffusionTransformerBlock`
+layers, ``forward(single, t_emb, attention_mask=None) -> single``, so
+it is a drop-in replacement for the baseline denoiser's transformer
+stack. A second method :meth:`forward_tracks` returns the full
+``(single, pair, R, t)`` tuple for tests that exercise frame-level
+equivariance.
+
+Developer-facing summary
+------------------------
+For most integrations, :class:`RFDiffusionMultiTrackStack` is the main
+entry point. Use ``forward(single, t_emb, attention_mask=None)`` when
+you only need updated single-residue features, and use
+``forward_tracks(...)`` when a downstream module needs direct access to
+the pair representation or the updated rigid frames.
+
+References
+----------
+.. [Jumper2021] Jumper, J. *et al.* "Highly accurate protein structure
+   prediction with AlphaFold." *Nature* **596** (2021): 583–589.
+.. [Baek2021] Baek, M. *et al.* "Accurate prediction of protein structures
+   and interactions using a three-track neural network." *Science*
+   **373** (2021): 871–876.
+.. [Watson2023] Watson, J. L. *et al.* "De novo design of protein structure
+   and function with RFdiffusion." *Nature* **620** (2023): 1089–1100.
+"""
+
+import math
+from typing import Optional, Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_tracks requires PyTorch to be installed.')
+
+from deepchem.models.torch_models.rfdiffusion_se3 import (
+    InvariantPointAttention,
+    make_identity_rigid,
+)
+
+
+# ---------------------------------------------------------------------------
+# Embedding utilities
+# ---------------------------------------------------------------------------
+
+
+class RelativePositionEmbedding(nn.Module):
+    """Symmetric clipped relative-position embedding for the pair track.
+
+    Given a sequence of length :math:`L` and a clip radius
+    :math:`r_{\\max}`, this module returns a tensor
+    :math:`p_{ij} \\in \\mathbb{R}^{L \\times L \\times C_z}` where each
+    entry is the embedding of :math:`\\min(|i - j|, r_{\\max})`. Because
+    the index depends on :math:`|i-j|` rather than :math:`i-j`, the
+    resulting embedding is exactly symmetric:
+    :math:`p_{ij} = p_{ji}`.
+
+    Parameters
+    ----------
+    pair_dim : int
+        Output channel size :math:`C_z`.
+    max_relative_position : int, default 32
+        Clip radius :math:`r_{\\max}`. Indices beyond this distance map
+        to the same embedding bucket.
+
+    Examples
+    --------
+    >>> import torch
+    >>> rel = RelativePositionEmbedding(pair_dim=16, max_relative_position=4)
+    >>> emb = rel(8)
+    >>> emb.shape
+    torch.Size([8, 8, 16])
+    """
+
+    def __init__(self,
+                 pair_dim: int,
+                 max_relative_position: int = 32) -> None:
+        super().__init__()
+        if pair_dim <= 0:
+            raise ValueError('pair_dim must be positive.')
+        if max_relative_position <= 0:
+            raise ValueError('max_relative_position must be positive.')
+        self.pair_dim = pair_dim
+        self.max_relative_position = max_relative_position
+        self.embedding = nn.Embedding(max_relative_position + 1, pair_dim)
+
+    def forward(self, seq_len: int, device=None) -> torch.Tensor:
+        """Build the :math:`(L, L, C_z)` symmetric relative-position tensor.
+
+        Parameters
+        ----------
+        seq_len : int
+            Sequence length :math:`L`.
+        device : torch.device, optional
+            Device on which to allocate the position index tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Relative-position embeddings of shape ``(L, L, pair_dim)``.
+        """
+        device = device or self.embedding.weight.device
+        idx = torch.arange(seq_len, device=device)
+        diff = (idx.unsqueeze(0) - idx.unsqueeze(1)).abs()
+        diff = diff.clamp(max=self.max_relative_position)
+        return self.embedding(diff)
+
+
+# ---------------------------------------------------------------------------
+# 1D → 2D update: outer-product mean
+# ---------------------------------------------------------------------------
+
+
+class OuterProductMean(nn.Module):
+    """Outer-product update from the single track to the pair track.
+
+    For each pair :math:`(i, j)`, computes the symmetrised flattened
+    outer product
+
+    .. math::
+
+        o_{ij} = W_{\\text{out}}\\,\\big(L_a(s_i) \\otimes L_b(s_j)\\big)
+        + W_{\\text{out}}\\,\\big(L_a(s_j) \\otimes L_b(s_i)\\big),
+
+    where :math:`L_a, L_b: \\mathbb{R}^{C_s} \\to \\mathbb{R}^{c_h}` are
+    linear projections and the symmetrisation enforces
+    :math:`o_{ij} = o_{ji}` exactly.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    hidden_dim : int, default 32
+        Projection size :math:`c_h` for the outer product.
+
+    Notes
+    -----
+    The pre-projection layer norm follows AlphaFold2's outer-product-mean
+    placement; only one residue context (the single representation
+    itself) participates because RFDiffusion does not use an MSA stack.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 hidden_dim: int = 32) -> None:
+        super().__init__()
+        if embed_dim <= 0 or pair_dim <= 0 or hidden_dim <= 0:
+            raise ValueError(
+                'embed_dim, pair_dim and hidden_dim must all be positive.')
+        self.layer_norm = nn.LayerNorm(embed_dim)
+        self.linear_a = nn.Linear(embed_dim, hidden_dim)
+        self.linear_b = nn.Linear(embed_dim, hidden_dim)
+        self.linear_out = nn.Linear(hidden_dim * hidden_dim, pair_dim)
+
+    def forward(self, single: torch.Tensor) -> torch.Tensor:
+        """Compute the outer-product mean.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Pair update of shape ``(B, L, L, C_z)`` (symmetric in i, j).
+        """
+        single = self.layer_norm(single)
+        a = self.linear_a(single)  # (B, L, c_h)
+        b = self.linear_b(single)  # (B, L, c_h)
+        # Outer product per pair: (B, L, L, c_h, c_h) → flatten last two.
+        outer_ab = torch.einsum('bic,bjd->bijcd', a, b)
+        outer_ba = torch.einsum('bjc,bid->bijcd', a, b)
+        outer = 0.5 * (outer_ab + outer_ba)
+        flat = outer.flatten(start_dim=-2)
+        return self.linear_out(flat)
+
+
+# ---------------------------------------------------------------------------
+# Triangular multiplicative update
+# ---------------------------------------------------------------------------
+
+
+class TriangleMultiplicativeUpdate(nn.Module):
+    """Triangle multiplicative update for the pair track.
+
+    Implements AlphaFold2 Algorithms 11 / 12 [Jumper2021]_. The
+    "outgoing" variant computes
+
+    .. math::
+
+        \\tilde z_{ij} = g_{ij} \\odot W_{\\text{out}}\\,
+        \\mathrm{LN}\\Big( \\sum_k a_{ik} \\odot b_{jk} \\Big),
+
+    and the "incoming" variant replaces the summation by
+    :math:`\\sum_k a_{ki} \\odot b_{kj}`. The values :math:`a, b, g`
+    are gated linear projections of the layer-normalised pair
+    representation.
+
+    A ``chunk_size`` argument controls the working-set size along the
+    :math:`i` axis when forming the cubic-cost contraction, bounding
+    peak memory to :math:`\\mathcal{O}(\\text{chunk\\_size} \\cdot L^2
+    \\cdot c_h)` independently of :math:`L`.
+
+    Parameters
+    ----------
+    pair_dim : int
+        Input/output channel size :math:`C_z`.
+    hidden_dim : int, default 128
+        Hidden channel size :math:`c_h` for the gated projections.
+    outgoing : bool, default True
+        If True, use the outgoing variant (sum over :math:`a_{ik}
+        b_{jk}`); otherwise use the incoming variant (sum over
+        :math:`a_{ki} b_{kj}`).
+    """
+
+    def __init__(self,
+                 pair_dim: int,
+                 hidden_dim: int = 128,
+                 outgoing: bool = True) -> None:
+        super().__init__()
+        if pair_dim <= 0 or hidden_dim <= 0:
+            raise ValueError('pair_dim and hidden_dim must be positive.')
+        self.outgoing = outgoing
+        self.layer_norm_in = nn.LayerNorm(pair_dim)
+        self.linear_a = nn.Linear(pair_dim, hidden_dim)
+        self.linear_a_gate = nn.Linear(pair_dim, hidden_dim)
+        self.linear_b = nn.Linear(pair_dim, hidden_dim)
+        self.linear_b_gate = nn.Linear(pair_dim, hidden_dim)
+        self.linear_g = nn.Linear(pair_dim, pair_dim)
+        self.layer_norm_out = nn.LayerNorm(hidden_dim)
+        self.linear_out = nn.Linear(hidden_dim, pair_dim)
+
+    def forward(self,
+                pair: torch.Tensor,
+                chunk_size: Optional[int] = None) -> torch.Tensor:
+        """Apply the triangular multiplicative update.
+
+        Parameters
+        ----------
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+        chunk_size : int, optional
+            If given, chunk the :math:`i` axis of the cubic contraction
+            into pieces of at most ``chunk_size`` rows. Must produce
+            the same output as the unchunked path (verified by tests).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated pair representation, same shape as input.
+        """
+        if pair.dim() != 4:
+            raise ValueError(
+                'pair must have shape (batch, L, L, pair_dim), got '
+                f'{tuple(pair.shape)}.')
+        z = self.layer_norm_in(pair)
+        a = torch.sigmoid(self.linear_a_gate(z)) * self.linear_a(z)
+        b = torch.sigmoid(self.linear_b_gate(z)) * self.linear_b(z)
+        g = torch.sigmoid(self.linear_g(z))
+        contracted = self._chunked_contract(a, b, chunk_size)
+        contracted = self.layer_norm_out(contracted)
+        return g * self.linear_out(contracted)
+
+    def _chunked_contract(self,
+                          a: torch.Tensor,
+                          b: torch.Tensor,
+                          chunk_size: Optional[int]) -> torch.Tensor:
+        """Compute :math:`\\sum_k a_{*k} \\odot b_{*k}` chunked over ``i``."""
+        seq_len = a.size(1)
+        if chunk_size is None or chunk_size >= seq_len:
+            if self.outgoing:
+                return torch.einsum('bikc,bjkc->bijc', a, b)
+            return torch.einsum('bkic,bkjc->bijc', a, b)
+        results = []
+        for start in range(0, seq_len, chunk_size):
+            end = min(start + chunk_size, seq_len)
+            if self.outgoing:
+                # a_chunk: (B, chunk, L, c) — k dim is L.
+                a_chunk = a[:, start:end]
+                results.append(torch.einsum('bikc,bjkc->bijc', a_chunk, b))
+            else:
+                # Need a[k, i_chunk]: slice on i (axis 2) of bkic.
+                a_chunk = a[:, :, start:end]
+                results.append(torch.einsum('bkic,bkjc->bijc', a_chunk, b))
+        return torch.cat(results, dim=1)
+
+
+# ---------------------------------------------------------------------------
+# Triangular self-attention
+# ---------------------------------------------------------------------------
+
+
+class TriangleAttention(nn.Module):
+    """Triangular self-attention for the pair track.
+
+    Implements AlphaFold2 Algorithms 13 / 14 [Jumper2021]_. In the
+    *starting-node* variant the attention runs along columns of each
+    row of the pair representation: for each :math:`i`, queries
+    :math:`q_{ij}` attend to keys :math:`k_{ik}` with the bias term
+    :math:`b_{jk}` derived linearly from the pair representation at
+    rows shared with the row being attended over. The *ending-node*
+    variant operates symmetrically along columns.
+
+    Memory is bounded by chunking over the :math:`i` axis (rows for the
+    starting-node variant, columns for the ending-node variant).
+
+    Parameters
+    ----------
+    pair_dim : int
+        Input/output channel size :math:`C_z`.
+    num_heads : int, default 4
+        Number of attention heads :math:`H`.
+    head_dim : int, default 32
+        Per-head channel size :math:`d_h`.
+    starting_node : bool, default True
+        Selects the starting-node (True) or ending-node (False) variant.
+    """
+
+    def __init__(self,
+                 pair_dim: int,
+                 num_heads: int = 4,
+                 head_dim: int = 32,
+                 starting_node: bool = True) -> None:
+        super().__init__()
+        if pair_dim <= 0 or num_heads <= 0 or head_dim <= 0:
+            raise ValueError(
+                'pair_dim, num_heads and head_dim must be positive.')
+        self.pair_dim = pair_dim
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.starting_node = starting_node
+        self.layer_norm = nn.LayerNorm(pair_dim)
+        inner = num_heads * head_dim
+        self.linear_q = nn.Linear(pair_dim, inner, bias=False)
+        self.linear_k = nn.Linear(pair_dim, inner, bias=False)
+        self.linear_v = nn.Linear(pair_dim, inner, bias=False)
+        self.linear_bias = nn.Linear(pair_dim, num_heads, bias=False)
+        self.linear_gate = nn.Linear(pair_dim, inner)
+        self.linear_out = nn.Linear(inner, pair_dim)
+        self.register_buffer('scale',
+                             torch.tensor(1.0 / math.sqrt(head_dim)))
+
+    def forward(self,
+                pair: torch.Tensor,
+                chunk_size: Optional[int] = None) -> torch.Tensor:
+        """Apply triangular self-attention.
+
+        Parameters
+        ----------
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+        chunk_size : int, optional
+            Chunk size for the row-index axis. Must produce identical
+            results to the unchunked path.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated pair representation, same shape as input.
+        """
+        if pair.dim() != 4:
+            raise ValueError('pair must be 4D (B, L, L, C_z).')
+        # For ending-node, swap i and j axes, run the starting-node
+        # kernel, then swap back. This guarantees identical numerics
+        # to a hand-written ending-node implementation.
+        z = pair if self.starting_node else pair.transpose(-2, -3)
+        z = self.layer_norm(z)
+        q = self._split_heads(self.linear_q(z))
+        k = self._split_heads(self.linear_k(z))
+        v = self._split_heads(self.linear_v(z))
+        bias = self.linear_bias(z)  # (B, L, L, H) — uses row-i context.
+        gate = torch.sigmoid(self.linear_gate(z))
+
+        out = self._chunked_attend(q, k, v, bias, chunk_size)
+        out = out * gate
+        out = self.linear_out(out)
+        if not self.starting_node:
+            out = out.transpose(-2, -3)
+        return out
+
+    def _split_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reshape ``(B, L, L, H*d) -> (B, L, L, H, d)``."""
+        batch, n1, n2, _ = tensor.shape
+        return tensor.view(batch, n1, n2, self.num_heads, self.head_dim)
+
+    def _chunked_attend(self,
+                        q: torch.Tensor,
+                        k: torch.Tensor,
+                        v: torch.Tensor,
+                        bias: torch.Tensor,
+                        chunk_size: Optional[int]) -> torch.Tensor:
+        """Row-wise scaled-dot-product attention with an additive bias.
+
+        For each row :math:`i`, the attention is computed across columns
+        :math:`(j, k)`. The bias :math:`b_{jk} = W_b z_{jk}` depends
+        only on the *column* pair :math:`(j, k)` and is broadcast across
+        all rows :math:`i` — this is precisely the AlphaFold2 starting-
+        node triangle-attention formulation [Jumper2021]_. Because
+        logits and attention weights are formed independently for each
+        row :math:`i`, chunking along :math:`i` is exactly numerically
+        equivalent to the dense path.
+        """
+        seq_len = q.size(1)
+        if chunk_size is None or chunk_size >= seq_len:
+            return self._attend_block(q, k, v, bias)
+        outputs = []
+        for start in range(0, seq_len, chunk_size):
+            end = min(start + chunk_size, seq_len)
+            outputs.append(
+                self._attend_block(q[:, start:end], k[:, start:end],
+                                   v[:, start:end], bias))
+        return torch.cat(outputs, dim=1)
+
+    @staticmethod
+    def _attend_block(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                      bias: torch.Tensor) -> torch.Tensor:
+        """Compute attention for a (possibly chunked) block of rows.
+
+        Parameters
+        ----------
+        q, k, v : torch.Tensor
+            Per-row queries/keys/values of shape ``(B, L_i, L, H, d)``.
+        bias : torch.Tensor
+            Pair bias of shape ``(B, L, L, H)`` indexed by ``(j, k)``;
+            broadcast across the row axis :math:`i`.
+        """
+        scale = 1.0 / math.sqrt(q.size(-1))
+        logits = torch.einsum('bijhd,bikhd->bhijk', q, k) * scale
+        # bias: (B, L_j, L_k, H) → (B, H, 1, L_j, L_k) so it broadcasts
+        # across the row index i.
+        logits = logits + bias.permute(0, 3, 1, 2).unsqueeze(2)
+        attn = F.softmax(logits, dim=-1)
+        out = torch.einsum('bhijk,bikhd->bijhd', attn, v)
+        return out.flatten(start_dim=-2)
+
+
+# ---------------------------------------------------------------------------
+# Pair transition (feed-forward)
+# ---------------------------------------------------------------------------
+
+
+class PairTransition(nn.Module):
+    """Two-layer feed-forward block applied position-wise to the pair."""
+
+    def __init__(self, pair_dim: int, expansion: int = 4) -> None:
+        super().__init__()
+        if pair_dim <= 0 or expansion <= 0:
+            raise ValueError('pair_dim and expansion must be positive.')
+        self.layer_norm = nn.LayerNorm(pair_dim)
+        self.linear_1 = nn.Linear(pair_dim, pair_dim * expansion)
+        self.linear_2 = nn.Linear(pair_dim * expansion, pair_dim)
+
+    def forward(self, pair: torch.Tensor) -> torch.Tensor:
+        """Apply the pair transition.
+
+        Parameters
+        ----------
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed pair representation, same shape as input.
+        """
+        z = self.layer_norm(pair)
+        return self.linear_2(F.relu(self.linear_1(z)))
+
+
+# ---------------------------------------------------------------------------
+# 2D → 1D update: pair-biased self-attention
+# ---------------------------------------------------------------------------
+
+
+class PairBiasedSingleAttention(nn.Module):
+    """Multi-head self-attention on the single track biased by the pair.
+
+    The attention logits are augmented by a per-head linear projection
+    of the pair representation, giving the pair channel a direct
+    pathway to modulate the single track. This is the AlphaFold2
+    "MSA row-wise attention with pair bias" reduced to a single MSA
+    row.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    num_heads : int, default 8
+        Number of attention heads.
+    dropout : float, default 0.0
+        Dropout probability applied to attention weights.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 num_heads: int = 8,
+                 dropout: float = 0.0) -> None:
+        super().__init__()
+        if embed_dim <= 0 or pair_dim <= 0 or num_heads <= 0:
+            raise ValueError(
+                'embed_dim, pair_dim and num_heads must be positive.')
+        if embed_dim % num_heads != 0:
+            raise ValueError('embed_dim must be divisible by num_heads.')
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError('dropout must lie in [0, 1).')
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.norm_single = nn.LayerNorm(embed_dim)
+        self.norm_pair = nn.LayerNorm(pair_dim)
+        self.linear_q = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.linear_k = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.linear_v = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.linear_bias = nn.Linear(pair_dim, num_heads, bias=False)
+        self.linear_out = nn.Linear(embed_dim, embed_dim)
+        self.dropout = nn.Dropout(dropout)
+        self.register_buffer('scale',
+                             torch.tensor(1.0 / math.sqrt(self.head_dim)))
+
+    def forward(self,
+                single: torch.Tensor,
+                pair: torch.Tensor,
+                mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+        mask : torch.Tensor, optional
+            Boolean mask of shape ``(B, L)`` where True marks valid
+            residues. Masked keys are excluded from attention; masked
+            queries receive zero output.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated single representation, same shape as input.
+        """
+        if single.dim() != 3:
+            raise ValueError('single must be 3D (B, L, C_s).')
+        if pair.dim() != 4:
+            raise ValueError('pair must be 4D (B, L, L, C_z).')
+
+        s_norm = self.norm_single(single)
+        z_norm = self.norm_pair(pair)
+        batch, seq_len, _ = s_norm.shape
+        q = self.linear_q(s_norm).view(batch, seq_len, self.num_heads,
+                                       self.head_dim)
+        k = self.linear_k(s_norm).view(batch, seq_len, self.num_heads,
+                                       self.head_dim)
+        v = self.linear_v(s_norm).view(batch, seq_len, self.num_heads,
+                                       self.head_dim)
+        # logits: (B, H, L_q, L_k) = (1/√d) qᵢ · kⱼ + bᵢⱼ
+        logits = torch.einsum('bihd,bjhd->bhij', q, k) * float(self.scale)
+        bias = self.linear_bias(z_norm).permute(0, 3, 1, 2)
+        logits = logits + bias
+        if mask is not None:
+            mask_bool = mask.to(dtype=torch.bool)
+            key_mask = mask_bool.view(batch, 1, 1, seq_len)
+            logits = logits.masked_fill(
+                ~key_mask, torch.finfo(logits.dtype).min)
+        attn = F.softmax(logits, dim=-1)
+        attn = self.dropout(attn)
+        out = torch.einsum('bhij,bjhd->bihd', attn, v)
+        out = out.reshape(batch, seq_len, self.embed_dim)
+        out = self.linear_out(out)
+        if mask is not None:
+            out = out * mask.to(dtype=out.dtype).unsqueeze(-1)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Single transition (feed-forward) with adaptive time conditioning
+# ---------------------------------------------------------------------------
+
+
+class SingleTransition(nn.Module):
+    """Position-wise feed-forward block on the single track with
+    adaLN-style timestep conditioning.
+
+    The block applies layer-norm, computes a time-dependent
+    :math:`(scale, shift)` pair from the timestep embedding, modulates
+    the normalised representation, then runs a two-layer MLP with GELU
+    activation.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    expansion : int, default 4
+        Hidden expansion of the MLP.
+    dropout : float, default 0.0
+        Dropout probability applied to the MLP hidden activations.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 expansion: int = 4,
+                 dropout: float = 0.0) -> None:
+        super().__init__()
+        if embed_dim <= 0 or expansion <= 0:
+            raise ValueError('embed_dim and expansion must be positive.')
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError('dropout must lie in [0, 1).')
+        self.norm = nn.LayerNorm(embed_dim)
+        self.time_mlp = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(embed_dim, embed_dim * 2),
+        )
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * expansion),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(embed_dim * expansion, embed_dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, single: torch.Tensor,
+                t_emb: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(B, C_s)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated single representation, same shape as input.
+        """
+        time_cond = self.time_mlp(t_emb)
+        scale, shift = time_cond.chunk(2, dim=-1)
+        h = self.norm(single)
+        h = h * (1.0 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+        return self.mlp(h)
+
+
+# ---------------------------------------------------------------------------
+# Backbone update head
+# ---------------------------------------------------------------------------
+
+
+def quaternion_to_rotation_matrix(quat: torch.Tensor) -> torch.Tensor:
+    """Convert a (possibly unnormalised) quaternion to a rotation matrix.
+
+    Uses the standard formula for a unit quaternion :math:`q = (w, x,
+    y, z)`:
+
+    .. math::
+
+        R = \\begin{pmatrix}
+            1 - 2y^2 - 2z^2 & 2xy - 2wz & 2xz + 2wy \\\\
+            2xy + 2wz & 1 - 2x^2 - 2z^2 & 2yz - 2wx \\\\
+            2xz - 2wy & 2yz + 2wx & 1 - 2x^2 - 2y^2
+        \\end{pmatrix}.
+
+    The quaternion is normalised internally so callers do not need to
+    pre-normalise.
+
+    Parameters
+    ----------
+    quat : torch.Tensor
+        Quaternion of shape ``(..., 4)`` with components in the order
+        :math:`(w, x, y, z)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrix of shape ``(..., 3, 3)``.
+    """
+    norm = torch.linalg.norm(quat, dim=-1, keepdim=True).clamp(min=1e-12)
+    w, x, y, z = (quat / norm).unbind(dim=-1)
+    two = 2.0
+    r00 = 1.0 - two * (y * y + z * z)
+    r01 = two * (x * y - w * z)
+    r02 = two * (x * z + w * y)
+    r10 = two * (x * y + w * z)
+    r11 = 1.0 - two * (x * x + z * z)
+    r12 = two * (y * z - w * x)
+    r20 = two * (x * z - w * y)
+    r21 = two * (y * z + w * x)
+    r22 = 1.0 - two * (x * x + y * y)
+    row0 = torch.stack([r00, r01, r02], dim=-1)
+    row1 = torch.stack([r10, r11, r12], dim=-1)
+    row2 = torch.stack([r20, r21, r22], dim=-1)
+    return torch.stack([row0, row1, row2], dim=-2)
+
+
+class BackboneUpdate(nn.Module):
+    """Predicts a per-residue rigid-frame update from the single track.
+
+    The head linearly projects the (layer-normed) single representation
+    to six channels: three real components :math:`(b, c, d)` of a
+    quaternion with implicit :math:`w = 1`, and three local-frame
+    translation components :math:`\\Delta t_{\\text{local}}`.
+
+    The frame update is then composed as
+
+    .. math::
+
+        R_i^{\\text{new}} = R_i \\, R_{\\Delta},\\qquad
+        t_i^{\\text{new}} = R_i \\, \\Delta t_{\\text{local}} + t_i,
+
+    so that under any global rigid motion :math:`(R_g, t_g)` acting on
+    the input frames the output frames transform equivariantly.
+    Zero-initialisation of the head's final linear layer makes the
+    initial update an identity, a standard diffusion practice.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    """
+
+    def __init__(self, embed_dim: int) -> None:
+        super().__init__()
+        if embed_dim <= 0:
+            raise ValueError('embed_dim must be positive.')
+        self.norm = nn.LayerNorm(embed_dim)
+        self.linear = nn.Linear(embed_dim, 6)
+        # Zero-init so the initial update is the identity transform.
+        nn.init.zeros_(self.linear.weight)
+        nn.init.zeros_(self.linear.bias)
+
+    def forward(
+        self,
+        single: torch.Tensor,
+        rotations: torch.Tensor,
+        translations: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply the backbone update.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        rotations : torch.Tensor
+            Current frame rotations of shape ``(B, L, 3, 3)``.
+        translations : torch.Tensor
+            Current frame translations of shape ``(B, L, 3)``.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            Updated ``(rotations, translations)`` of shapes ``(B, L, 3,
+            3)`` and ``(B, L, 3)``.
+        """
+        update = self.linear(self.norm(single))
+        quat_imag = update[..., :3]
+        delta_t_local = update[..., 3:]
+        # Construct the quaternion (1, b, c, d). Using an implicit
+        # w=1 component biases the initial update toward identity.
+        ones = torch.ones_like(quat_imag[..., :1])
+        quat = torch.cat([ones, quat_imag], dim=-1)
+        r_update = quaternion_to_rotation_matrix(quat)
+        new_rotations = rotations @ r_update
+        # t_new = R · Δt_local + t. Use einsum to broadcast cleanly.
+        new_translations = (
+            torch.einsum('blij,blj->bli', rotations, delta_t_local)
+            + translations)
+        return new_rotations, new_translations
+
+
+# ---------------------------------------------------------------------------
+# Full multi-track block and stack
+# ---------------------------------------------------------------------------
+
+
+class RFDiffusionTrackBlock(nn.Module):
+    """One iteration of the three-track RFDiffusion architecture.
+
+    Each block executes, in order:
+
+    1. **Single → pair** via :class:`OuterProductMean`.
+    2. **Pair self-update** via outgoing and incoming
+       :class:`TriangleMultiplicativeUpdate`, starting- and ending-node
+       :class:`TriangleAttention`, and a :class:`PairTransition`. After
+       each update the pair is symmetrised, preserving
+       :math:`z_{ij} = z_{ji}`.
+    3. **Pair → single** via :class:`PairBiasedSingleAttention`,
+       followed by an adaLN-style :class:`SingleTransition` modulated
+       by the timestep embedding.
+    4. **Frame update** via :class:`InvariantPointAttention` (using the
+       updated single and pair) and :class:`BackboneUpdate`.
+
+    Every operation that touches the pair is symmetric in :math:`(i,
+    j)`, and every operation that touches the frames is built so that
+    composing a global rigid motion on the input frames yields the same
+    motion on the output frames.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    num_heads : int, default 8
+        Heads for the single-track and IPA attentions.
+    pair_num_heads : int, default 4
+        Heads for the triangular self-attention.
+    triangle_hidden_dim : int, default 64
+        Hidden dimension of the triangular multiplicative update.
+    triangle_head_dim : int, default 32
+        Per-head channel size for triangular attention.
+    opm_hidden_dim : int, default 16
+        Projection size of the outer-product mean.
+    num_qk_points : int, default 4
+        Number of query/key 3-D points for IPA.
+    num_v_points : int, default 8
+        Number of value 3-D points for IPA.
+    dropout : float, default 0.0
+        Dropout probability for attention paths and MLPs.
+    chunk_size : int, optional
+        Default chunk size applied to triangular operations. ``None``
+        means no chunking (dense path). Tests verify chunked and dense
+        outputs match to within ``atol=1e-5``.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 num_heads: int = 8,
+                 pair_num_heads: int = 4,
+                 triangle_hidden_dim: int = 64,
+                 triangle_head_dim: int = 32,
+                 opm_hidden_dim: int = 16,
+                 num_qk_points: int = 4,
+                 num_v_points: int = 8,
+                 dropout: float = 0.0,
+                 chunk_size: Optional[int] = None) -> None:
+        super().__init__()
+        self.chunk_size = chunk_size
+        self.outer_product_mean = OuterProductMean(embed_dim, pair_dim,
+                                                   opm_hidden_dim)
+        self.tri_mul_out = TriangleMultiplicativeUpdate(
+            pair_dim, triangle_hidden_dim, outgoing=True)
+        self.tri_mul_in = TriangleMultiplicativeUpdate(
+            pair_dim, triangle_hidden_dim, outgoing=False)
+        self.tri_attn_start = TriangleAttention(pair_dim,
+                                                pair_num_heads,
+                                                triangle_head_dim,
+                                                starting_node=True)
+        self.tri_attn_end = TriangleAttention(pair_dim,
+                                              pair_num_heads,
+                                              triangle_head_dim,
+                                              starting_node=False)
+        self.pair_transition = PairTransition(pair_dim)
+        self.pair_to_single = PairBiasedSingleAttention(
+            embed_dim,
+            pair_dim,
+            num_heads=num_heads,
+            dropout=dropout)
+        self.single_transition = SingleTransition(embed_dim, dropout=dropout)
+        self.ipa = InvariantPointAttention(embed_dim,
+                                           num_heads=num_heads,
+                                           num_qk_points=num_qk_points,
+                                           num_v_points=num_v_points,
+                                           pair_dim=pair_dim,
+                                           dropout=dropout)
+        self.ipa_norm = nn.LayerNorm(embed_dim)
+        self.backbone_update = BackboneUpdate(embed_dim)
+
+    def forward(
+        self,
+        single: torch.Tensor,
+        pair: torch.Tensor,
+        rotations: torch.Tensor,
+        translations: torch.Tensor,
+        t_emb: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        chunk_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run one multi-track update.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Shape ``(B, L, C_s)``.
+        pair : torch.Tensor
+            Shape ``(B, L, L, C_z)``.
+        rotations : torch.Tensor
+            Shape ``(B, L, 3, 3)``.
+        translations : torch.Tensor
+            Shape ``(B, L, 3)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(B, C_s)``.
+        mask : torch.Tensor, optional
+            Residue mask of shape ``(B, L)``.
+        chunk_size : int, optional
+            Override the block-level default chunk size for this call.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+            Updated ``(single, pair, rotations, translations)``.
+        """
+        active_chunk = chunk_size if chunk_size is not None else self.chunk_size
+        # Single → pair (residual + symmetrise).
+        pair = pair + self.outer_product_mean(single)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        # Pair self-updates.
+        pair = pair + self.tri_mul_out(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.tri_mul_in(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.tri_attn_start(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.tri_attn_end(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.pair_transition(pair)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        # Pair → single + transition.
+        single = single + self.pair_to_single(single, pair, mask=mask)
+        single = single + self.single_transition(single, t_emb)
+        # Frame update: IPA produces an invariant single increment.
+        ipa_out = self.ipa(self.ipa_norm(single), rotations, translations,
+                           pair_repr=pair, mask=mask)
+        single = single + ipa_out
+        rotations, translations = self.backbone_update(
+            single, rotations, translations)
+        return single, pair, rotations, translations
+
+
+class RFDiffusionMultiTrackStack(nn.Module):
+    """Stacked multi-track architecture matching ``DiffusionTransformerBlock``.
+
+    Wraps a sequence of :class:`RFDiffusionTrackBlock` updates so that
+    the public :meth:`forward` signature ``forward(single, t_emb,
+    attention_mask=None) -> single`` is identical to the baseline
+    transformer block stack in
+    :mod:`deepchem.models.torch_models.rfdiffusion`. The pair
+    representation and rigid frames live entirely within the stack and
+    are initialised fresh on every forward pass.
+
+    Use :meth:`forward_tracks` from tests to retrieve the final
+    ``(single, pair, rotations, translations)`` tuple — this enables
+    direct equivariance checks on the frame outputs.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    num_blocks : int, default 2
+        Number of stacked multi-track blocks.
+    num_heads : int, default 8
+        Heads for single-track and IPA attention.
+    pair_num_heads : int, default 4
+        Heads for triangular self-attention.
+    chunk_size : int, optional
+        Default chunk size for triangular operations.
+    dropout : float, default 0.0
+        Shared dropout probability.
+    max_relative_position : int, default 32
+        Clip radius for the relative-position embedding used to
+        initialise the pair representation.
+    opm_hidden_dim : int, default 16
+        Hidden size of the outer-product-mean projection used in each
+        block.
+    triangle_hidden_dim : int, default 64
+        Hidden size for the triangular multiplicative update.
+    triangle_head_dim : int, default 32
+        Per-head channel size for triangular attention.
+    num_qk_points : int, default 4
+        IPA query/key 3-D point count.
+    num_v_points : int, default 8
+        IPA value 3-D point count.
+
+    Examples
+    --------
+    >>> import torch
+    >>> stack = RFDiffusionMultiTrackStack(
+    ...     embed_dim=32, pair_dim=16, num_blocks=2, num_heads=4,
+    ...     pair_num_heads=2, triangle_hidden_dim=16,
+    ...     triangle_head_dim=8, opm_hidden_dim=8)
+    >>> single = torch.randn(2, 6, 32)
+    >>> t_emb = torch.randn(2, 32)
+    >>> out = stack(single, t_emb)
+    >>> out.shape
+    torch.Size([2, 6, 32])
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 num_blocks: int = 2,
+                 num_heads: int = 8,
+                 pair_num_heads: int = 4,
+                 chunk_size: Optional[int] = None,
+                 dropout: float = 0.0,
+                 max_relative_position: int = 32,
+                 opm_hidden_dim: int = 16,
+                 triangle_hidden_dim: int = 64,
+                 triangle_head_dim: int = 32,
+                 num_qk_points: int = 4,
+                 num_v_points: int = 8) -> None:
+        super().__init__()
+        if num_blocks <= 0:
+            raise ValueError('num_blocks must be positive.')
+        self.embed_dim = embed_dim
+        self.pair_dim = pair_dim
+        self.num_blocks = num_blocks
+        self.chunk_size = chunk_size
+        # Pair initialiser: relpos + initial OPM-style outer product
+        # mean of the input single representation.
+        self.rel_pos = RelativePositionEmbedding(pair_dim,
+                                                 max_relative_position)
+        self.initial_opm = OuterProductMean(embed_dim, pair_dim,
+                                            opm_hidden_dim)
+        self.blocks = nn.ModuleList([
+            RFDiffusionTrackBlock(embed_dim,
+                                  pair_dim,
+                                  num_heads=num_heads,
+                                  pair_num_heads=pair_num_heads,
+                                  triangle_hidden_dim=triangle_hidden_dim,
+                                  triangle_head_dim=triangle_head_dim,
+                                  opm_hidden_dim=opm_hidden_dim,
+                                  num_qk_points=num_qk_points,
+                                  num_v_points=num_v_points,
+                                  dropout=dropout,
+                                  chunk_size=chunk_size)
+            for _ in range(num_blocks)
+        ])
+        self.final_norm = nn.LayerNorm(embed_dim)
+
+    # -- DropIn-compatible forward ------------------------------------
+
+    def forward(self,
+                single: torch.Tensor,
+                t_emb: torch.Tensor,
+                attention_mask: Optional[torch.Tensor] = None
+                ) -> torch.Tensor:
+        """Drop-in replacement for the baseline transformer block stack.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(B, C_s)``.
+        attention_mask : torch.Tensor, optional
+            Boolean mask of shape ``(B, L)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated single representation, shape ``(B, L, C_s)``.
+        """
+        single_out, _, _, _ = self.forward_tracks(single, t_emb,
+                                                  attention_mask)
+        return single_out
+
+    # -- Full multi-track API (for tests and downstream consumers) ----
+
+    def forward_tracks(
+        self,
+        single: torch.Tensor,
+        t_emb: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        rotations: Optional[torch.Tensor] = None,
+        translations: Optional[torch.Tensor] = None,
+        chunk_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run all tracks and return ``(single, pair, rotations, translations)``.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Shape ``(B, L, C_s)``.
+        t_emb : torch.Tensor
+            Shape ``(B, C_s)``.
+        attention_mask : torch.Tensor, optional
+            Shape ``(B, L)``.
+        rotations : torch.Tensor, optional
+            Initial frame rotations of shape ``(B, L, 3, 3)``. If
+            ``None``, identity rotations are used.
+        translations : torch.Tensor, optional
+            Initial frame translations of shape ``(B, L, 3)``. If
+            ``None``, zero translations are used.
+        chunk_size : int, optional
+            Override the stack-level default chunk size for this call.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+            Final ``(single, pair, rotations, translations)``.
+        """
+        if single.dim() != 3:
+            raise ValueError('single must be 3D (B, L, C_s).')
+        if single.size(-1) != self.embed_dim:
+            raise ValueError(
+                f'Expected embed_dim {self.embed_dim}, got {single.size(-1)}.')
+        if t_emb.dim() != 2 or t_emb.size(-1) != self.embed_dim:
+            raise ValueError(
+                't_emb must have shape (B, embed_dim).')
+
+        batch, seq_len, _ = single.shape
+        device = single.device
+        dtype = single.dtype
+
+        # Mask coercion.
+        mask = None
+        if attention_mask is not None:
+            mask = attention_mask.to(device=device, dtype=torch.bool)
+            if mask.shape != (batch, seq_len):
+                raise ValueError(
+                    'attention_mask must have shape (B, L).')
+
+        # Initial frames.
+        if rotations is None:
+            rotations, translations_id = make_identity_rigid(
+                (batch, seq_len), device=device, dtype=dtype)
+            if translations is None:
+                translations = translations_id
+        elif translations is None:
+            translations = torch.zeros(batch, seq_len, 3,
+                                       device=device, dtype=dtype)
+
+        # Initial pair: symmetric relpos + symmetric OPM.
+        rel = self.rel_pos(seq_len, device=device).to(dtype)
+        pair = rel.unsqueeze(0).expand(batch, -1, -1, -1).contiguous()
+        pair = pair + self.initial_opm(single)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+
+        active_chunk = (chunk_size
+                        if chunk_size is not None else self.chunk_size)
+
+        for block in self.blocks:
+            single, pair, rotations, translations = block(
+                single, pair, rotations, translations, t_emb,
+                mask=mask, chunk_size=active_chunk)
+            # Re-mask single for masked residues so that downstream
+            # consumers see exactly zeros for padded entries.
+            if mask is not None:
+                single = single * mask.unsqueeze(-1).to(single.dtype)
+
+        single = self.final_norm(single)
+        return single, pair, rotations, translations

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_se3.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_se3.py
@@ -1,0 +1,660 @@
+"""Exhaustive tests for SE(3) rigid-frame utilities and Invariant Point
+Attention.
+
+The test suite is organised by mathematical property:
+
+* **Frame construction** — orthonormality, right-handedness, exact
+  agreement with AlphaFold2 Algorithm 21 on a hand-computed example,
+  invariance to atom ordering, behaviour under near-degenerate inputs.
+* **Rigid algebra** — round-trips for ``apply``/``apply_inverse`` and
+  ``invert``, associativity of ``compose_rigids``, identity element,
+  broadcasting over arbitrary trailing dimensions.
+* **Invariant Point Attention** — shape preservation, exact SE(3)
+  invariance of the scalar output to global rotations *and*
+  translations, key/query masking semantics, deterministic gradient
+  flow into every learnable parameter, fp64 promotion, dropout-eval
+  determinism, doubled-token symmetry, construction validation, and
+  consistency between the no-pair and with-pair code paths.
+
+All numerical tests use a strict ``atol = 1e-4`` in fp32 and
+``atol = 1e-7`` in fp64, matching the project's standards contract
+(Phase 1 of the Technical Readiness Report).
+"""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion_se3 import (
+        InvariantPointAttention,
+        apply_inverse_rigid,
+        apply_rigid,
+        build_backbone_frames,
+        compose_rigids,
+        invert_rigid,
+        make_identity_rigid,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _random_rotation(device=None, dtype=torch.float32, generator=None):
+    """Sample a uniformly random right-handed rotation via QR.
+
+    The Haar distribution on SO(3) is approximated by Q from the
+    QR-decomposition of an i.i.d. Gaussian matrix, with the signs of R's
+    diagonal absorbed into Q (Mezzadri 2007). A final det-flip ensures
+    ``det(Q) = +1``.
+    """
+    matrix = torch.randn(3, 3, device=device, dtype=dtype, generator=generator)
+    q_matrix, r_matrix = torch.linalg.qr(matrix)
+    signs = torch.sign(torch.diagonal(r_matrix))
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    q_matrix = q_matrix @ torch.diag(signs)
+    if torch.det(q_matrix) < 0:
+        q_matrix[:, -1] = -q_matrix[:, -1]
+    return q_matrix
+
+
+def _make_backbone(batch_size=2,
+                   seq_len=5,
+                   dtype=torch.float32,
+                   seed=0):
+    """Construct nondegenerate ``(N, Cα, C)`` backbones around a planar template."""
+    generator = torch.Generator().manual_seed(seed)
+    base = torch.tensor([[-1.2, 1.1, 0.0],
+                         [0.0, 0.0, 0.0],
+                         [1.5, 0.0, 0.0]],
+                        dtype=dtype)
+    offsets = torch.randn(batch_size,
+                          seq_len,
+                          1,
+                          3,
+                          dtype=dtype,
+                          generator=generator)
+    return base.view(1, 1, 3, 3) + offsets
+
+
+# ---------------------------------------------------------------------------
+# Rigid-frame utilities
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestRigidFrameUtilities:
+    """Tests for :func:`build_backbone_frames` and rigid algebra."""
+
+    # --- Frame construction ----------------------------------------
+
+    def test_frames_are_orthonormal_and_right_handed(self):
+        backbone = _make_backbone(batch_size=3, seq_len=7)
+        R, t = build_backbone_frames(backbone)
+        assert R.shape == (3, 7, 3, 3)
+        assert t.shape == (3, 7, 3)
+        gram = R.transpose(-1, -2) @ R
+        identity = torch.eye(3).expand_as(gram)
+        assert torch.allclose(gram, identity, atol=1e-5)
+        det = torch.det(R)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+
+    def test_translation_is_alpha_carbon(self):
+        backbone = _make_backbone()
+        _, t = build_backbone_frames(backbone)
+        assert torch.allclose(t, backbone[..., 1, :], atol=0.0)
+
+    def test_local_x_axis_is_unit_ca_to_c(self):
+        """The first column of R must equal (C − Cα) / ‖C − Cα‖."""
+        backbone = _make_backbone(seed=42)
+        R, _ = build_backbone_frames(backbone)
+        expected_x = backbone[..., 2, :] - backbone[..., 1, :]
+        expected_x = expected_x / torch.linalg.norm(
+            expected_x, dim=-1, keepdim=True)
+        assert torch.allclose(R[..., :, 0], expected_x, atol=1e-6)
+
+    def test_local_y_axis_perpendicular_to_x(self):
+        """ê₂ must be orthogonal to ê₁ and lie in the (Cα→N) plane."""
+        backbone = _make_backbone(seed=7)
+        R, _ = build_backbone_frames(backbone)
+        x_axis = R[..., :, 0]
+        y_axis = R[..., :, 1]
+        dot = (x_axis * y_axis).sum(dim=-1)
+        assert torch.allclose(dot, torch.zeros_like(dot), atol=1e-6)
+
+    def test_frames_match_alphafold_algorithm_21_on_canonical_residue(self):
+        """Hand-computed reference for a canonical planar residue."""
+        backbone = torch.tensor([[[-1.0, 1.0, 0.0],
+                                  [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        R, t = build_backbone_frames(backbone)
+        # x̂ = (1, 0, 0); the N atom contributes a +y component after
+        # projection so ŷ = (0, 1, 0); ẑ = x̂ × ŷ = (0, 0, 1).
+        expected_R = torch.eye(3).unsqueeze(0)
+        assert torch.allclose(R, expected_R, atol=1e-6)
+        assert torch.allclose(t, torch.zeros(1, 3), atol=0.0)
+
+    def test_frames_match_upstream_epsilon_normalization(self):
+        backbone = torch.tensor([[[[-1.1, 0.9, 0.2],
+                                   [0.2, -0.3, 0.4],
+                                   [1.4, 0.1, -0.2]]]], dtype=torch.float64)
+        R, t = build_backbone_frames(backbone, eps=1e-8)
+        n_atom = backbone[..., 0, :]
+        ca_atom = backbone[..., 1, :]
+        c_atom = backbone[..., 2, :]
+        e1 = c_atom - ca_atom
+        e1 = e1 / (torch.linalg.norm(e1, dim=-1, keepdim=True) + 1e-8)
+        v2 = n_atom - ca_atom
+        u2 = v2 - (e1 * v2).sum(dim=-1, keepdim=True) * e1
+        e2 = u2 / (torch.linalg.norm(u2, dim=-1, keepdim=True) + 1e-8)
+        e3 = torch.cross(e1, e2, dim=-1)
+        expected = torch.stack([e1, e2, e3], dim=-1)
+        assert torch.allclose(R, expected, atol=0.0, rtol=0.0)
+        assert torch.allclose(t, ca_atom, atol=0.0, rtol=0.0)
+
+    def test_frames_handle_small_n_ca_c_angle(self):
+        """A small but recoverable ∠N-Cα-C still yields orthonormal frames.
+
+        The N-Cα-C angle is intentionally small (≈1 mrad) so that the
+        Gram-Schmidt y component before normalization has magnitude
+        ≈1e-3, well above ``eps = 1e-8``. The upstream ``norm + eps``
+        convention still leaves a tiny O(eps / angle) norm error.
+        """
+        backbone = torch.tensor([[[1.0, 1e-3, 0.0],
+                                  [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        R, _ = build_backbone_frames(backbone)
+        assert torch.isfinite(R).all()
+        gram = R.transpose(-1, -2) @ R
+        assert torch.allclose(gram, torch.eye(3).unsqueeze(0), atol=3e-5)
+
+    def test_frames_handle_pathologically_collinear_atoms(self):
+        """Truly degenerate (N − Cα ∥ C − Cα) inputs must not produce NaN.
+
+        ε-stabilization cannot manufacture orthogonality from zero
+        information, but it must keep the result finite — otherwise a
+        single bad residue would corrupt an entire batch's gradient.
+        """
+        backbone = torch.tensor([[[1.0, 0.0, 0.0],
+                                  [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        R, t = build_backbone_frames(backbone)
+        assert torch.isfinite(R).all()
+        assert torch.isfinite(t).all()
+
+    def test_frames_se3_equivariance(self):
+        """build_backbone_frames is SE(3)-equivariant in (R, t)."""
+        backbone = _make_backbone(seed=11)
+        R, t = build_backbone_frames(backbone)
+        global_R = _random_rotation()
+        global_t = torch.randn(3)
+        moved = apply_rigid(global_R, global_t, backbone)
+        R_moved, t_moved = build_backbone_frames(moved)
+        assert torch.allclose(R_moved, global_R @ R, atol=1e-5)
+        expected_t = apply_rigid(global_R, global_t, t)
+        assert torch.allclose(t_moved, expected_t, atol=1e-5)
+
+    def test_frames_raise_on_bad_shape(self):
+        with pytest.raises(ValueError, match=r'\(\.\.\., 3, 3\)'):
+            build_backbone_frames(torch.zeros(2, 5, 3))
+
+    def test_frames_raise_on_nonpositive_eps(self):
+        backbone = _make_backbone()
+        with pytest.raises(ValueError, match='eps'):
+            build_backbone_frames(backbone, eps=0.0)
+
+    # --- make_identity_rigid ----------------------------------------
+
+    def test_make_identity_rigid_shape_and_values(self):
+        R, t = make_identity_rigid((4, 3))
+        assert R.shape == (4, 3, 3, 3)
+        assert t.shape == (4, 3, 3)
+        identity = torch.eye(3).expand_as(R)
+        assert torch.equal(R, identity)
+        assert torch.equal(t, torch.zeros_like(t))
+
+    def test_make_identity_rigid_scalar_shape(self):
+        R, t = make_identity_rigid(())
+        assert R.shape == (3, 3)
+        assert t.shape == (3,)
+
+    def test_make_identity_rigid_respects_dtype(self):
+        R, t = make_identity_rigid((2,), dtype=torch.float64)
+        assert R.dtype == torch.float64
+        assert t.dtype == torch.float64
+
+    def test_make_identity_rigid_returns_writable_tensor(self):
+        """The returned R must be a fresh tensor (no expanded strides)."""
+        R, _ = make_identity_rigid((4, 3))
+        R[0, 0, 0, 0] = 99.0  # Must not raise (no broadcasting view).
+        assert R[0, 0, 0, 0].item() == 99.0
+        assert R[0, 1, 0, 0].item() == 1.0  # Other slices unaffected.
+
+    # --- apply_rigid / apply_inverse_rigid --------------------------
+
+    def test_apply_rigid_inverse_roundtrip(self):
+        backbone = _make_backbone()
+        R, t = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(R, t, backbone)
+        recovered = apply_rigid(R, t, local)
+        assert torch.allclose(recovered, backbone, atol=1e-5)
+
+    def test_apply_rigid_broadcasts_over_extra_dims(self):
+        """Trailing point dimensions must broadcast cleanly."""
+        R, t = make_identity_rigid((2, 3))
+        R = R.clone()
+        for b in range(2):
+            for s in range(3):
+                R[b, s] = _random_rotation()
+        t = torch.randn(2, 3, 3)
+        # points shape: (B, L, K, M, 3) with two extra dims K, M.
+        points = torch.randn(2, 3, 4, 5, 3)
+        moved = apply_rigid(R, t, points)
+        assert moved.shape == points.shape
+        # Manual reconstruction.
+        expected = torch.einsum('blij,blkmj->blkmi', R, points) + \
+            t.view(2, 3, 1, 1, 3)
+        assert torch.allclose(moved, expected, atol=1e-5)
+
+    def test_apply_rigid_identity_is_noop(self):
+        R, t = make_identity_rigid((2, 5))
+        points = torch.randn(2, 5, 3)
+        moved = apply_rigid(R, t, points)
+        assert torch.allclose(moved, points, atol=0.0)
+
+    def test_apply_rigid_translation_only(self):
+        R, _ = make_identity_rigid((2, 5))
+        t = torch.randn(2, 5, 3)
+        points = torch.randn(2, 5, 3)
+        assert torch.allclose(apply_rigid(R, t, points),
+                              points + t,
+                              atol=1e-6)
+
+    def test_apply_rigid_raises_on_too_few_point_dims(self):
+        R, t = make_identity_rigid((2, 3))
+        bad = torch.randn(3)  # rank 1, fewer than the transform's 2 dims.
+        with pytest.raises(ValueError, match='at least'):
+            apply_rigid(R, t, bad)
+
+    # --- invert_rigid -----------------------------------------------
+
+    def test_invert_rigid_is_left_and_right_inverse(self):
+        backbone = _make_backbone()
+        R, t = build_backbone_frames(backbone)
+        Rinv, tinv = invert_rigid(R, t)
+        # Left inverse: T⁻¹ ∘ T = I.
+        R_left, t_left = compose_rigids(Rinv, tinv, R, t)
+        assert torch.allclose(R_left, torch.eye(3).expand_as(R_left), atol=1e-5)
+        assert torch.allclose(t_left, torch.zeros_like(t_left), atol=1e-5)
+        # Right inverse: T ∘ T⁻¹ = I.
+        R_right, t_right = compose_rigids(R, t, Rinv, tinv)
+        assert torch.allclose(R_right,
+                              torch.eye(3).expand_as(R_right),
+                              atol=1e-5)
+        assert torch.allclose(t_right, torch.zeros_like(t_right), atol=1e-5)
+
+    def test_double_inverse_is_identity(self):
+        backbone = _make_backbone()
+        R, t = build_backbone_frames(backbone)
+        R2, t2 = invert_rigid(*invert_rigid(R, t))
+        assert torch.allclose(R2, R, atol=1e-6)
+        assert torch.allclose(t2, t, atol=1e-6)
+
+    # --- compose_rigids ---------------------------------------------
+
+    def test_compose_matches_sequential_application(self):
+        Ra = torch.stack([_random_rotation() for _ in range(6)]).view(2, 3, 3, 3)
+        Rb = torch.stack([_random_rotation() for _ in range(6)]).view(2, 3, 3, 3)
+        ta = torch.randn(2, 3, 3)
+        tb = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 7, 3)
+
+        sequential = apply_rigid(Ra, ta, apply_rigid(Rb, tb, points))
+        R, t = compose_rigids(Ra, ta, Rb, tb)
+        composed = apply_rigid(R, t, points)
+        assert torch.allclose(composed, sequential, atol=1e-5)
+
+    def test_compose_is_associative(self):
+        rotations = [_random_rotation() for _ in range(3)]
+        translations = [torch.randn(3) for _ in range(3)]
+        Ra, Rb, Rc = rotations
+        ta, tb, tc = translations
+
+        R_left, t_left = compose_rigids(
+            *compose_rigids(Ra, ta, Rb, tb), Rc, tc)
+        R_right, t_right = compose_rigids(Ra, ta,
+                                          *compose_rigids(Rb, tb, Rc, tc))
+        assert torch.allclose(R_left, R_right, atol=1e-5)
+        assert torch.allclose(t_left, t_right, atol=1e-5)
+
+    def test_compose_with_identity_is_noop(self):
+        Ra = _random_rotation()
+        ta = torch.randn(3)
+        Ri, ti = make_identity_rigid(())
+        Ri = Ri.to(Ra)
+        ti = ti.to(ta)
+        R_left, t_left = compose_rigids(Ri, ti, Ra, ta)
+        R_right, t_right = compose_rigids(Ra, ta, Ri, ti)
+        assert torch.allclose(R_left, Ra, atol=1e-6)
+        assert torch.allclose(t_left, ta, atol=1e-6)
+        assert torch.allclose(R_right, Ra, atol=1e-6)
+        assert torch.allclose(t_right, ta, atol=1e-6)
+
+    def test_apply_rigid_supports_fp64_precision(self):
+        backbone = _make_backbone(dtype=torch.float64, seed=3)
+        R, t = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(R, t, backbone)
+        recovered = apply_rigid(R, t, local)
+        # Strict fp64 tolerance.
+        assert torch.allclose(recovered, backbone, atol=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Invariant Point Attention
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestInvariantPointAttention:
+    """Tests for :class:`InvariantPointAttention`."""
+
+    # --- Construction validation ------------------------------------
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(embed_dim=0, num_heads=2),
+        dict(embed_dim=16, num_heads=0),
+        dict(embed_dim=30, num_heads=8),
+        dict(embed_dim=16, num_heads=4, num_qk_points=0),
+        dict(embed_dim=16, num_heads=4, num_v_points=0),
+        dict(embed_dim=16, num_heads=4, pair_dim=0),
+        dict(embed_dim=16, num_heads=4, dropout=-0.1),
+        dict(embed_dim=16, num_heads=4, dropout=1.0),
+        dict(embed_dim=16, num_heads=4, eps=0.0),
+    ])
+    def test_invalid_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            InvariantPointAttention(**kwargs)
+
+    # --- Shape -------------------------------------------------------
+
+    def test_output_shape_no_pair(self):
+        backbone = _make_backbone(batch_size=2, seq_len=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        out = layer(torch.randn(2, 6, 32), R, t)
+        assert out.shape == (2, 6, 32)
+
+    def test_output_shape_with_pair(self):
+        backbone = _make_backbone(batch_size=2, seq_len=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32,
+                                        num_heads=4,
+                                        pair_dim=8)
+        out = layer(torch.randn(2, 6, 32),
+                    R,
+                    t,
+                    pair_repr=torch.randn(2, 6, 6, 8))
+        assert out.shape == (2, 6, 32)
+
+    # --- SE(3) invariance -------------------------------------------
+
+    @pytest.mark.parametrize('seed', [0, 1, 17, 2026])
+    def test_global_rotation_invariance(self, seed):
+        torch.manual_seed(seed)
+        backbone = _make_backbone(batch_size=2, seq_len=6, seed=seed)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32,
+                                        num_heads=4,
+                                        num_qk_points=3,
+                                        num_v_points=4).eval()
+        single = torch.randn(2, 6, 32)
+
+        out = layer(single, R, t)
+        global_R = _random_rotation()
+        global_t = torch.randn(3)
+        R_moved = global_R @ R
+        t_moved = apply_rigid(global_R, global_t, t)
+        out_moved = layer(single, R_moved, t_moved)
+        assert torch.allclose(out, out_moved, atol=1e-4)
+
+    def test_translation_only_invariance(self):
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=2, seq_len=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4).eval()
+        single = torch.randn(2, 6, 32)
+        out = layer(single, R, t)
+        translation = torch.randn(3) * 100.0  # Very large translation.
+        out_translated = layer(single, R, t + translation)
+        assert torch.allclose(out, out_translated, atol=1e-4)
+
+    def test_pair_bias_invariance(self):
+        """Output remains invariant when a pair bias term is present."""
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=2, seq_len=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32,
+                                        num_heads=4,
+                                        pair_dim=8).eval()
+        single = torch.randn(2, 6, 32)
+        pair = torch.randn(2, 6, 6, 8)
+        out = layer(single, R, t, pair_repr=pair)
+        global_R = _random_rotation()
+        global_t = torch.randn(3)
+        R_moved = global_R @ R
+        t_moved = apply_rigid(global_R, global_t, t)
+        out_moved = layer(single, R_moved, t_moved, pair_repr=pair)
+        assert torch.allclose(out, out_moved, atol=1e-4)
+
+    def test_invariance_in_fp64(self):
+        """fp64 numerics should hit a much tighter tolerance."""
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=1,
+                                  seq_len=4,
+                                  dtype=torch.float64)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4).eval()
+        layer = layer.to(dtype=torch.float64)
+        single = torch.randn(1, 4, 16, dtype=torch.float64)
+        out = layer(single, R, t)
+        global_R = _random_rotation(dtype=torch.float64)
+        global_t = torch.randn(3, dtype=torch.float64)
+        R_moved = global_R @ R
+        t_moved = apply_rigid(global_R, global_t, t)
+        out_moved = layer(single, R_moved, t_moved)
+        assert torch.allclose(out, out_moved, atol=1e-7)
+
+    # --- Masking -----------------------------------------------------
+
+    def test_masked_query_outputs_are_zero(self):
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=1, seq_len=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        single = torch.randn(1, 5, 32)
+        mask = torch.tensor([[1, 1, 1, 0, 0]], dtype=torch.bool)
+        out = layer(single, R, t, mask=mask)
+        assert torch.allclose(out[:, 3:], torch.zeros_like(out[:, 3:]),
+                              atol=0.0)
+
+    def test_masked_keys_do_not_influence_unmasked_queries(self):
+        """Perturbing a masked residue must leave unmasked outputs intact."""
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=1, seq_len=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4).eval()
+        single = torch.randn(1, 5, 32)
+        mask = torch.tensor([[1, 1, 1, 0, 0]], dtype=torch.bool)
+
+        out_a = layer(single, R, t, mask=mask)
+        # Replace masked rows with arbitrary content.
+        perturbed = single.clone()
+        perturbed[:, 3:] = torch.randn(1, 2, 32) * 1e3
+        R_p = R.clone()
+        t_p = t.clone()
+        R_p[:, 3:] = R_p[:, 3:] @ _random_rotation()
+        t_p[:, 3:] = torch.randn(1, 2, 3) * 100.0
+        out_b = layer(perturbed, R_p, t_p, mask=mask)
+        assert torch.allclose(out_a[:, :3], out_b[:, :3], atol=1e-4)
+
+    def test_mask_raises_on_wrong_shape(self):
+        backbone = _make_backbone(batch_size=1, seq_len=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        with pytest.raises(ValueError, match='mask'):
+            layer(torch.randn(1, 5, 16),
+                  R,
+                  t,
+                  mask=torch.ones(1, 5, 1, dtype=torch.bool))
+
+    # --- Pair-repr argument validation ------------------------------
+
+    def test_missing_pair_repr_raises(self):
+        backbone = _make_backbone(batch_size=1, seq_len=4)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16,
+                                        num_heads=4,
+                                        pair_dim=4)
+        with pytest.raises(ValueError, match='pair_repr'):
+            layer(torch.randn(1, 4, 16), R, t)
+
+    def test_extra_pair_repr_raises(self):
+        backbone = _make_backbone(batch_size=1, seq_len=4)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        with pytest.raises(ValueError, match='pair_repr'):
+            layer(torch.randn(1, 4, 16),
+                  R,
+                  t,
+                  pair_repr=torch.randn(1, 4, 4, 4))
+
+    def test_input_shape_validation(self):
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        single = torch.randn(2, 5, 16)
+        with pytest.raises(ValueError, match='single_repr'):
+            layer(torch.randn(2, 5), torch.randn(2, 5, 3, 3),
+                  torch.randn(2, 5, 3))
+        with pytest.raises(ValueError, match='rotations'):
+            layer(single, torch.randn(2, 5, 3, 4), torch.randn(2, 5, 3))
+        with pytest.raises(ValueError, match='translations'):
+            layer(single, torch.randn(2, 5, 3, 3), torch.randn(2, 5, 4))
+
+    # --- Gradient flow ----------------------------------------------
+
+    def test_gradient_flow_into_all_inputs_and_parameters(self):
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=1, seq_len=4)
+        R, t = build_backbone_frames(backbone)
+        R = R.detach().clone().requires_grad_(True)
+        t = t.detach().clone().requires_grad_(True)
+        single = torch.randn(1, 4, 16, requires_grad=True)
+        pair = torch.randn(1, 4, 4, 4, requires_grad=True)
+        layer = InvariantPointAttention(embed_dim=16,
+                                        num_heads=4,
+                                        pair_dim=4)
+        out = layer(single, R, t, pair_repr=pair)
+        out.sum().backward()
+        # Input gradients.
+        assert single.grad is not None and torch.isfinite(single.grad).all()
+        assert R.grad is not None and torch.isfinite(R.grad).all()
+        assert t.grad is not None and torch.isfinite(t.grad).all()
+        assert pair.grad is not None and torch.isfinite(pair.grad).all()
+        # Parameter gradients (every learnable tensor must receive a grad).
+        for name, parameter in layer.named_parameters():
+            assert parameter.grad is not None, f'no grad for {name}'
+            assert torch.isfinite(parameter.grad).all(), \
+                f'non-finite grad for {name}'
+
+    def test_point_weights_softplus_keeps_gamma_positive(self):
+        """softplus(γ̂) ≥ 0 always; verify γ is strictly positive after a step."""
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        # A single gradient step should not be able to drive γ negative.
+        with torch.no_grad():
+            layer.point_weights.fill_(-50.0)
+        gamma = torch.nn.functional.softplus(layer.point_weights)
+        assert torch.all(gamma >= 0.0)
+        # Even with a huge negative bias, softplus is still finite.
+        assert torch.isfinite(gamma).all()
+
+    # --- Numerical / structural sanity checks ------------------------
+
+    def test_dropout_eval_is_deterministic(self):
+        torch.manual_seed(0)
+        backbone = _make_backbone(batch_size=1, seq_len=4)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16,
+                                        num_heads=4,
+                                        dropout=0.5).eval()
+        single = torch.randn(1, 4, 16)
+        out_a = layer(single, R, t)
+        out_b = layer(single, R, t)
+        assert torch.allclose(out_a, out_b, atol=0.0)
+
+    def test_weighting_constants_have_expected_values(self):
+        """w_C must equal √(2/(9·N_qk)) and w_L must equal √(1/L)."""
+        no_pair = InvariantPointAttention(embed_dim=16,
+                                          num_heads=4,
+                                          num_qk_points=4)
+        with_pair = InvariantPointAttention(embed_dim=16,
+                                            num_heads=4,
+                                            num_qk_points=4,
+                                            pair_dim=8)
+        expected_w_c = math.sqrt(2.0 / (9.0 * 4))
+        assert math.isclose(no_pair.w_c.item(), expected_w_c, rel_tol=1e-7)
+        assert math.isclose(with_pair.w_c.item(), expected_w_c, rel_tol=1e-7)
+        assert math.isclose(no_pair.w_l.item(),
+                            math.sqrt(1.0 / 2.0),
+                            rel_tol=1e-7)
+        assert math.isclose(with_pair.w_l.item(),
+                            math.sqrt(1.0 / 3.0),
+                            rel_tol=1e-7)
+
+    def test_identity_frame_input_is_pure_self_attention(self):
+        """With identity frames and no pair bias, point distances depend only
+        on the projected local points and the layer reduces to a structured
+        self-attention block. The output must remain finite and shape-stable
+        and depend continuously on the single representation.
+        """
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4).eval()
+        R, t = make_identity_rigid((1, 4))
+        single = torch.randn(1, 4, 16)
+        out_a = layer(single, R, t)
+        out_b = layer(single + 1e-6, R, t)
+        assert torch.isfinite(out_a).all()
+        # Continuity: tiny input perturbation produces tiny output change.
+        assert (out_a - out_b).abs().max().item() < 1e-2
+
+    def test_attention_distinguishes_residues_by_geometry_alone(self):
+        """Two residues differing only in frame translations should be
+        mapped to different outputs, demonstrating the point-distance
+        term contributes meaningfully to the attention logits.
+        """
+        torch.manual_seed(0)
+        # Construct two configurations that share scalar inputs and
+        # rotations but differ in translations only.
+        layer = InvariantPointAttention(embed_dim=16,
+                                        num_heads=4,
+                                        num_qk_points=4,
+                                        num_v_points=4).eval()
+        R, _ = make_identity_rigid((1, 3))
+        single = torch.randn(1, 3, 16)
+        t_close = torch.tensor([[[0.0, 0.0, 0.0],
+                                 [1.0, 0.0, 0.0],
+                                 [2.0, 0.0, 0.0]]])
+        t_far = torch.tensor([[[0.0, 0.0, 0.0],
+                               [50.0, 0.0, 0.0],
+                               [100.0, 0.0, 0.0]]])
+        out_close = layer(single, R, t_close)
+        out_far = layer(single, R, t_far)
+        # The two outputs must differ (point-distance term is active).
+        assert not torch.allclose(out_close, out_far, atol=1e-3)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_tracks.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_tracks.py
@@ -1,0 +1,705 @@
+"""Exhaustive tests for the RFDiffusion multi-track architecture.
+
+The suite covers four mutually independent guarantees that the
+multi-track stack must uphold:
+
+* **Geometric correctness** — frame outputs are SE(3)-equivariant
+  under any global rigid motion applied to the input frames; the
+  scalar (single) output is exactly invariant.
+* **Algebraic symmetry** — the pair representation produced by every
+  block satisfies :math:`z_{ij} = z_{ji}` to within fp32 round-off.
+* **Memory-bounded correctness** — chunked execution of the
+  triangular updates and triangular attention produces *bitwise-equal*
+  outputs to the dense path (the chunking trick must not change the
+  numerics, only the working-set size).
+* **Holistic DeepChem integration** — the new stack is a drop-in
+  replacement for the existing
+  :class:`~deepchem.models.torch_models.rfdiffusion.DiffusionTransformerBlock`
+  stack inside :class:`~deepchem.models.torch_models.rfdiffusion.BackboneDiffusion`.
+  The full denoiser must produce the correct output shape, route
+  timestep and self-conditioning inputs through, and propagate
+  gradients into every parameter of the multi-track stack.
+
+All numerical tolerances follow the standards contract in the Phase 1
+Technical Readiness Report (fp32 ``atol = 1e-4``; chunk-vs-dense must
+be exact).
+"""
+
+import pytest
+
+try:
+    import torch
+    import torch.nn as nn
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion import BackboneDiffusion
+    from deepchem.models.torch_models.rfdiffusion_se3 import (
+        apply_rigid,
+        build_backbone_frames,
+        make_identity_rigid,
+    )
+    from deepchem.models.torch_models.rfdiffusion_tracks import (
+        BackboneUpdate,
+        OuterProductMean,
+        PairBiasedSingleAttention,
+        PairTransition,
+        RelativePositionEmbedding,
+        RFDiffusionMultiTrackStack,
+        RFDiffusionTrackBlock,
+        SingleTransition,
+        TriangleAttention,
+        TriangleMultiplicativeUpdate,
+        quaternion_to_rotation_matrix,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _random_rotation(dtype=torch.float32):
+    matrix = torch.randn(3, 3, dtype=dtype)
+    q, r = torch.linalg.qr(matrix)
+    signs = torch.sign(torch.diagonal(r))
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    q = q @ torch.diag(signs)
+    if torch.det(q) < 0:
+        q[:, -1] = -q[:, -1]
+    return q
+
+
+def _make_stack(num_blocks=2, chunk_size=None, dropout=0.0):
+    """Construct a small but non-trivial multi-track stack."""
+    return RFDiffusionMultiTrackStack(
+        embed_dim=32,
+        pair_dim=16,
+        num_blocks=num_blocks,
+        num_heads=4,
+        pair_num_heads=2,
+        triangle_hidden_dim=16,
+        triangle_head_dim=8,
+        opm_hidden_dim=8,
+        num_qk_points=2,
+        num_v_points=4,
+        max_relative_position=8,
+        chunk_size=chunk_size,
+        dropout=dropout,
+    )
+
+
+def _randomise_backbone_update(stack):
+    """Replace zero-init backbone-update weights with random non-zero ones.
+
+    The default zero-init is correct for stable diffusion training but
+    makes the per-block frame update an identity, which would make
+    SE(3) equivariance trivial. Randomising the head exposes the
+    *true* equivariance of the architecture.
+    """
+    for block in stack.blocks:
+        torch.nn.init.normal_(block.backbone_update.linear.weight, std=0.05)
+        torch.nn.init.normal_(block.backbone_update.linear.bias, std=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Sub-module unit tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestSubmodules:
+    """Per-module sanity checks."""
+
+    def test_relpos_is_symmetric(self):
+        rel = RelativePositionEmbedding(pair_dim=12, max_relative_position=4)
+        emb = rel(7)
+        assert emb.shape == (7, 7, 12)
+        assert torch.allclose(emb, emb.transpose(0, 1), atol=0.0)
+        # Saturates beyond the clip radius.
+        assert torch.allclose(emb[0, 5], emb[0, 6], atol=0.0)
+
+    def test_outer_product_mean_is_symmetric(self):
+        torch.manual_seed(0)
+        layer = OuterProductMean(embed_dim=16, pair_dim=8, hidden_dim=4)
+        single = torch.randn(2, 5, 16)
+        pair = layer(single)
+        assert pair.shape == (2, 5, 5, 8)
+        assert torch.allclose(pair, pair.transpose(-2, -3), atol=1e-6)
+
+    def test_triangle_multiplication_chunked_equals_dense(self):
+        torch.manual_seed(0)
+        for outgoing in (True, False):
+            layer = TriangleMultiplicativeUpdate(pair_dim=8,
+                                                 hidden_dim=4,
+                                                 outgoing=outgoing).eval()
+            pair = torch.randn(2, 7, 7, 8)
+            dense = layer(pair, chunk_size=None)
+            for chunk in (1, 2, 3, 7, 100):
+                chunked = layer(pair, chunk_size=chunk)
+                assert torch.allclose(dense, chunked, atol=1e-6), (
+                    f'outgoing={outgoing}, chunk={chunk} mismatch')
+
+    def test_triangle_attention_chunked_equals_dense(self):
+        torch.manual_seed(0)
+        for start in (True, False):
+            layer = TriangleAttention(pair_dim=8,
+                                      num_heads=2,
+                                      head_dim=4,
+                                      starting_node=start).eval()
+            pair = torch.randn(2, 6, 6, 8)
+            dense = layer(pair, chunk_size=None)
+            for chunk in (1, 2, 3, 6, 100):
+                chunked = layer(pair, chunk_size=chunk)
+                assert torch.allclose(dense, chunked, atol=1e-6), (
+                    f'starting_node={start}, chunk={chunk} mismatch')
+
+    def test_pair_transition_preserves_shape(self):
+        layer = PairTransition(pair_dim=8)
+        pair = torch.randn(2, 5, 5, 8)
+        assert layer(pair).shape == pair.shape
+
+    def test_single_transition_uses_timestep(self):
+        torch.manual_seed(0)
+        layer = SingleTransition(embed_dim=16).eval()
+        single = torch.randn(2, 4, 16)
+        t1 = torch.zeros(2, 16)
+        t2 = torch.randn(2, 16) * 5.0
+        out1 = layer(single, t1)
+        out2 = layer(single, t2)
+        assert not torch.allclose(out1, out2, atol=1e-4)
+
+    def test_pair_biased_single_attention_uses_pair(self):
+        torch.manual_seed(0)
+        layer = PairBiasedSingleAttention(embed_dim=16,
+                                          pair_dim=8,
+                                          num_heads=4).eval()
+        single = torch.randn(2, 5, 16)
+        pair_a = torch.zeros(2, 5, 5, 8)
+        pair_b = torch.randn(2, 5, 5, 8)
+        out_a = layer(single, pair_a)
+        out_b = layer(single, pair_b)
+        assert not torch.allclose(out_a, out_b, atol=1e-4)
+
+    def test_quaternion_identity_is_identity_rotation(self):
+        quat = torch.tensor([1.0, 0.0, 0.0, 0.0])
+        R = quaternion_to_rotation_matrix(quat)
+        assert torch.allclose(R, torch.eye(3), atol=1e-7)
+
+    def test_quaternion_rotation_is_proper_rotation(self):
+        torch.manual_seed(0)
+        quat = torch.randn(8, 4)
+        R = quaternion_to_rotation_matrix(quat)
+        gram = R.transpose(-1, -2) @ R
+        identity = torch.eye(3).expand_as(gram)
+        assert torch.allclose(gram, identity, atol=1e-6)
+        det = torch.det(R)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-6)
+
+    def test_backbone_update_is_identity_at_init(self):
+        """Zero-initialised head must yield (R, t) unchanged."""
+        torch.manual_seed(0)
+        head = BackboneUpdate(embed_dim=16)
+        single = torch.randn(2, 4, 16)
+        R, t = make_identity_rigid((2, 4))
+        R = R.clone()
+        # Use non-identity input frames to make the test sharper.
+        R[0, 0] = _random_rotation()
+        t = torch.randn(2, 4, 3)
+        R_new, t_new = head(single, R, t)
+        assert torch.allclose(R_new, R, atol=1e-7)
+        assert torch.allclose(t_new, t, atol=1e-7)
+
+    def test_backbone_update_equivariance(self):
+        """After random head weights, frames update equivariantly."""
+        torch.manual_seed(0)
+        head = BackboneUpdate(embed_dim=16)
+        nn.init.normal_(head.linear.weight, std=0.05)
+        nn.init.normal_(head.linear.bias, std=0.05)
+        single = torch.randn(1, 4, 16)
+        R = torch.stack([_random_rotation() for _ in range(4)]).unsqueeze(0)
+        t = torch.randn(1, 4, 3)
+        R_new, t_new = head(single, R, t)
+        # Apply global SE(3).
+        Q = _random_rotation()
+        tg = torch.randn(3)
+        R_moved = Q @ R
+        t_moved = apply_rigid(Q, tg, t)
+        R_new_moved, t_new_moved = head(single, R_moved, t_moved)
+        assert torch.allclose(R_new_moved, Q @ R_new, atol=1e-5)
+        assert torch.allclose(t_new_moved,
+                              apply_rigid(Q, tg, t_new),
+                              atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Block-level integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestTrackBlock:
+    """Tests of a single :class:`RFDiffusionTrackBlock`."""
+
+    def test_block_preserves_track_shapes(self):
+        torch.manual_seed(0)
+        block = RFDiffusionTrackBlock(embed_dim=16,
+                                      pair_dim=8,
+                                      num_heads=4,
+                                      pair_num_heads=2,
+                                      triangle_hidden_dim=8,
+                                      triangle_head_dim=4,
+                                      opm_hidden_dim=4,
+                                      num_qk_points=2,
+                                      num_v_points=2).eval()
+        single = torch.randn(2, 5, 16)
+        pair = torch.randn(2, 5, 5, 8)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        R, t = make_identity_rigid((2, 5))
+        t_emb = torch.randn(2, 16)
+        out_s, out_z, out_R, out_t = block(single, pair, R, t, t_emb)
+        assert out_s.shape == single.shape
+        assert out_z.shape == pair.shape
+        assert out_R.shape == R.shape
+        assert out_t.shape == t.shape
+
+    def test_block_preserves_pair_symmetry(self):
+        torch.manual_seed(0)
+        block = RFDiffusionTrackBlock(embed_dim=16,
+                                      pair_dim=8,
+                                      num_heads=4,
+                                      pair_num_heads=2,
+                                      triangle_hidden_dim=8,
+                                      triangle_head_dim=4,
+                                      opm_hidden_dim=4).eval()
+        single = torch.randn(1, 6, 16)
+        pair = torch.randn(1, 6, 6, 8)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        R, t = make_identity_rigid((1, 6))
+        t_emb = torch.randn(1, 16)
+        _, out_z, _, _ = block(single, pair, R, t, t_emb)
+        assert torch.allclose(out_z, out_z.transpose(-2, -3), atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Stack-level tests (the core deliverable)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestMultiTrackStack:
+    """Tests of the full :class:`RFDiffusionMultiTrackStack`."""
+
+    # -- Shape / construction -----------------------------------------
+
+    def test_stack_construction_rejects_bad_num_blocks(self):
+        with pytest.raises(ValueError, match='num_blocks'):
+            RFDiffusionMultiTrackStack(
+                embed_dim=16, pair_dim=8, num_blocks=0)
+
+    def test_forward_shape(self):
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        single = torch.randn(2, 6, 32)
+        t_emb = torch.randn(2, 32)
+        out = stack(single, t_emb)
+        assert out.shape == (2, 6, 32)
+
+    def test_forward_tracks_shapes(self):
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        single = torch.randn(2, 6, 32)
+        t_emb = torch.randn(2, 32)
+        s, z, R, t = stack.forward_tracks(single, t_emb)
+        assert s.shape == (2, 6, 32)
+        assert z.shape == (2, 6, 6, 16)
+        assert R.shape == (2, 6, 3, 3)
+        assert t.shape == (2, 6, 3)
+
+    def test_forward_rejects_wrong_input_shapes(self):
+        stack = _make_stack().eval()
+        # Wrong embed_dim.
+        with pytest.raises(ValueError, match='embed_dim'):
+            stack(torch.randn(2, 6, 16), torch.randn(2, 32))
+        # Wrong t_emb.
+        with pytest.raises(ValueError, match='t_emb'):
+            stack(torch.randn(2, 6, 32), torch.randn(2, 16))
+        # Wrong single rank.
+        with pytest.raises(ValueError, match='single'):
+            stack(torch.randn(2, 32), torch.randn(2, 32))
+        # Wrong mask shape.
+        with pytest.raises(ValueError, match='attention_mask'):
+            stack(torch.randn(2, 6, 32),
+                  torch.randn(2, 32),
+                  attention_mask=torch.ones(2, 7))
+
+    # -- Pair symmetry ------------------------------------------------
+
+    def test_pair_output_symmetry(self):
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        single = torch.randn(2, 7, 32)
+        t_emb = torch.randn(2, 32)
+        _, pair, _, _ = stack.forward_tracks(single, t_emb)
+        assert torch.allclose(pair, pair.transpose(-2, -3), atol=1e-5)
+
+    # -- SE(3) equivariance / invariance ------------------------------
+
+    @pytest.mark.parametrize('seed', [0, 17, 2026])
+    def test_frame_equivariance_under_global_se3(self, seed):
+        """Frames transform equivariantly; the single output is invariant."""
+        torch.manual_seed(seed)
+        stack = _make_stack().eval()
+        _randomise_backbone_update(stack)
+
+        single = torch.randn(2, 5, 32)
+        t_emb = torch.randn(2, 32)
+        # Non-trivial initial frames so the test exercises composition.
+        R_init = torch.stack(
+            [_random_rotation() for _ in range(10)]).view(2, 5, 3, 3)
+        t_init = torch.randn(2, 5, 3)
+
+        s_a, _, R_a, t_a = stack.forward_tracks(single,
+                                                t_emb,
+                                                rotations=R_init,
+                                                translations=t_init)
+
+        # Apply global SE(3) to initial frames.
+        Q = _random_rotation()
+        tg = torch.randn(3)
+        R_init_g = Q @ R_init
+        t_init_g = apply_rigid(Q, tg, t_init)
+
+        s_b, _, R_b, t_b = stack.forward_tracks(single,
+                                                t_emb,
+                                                rotations=R_init_g,
+                                                translations=t_init_g)
+        assert torch.allclose(s_b, s_a, atol=1e-4)
+        assert torch.allclose(R_b, Q @ R_a, atol=1e-4)
+        assert torch.allclose(t_b, apply_rigid(Q, tg, t_a), atol=1e-4)
+
+    def test_translation_only_invariance_of_single(self):
+        """A pure global translation must leave the single output unchanged."""
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        _randomise_backbone_update(stack)
+        single = torch.randn(1, 4, 32)
+        t_emb = torch.randn(1, 32)
+        R_init = torch.stack(
+            [_random_rotation() for _ in range(4)]).view(1, 4, 3, 3)
+        t_init = torch.randn(1, 4, 3)
+        s_a, _, _, _ = stack.forward_tracks(single,
+                                            t_emb,
+                                            rotations=R_init,
+                                            translations=t_init)
+        tg = torch.randn(3) * 100.0
+        s_b, _, _, _ = stack.forward_tracks(single,
+                                            t_emb,
+                                            rotations=R_init,
+                                            translations=t_init + tg)
+        assert torch.allclose(s_a, s_b, atol=1e-4)
+
+    # -- Chunking correctness -----------------------------------------
+
+    @pytest.mark.parametrize('chunk_size', [1, 2, 3, 4])
+    def test_chunked_matches_dense_exactly(self, chunk_size):
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        single = torch.randn(2, 8, 32)
+        t_emb = torch.randn(2, 32)
+        s_d, z_d, R_d, t_d = stack.forward_tracks(single,
+                                                  t_emb,
+                                                  chunk_size=None)
+        s_c, z_c, R_c, t_c = stack.forward_tracks(single,
+                                                  t_emb,
+                                                  chunk_size=chunk_size)
+        # Bitwise / extremely tight tolerance.
+        assert torch.allclose(s_d, s_c, atol=1e-6), (
+            f'single mismatch for chunk_size={chunk_size}')
+        assert torch.allclose(z_d, z_c, atol=1e-6), (
+            f'pair mismatch for chunk_size={chunk_size}')
+        assert torch.allclose(R_d, R_c, atol=1e-6)
+        assert torch.allclose(t_d, t_c, atol=1e-6)
+
+    # -- Timestep sensitivity -----------------------------------------
+
+    def test_single_output_depends_on_timestep(self):
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        single = torch.randn(2, 5, 32)
+        t_a = torch.zeros(2, 32)
+        t_b = torch.randn(2, 32) * 5.0
+        out_a = stack(single, t_a)
+        out_b = stack(single, t_b)
+        assert not torch.allclose(out_a, out_b, atol=1e-4)
+
+    # -- Masking -----------------------------------------------------
+
+    def test_masked_residues_have_zero_output(self):
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        single = torch.randn(2, 6, 32)
+        t_emb = torch.randn(2, 32)
+        mask = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 1, 0]],
+                            dtype=torch.bool)
+        out = stack(single, t_emb, attention_mask=mask)
+        assert torch.allclose(out[0, 4:],
+                              torch.zeros_like(out[0, 4:]),
+                              atol=0.0)
+        assert torch.allclose(out[1, 5:],
+                              torch.zeros_like(out[1, 5:]),
+                              atol=0.0)
+
+    # -- Gradient flow -----------------------------------------------
+
+    def test_gradient_flows_into_all_tracks(self):
+        """Use the full ``forward_tracks`` output so every parameter
+        contributes — including the last block's ``backbone_update``
+        which is architecturally orphaned when only the single output
+        is returned (its frames are never consumed downstream).
+        """
+        torch.manual_seed(0)
+        stack = _make_stack(dropout=0.0)
+        single = torch.randn(1, 5, 32, requires_grad=True)
+        t_emb = torch.randn(1, 32, requires_grad=True)
+        s, z, R, t = stack.forward_tracks(single, t_emb)
+        (s.sum() + z.sum() + R.sum() + t.sum()).backward()
+        assert single.grad is not None and torch.isfinite(single.grad).all()
+        assert t_emb.grad is not None and torch.isfinite(t_emb.grad).all()
+        # Every learnable parameter receives a finite gradient.
+        for name, parameter in stack.named_parameters():
+            assert parameter.grad is not None, f'no grad for {name}'
+            assert torch.isfinite(parameter.grad).all(), \
+                f'non-finite grad for {name}'
+
+    def test_gradient_flows_into_initial_frames(self):
+        torch.manual_seed(0)
+        stack = _make_stack()
+        _randomise_backbone_update(stack)
+        single = torch.randn(1, 4, 32)
+        t_emb = torch.randn(1, 32)
+        R = torch.stack(
+            [_random_rotation() for _ in range(4)]).view(1, 4, 3, 3)
+        R = R.detach().clone().requires_grad_(True)
+        t = torch.randn(1, 4, 3, requires_grad=True)
+        s, _, R_out, t_out = stack.forward_tracks(single, t_emb,
+                                                  rotations=R,
+                                                  translations=t)
+        (R_out.sum() + t_out.sum() + s.sum()).backward()
+        assert R.grad is not None and torch.isfinite(R.grad).all()
+        assert t.grad is not None and torch.isfinite(t.grad).all()
+
+
+# ---------------------------------------------------------------------------
+# Holistic DeepChem integration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestBackboneDiffusionIntegration:
+    """Drop-in compatibility with :class:`BackboneDiffusion`."""
+
+    @staticmethod
+    def _replace_transformer_with_multitrack(model: 'BackboneDiffusion',
+                                             chunk_size=None
+                                             ) -> 'BackboneDiffusion':
+        """Swap the baseline transformer layer stack for the multi-track."""
+        stack = RFDiffusionMultiTrackStack(
+            embed_dim=model.embed_dim,
+            pair_dim=16,
+            num_blocks=2,
+            num_heads=4,
+            pair_num_heads=2,
+            triangle_hidden_dim=16,
+            triangle_head_dim=8,
+            opm_hidden_dim=8,
+            num_qk_points=2,
+            num_v_points=4,
+            max_relative_position=8,
+            chunk_size=chunk_size,
+        )
+        # The BackboneDiffusion forward loops over `self.layers`; a
+        # ModuleList containing a single multi-track stack therefore
+        # invokes the stack exactly once with the (h, t_emb, mask)
+        # signature it already expects.
+        model.layers = torch.nn.ModuleList([stack])
+        return model
+
+    def test_drop_in_forward_preserves_output_shape(self):
+        torch.manual_seed(0)
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=32,
+                                  time_dim=16,
+                                  num_layers=1,
+                                  num_heads=4,
+                                  max_seq_len=32).eval()
+        self._replace_transformer_with_multitrack(model)
+        coords = torch.randn(2, 6, 9)
+        timesteps = torch.randint(0, 100, (2,))
+        noise = model([coords, timesteps])
+        assert noise.shape == coords.shape
+
+    def test_drop_in_supports_self_conditioning(self):
+        torch.manual_seed(0)
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=32,
+                                  time_dim=16,
+                                  num_layers=1,
+                                  num_heads=4,
+                                  max_seq_len=32,
+                                  self_conditioning=True).eval()
+        self._replace_transformer_with_multitrack(model)
+        coords = torch.randn(2, 5, 9)
+        x0_prev = torch.randn(2, 5, 9)
+        timesteps = torch.randint(0, 100, (2,))
+        noise = model([coords, timesteps, x0_prev])
+        assert noise.shape == coords.shape
+
+    def test_drop_in_supports_mask(self):
+        torch.manual_seed(0)
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=32,
+                                  time_dim=16,
+                                  num_layers=1,
+                                  num_heads=4,
+                                  max_seq_len=32).eval()
+        self._replace_transformer_with_multitrack(model)
+        coords = torch.randn(2, 6, 9)
+        timesteps = torch.randint(0, 100, (2,))
+        mask = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 1, 1, 0]],
+                            dtype=torch.float32)
+        noise = model([coords, timesteps, mask])
+        assert noise.shape == coords.shape
+        # Masked residues must have zero predicted noise (because the
+        # output is multiplied by the mask in BackboneDiffusion).
+        assert torch.allclose(noise[0, 4:],
+                              torch.zeros_like(noise[0, 4:]),
+                              atol=0.0)
+        assert torch.allclose(noise[1, 5:],
+                              torch.zeros_like(noise[1, 5:]),
+                              atol=0.0)
+
+    def test_drop_in_responds_to_timestep(self):
+        torch.manual_seed(0)
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=32,
+                                  time_dim=16,
+                                  num_layers=1,
+                                  num_heads=4,
+                                  max_seq_len=32).eval()
+        # ``BackboneDiffusion`` zero-initialises its final output
+        # projection so the *trained* network starts from an identity
+        # noise prediction; for this sensitivity test we randomise it so
+        # the signal reaches the output.
+        nn.init.normal_(model.output_proj[-1].weight, std=0.05)
+        nn.init.normal_(model.output_proj[-1].bias, std=0.05)
+        self._replace_transformer_with_multitrack(model)
+        coords = torch.randn(2, 5, 9)
+        n_a = model([coords, torch.zeros(2, dtype=torch.long)])
+        n_b = model([coords, torch.full((2,), 99, dtype=torch.long)])
+        assert not torch.allclose(n_a, n_b, atol=1e-4)
+
+    def test_drop_in_chunking_matches_dense_end_to_end(self):
+        """Chunked execution inside BackboneDiffusion must match dense."""
+        torch.manual_seed(0)
+        model_dense = BackboneDiffusion(coord_dim=9,
+                                        embed_dim=32,
+                                        time_dim=16,
+                                        num_layers=1,
+                                        num_heads=4,
+                                        max_seq_len=32).eval()
+        self._replace_transformer_with_multitrack(model_dense, chunk_size=None)
+        # Build a chunked variant sharing the *same* multi-track weights.
+        model_chunked = BackboneDiffusion(coord_dim=9,
+                                          embed_dim=32,
+                                          time_dim=16,
+                                          num_layers=1,
+                                          num_heads=4,
+                                          max_seq_len=32).eval()
+        self._replace_transformer_with_multitrack(model_chunked, chunk_size=2)
+        # Copy *all* parameters from dense to chunked so the only
+        # difference is the chunk_size.
+        model_chunked.load_state_dict(model_dense.state_dict())
+        coords = torch.randn(2, 8, 9)
+        timesteps = torch.randint(0, 100, (2,))
+        out_d = model_dense([coords, timesteps])
+        out_c = model_chunked([coords, timesteps])
+        assert torch.allclose(out_d, out_c, atol=1e-5)
+
+    def test_end_to_end_gradients_into_multitrack_parameters(self):
+        """Every non-orphaned multi-track parameter must receive a
+        finite gradient when only the single representation is read out
+        (the drop-in path).
+
+        The very last block's ``backbone_update`` parameters are
+        architecturally orphaned in the single-only output path because
+        their predicted frames are never consumed downstream. These are
+        explicitly excluded; tests in :class:`TestMultiTrackStack`
+        already cover the full-track gradient flow.
+        """
+        torch.manual_seed(0)
+        model = BackboneDiffusion(coord_dim=9,
+                                  embed_dim=32,
+                                  time_dim=16,
+                                  num_layers=1,
+                                  num_heads=4,
+                                  max_seq_len=32)
+        # Randomise the zero-initialised output projection so gradient
+        # actually flows through every layer.
+        nn.init.normal_(model.output_proj[-1].weight, std=0.05)
+        nn.init.normal_(model.output_proj[-1].bias, std=0.05)
+        self._replace_transformer_with_multitrack(model)
+        coords = torch.randn(2, 5, 9, requires_grad=True)
+        timesteps = torch.randint(0, 100, (2,))
+        noise = model([coords, timesteps])
+        noise.sum().backward()
+        # The multi-track stack is at model.layers[0].
+        stack = model.layers[0]
+        last_block_prefix = f'blocks.{len(stack.blocks) - 1}.backbone_update'
+        for name, parameter in stack.named_parameters():
+            if name.startswith(last_block_prefix):
+                continue
+            assert parameter.grad is not None, (
+                f'no grad reached multitrack parameter {name}')
+            assert torch.isfinite(parameter.grad).all(), (
+                f'non-finite grad for multitrack parameter {name}')
+
+    def test_end_to_end_se3_equivariance_of_frame_outputs(self):
+        """Use the multi-track stack directly with backbone-derived frames.
+
+        The end-to-end *coordinate* output of ``BackboneDiffusion`` is
+        not SE(3)-equivariant because its coordinate embedding is a
+        plain linear layer over raw coordinates. The architectural
+        guarantee is that the *frame outputs* of the multi-track stack
+        are equivariant under any global rigid motion applied to the
+        frames derived from the input backbone, which is what we test
+        here against frames built by
+        :func:`build_backbone_frames`.
+        """
+        torch.manual_seed(0)
+        stack = _make_stack().eval()
+        _randomise_backbone_update(stack)
+        backbone = torch.randn(1, 5, 3, 3)
+        R_init, t_init = build_backbone_frames(backbone)
+        single = torch.randn(1, 5, 32)
+        t_emb = torch.randn(1, 32)
+        s_a, _, R_a, t_a = stack.forward_tracks(single, t_emb,
+                                                rotations=R_init,
+                                                translations=t_init)
+        # Apply a global rigid motion to the backbone, derive new frames.
+        Q = _random_rotation()
+        tg = torch.randn(3)
+        backbone_moved = apply_rigid(Q, tg, backbone)
+        R_init_b, t_init_b = build_backbone_frames(backbone_moved)
+        s_b, _, R_b, t_b = stack.forward_tracks(single, t_emb,
+                                                rotations=R_init_b,
+                                                translations=t_init_b)
+        assert torch.allclose(s_b, s_a, atol=1e-4)
+        assert torch.allclose(R_b, Q @ R_a, atol=1e-4)
+        assert torch.allclose(t_b, apply_rigid(Q, tg, t_a), atol=1e-4)


### PR DESCRIPTION
## Summary
- add the local SE(3) rigid-frame and Invariant Point Attention implementation used by the RFDiffusion denoiser
- add the RoseTTAFold-style multi-track stack that couples single, pair, and frame updates
- include focused SE(3) tests plus the track module and tests as the visibility surface for the architecture

> This is a Draft PR pushed to establish the core RFDiffusion architecture foundation for the RF Antibody extensions. This code will be further formatted, modularly tested, and split into smaller, independent PRs for official review in the coming weeks.

## Notes for RF Antibodies Extension
- `rfdiffusion_se3.py` is the geometry entry point: downstream modules should consume the `(rotations, translations)` residue frames and use `InvariantPointAttention` when they need SE(3)-aware residue updates.
- `rfdiffusion_tracks.py` is the architecture entry point: `RFDiffusionMultiTrackStack` is the main module to plug into any antibody-specific denoiser that needs coupled 1D, 2D, and 3D updates.
- This draft sits on top of the already-open baseline `rfdiffusion.py` diffusion / wrapper work, so a downstream RF Antibodies head should interface with these modules rather than reimplementing the denoiser backbone.
