### PR TITLE
[WIP] RFDiffusion: SO(3), Contigs, and Quality Utilities

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -1,0 +1,566 @@
+"""SO(3) diffusion utilities for RFDiffusion.
+
+This module implements the rotational component of the RFDiffusion noise
+process [Watson2023]_: an IGSO(3) (Isotropic Gaussian on SO(3)) diffusion
+with a logarithmic variance schedule and a reverse-time Euler-Maruyama
+integrator on the so(3) tangent space [Leach2022]_, [Yim2023]_.
+
+Conventions
+-----------
+* Rotations are represented as ``(..., 3, 3)`` proper rotation matrices
+  R ∈ SO(3) with det(R) = +1.
+* A rotation is parameterised on the tangent space so(3) ≅ ℝ³ by a
+  rotation vector τ = ω · u where ω ∈ [0, π] is the rotation angle
+  (geodesic distance from the identity) and u ∈ S² is the rotation axis.
+* The matrix exponential of a tangent vector uses Rodrigues' formula
+  R = I + sin(ω) [u]_× + (1 − cos(ω)) [u]_×² where [u]_× is the
+  skew-symmetric matrix associated with u.
+
+Mathematical reference
+----------------------
+The IGSO(3) density on the rotation angle ω is
+
+.. math::
+
+    f(\\omega; \\sigma) = \\sum_{l=0}^{\\infty}
+        (2l+1)\\,
+        \\exp\\!\\left(-\\tfrac{l(l+1)}{2}\\sigma^{2}\\right)\\,
+        \\frac{\\sin\\!\\big((l+\\tfrac{1}{2})\\omega\\big)}
+             {\\sin(\\omega/2)}
+
+and the marginal density on ω ∈ [0, π] is
+
+.. math::
+
+    p(\\omega; \\sigma) = \\frac{1 - \\cos \\omega}{\\pi}\\, f(\\omega; \\sigma).
+
+The score on the rotation angle is
+
+.. math::
+
+    s(\\omega; \\sigma) = \\partial_{\\omega}\\log f(\\omega; \\sigma)
+
+and the score on so(3) — used as the drift term in the reverse SDE —
+points along the geodesic from the identity to R with magnitude
+``s(ω; σ)``.
+
+Developer-facing summary
+------------------------
+This file is the rotation-noise backend for RFDiffusion. Use
+``so3_exp_map`` and ``so3_log_map`` to move between tangent vectors and
+rotation matrices, build an ``IGSO3`` table once for cached score /
+sampling queries, and call ``so3_reverse_step`` during sampling to move
+one denoising step from ``R_t`` to ``R_{t-1}``.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+.. [Leach2022] Leach et al. "Denoising Diffusion Probabilistic Models on
+   SO(3) for Rotational Alignment." ICLR Workshop on Geometric and
+   Topological Representation Learning (2022).
+.. [Yim2023] Yim et al. "SE(3) Diffusion Model with Application to Protein
+   Backbone Generation." ICML (2023).
+"""
+
+import math
+from typing import Optional, Tuple
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_so3 requires PyTorch to be installed.')
+
+__all__ = [
+    'IGSO3',
+    'log_beta_schedule',
+    'so3_log_map',
+    'so3_exp_map',
+    'so3_reverse_step',
+]
+
+# Threshold below which series expansions are used instead of the closed
+# form to preserve numerical stability.
+_SMALL_OMEGA: float = 1e-4
+_SMALL_SIGMA: float = 5e-2
+
+
+def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
+    """Return ``sin(x) / x`` with a stable Taylor series near zero.
+
+    Computes the second-order Taylor expansion ``1 - x²/6`` when
+    |x| < ``_SMALL_OMEGA`` and the closed-form expression elsewhere.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of arbitrary shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x`` containing ``sin(x) / x``.
+    """
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
+
+
+def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
+    """Return ``(1 − cos x) / x²`` with a Taylor series near zero.
+
+    Computes ``1/2 − x²/24`` when |x| < ``_SMALL_OMEGA`` and the closed
+    form ``(1 − cos x) / x²`` elsewhere.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of arbitrary shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x``.
+    """
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)
+    series = 0.5 - x * x / 24.0
+    return torch.where(small, series, closed)
+
+
+def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
+    """Map a tangent vector in so(3) ≅ ℝ³ to a rotation matrix.
+
+    Implements Rodrigues' rotation formula
+
+    .. math::
+
+        R = I + \\frac{\\sin\\omega}{\\omega}\\,[\\tau]_{\\times}
+            + \\frac{1 - \\cos\\omega}{\\omega^{2}}\\,[\\tau]_{\\times}^{2}
+
+    where ω = ‖τ‖ and [τ]_× is the skew-symmetric matrix of τ. Small-ω
+    Taylor expansions are used to maintain numerical stability.
+
+    Parameters
+    ----------
+    tangent : torch.Tensor
+        Tangent vector(s) of shape ``(..., 3)`` representing rotation
+        vectors τ = ω · u.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+    """
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)  # (..., 1)
+    # Build the skew matrix [τ]_×.
+    zeros = torch.zeros_like(tangent[..., 0])
+    tx, ty, tz = tangent[..., 0], tangent[..., 1], tangent[..., 2]
+    skew = torch.stack([
+        torch.stack([zeros, -tz, ty], dim=-1),
+        torch.stack([tz, zeros, -tx], dim=-1),
+        torch.stack([-ty, tx, zeros], dim=-1),
+    ], dim=-2)  # (..., 3, 3)
+    eye = torch.eye(3, dtype=tangent.dtype, device=tangent.device)
+    sin_coeff = _safe_sin_div_x(omega).unsqueeze(-1)         # (..., 1, 1)
+    cos_coeff = _safe_one_minus_cos_div_x_sq(omega).unsqueeze(-1)
+    skew_sq = torch.matmul(skew, skew)
+    return eye + sin_coeff * skew + cos_coeff * skew_sq
+
+
+def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
+    """Map rotation matrices to their tangent vectors in so(3).
+
+    Computes the principal-branch logarithm: ω = arccos((tr R − 1) / 2)
+    and τ = (ω / (2 sin ω)) · vee(R − Rᵀ), with stable expansions when
+    ω is close to 0 or π.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Tangent vectors of shape ``(..., 3)``.
+    """
+    trace = rotations.diagonal(offset=0, dim1=-2, dim2=-1).sum(-1)
+    cos_omega = ((trace - 1.0) * 0.5).clamp(-1.0, 1.0)
+    omega = torch.acos(cos_omega)  # (..., ) in [0, π]
+    # vee(R - Rᵀ) extracts the skew components.
+    skew = rotations - rotations.transpose(-1, -2)
+    vec = torch.stack([
+        skew[..., 2, 1],
+        skew[..., 0, 2],
+        skew[..., 1, 0],
+    ], dim=-1)  # (..., 3)
+    # τ = ω / (2 sin ω) · vec.  Use Taylor expansion when sin ω small.
+    sin_omega = torch.sin(omega)
+    small = omega < _SMALL_OMEGA
+    near_pi = (math.pi - omega) < 1e-3
+    coeff_closed = omega / (2.0 * torch.where(
+        small | near_pi, torch.ones_like(sin_omega), sin_omega))
+    coeff = torch.where(small, torch.full_like(omega, 0.5), coeff_closed)
+    tangent = coeff.unsqueeze(-1) * vec
+
+    # The standard formula is ill-conditioned near π because sin(ω) is
+    # close to zero. Recover the axis from the diagonal and use the skew
+    # part only for signs, matching scipy Rotation.as_rotvec() on the
+    # principal branch for rotations just below π.
+    diag = rotations.diagonal(offset=0, dim1=-2, dim2=-1)
+    axis_abs = torch.sqrt(((diag + 1.0) * 0.5).clamp(min=0.0))
+    signs = torch.sign(vec)
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    axis = axis_abs * signs
+    axis = axis / axis.norm(dim=-1, keepdim=True).clamp(min=1e-12)
+    tangent_near_pi = omega.unsqueeze(-1) * axis
+    return torch.where(near_pi.unsqueeze(-1), tangent_near_pi, tangent)
+
+
+def log_beta_schedule(num_steps: int,
+                      beta_min: float = 0.1,
+                      beta_max: float = 1.5) -> torch.Tensor:
+    """Logarithmic variance schedule for IGSO(3) diffusion.
+
+    Returns σ_t = exp(linear(log β_min, log β_max)) for t = 1 .. T. This
+    is the schedule used by [Watson2023]_ and [Yim2023]_ for rotational
+    diffusion. The schedule is **monotonically increasing** in t.
+
+    Parameters
+    ----------
+    num_steps : int
+        Number of diffusion steps T (must be ≥ 2).
+    beta_min : float, default 0.1
+        Smallest σ value (at t = 1).
+    beta_max : float, default 1.5
+        Largest σ value (at t = T).
+
+    Returns
+    -------
+    torch.Tensor
+        Schedule tensor of shape ``(num_steps,)`` containing σ_t values.
+    """
+    if num_steps < 2:
+        raise ValueError('num_steps must be >= 2.')
+    if beta_min <= 0 or beta_max <= 0 or beta_max <= beta_min:
+        raise ValueError(
+            'Require 0 < beta_min < beta_max; got '
+            f'beta_min={beta_min}, beta_max={beta_max}.')
+    log_min = math.log(beta_min)
+    log_max = math.log(beta_max)
+    return torch.exp(torch.linspace(log_min, log_max, num_steps))
+
+
+class IGSO3:
+    """Isotropic Gaussian distribution on SO(3).
+
+    The IGSO(3) density on the rotation angle ω ∈ [0, π] is the heat
+    kernel of the Laplace-Beltrami operator on SO(3) evaluated at
+    rotations whose geodesic distance from the identity is ω
+    [Nikolayev1997]_, [Leach2022]_.
+
+    The class caches a discretised PDF / CDF over a ``num_omega`` grid
+    for the supplied ``sigma`` values so that ``sample`` and ``score``
+    queries are fast.
+
+    Parameters
+    ----------
+    sigmas : torch.Tensor
+        1-D tensor of strictly positive σ values (one per discrete
+        diffusion step).
+    num_omega : int, default 1024
+        Number of grid points used to discretise ω ∈ (0, π).
+    lmax : int, default 1999
+        Maximum degree retained in the infinite-series PDF. This gives
+        2000 terms, matching upstream RFdiffusion's default truncation
+        level.
+    cache : bool, default True
+        If ``True`` precompute and cache the discretised PDF / CDF for
+        each σ in ``sigmas``.
+
+    Examples
+    --------
+    >>> sigmas = torch.tensor([0.5])
+    >>> dist = IGSO3(sigmas, num_omega=256)
+    >>> samples = dist.sample(sigma_index=0, shape=(8,))
+    >>> samples.shape
+    torch.Size([8, 3, 3])
+
+    References
+    ----------
+    .. [Nikolayev1997] Nikolayev, D. I. & Savyolov, T. I. "Normal
+       distribution on the rotation group SO(3)." Textures and
+       Microstructures 29 (1997) 201-233.
+    """
+
+    def __init__(self,
+                 sigmas: torch.Tensor,
+                 num_omega: int = 1024,
+                 lmax: int = 1999,
+                 cache: bool = True) -> None:
+        if sigmas.ndim != 1:
+            raise ValueError('sigmas must be a 1-D tensor.')
+        if (sigmas <= 0).any():
+            raise ValueError('sigmas must be strictly positive.')
+        if num_omega < 64:
+            raise ValueError('num_omega must be at least 64.')
+        if lmax < 1:
+            raise ValueError('lmax must be at least 1.')
+        self.sigmas = sigmas.to(dtype=torch.float64)
+        self.num_omega = int(num_omega)
+        self.lmax = int(lmax)
+        # Upstream RFdiffusion discretises ω as linspace(0, π, N+1)[1:]:
+        # zero is skipped, π is included.
+        self.omegas = torch.linspace(
+            0.0, math.pi, self.num_omega + 1, dtype=torch.float64)[1:]
+        self.domega = float(self.omegas[1] - self.omegas[0])
+        self._pdf: Optional[torch.Tensor] = None
+        self._cdf: Optional[torch.Tensor] = None
+        self._score: Optional[torch.Tensor] = None
+        if cache:
+            self._compute_tables()
+
+    # ------------------------------------------------------------------
+    # PDF / CDF / score on the rotation angle ω
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _f_omega(omega: torch.Tensor, sigma: torch.Tensor,
+                 lmax: int) -> torch.Tensor:
+        """Evaluate the heat-kernel series f(ω; σ).
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of shape ``(N,)`` containing rotation angles ω.
+        sigma : torch.Tensor
+            Tensor of shape ``(M,)`` containing σ values.
+        lmax : int
+            Truncation degree of the series.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(M, N)`` with ``f(ω_n; σ_m)``.
+        """
+        l_values = torch.arange(lmax + 1, device=omega.device)[None]
+        omega_col = omega[:, None]
+        rows = []
+        for sigma_i in sigma:
+            sigma_sq = float(sigma_i.detach().cpu().item() ** 2)
+            terms = ((2 * l_values + 1)
+                     * torch.exp(-l_values * (l_values + 1) * sigma_sq / 2)
+                     * torch.sin(omega_col * (l_values + 0.5))
+                     / torch.sin(omega_col / 2))
+            rows.append(terms.sum(dim=-1))
+        return torch.stack(rows, dim=0)
+
+    @staticmethod
+    def _score_omega(omega: torch.Tensor, sigma: torch.Tensor,
+                     lmax: int) -> torch.Tensor:
+        """Evaluate ∂ω log f(ω; σ) using upstream-style autograd."""
+        with torch.enable_grad():
+            omega_var = omega.detach().clone().requires_grad_(True)
+            f = IGSO3._f_omega(omega_var, sigma.detach(), lmax)
+            scores = []
+            for row in f:
+                log_f = torch.log(row)
+                grad = torch.autograd.grad(log_f.sum(), omega_var,
+                                           retain_graph=True)[0]
+                scores.append(grad.detach())
+        return torch.stack(scores, dim=0)
+
+    def _compute_tables(self) -> None:
+        """Populate the PDF / CDF / score caches."""
+        f = self._f_omega(self.omegas, self.sigmas, self.lmax)  # (M, N)
+        # Marginal density on ω: p(ω) = (1 − cos ω)/π · f(ω).
+        prefactor = (1.0 - torch.cos(self.omegas)) / math.pi  # (N,)
+        pdf = prefactor[None, :] * f
+        cdf = torch.cumsum(pdf, dim=-1) * self.domega
+        # Score s(ω; σ) = ∂ω log f(ω; σ), matching the upstream
+        # autograd derivative of the truncated heat-kernel series.
+        score = self._score_omega(self.omegas, self.sigmas, self.lmax)
+        self._pdf = pdf
+        self._cdf = cdf
+        self._score = score
+
+    def pdf(self, omega: torch.Tensor,
+            sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached PDF at the supplied angles.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles ω ∈ (0, π) of arbitrary shape.
+        sigma_index : int
+            Index of σ in ``self.sigmas`` whose PDF to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            PDF evaluated at the supplied angles.
+        """
+        if self._pdf is None:
+            self._compute_tables()
+        return self._interp(omega, self._pdf[sigma_index])
+
+    def cdf(self, omega: torch.Tensor,
+            sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached CDF at the supplied angles."""
+        if self._cdf is None:
+            self._compute_tables()
+        return self._interp(omega, self._cdf[sigma_index])
+
+    def score(self, omega: torch.Tensor,
+              sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached score s(ω; σ) at the supplied angles.
+
+        For small σ the IGSO(3) collapses to a wrapped Gaussian on
+        so(3); the score is then approximately −ω / σ². The cached
+        table already encodes this limit, so no special branch is
+        required at query time.
+        """
+        if self._score is None:
+            self._compute_tables()
+        return self._interp(omega, self._score[sigma_index])
+
+    def _interp(self, omega: torch.Tensor,
+                table: torch.Tensor) -> torch.Tensor:
+        """Linear interpolation of a 1-D cached table on the ω grid."""
+        omega = omega.to(dtype=torch.float64)
+        x = (omega - self.omegas[0]) / self.domega
+        x = x.clamp(0.0, float(self.num_omega - 1))
+        lo = x.floor().long()
+        hi = (lo + 1).clamp(max=self.num_omega - 1)
+        frac = (x - lo.to(x.dtype))
+        return (1.0 - frac) * table[lo] + frac * table[hi]
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+    def sample_angle(self, sigma_index: int,
+                     shape: Tuple[int, ...],
+                     generator: Optional[torch.Generator] = None
+                     ) -> torch.Tensor:
+        """Sample rotation angles ω from IGSO(3) by inverse CDF."""
+        if self._cdf is None:
+            self._compute_tables()
+        cdf = self._cdf[sigma_index]
+        u = torch.rand(shape, dtype=torch.float64, generator=generator)
+        idx = torch.searchsorted(cdf, u.flatten()).clamp(
+            max=self.num_omega - 1)
+        return self.omegas[idx].reshape(shape)
+
+    def sample(self, sigma_index: int,
+               shape: Tuple[int, ...],
+               generator: Optional[torch.Generator] = None) -> torch.Tensor:
+        """Sample rotation matrices from IGSO(3, σ).
+
+        Sampling proceeds by:
+
+        1. drawing ω ~ p(ω; σ) via inverse CDF;
+        2. drawing a uniform axis u ∈ S² (rejection-free);
+        3. mapping τ = ω · u through Rodrigues' formula.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of σ in ``self.sigmas``.
+        shape : tuple of int
+            Output batch shape; the returned tensor has shape
+            ``shape + (3, 3)``.
+        generator : torch.Generator, optional
+            PyTorch random generator for reproducibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Sampled rotation matrices of shape ``shape + (3, 3)`` in
+            ``torch.float32``.
+        """
+        omega = self.sample_angle(sigma_index, shape, generator=generator)
+        # Uniform axis on S² via standard normal normalisation.
+        axis = torch.randn(shape + (3,), dtype=torch.float64,
+                           generator=generator)
+        axis = axis / axis.norm(dim=-1, keepdim=True).clamp(min=1e-12)
+        tangent = (omega.unsqueeze(-1) * axis).to(dtype=torch.float32)
+        return so3_exp_map(tangent)
+
+    # ------------------------------------------------------------------
+    # Discrete normalisation check
+    # ------------------------------------------------------------------
+    def normalisation_error(self, sigma_index: int) -> float:
+        """Return |∫p(ω;σ) dω − 1| on the cached grid.
+
+        This mirrors the upstream RFdiffusion Riemann-sum check; the
+        table is not renormalised after truncation.
+        """
+        if self._pdf is None:
+            self._compute_tables()
+        total = float(self._pdf[sigma_index].sum() * self.domega)
+        return abs(total - 1.0)
+
+
+def so3_reverse_step(rotations: torch.Tensor,
+                     score: torch.Tensor,
+                     sigma_t: float,
+                     sigma_t_minus_1: float,
+                     noise: Optional[torch.Tensor] = None
+                     ) -> torch.Tensor:
+    """Single reverse-time Euler-Maruyama step on SO(3).
+
+    Implements the discretisation [Yim2023]_
+
+    .. math::
+
+        \\tau_{t-1} = (\\sigma_{t-1}^{2}/\\sigma_{t}^{2})\\,\\tau_{t}
+                    + (\\sigma_{t}^{2} - \\sigma_{t-1}^{2})\\,
+                      s(\\omega_t; \\sigma_t)\\,
+                      \\frac{\\tau_t}{\\omega_t}
+                    + \\sqrt{\\sigma_{t-1}^{2}\\,
+                            (1 - \\sigma_{t-1}^{2}/\\sigma_{t}^{2})}\\,
+                      \\xi
+
+    where ξ ∼ N(0, I₃), τ_t = log(R_t) and the resulting τ_{t−1} is
+    re-exponentiated via Rodrigues' formula to give R_{t−1}.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Current rotation matrices of shape ``(..., 3, 3)``.
+    score : torch.Tensor
+        Score s(ω_t; σ_t) evaluated at the current rotation angles,
+        broadcastable to the leading dimensions of ``rotations``.
+    sigma_t : float
+        Noise level at the current step.
+    sigma_t_minus_1 : float
+        Noise level at the previous step (must be < σ_t).
+    noise : torch.Tensor, optional
+        Standard normal noise of shape ``rotations.shape[:-2] + (3,)``.
+        If ``None`` a fresh sample is drawn.
+
+    Returns
+    -------
+    torch.Tensor
+        Updated rotation matrices of shape ``(..., 3, 3)``.
+    """
+    if sigma_t <= 0 or sigma_t_minus_1 <= 0:
+        raise ValueError('sigma values must be strictly positive.')
+    if sigma_t_minus_1 >= sigma_t:
+        raise ValueError(
+            'Reverse step requires sigma_t_minus_1 < sigma_t; got '
+            f'{sigma_t_minus_1} >= {sigma_t}.')
+    tau_t = so3_log_map(rotations)
+    omega = tau_t.norm(dim=-1, keepdim=True).clamp(min=_SMALL_OMEGA)
+    direction = tau_t / omega
+    score = score.unsqueeze(-1) if score.dim() == tau_t.dim() - 1 else score
+    ratio = (sigma_t_minus_1 / sigma_t) ** 2
+    drift = ratio * tau_t + (sigma_t ** 2 - sigma_t_minus_1 ** 2) * (
+        score * direction)
+    diffusion_std = math.sqrt(
+        max(0.0, sigma_t_minus_1 ** 2 * (1.0 - ratio)))
+    if noise is None:
+        noise = torch.randn_like(tau_t)
+    tau_prev = drift + diffusion_std * noise
+    return so3_exp_map(tau_prev)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_so3.py
@@ -1,0 +1,187 @@
+"""Exhaustive tests for the IGSO(3) diffusion utilities.
+
+These tests verify:
+
+* PDF normalisation to within 1e-3 on a dense ω grid.
+* Series-expansion stability of ``so3_exp_map`` and ``so3_log_map``
+  near ω = 0 and ω = π.
+* Round-trip ``log ∘ exp = id`` to fp32 precision on the principal
+  branch.
+* Logarithmic β-schedule monotonicity and endpoint correctness.
+* Single-step reverse Euler-Maruyama produces a proper rotation matrix
+  with finite entries and is deterministic for ``noise = 0``.
+"""
+
+import math
+
+import pytest
+import torch
+
+from deepchem.models.torch_models.rfdiffusion_so3 import (
+    IGSO3,
+    log_beta_schedule,
+    so3_exp_map,
+    so3_log_map,
+    so3_reverse_step,
+)
+
+
+@pytest.fixture(scope='module')
+def igso3():
+    sigmas = torch.tensor([0.05, 0.1, 0.3, 0.5, 1.0, 1.5])
+    return IGSO3(sigmas, num_omega=2048, lmax=500)
+
+
+class TestExpLogMaps:
+
+    def test_exp_returns_proper_rotation(self):
+        torch.manual_seed(0)
+        tau = torch.randn(32, 3) * 0.5
+        R = so3_exp_map(tau)
+        det = torch.det(R)
+        ortho_err = (R @ R.transpose(-1, -2)
+                     - torch.eye(3)).abs().max()
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+        assert ortho_err < 1e-5
+
+    def test_exp_zero_tangent_gives_identity(self):
+        R = so3_exp_map(torch.zeros(4, 3))
+        eye = torch.eye(3).expand(4, 3, 3)
+        assert torch.allclose(R, eye, atol=1e-7)
+
+    def test_log_exp_roundtrip_principal_branch(self):
+        torch.manual_seed(1)
+        u = torch.randn(50, 3)
+        u = u / u.norm(dim=-1, keepdim=True)
+        omega = torch.rand(50) * (math.pi - 1e-3) + 1e-4
+        tau = omega.unsqueeze(-1) * u
+        tau_back = so3_log_map(so3_exp_map(tau))
+        # fp32 precision degrades near ω = π; 1e-3 captures the worst case.
+        assert (tau - tau_back).norm(dim=-1).max() < 1e-3
+
+    def test_log_map_stable_near_pi(self):
+        axis = torch.tensor([[0.6, -0.2, 0.7745967]])
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        tau = (math.pi - 1e-4) * axis
+        tau_back = so3_log_map(so3_exp_map(tau))
+        assert torch.allclose(tau_back, tau, atol=1e-3)
+
+    def test_small_omega_taylor_branch(self):
+        tau = torch.tensor([[1e-7, 0.0, 0.0], [0.0, 1e-7, 0.0]])
+        R = so3_exp_map(tau)
+        eye = torch.eye(3).expand_as(R)
+        assert (R - eye).abs().max() < 1e-6
+
+
+class TestLogBetaSchedule:
+
+    def test_endpoints(self):
+        s = log_beta_schedule(50, beta_min=0.1, beta_max=1.5)
+        assert s[0].item() == pytest.approx(0.1, rel=1e-6)
+        assert s[-1].item() == pytest.approx(1.5, rel=1e-6)
+
+    def test_monotone(self):
+        s = log_beta_schedule(100, 0.1, 1.5)
+        diffs = s[1:] - s[:-1]
+        assert (diffs >= -1e-7).all()
+
+    def test_logarithmic_spacing(self):
+        s = log_beta_schedule(100, 0.1, 1.5)
+        log_s = torch.log(s)
+        diffs = log_s[1:] - log_s[:-1]
+        assert (diffs - diffs[0]).abs().max() < 1e-6
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            log_beta_schedule(1)
+        with pytest.raises(ValueError):
+            log_beta_schedule(10, beta_min=0.0)
+        with pytest.raises(ValueError):
+            log_beta_schedule(10, beta_min=0.5, beta_max=0.4)
+
+
+class TestIGSO3:
+
+    def test_construction_validates(self):
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([[1.0]]))
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([0.5, -0.1]))
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([0.5]), num_omega=4)
+
+    @pytest.mark.parametrize('idx', range(6))
+    def test_normalisation_within_tolerance(self, igso3, idx):
+        assert igso3.normalisation_error(idx) < 1e-3
+
+    def test_pdf_nonnegative(self, igso3):
+        for idx in range(len(igso3.sigmas)):
+            # The upstream truncated series can have tiny negative tails
+            # from cancellation, especially at small σ.
+            assert igso3._pdf[idx].min().item() > -1e-5
+
+    def test_cdf_monotone_and_unit(self, igso3):
+        for idx in range(len(igso3.sigmas)):
+            cdf = igso3._cdf[idx]
+            assert (cdf[1:] - cdf[:-1] >= -2e-8).all()
+            assert abs(cdf[-1].item() - 1.0) < 5e-4
+
+    def test_mean_angle_increases_with_sigma(self, igso3):
+        torch.manual_seed(0)
+        means = []
+        for idx in range(len(igso3.sigmas)):
+            sam = igso3.sample(idx, (2000,))
+            omegas = so3_log_map(sam).norm(dim=-1)
+            means.append(omegas.mean().item())
+        diffs = [b - a for a, b in zip(means[:-1], means[1:])]
+        assert all(d > 0 for d in diffs), f'means not monotone: {means}'
+
+    def test_sampled_rotations_are_proper(self, igso3):
+        sam = igso3.sample(2, (16,))
+        assert torch.allclose(torch.det(sam), torch.ones(16), atol=1e-4)
+
+    def test_score_finite(self, igso3):
+        omega = torch.linspace(0.01, math.pi - 0.01, 64,
+                               dtype=torch.float64)
+        for idx in range(len(igso3.sigmas)):
+            s = igso3.score(omega, idx)
+            assert torch.isfinite(s).all()
+
+    def test_score_matches_autograd_series(self):
+        omega = torch.linspace(0.05, 1.25, 16, dtype=torch.float64)
+        sigma = torch.tensor([0.3], dtype=torch.float64)
+        omega_var = omega.clone().requires_grad_(True)
+        f_val = IGSO3._f_omega(omega_var, sigma, lmax=64)[0]
+        expected = torch.autograd.grad(torch.log(f_val).sum(), omega_var)[0]
+        actual = IGSO3._score_omega(omega, sigma, lmax=64)[0]
+        assert torch.allclose(actual, expected, atol=0.0, rtol=0.0)
+
+
+class TestReverseStep:
+
+    def test_zero_score_zero_noise_drift(self):
+        torch.manual_seed(0)
+        tau = torch.randn(4, 3) * 0.5
+        R = so3_exp_map(tau)
+        out = so3_reverse_step(R, torch.zeros(4),
+                               sigma_t=1.0,
+                               sigma_t_minus_1=0.8,
+                               noise=torch.zeros(4, 3))
+        det = torch.det(out)
+        assert torch.allclose(det, torch.ones(4), atol=1e-4)
+
+    def test_validation(self):
+        R = so3_exp_map(torch.zeros(1, 3))
+        with pytest.raises(ValueError):
+            so3_reverse_step(R, torch.zeros(1), -0.1, 0.05)
+        with pytest.raises(ValueError):
+            so3_reverse_step(R, torch.zeros(1), 0.5, 0.6)
+
+    def test_noise_changes_output(self):
+        torch.manual_seed(0)
+        R = so3_exp_map(torch.randn(4, 3) * 0.3)
+        out_a = so3_reverse_step(R, torch.zeros(4), 1.0, 0.8,
+                                 noise=torch.zeros(4, 3))
+        out_b = so3_reverse_step(R, torch.zeros(4), 1.0, 0.8,
+                                 noise=torch.randn(4, 3))
+        assert not torch.allclose(out_a, out_b, atol=1e-3)

--- a/deepchem/utils/protein_quality.py
+++ b/deepchem/utils/protein_quality.py
@@ -1,0 +1,352 @@
+"""Protein-structure quality metrics for RFDiffusion evaluation.
+
+All functions here are stateless: they take ``numpy`` arrays (or
+file paths for the self-consistency metrics) and return a Python
+``float``, so they wrap cleanly as ``deepchem.metrics.Metric``
+callables.
+
+Implemented metrics
+-------------------
+* :func:`radius_of_gyration` — R_g = √(Σ ‖x_i − x̄‖² / N).
+* :func:`clash_score` — fraction of atom pairs whose distance is
+  smaller than r_i + r_j − threshold Å.
+* :func:`sc_rmsd` — self-consistency RMSD between a designed PDB and
+  its refolded prediction. The refolder is provided as a callable so
+  no hard dependency on ESMFold/AlphaFold/etc. is introduced.
+* :func:`sc_tm` — self-consistency TM-score, computed with a pure
+  Python implementation of the Zhang-Skolnick formula
+  [Zhang2004]_ — no ``TMalign`` binary required.
+
+References
+----------
+.. [Zhang2004] Zhang, Y. & Skolnick, J. "Scoring function for
+   automated assessment of protein structure template quality."
+   Proteins 57 (2004) 702-710.
+.. [Kabsch1976] Kabsch, W. "A solution for the best rotation to
+   relate two sets of vectors." Acta Crystallographica A32 (1976)
+   922-923.
+.. [Watson2023] Watson, J. L., et al. "De novo design of protein
+   structure and function with RFdiffusion." Nature 620 (2023)
+   1089-1100.
+"""
+
+from typing import Callable, Optional
+
+import numpy as np
+
+__all__ = [
+    'radius_of_gyration',
+    'clash_score',
+    'sc_rmsd',
+    'sc_tm',
+    'kabsch_align',
+    'tm_score',
+    'load_ca_coordinates',
+]
+
+
+# ----------------------------------------------------------------------
+# Geometric metrics on bare coordinate arrays.
+# ----------------------------------------------------------------------
+def radius_of_gyration(coords: np.ndarray) -> float:
+    """Radius of gyration of a point cloud.
+
+    Computes ``R_g = √( Σ_i ‖x_i − x̄‖² / N )`` where ``x̄`` is the
+    centroid of ``coords``.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray
+        Array of shape ``(N, 3)`` or ``(N, A, 3)``. Multi-atom inputs
+        are flattened to a single point cloud of size ``N · A``.
+
+    Returns
+    -------
+    float
+        Radius of gyration in the same units as ``coords``.
+
+    Raises
+    ------
+    ValueError
+        If ``coords`` does not have a trailing dimension of 3 or
+        contains fewer than one point.
+    """
+    arr = np.asarray(coords, dtype=np.float64)
+    if arr.ndim < 2 or arr.shape[-1] != 3:
+        raise ValueError(
+            f'coords must end in a dimension of size 3; got shape {arr.shape}.')
+    pts = arr.reshape(-1, 3)
+    if pts.shape[0] == 0:
+        raise ValueError('coords must contain at least one point.')
+    centroid = pts.mean(axis=0)
+    sq = ((pts - centroid) ** 2).sum(axis=1)
+    return float(np.sqrt(sq.mean()))
+
+
+def clash_score(coords: np.ndarray,
+                atom_radii: np.ndarray,
+                threshold: float = 0.6) -> float:
+    """Fraction of atom pairs whose distance violates van-der-Waals contact.
+
+    A pair (i, j) (with i < j) is counted as a clash when
+
+    .. math::
+
+        \\| x_i - x_j \\|_2 < r_i + r_j - t,
+
+    where ``t`` is the ``threshold`` argument (default 0.6 Å, matching
+    the convention used by the RFDiffusion evaluation pipeline
+    [Watson2023]_). The score returned is the fraction
+    ``num_clashes / num_pairs`` and therefore lies in ``[0, 1]``.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray
+        Array of shape ``(N, 3)`` containing heavy-atom coordinates.
+    atom_radii : numpy.ndarray
+        Array of shape ``(N,)`` containing the van-der-Waals radius
+        of each atom in the same units as ``coords``.
+    threshold : float, default 0.6
+        Tolerance ``t`` subtracted from the sum of radii. A positive
+        value allows the atoms to overlap by that amount before
+        being declared clashing.
+
+    Returns
+    -------
+    float
+        Clash fraction in ``[0, 1]``.
+    """
+    coords = np.asarray(coords, dtype=np.float64)
+    radii = np.asarray(atom_radii, dtype=np.float64)
+    if coords.ndim != 2 or coords.shape[1] != 3:
+        raise ValueError('coords must have shape (N, 3).')
+    if radii.shape != (coords.shape[0],):
+        raise ValueError('atom_radii must have shape (N,).')
+    n = coords.shape[0]
+    if n < 2:
+        return 0.0
+    diff = coords[:, None, :] - coords[None, :, :]
+    dist = np.sqrt((diff * diff).sum(-1))
+    cutoff = radii[:, None] + radii[None, :] - float(threshold)
+    iu = np.triu_indices(n, k=1)
+    pair_dist = dist[iu]
+    pair_cut = cutoff[iu]
+    clashes = int((pair_dist < pair_cut).sum())
+    return float(clashes) / float(pair_dist.size)
+
+
+# ----------------------------------------------------------------------
+# Kabsch alignment + TM-score (Zhang-Skolnick).
+# ----------------------------------------------------------------------
+def kabsch_align(mobile: np.ndarray,
+                 target: np.ndarray) -> np.ndarray:
+    """Return ``mobile`` superposed onto ``target`` (Kabsch algorithm).
+
+    Implements the closed-form least-squares rigid alignment of
+    [Kabsch1976]_. Reflections are removed by the standard
+    determinant sign correction.
+
+    Parameters
+    ----------
+    mobile, target : numpy.ndarray
+        Coordinate arrays of shape ``(N, 3)`` with matching ``N``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Aligned copy of ``mobile`` of shape ``(N, 3)``.
+    """
+    mobile = np.asarray(mobile, dtype=np.float64)
+    target = np.asarray(target, dtype=np.float64)
+    if mobile.shape != target.shape:
+        raise ValueError('mobile and target must have the same shape.')
+    if mobile.ndim != 2 or mobile.shape[1] != 3:
+        raise ValueError('inputs must have shape (N, 3).')
+    cm = mobile.mean(axis=0)
+    ct = target.mean(axis=0)
+    p = mobile - cm
+    q = target - ct
+    h = p.T @ q
+    u, _, vt = np.linalg.svd(h)
+    d = np.sign(np.linalg.det(vt.T @ u.T))
+    diag = np.diag([1.0, 1.0, d if d != 0.0 else 1.0])
+    r = vt.T @ diag @ u.T
+    return (p @ r.T) + ct
+
+
+def _zhang_d0(length: int) -> float:
+    """Normalisation scale ``d_0(L)`` from the Zhang-Skolnick formula."""
+    if length < 17:
+        return 0.5
+    return 1.24 * (length - 15) ** (1.0 / 3.0) - 1.8
+
+
+def tm_score(mobile: np.ndarray,
+             target: np.ndarray,
+             length_normaliser: Optional[int] = None) -> float:
+    """Pure-Python TM-score [Zhang2004]_.
+
+    Computes
+
+    .. math::
+
+        \\mathrm{TM} = \\frac{1}{L_{\\rm ref}}
+            \\sum_{i=1}^{L_{\\rm aln}}
+            \\frac{1}{1 + (d_i / d_0(L_{\\rm ref}))^2},
+
+    where ``L_ref`` defaults to the length of ``target`` and ``d_i``
+    is the per-residue distance after Kabsch superposition.
+
+    Parameters
+    ----------
+    mobile, target : numpy.ndarray
+        Cα-coordinate arrays of shape ``(L, 3)`` with matching ``L``.
+        Residues are assumed to be in 1:1 correspondence.
+    length_normaliser : int, optional
+        Length used for the ``d_0`` normalisation. Defaults to the
+        target length, matching the convention of TMalign's
+        ``-l ref`` flag.
+
+    Returns
+    -------
+    float
+        TM-score in ``(0, 1]``. Values above 0.5 indicate the same
+        global fold; values below 0.2 are statistically random.
+    """
+    mobile = np.asarray(mobile, dtype=np.float64)
+    target = np.asarray(target, dtype=np.float64)
+    if mobile.shape != target.shape:
+        raise ValueError('mobile and target must have the same shape.')
+    if mobile.ndim != 2 or mobile.shape[1] != 3:
+        raise ValueError('inputs must have shape (L, 3).')
+    length = mobile.shape[0]
+    l_ref = int(length_normaliser) if length_normaliser is not None else length
+    if l_ref <= 0:
+        raise ValueError('length_normaliser must be positive.')
+    aligned = kabsch_align(mobile, target)
+    di = np.linalg.norm(aligned - target, axis=1)
+    d0 = _zhang_d0(l_ref)
+    return float(np.sum(1.0 / (1.0 + (di / d0) ** 2)) / l_ref)
+
+
+# ----------------------------------------------------------------------
+# Self-consistency metrics (pluggable refolder, no external binaries).
+# ----------------------------------------------------------------------
+def load_ca_coordinates(pdb_path: str) -> np.ndarray:
+    """Load Cα coordinates from a PDB file (requires BioPython).
+
+    Parameters
+    ----------
+    pdb_path : str
+        Path to a PDB file.
+
+    Returns
+    -------
+    numpy.ndarray
+        Array of shape ``(L, 3)`` containing Cα coordinates of the
+        first model, in residue order across all chains.
+    """
+    try:
+        from Bio.PDB import PDBParser, is_aa
+    except ImportError as exc:
+        raise ImportError(
+            'load_ca_coordinates requires BioPython.') from exc
+    parser = PDBParser(QUIET=True)
+    structure = parser.get_structure('p', pdb_path)
+    coords = []
+    for model in structure:
+        for chain in model:
+            for residue in chain:
+                if not is_aa(residue, standard=True):
+                    continue
+                if 'CA' in residue:
+                    coords.append(residue['CA'].get_coord())
+        break  # only first model
+    if not coords:
+        raise ValueError(f'No Cα atoms found in {pdb_path}.')
+    return np.asarray(coords, dtype=np.float64)
+
+
+def sc_rmsd(designed_pdb: str,
+            refolded_pdb: str,
+            refolder: Optional[Callable[[str], str]] = None) -> float:
+    """Self-consistency RMSD between a designed and a refolded structure.
+
+    The function computes the Kabsch-aligned Cα RMSD between
+    ``designed_pdb`` and ``refolded_pdb``. If ``refolded_pdb`` is
+    ``None`` *or* a non-existent path *and* ``refolder`` is supplied,
+    the refolder is invoked with ``designed_pdb`` and is expected to
+    return the path to a refolded PDB. This keeps the API decoupled
+    from any specific structure-prediction backend (ESMFold,
+    AlphaFold, RoseTTAFold, …).
+
+    Parameters
+    ----------
+    designed_pdb : str
+        Path to the designed structure (PDB file).
+    refolded_pdb : str
+        Path to the refolded structure. May be ``''`` or ``None`` if
+        a ``refolder`` callable is supplied.
+    refolder : Callable[[str], str], optional
+        Function ``designed_pdb -> refolded_pdb_path``. Invoked only
+        when ``refolded_pdb`` is missing.
+
+    Returns
+    -------
+    float
+        Cα RMSD in Å.
+    """
+    import os
+    if not refolded_pdb or not os.path.exists(refolded_pdb):
+        if refolder is None:
+            raise ValueError(
+                'refolded_pdb does not exist and no refolder was supplied.')
+        refolded_pdb = refolder(designed_pdb)
+    designed = load_ca_coordinates(designed_pdb)
+    refolded = load_ca_coordinates(refolded_pdb)
+    if designed.shape != refolded.shape:
+        raise ValueError(
+            f'Length mismatch: designed has {designed.shape[0]} residues, '
+            f'refolded has {refolded.shape[0]}.')
+    aligned = kabsch_align(designed, refolded)
+    diff = aligned - refolded
+    return float(np.sqrt((diff * diff).sum(axis=1).mean()))
+
+
+def sc_tm(designed_pdb: str,
+          refolded_pdb: str,
+          refolder: Optional[Callable[[str], str]] = None) -> float:
+    """Self-consistency TM-score between a designed and a refolded structure.
+
+    See :func:`sc_rmsd` for the refolder protocol. The TM-score is
+    computed via the pure-Python :func:`tm_score`, so no external
+    ``TMalign`` binary is required.
+
+    Parameters
+    ----------
+    designed_pdb : str
+        Path to the designed structure (PDB).
+    refolded_pdb : str
+        Path to the refolded structure, or empty/missing to defer to
+        ``refolder``.
+    refolder : Callable[[str], str], optional
+        Function ``designed_pdb -> refolded_pdb_path``.
+
+    Returns
+    -------
+    float
+        TM-score in ``(0, 1]``.
+    """
+    import os
+    if not refolded_pdb or not os.path.exists(refolded_pdb):
+        if refolder is None:
+            raise ValueError(
+                'refolded_pdb does not exist and no refolder was supplied.')
+        refolded_pdb = refolder(designed_pdb)
+    designed = load_ca_coordinates(designed_pdb)
+    refolded = load_ca_coordinates(refolded_pdb)
+    if designed.shape != refolded.shape:
+        raise ValueError(
+            f'Length mismatch: designed has {designed.shape[0]} residues, '
+            f'refolded has {refolded.shape[0]}.')
+    return tm_score(designed, refolded)

--- a/deepchem/utils/rfdiffusion_contigs.py
+++ b/deepchem/utils/rfdiffusion_contigs.py
@@ -1,0 +1,450 @@
+"""Contig-map parsing and motif scaffolding utilities for RFDiffusion.
+
+RFDiffusion's inpainting / motif-scaffolding pipeline [Watson2023]_ uses a
+*contig string* to describe an output protein in terms of fixed motif
+segments copied from a reference structure interspersed with sampled
+linkers of variable length. This module implements a self-contained
+parser and a coordinate-masking helper that the diffusion sampler can
+use to keep motif atoms frozen at the reference geometry while the
+remainder of the chain is denoised.
+
+The contig grammar is the same dialect accepted by the official
+RFDiffusion CLI:
+
+* ``"10-20"`` — a sampled linker of between 10 and 20 residues.
+* ``"A12-30"`` — copy residues 12-30 of chain ``A`` from the reference.
+* ``"A12-30/0 5-10"`` — chain-break after the motif then 5-10 linker.
+* ``"/"`` — separator between segments.
+
+Each contig segment is one of two types:
+
+``MotifSegment``
+    Fixed-coordinate residues sourced from the reference.
+``LinkerSegment``
+    Variable-length sampled residues with an inclusive ``[lo, hi]``
+    range.
+
+Developer-facing summary
+------------------------
+Call ``parse_contig_string`` first to turn a CLI-style contig string
+into a :class:`ContigMap`. Then call ``realise()`` to sample concrete
+linker lengths, ``build_motif_mask`` to align the realised layout with
+reference coordinates, and ``freeze_motif_coords`` inside the sampling
+loop to keep motif residues fixed.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_contigs requires NumPy to be installed.')
+
+__all__ = [
+    'LinkerSegment',
+    'MotifSegment',
+    'ContigMap',
+    'parse_contig_string',
+    'build_motif_mask',
+]
+
+_MOTIF_RE = re.compile(r'^([A-Za-z])(-?\d+)-(-?\d+)$')
+_LINKER_RE = re.compile(r'^(\d+)-(\d+)$')
+_FIXED_LINKER_RE = re.compile(r'^(\d+)$')
+
+
+@dataclass(frozen=True)
+class LinkerSegment:
+    """Variable-length sampled linker segment.
+
+    Parameters
+    ----------
+    lo : int
+        Inclusive lower bound on the linker length.
+    hi : int
+        Inclusive upper bound on the linker length (``hi ≥ lo``).
+    """
+
+    lo: int
+    hi: int
+
+    def sample_length(self,
+                      rng: Optional[np.random.Generator] = None) -> int:
+        """Draw a length uniformly from [lo, hi]."""
+        if rng is None:
+            rng = np.random.default_rng()
+        return int(rng.integers(self.lo, self.hi + 1))
+
+    def __post_init__(self) -> None:
+        if self.lo < 0 or self.hi < self.lo:
+            raise ValueError(
+                f'Invalid linker range [{self.lo}, {self.hi}].')
+
+
+@dataclass(frozen=True)
+class MotifSegment:
+    """Fixed motif segment copied from a reference structure.
+
+    Parameters
+    ----------
+    chain : str
+        Single-letter chain identifier in the reference.
+    start : int
+        Inclusive start residue index (PDB numbering) in the reference.
+    end : int
+        Inclusive end residue index (PDB numbering) in the reference.
+    """
+
+    chain: str
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if len(self.chain) != 1 or not self.chain.isalpha():
+            raise ValueError(
+                f'Motif chain must be a single letter; got {self.chain!r}.')
+        if self.end < self.start:
+            raise ValueError(
+                f'Motif end {self.end} < start {self.start}.')
+
+    @property
+    def length(self) -> int:
+        """Number of residues in the motif (end − start + 1)."""
+        return self.end - self.start + 1
+
+
+Segment = Union[LinkerSegment, MotifSegment]
+
+
+@dataclass
+class ContigMap:
+    """Parsed contig map describing a generated chain.
+
+    Parameters
+    ----------
+    segments : list of Segment
+        Ordered list of motif and linker segments.
+    """
+
+    segments: List[Segment]
+
+    def total_length_range(self) -> Tuple[int, int]:
+        """Return ``(min_total, max_total)`` for the chain length."""
+        lo = 0
+        hi = 0
+        for seg in self.segments:
+            if isinstance(seg, MotifSegment):
+                lo += seg.length
+                hi += seg.length
+            else:
+                lo += seg.lo
+                hi += seg.hi
+        return lo, hi
+
+    def realise(self,
+                rng: Optional[np.random.Generator] = None
+                ) -> 'RealisedContig':
+        """Sample concrete linker lengths and produce a ``RealisedContig``.
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator, optional
+            Random number generator.
+
+        Returns
+        -------
+        RealisedContig
+            Concrete plan with sampled linker lengths and the implied
+            mapping from generated positions to motif source residues.
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+        layout: List[Tuple[Segment, int]] = []
+        for seg in self.segments:
+            if isinstance(seg, MotifSegment):
+                layout.append((seg, seg.length))
+            else:
+                layout.append((seg, seg.sample_length(rng)))
+        return RealisedContig(layout=layout)
+
+
+@dataclass
+class RealisedContig:
+    """Concrete chain layout with sampled linker lengths.
+
+    Attributes
+    ----------
+    layout : list of (Segment, int)
+        Ordered list of ``(segment, realised_length)`` pairs.
+    """
+
+    layout: List[Tuple[Segment, int]]
+
+    @property
+    def total_length(self) -> int:
+        """Realised chain length (sum of motif + sampled linker lengths)."""
+        return sum(length for _, length in self.layout)
+
+    def motif_mask(self) -> np.ndarray:
+        """Boolean mask of shape ``(L,)`` flagging fixed motif positions.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of ``bool`` with ``True`` at motif residues.
+        """
+        mask = np.zeros(self.total_length, dtype=bool)
+        cursor = 0
+        for seg, length in self.layout:
+            if isinstance(seg, MotifSegment):
+                mask[cursor:cursor + length] = True
+            cursor += length
+        return mask
+
+    def motif_source_index(self) -> List[Optional[Tuple[str, int]]]:
+        """Per-position list of source ``(chain, residue_index)`` tuples.
+
+        Returns
+        -------
+        list of (str, int) or None
+            ``None`` for sampled-linker residues; ``(chain, idx)`` for
+            motif residues. Length matches ``total_length``.
+        """
+        sources: List[Optional[Tuple[str, int]]] = []
+        for seg, length in self.layout:
+            if isinstance(seg, MotifSegment):
+                for offset in range(length):
+                    sources.append((seg.chain, seg.start + offset))
+            else:
+                sources.extend([None] * length)
+        return sources
+
+
+def parse_contig_string(text: str) -> ContigMap:
+    """Parse a contig specification string into a :class:`ContigMap`.
+
+    Tokens are separated by '/' or whitespace. Each token is one of:
+
+    * ``<chain><start>-<end>`` — motif segment.
+    * ``<lo>-<hi>`` — variable linker.
+    * ``<n>`` — fixed-length linker of exactly ``n`` residues.
+
+    Parameters
+    ----------
+    text : str
+        Contig string in the RFDiffusion CLI dialect.
+
+    Returns
+    -------
+    ContigMap
+        Parsed contig map.
+
+    Raises
+    ------
+    ValueError
+        If a token does not match any of the accepted patterns.
+
+    Examples
+    --------
+    >>> cm = parse_contig_string('5-10/A12-30/5-10')
+    >>> cm.total_length_range()
+    (29, 39)
+    """
+    if not text or not text.strip():
+        raise ValueError('Empty contig string.')
+    tokens = [tok for tok in re.split(r'[/\s]+', text.strip()) if tok]
+    segments: List[Segment] = []
+    for tok in tokens:
+        m_motif = _MOTIF_RE.match(tok)
+        if m_motif is not None:
+            chain = m_motif.group(1)
+            start = int(m_motif.group(2))
+            end = int(m_motif.group(3))
+            segments.append(MotifSegment(chain=chain, start=start, end=end))
+            continue
+        m_linker = _LINKER_RE.match(tok)
+        if m_linker is not None:
+            lo = int(m_linker.group(1))
+            hi = int(m_linker.group(2))
+            segments.append(LinkerSegment(lo=lo, hi=hi))
+            continue
+        m_fixed = _FIXED_LINKER_RE.match(tok)
+        if m_fixed is not None:
+            n = int(m_fixed.group(1))
+            segments.append(LinkerSegment(lo=n, hi=n))
+            continue
+        raise ValueError(f'Unrecognised contig token: {tok!r}')
+    if not segments:
+        raise ValueError('Contig string produced no segments.')
+    return ContigMap(segments=segments)
+
+
+def build_motif_mask(realised: RealisedContig,
+                     reference_coords: Dict[str, np.ndarray],
+                     reference_offset: Optional[Dict[str, int]] = None,
+                     atoms_per_residue: int = 3,
+                     atom_dim: int = 3
+                     ) -> Tuple[np.ndarray, np.ndarray]:
+    """Build aligned ``(reference_coords, motif_mask)`` arrays.
+
+    Iterates over a :class:`RealisedContig` and, for every position whose
+    source is a motif residue, copies the corresponding atom coordinates
+    from ``reference_coords[chain]`` into the output array. Linker
+    positions receive zeros and the mask flags them as not fixed.
+
+    Parameters
+    ----------
+    realised : RealisedContig
+        Realised contig with concrete linker lengths.
+    reference_coords : dict
+        Mapping from chain id to ``(N_chain, atoms_per_residue, atom_dim)``
+        array of reference coordinates. PDB residue indices map to
+        array rows via ``reference_offset[chain]`` (default 0 — i.e.
+        residue 1 lives at array index ``1 - offset``).
+    reference_offset : dict, optional
+        Mapping from chain id to the PDB residue index that lives at
+        row 0 of the reference array. Defaults to ``{c: 1 for c in
+        reference_coords}`` matching the most common PDB convention.
+    atoms_per_residue : int, default 3
+        Number of atoms stored per residue (3 for N/CA/C backbones,
+        14 for AlphaFold2 atom14).
+    atom_dim : int, default 3
+        Atom coordinate dimensionality (3 for ℝ³).
+
+    Returns
+    -------
+    coords : numpy.ndarray
+        Array of shape ``(L, atoms_per_residue, atom_dim)`` with motif
+        coordinates filled in.
+    motif_mask : numpy.ndarray
+        Boolean array of shape ``(L,)`` — ``True`` for fixed motif
+        positions.
+
+    Raises
+    ------
+    KeyError
+        If a motif refers to a chain not present in ``reference_coords``.
+    IndexError
+        If a motif residue index is out of range for its chain.
+    """
+    if reference_offset is None:
+        reference_offset = {c: 1 for c in reference_coords}
+    total_length = realised.total_length
+    coords = np.zeros((total_length, atoms_per_residue, atom_dim),
+                      dtype=np.float32)
+    mask = realised.motif_mask()
+    sources = realised.motif_source_index()
+    for out_idx, src in enumerate(sources):
+        if src is None:
+            continue
+        chain, res = src
+        if chain not in reference_coords:
+            raise KeyError(
+                f'Reference does not contain chain {chain!r}.')
+        offset = reference_offset.get(chain, 1)
+        row = res - offset
+        ref = reference_coords[chain]
+        if row < 0 or row >= ref.shape[0]:
+            raise IndexError(
+                f'Motif residue {chain}{res} is out of range; '
+                f'reference chain {chain} has {ref.shape[0]} residues '
+                f'starting at PDB index {offset}.')
+        coords[out_idx] = ref[row, :atoms_per_residue, :atom_dim]
+    return coords, mask
+
+
+def freeze_motif_coords(generated: np.ndarray,
+                        reference: np.ndarray,
+                        motif_mask: np.ndarray) -> np.ndarray:
+    """Overwrite motif positions of ``generated`` with ``reference``.
+
+    Parameters
+    ----------
+    generated : numpy.ndarray
+        Array of shape ``(L, ...)`` containing the current generated
+        coordinates.
+    reference : numpy.ndarray
+        Array of shape ``(L, ...)`` with the same suffix dims as
+        ``generated`` containing the frozen reference coordinates.
+    motif_mask : numpy.ndarray
+        Boolean array of shape ``(L,)`` flagging motif positions.
+
+    Returns
+    -------
+    numpy.ndarray
+        New array equal to ``reference`` at motif positions and
+        ``generated`` elsewhere. The input arrays are not modified.
+
+    Raises
+    ------
+    ValueError
+        If the shapes are inconsistent.
+    """
+    if generated.shape != reference.shape:
+        raise ValueError(
+            f'Shape mismatch: generated {generated.shape} vs '
+            f'reference {reference.shape}.')
+    if motif_mask.shape[0] != generated.shape[0]:
+        raise ValueError(
+            f'motif_mask length {motif_mask.shape[0]} does not match '
+            f'coordinate length {generated.shape[0]}.')
+    out = generated.copy()
+    out[motif_mask] = reference[motif_mask]
+    return out
+
+
+def realised_to_index_arrays(
+        realised: RealisedContig) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (motif_indices, linker_indices) arrays of int positions."""
+    mask = realised.motif_mask()
+    idx = np.arange(realised.total_length, dtype=np.int64)
+    return idx[mask], idx[~mask]
+
+
+def fixed_layout(motif_lengths: Sequence[int],
+                 linker_lengths: Sequence[int],
+                 chain: str = 'A',
+                 motif_start: int = 1) -> RealisedContig:
+    """Build a deterministic ``RealisedContig`` from explicit lengths.
+
+    Convenience constructor used in tests where we want a deterministic
+    motif placement without invoking the random sampler.
+
+    Parameters
+    ----------
+    motif_lengths : sequence of int
+        Length of each motif block.
+    linker_lengths : sequence of int
+        Length of each linker block. Must satisfy
+        ``len(linker_lengths) == len(motif_lengths) + 1``: layout is
+        linker-motif-linker-motif-…-linker.
+    chain : str, default 'A'
+        Reference chain id assigned to every motif.
+    motif_start : int, default 1
+        Starting PDB residue index assigned to the first motif.
+
+    Returns
+    -------
+    RealisedContig
+        Deterministic realised contig.
+    """
+    if len(linker_lengths) != len(motif_lengths) + 1:
+        raise ValueError(
+            'linker_lengths must have one more entry than motif_lengths.')
+    layout: List[Tuple[Segment, int]] = []
+    cursor = motif_start
+    for i, lin_len in enumerate(linker_lengths):
+        layout.append((LinkerSegment(lo=lin_len, hi=lin_len), lin_len))
+        if i < len(motif_lengths):
+            m = MotifSegment(chain=chain, start=cursor,
+                             end=cursor + motif_lengths[i] - 1)
+            layout.append((m, motif_lengths[i]))
+            cursor += motif_lengths[i]
+    return RealisedContig(layout=layout)

--- a/deepchem/utils/test/test_protein_quality.py
+++ b/deepchem/utils/test/test_protein_quality.py
@@ -1,0 +1,308 @@
+"""Tests for :mod:`deepchem.utils.protein_quality`.
+
+Ground-truth values are computed by hand on a 3-residue toy structure
+so the tests double as a specification.
+"""
+
+import math
+import os
+import tempfile
+
+import numpy as np
+import pytest
+
+try:
+    from Bio.PDB import PDBParser  # noqa: F401
+    has_biopython = True
+except ImportError:
+    has_biopython = False
+
+from deepchem.utils.protein_quality import (
+    clash_score,
+    kabsch_align,
+    radius_of_gyration,
+    sc_rmsd,
+    sc_tm,
+    tm_score,
+)
+
+
+# ----------------------------------------------------------------------
+# radius_of_gyration
+# ----------------------------------------------------------------------
+class TestRadiusOfGyration:
+
+    def test_known_value_unit_cube(self):
+        # Two points at (±1, 0, 0): centroid = origin, R_g = 1.
+        pts = np.array([[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]])
+        assert math.isclose(radius_of_gyration(pts), 1.0, rel_tol=1e-12)
+
+    def test_three_residue_toy(self):
+        # Equilateral triangle of side 1 in the xy-plane.
+        pts = np.array([
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.5, math.sqrt(3) / 2.0, 0.0],
+        ])
+        # Centroid = (0.5, √3/6, 0). Distances² to centroid:
+        # corner1: 0.25 + 1/12 = 1/3; same for the other two.
+        # R_g = √(1/3) ≈ 0.577350.
+        assert math.isclose(radius_of_gyration(pts),
+                            math.sqrt(1.0 / 3.0),
+                            rel_tol=1e-12)
+
+    def test_translation_invariance(self):
+        rng = np.random.default_rng(0)
+        pts = rng.normal(size=(50, 3))
+        rg = radius_of_gyration(pts)
+        rg_shift = radius_of_gyration(pts + np.array([10.0, -3.5, 7.2]))
+        assert math.isclose(rg, rg_shift, rel_tol=1e-12)
+
+    def test_rotation_invariance(self):
+        rng = np.random.default_rng(1)
+        pts = rng.normal(size=(50, 3))
+        # Random rotation via QR.
+        q, _ = np.linalg.qr(rng.normal(size=(3, 3)))
+        if np.linalg.det(q) < 0:
+            q[:, 0] = -q[:, 0]
+        assert math.isclose(radius_of_gyration(pts),
+                            radius_of_gyration(pts @ q.T),
+                            rel_tol=1e-12)
+
+    def test_multi_atom_input_flattens(self):
+        pts = np.zeros((4, 3, 3))
+        pts[0, 0] = [1.0, 0.0, 0.0]
+        pts[0, 1] = [-1.0, 0.0, 0.0]
+        # All others zero. Centroid = (0,0,0)/12 = origin; R_g = √(2/12).
+        expected = math.sqrt(2.0 / 12.0)
+        assert math.isclose(radius_of_gyration(pts), expected,
+                            rel_tol=1e-12)
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            radius_of_gyration(np.zeros((4, 2)))
+        with pytest.raises(ValueError):
+            radius_of_gyration(np.zeros((0, 3)))
+
+
+# ----------------------------------------------------------------------
+# clash_score
+# ----------------------------------------------------------------------
+class TestClashScore:
+
+    def test_no_pairs(self):
+        coords = np.zeros((1, 3))
+        radii = np.array([1.0])
+        assert clash_score(coords, radii) == 0.0
+
+    def test_handcomputed_three_atoms(self):
+        # Atoms at distances 1, 5, 4 with radii (1, 1, 1) and t=0.6 →
+        # cutoff = 2 - 0.6 = 1.4 for every pair.
+        # d(0,1)=1.0 < 1.4 → clash. d(0,2)=4.0, d(1,2)=5.0 → no clash.
+        # Score = 1 / 3 pairs.
+        coords = np.array([[0.0, 0.0, 0.0],
+                           [1.0, 0.0, 0.0],
+                           [4.0, 0.0, 0.0]])
+        radii = np.ones(3)
+        assert math.isclose(clash_score(coords, radii, threshold=0.6),
+                            1.0 / 3.0, rel_tol=1e-12)
+
+    def test_all_clashing(self):
+        # Three coincident atoms always clash.
+        coords = np.zeros((3, 3))
+        radii = np.array([1.0, 1.0, 1.0])
+        assert clash_score(coords, radii) == 1.0
+
+    def test_none_clashing(self):
+        # Atoms 100 Å apart: nothing can clash.
+        coords = np.arange(15).reshape(5, 3).astype(np.float64) * 100.0
+        radii = np.ones(5) * 1.7
+        assert clash_score(coords, radii) == 0.0
+
+    def test_threshold_relaxation_reduces_clashes(self):
+        coords = np.array([[0.0, 0.0, 0.0],
+                           [1.5, 0.0, 0.0]])
+        radii = np.array([1.0, 1.0])
+        strict = clash_score(coords, radii, threshold=0.0)  # cutoff 2.0
+        lenient = clash_score(coords, radii, threshold=1.0)  # cutoff 1.0
+        assert strict == 1.0
+        assert lenient == 0.0
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            clash_score(np.zeros((4, 2)), np.ones(4))
+        with pytest.raises(ValueError):
+            clash_score(np.zeros((4, 3)), np.ones(3))
+
+
+# ----------------------------------------------------------------------
+# kabsch_align + tm_score
+# ----------------------------------------------------------------------
+class TestKabsch:
+
+    def test_aligns_translated_target(self):
+        rng = np.random.default_rng(2)
+        target = rng.normal(size=(20, 3))
+        mobile = target + np.array([5.0, -2.0, 1.5])
+        aligned = kabsch_align(mobile, target)
+        assert np.allclose(aligned, target, atol=1e-10)
+
+    def test_aligns_rotated_target(self):
+        rng = np.random.default_rng(3)
+        target = rng.normal(size=(30, 3))
+        # Build a proper rotation.
+        q, _ = np.linalg.qr(rng.normal(size=(3, 3)))
+        if np.linalg.det(q) < 0:
+            q[:, 0] = -q[:, 0]
+        mobile = (target @ q.T) + np.array([10.0, 0.0, 0.0])
+        aligned = kabsch_align(mobile, target)
+        assert np.allclose(aligned, target, atol=1e-9)
+
+
+class TestTMScore:
+
+    def test_identity_is_one(self):
+        rng = np.random.default_rng(4)
+        coords = rng.normal(size=(25, 3))
+        assert math.isclose(tm_score(coords, coords), 1.0, rel_tol=1e-12)
+
+    def test_three_residue_toy(self):
+        # Toy: target on x-axis, mobile = target + 1Å shift on x.
+        # After Kabsch the shift is removed → TM = 1 because residues
+        # superpose perfectly.
+        target = np.array([[0.0, 0.0, 0.0],
+                           [1.0, 0.0, 0.0],
+                           [2.0, 0.0, 0.0]])
+        mobile = target + np.array([1.0, 0.0, 0.0])
+        assert math.isclose(tm_score(mobile, target), 1.0, rel_tol=1e-9)
+
+    def test_random_alignment_low_score(self):
+        rng = np.random.default_rng(5)
+        target = rng.normal(size=(50, 3)) * 5.0
+        mobile = rng.normal(size=(50, 3)) * 5.0
+        score = tm_score(mobile, target)
+        # Random pairs should not look like the same fold.
+        assert 0.0 < score < 0.5
+
+    def test_zhang_d0_three_residue(self):
+        # For L < 17 the Zhang-Skolnick formula returns d0 = 0.5.
+        # Per-residue di = 1 → contribution 1/(1 + 4) = 0.2; with three
+        # residues TM = 3 * 0.2 / 3 = 0.2.
+        target = np.zeros((3, 3))
+        # Mobile must be incompatible with rigid alignment, otherwise
+        # Kabsch would remove the difference. Use three orthogonal
+        # offsets so that no rigid transform reduces the per-atom
+        # distance below 1 Å.
+        mobile = np.array([[1.0, 0.0, 0.0],
+                           [0.0, 1.0, 0.0],
+                           [0.0, 0.0, 1.0]])
+        score = tm_score(mobile, target)
+        # All three distances become exactly 1 (centroid removed):
+        # offsets minus mean offset → norms 1·√(2/3). With d0 = 0.5
+        # and d² = 2/3, contribution 1/(1 + (2/3)/0.25) = 1/(1+8/3)
+        # = 3/11. TM = 3 · 3/11 / 3 = 3/11 ≈ 0.2727.
+        assert math.isclose(score, 3.0 / 11.0, rel_tol=1e-9)
+
+
+# ----------------------------------------------------------------------
+# sc_rmsd / sc_tm with a synthetic refolder.
+# ----------------------------------------------------------------------
+_TOY_PDB = (
+    'ATOM      1  N   ALA A   1       0.000   0.000   0.000  '
+    '1.00  0.00           N\n'
+    'ATOM      2  CA  ALA A   1       1.000   0.000   0.000  '
+    '1.00  0.00           C\n'
+    'ATOM      3  C   ALA A   1       2.000   0.000   0.000  '
+    '1.00  0.00           C\n'
+    'ATOM      4  N   ALA A   2       3.000   0.000   0.000  '
+    '1.00  0.00           N\n'
+    'ATOM      5  CA  ALA A   2       4.000   0.000   0.000  '
+    '1.00  0.00           C\n'
+    'ATOM      6  C   ALA A   2       5.000   0.000   0.000  '
+    '1.00  0.00           C\n'
+    'ATOM      7  N   ALA A   3       6.000   0.000   0.000  '
+    '1.00  0.00           N\n'
+    'ATOM      8  CA  ALA A   3       7.000   0.000   0.000  '
+    '1.00  0.00           C\n'
+    'ATOM      9  C   ALA A   3       8.000   0.000   0.000  '
+    '1.00  0.00           C\n'
+    'END\n')
+
+
+@pytest.fixture
+def designed_pdb():
+    fh = tempfile.NamedTemporaryFile(mode='w', suffix='.pdb', delete=False)
+    fh.write(_TOY_PDB)
+    fh.close()
+    yield fh.name
+    os.unlink(fh.name)
+
+
+@pytest.mark.skipif(not has_biopython, reason='BioPython required.')
+class TestSelfConsistency:
+
+    def test_sc_rmsd_zero_against_self(self, designed_pdb):
+        # Refolder returns the input path unchanged → RMSD = 0.
+        rmsd = sc_rmsd(designed_pdb, refolded_pdb='',
+                       refolder=lambda p: p)
+        assert rmsd < 1e-10
+
+    def test_sc_tm_one_against_self(self, designed_pdb):
+        score = sc_tm(designed_pdb, refolded_pdb='',
+                      refolder=lambda p: p)
+        assert math.isclose(score, 1.0, rel_tol=1e-9)
+
+    def test_refolder_invoked_only_when_needed(self, designed_pdb):
+        called = {'n': 0}
+
+        def fake_refolder(path):
+            called['n'] += 1
+            return path
+
+        sc_rmsd(designed_pdb, refolded_pdb='', refolder=fake_refolder)
+        sc_rmsd(designed_pdb, refolded_pdb=designed_pdb,
+                refolder=fake_refolder)
+        assert called['n'] == 1
+
+    def test_missing_refolder_raises(self, designed_pdb):
+        with pytest.raises(ValueError):
+            sc_rmsd(designed_pdb, refolded_pdb='')
+
+    def test_perturbed_refolder_positive_rmsd(self, designed_pdb,
+                                              tmp_path):
+        # Build a second PDB by shifting the original by 1Å on y. After
+        # Kabsch alignment the shift is removed → RMSD must be < 1e-9.
+        # Use a non-rigid perturbation (per-residue shifts) instead.
+        path2 = tmp_path / 'perturbed.pdb'
+        with open(designed_pdb) as fh:
+            text = fh.read()
+        # Replace CA y-coords by injecting per-residue jitter.
+        lines = text.splitlines()
+        new_lines = []
+        offsets = {1: 0.3, 2: -0.4, 3: 0.5}
+        for line in lines:
+            if line.startswith('ATOM') and ' CA ' in line:
+                resnum = int(line[22:26])
+                # PDB y coordinate columns 39:46 (8-wide right-aligned).
+                y = offsets[resnum]
+                line = line[:38] + f'{y:8.3f}' + line[46:]
+            new_lines.append(line)
+        path2.write_text('\n'.join(new_lines) + '\n')
+        rmsd = sc_rmsd(designed_pdb, refolded_pdb=str(path2))
+        assert rmsd > 1e-3
+
+    def test_length_mismatch_raises(self, designed_pdb, tmp_path):
+        short = tmp_path / 'short.pdb'
+        with open(designed_pdb) as fh:
+            text = fh.read()
+        # Keep only residues 1 and 2.
+        kept = []
+        for line in text.splitlines():
+            if line.startswith('ATOM'):
+                resnum = int(line[22:26])
+                if resnum > 2:
+                    continue
+            kept.append(line)
+        short.write_text('\n'.join(kept) + '\n')
+        with pytest.raises(ValueError):
+            sc_rmsd(designed_pdb, refolded_pdb=str(short))

--- a/deepchem/utils/test/test_rfdiffusion_contigs.py
+++ b/deepchem/utils/test/test_rfdiffusion_contigs.py
@@ -1,0 +1,172 @@
+"""Tests for contig-map parsing and motif scaffolding."""
+
+import numpy as np
+import pytest
+
+from deepchem.utils.rfdiffusion_contigs import (
+    ContigMap,
+    LinkerSegment,
+    MotifSegment,
+    build_motif_mask,
+    fixed_layout,
+    freeze_motif_coords,
+    parse_contig_string,
+)
+
+
+class TestParser:
+
+    def test_simple(self):
+        cm = parse_contig_string('5-10/A12-30/5-10')
+        assert isinstance(cm, ContigMap)
+        assert len(cm.segments) == 3
+        assert isinstance(cm.segments[0], LinkerSegment)
+        assert isinstance(cm.segments[1], MotifSegment)
+        lo, hi = cm.total_length_range()
+        assert lo == 5 + 19 + 5
+        assert hi == 10 + 19 + 10
+
+    def test_fixed_linker_token(self):
+        cm = parse_contig_string('5/A1-3/7')
+        lo, hi = cm.total_length_range()
+        assert lo == hi == 5 + 3 + 7
+
+    def test_whitespace_separator(self):
+        cm = parse_contig_string('5-5 A1-5 5-5')
+        assert len(cm.segments) == 3
+        assert cm.total_length_range() == (15, 15)
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError):
+            parse_contig_string('')
+        with pytest.raises(ValueError):
+            parse_contig_string('   ')
+
+    def test_rejects_garbage_token(self):
+        with pytest.raises(ValueError):
+            parse_contig_string('5-10/!!!')
+
+    def test_motif_validation(self):
+        with pytest.raises(ValueError):
+            MotifSegment(chain='AB', start=1, end=5)
+        with pytest.raises(ValueError):
+            MotifSegment(chain='A', start=5, end=3)
+
+    def test_linker_validation(self):
+        with pytest.raises(ValueError):
+            LinkerSegment(lo=5, hi=3)
+
+
+class TestRealisation:
+
+    def test_realise_within_range(self):
+        cm = parse_contig_string('5-10/A1-5/5-10')
+        rng = np.random.default_rng(0)
+        rc = cm.realise(rng)
+        lo, hi = cm.total_length_range()
+        assert lo <= rc.total_length <= hi
+        # The motif length (5) must be included exactly once.
+        motif_total = sum(length for seg, length in rc.layout
+                          if hasattr(seg, 'chain'))
+        assert motif_total == 5
+
+    def test_motif_mask(self):
+        rc = fixed_layout(motif_lengths=[3, 2],
+                          linker_lengths=[4, 5, 2])
+        mask = rc.motif_mask()
+        # Layout: 4-linker, 3-motif, 5-linker, 2-motif, 2-linker → L=16.
+        expected = np.array(
+            [0]*4 + [1]*3 + [0]*5 + [1]*2 + [0]*2, dtype=bool)
+        np.testing.assert_array_equal(mask, expected)
+
+    def test_motif_source_index(self):
+        rc = fixed_layout(motif_lengths=[3, 2],
+                          linker_lengths=[1, 1, 1], chain='B', motif_start=10)
+        srcs = rc.motif_source_index()
+        assert srcs[0] is None
+        assert srcs[1] == ('B', 10)
+        assert srcs[2] == ('B', 11)
+        assert srcs[3] == ('B', 12)
+        assert srcs[4] is None
+        assert srcs[5] == ('B', 13)
+        assert srcs[6] == ('B', 14)
+        assert srcs[7] is None
+
+    def test_fixed_layout_validation(self):
+        with pytest.raises(ValueError):
+            fixed_layout(motif_lengths=[3], linker_lengths=[1, 1, 1])
+
+
+class TestMotifMaskBuilding:
+
+    def test_motif_copies_reference_coords(self):
+        rc = fixed_layout(motif_lengths=[2], linker_lengths=[1, 1])
+        ref = {'A': np.arange(2 * 3 * 3, dtype=np.float32).reshape(2, 3, 3)
+               + 10.0}
+        coords, mask = build_motif_mask(rc, reference_coords=ref)
+        assert coords.shape == (4, 3, 3)
+        assert mask.tolist() == [False, True, True, False]
+        np.testing.assert_array_equal(coords[1], ref['A'][0])
+        np.testing.assert_array_equal(coords[2], ref['A'][1])
+        # Linker positions are zero.
+        assert (coords[0] == 0).all()
+        assert (coords[3] == 0).all()
+
+    def test_missing_chain_raises(self):
+        rc = fixed_layout(motif_lengths=[1], linker_lengths=[0, 0])
+        with pytest.raises(KeyError):
+            build_motif_mask(rc, reference_coords={'B': np.zeros((1, 3, 3))})
+
+    def test_out_of_range_raises(self):
+        rc = fixed_layout(motif_lengths=[3], linker_lengths=[0, 0],
+                          motif_start=10)
+        with pytest.raises(IndexError):
+            build_motif_mask(rc, reference_coords={'A': np.zeros((2, 3, 3))})
+
+    def test_atom14_layout(self):
+        rc = fixed_layout(motif_lengths=[1], linker_lengths=[0, 0])
+        ref = {'A': np.ones((1, 14, 3), dtype=np.float32)}
+        coords, _ = build_motif_mask(rc, reference_coords=ref,
+                                     atoms_per_residue=14)
+        assert coords.shape == (1, 14, 3)
+        np.testing.assert_array_equal(coords[0], np.ones((14, 3)))
+
+
+class TestFreezeMotif:
+
+    def test_freeze_replaces_motif_only(self):
+        rc = fixed_layout(motif_lengths=[2], linker_lengths=[1, 1])
+        mask = rc.motif_mask()
+        ref = np.ones((4, 3, 3), dtype=np.float32) * 7.0
+        gen = np.zeros((4, 3, 3), dtype=np.float32)
+        out = freeze_motif_coords(gen, ref, mask)
+        # Motif positions become reference.
+        assert np.allclose(out[1], 7.0)
+        assert np.allclose(out[2], 7.0)
+        # Linker positions stay zero.
+        assert np.allclose(out[0], 0.0)
+        assert np.allclose(out[3], 0.0)
+        # Reference must remain untouched (function does not mutate).
+        assert np.allclose(ref, 7.0)
+        assert np.allclose(gen, 0.0)
+
+    def test_motif_freeze_within_tolerance(self):
+        """After freezing, the motif positions deviate from the
+        reference by < 1e-4 Å (in fact they are exactly equal)."""
+        rc = fixed_layout(motif_lengths=[3, 2], linker_lengths=[2, 2, 2])
+        ref = np.random.default_rng(0).normal(
+            size=(rc.total_length, 3, 3)).astype(np.float32)
+        gen = np.random.default_rng(1).normal(
+            size=(rc.total_length, 3, 3)).astype(np.float32)
+        mask = rc.motif_mask()
+        out = freeze_motif_coords(gen, ref, mask)
+        err = np.abs(out[mask] - ref[mask]).max()
+        assert err < 1e-4
+
+    def test_shape_validation(self):
+        with pytest.raises(ValueError):
+            freeze_motif_coords(np.zeros((4, 3, 3)), np.zeros((5, 3, 3)),
+                                np.zeros(4, dtype=bool))
+        with pytest.raises(ValueError):
+            freeze_motif_coords(np.zeros((4, 3, 3)), np.zeros((4, 3, 3)),
+                                np.zeros(3, dtype=bool))


### PR DESCRIPTION
## Summary
- add the SO(3) diffusion math used for rotational noise, cached IGSO(3) tables, and reverse-time updates
- add contig parsing and motif-freezing utilities for scaffolded generation
- add pure-Python quality metrics for evaluating generated protein backbones

> This is a Draft PR pushed to establish the core RFDiffusion architecture foundation for the RF Antibody extensions. This code will be further formatted, modularly tested, and split into smaller, independent PRs for official review in the coming weeks.

## Notes for RF Antibodies Extension
- `rfdiffusion_so3.py` is the rotation backend: reuse `IGSO3`, `so3_exp_map`, `so3_log_map`, and `so3_reverse_step` if antibody-specific sampling needs frame or orientation denoising.
- `rfdiffusion_contigs.py` is the scaffold / motif interface: RF Antibodies can use it to keep known epitope-contact motifs or framework regions fixed while generating surrounding structure.
- `protein_quality.py` provides lightweight evaluation hooks that can be called directly from antibody experiments without depending on external TM-score or alignment binaries.
