### PR TITLE
[WIP] RFDiffusion: Symmetry, Conditioning, and Loss Interfaces

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion_conditioning.py
+++ b/deepchem/models/torch_models/rfdiffusion_conditioning.py
@@ -1,0 +1,235 @@
+"""Advanced conditioning blocks for RFDiffusion.
+
+Two conditioning mechanisms are exposed here:
+
+* :class:`BinderCrossAttention` — a single multi-head cross-attention
+  block over a *frozen* target representation. Used to condition the
+  generated chain on a binder partner without backpropagating into
+  the target weights [Watson2023]_.
+* :class:`LengthConditioning` — sinusoidal embedding of a desired
+  output chain length followed by an MLP, added to the time embedding
+  so the model can be steered to specific lengths.
+
+Developer-facing summary
+------------------------
+Use :class:`LengthConditioning` when a caller wants to bias generation
+to a target chain length, and use :class:`BinderCrossAttention` when a
+generated chain should attend to a frozen partner representation. Both
+blocks return tensors that can be added into an existing denoiser
+without changing its outer training loop.
+
+References
+----------
+.. [Watson2023] Watson, J. L., et al. "De novo design of protein
+   structure and function with RFdiffusion." Nature 620 (2023)
+   1089-1100.
+"""
+
+import math
+from typing import Optional
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError(
+        'rfdiffusion_conditioning requires PyTorch to be installed.')
+
+__all__ = [
+    'BinderCrossAttention',
+    'LengthConditioning',
+    'sinusoidal_length_embedding',
+]
+
+
+def sinusoidal_length_embedding(length: torch.Tensor,
+                                embed_dim: int,
+                                max_period: float = 10000.0
+                                ) -> torch.Tensor:
+    """Sinusoidal embedding of integer lengths.
+
+    Equivalent in form to the timestep embedding of :class:`Transformer`
+    architectures: half of the embedding is ``sin``, half is ``cos``,
+    with frequencies geometrically spaced between 1 and
+    ``1/max_period``.
+
+    Parameters
+    ----------
+    length : torch.Tensor
+        Integer or float tensor of shape ``(B,)`` containing the
+        requested chain lengths.
+    embed_dim : int
+        Embedding dimensionality (must be even).
+    max_period : float, default 10000.0
+        Largest period used in the geometric frequency progression.
+
+    Returns
+    -------
+    torch.Tensor
+        Embedding of shape ``(B, embed_dim)``.
+    """
+    if embed_dim % 2 != 0:
+        raise ValueError('embed_dim must be even.')
+    half = embed_dim // 2
+    freqs = torch.exp(
+        -math.log(max_period)
+        * torch.arange(half, dtype=torch.float32,
+                       device=length.device) / half)
+    args = length.to(torch.float32).unsqueeze(-1) * freqs.unsqueeze(0)
+    return torch.cat([torch.sin(args), torch.cos(args)], dim=-1)
+
+
+class LengthConditioning(nn.Module):
+    """Project a desired chain length into the time-embedding space.
+
+    The module computes a sinusoidal embedding of the requested length
+    and feeds it through a two-layer MLP whose output dimensionality
+    matches ``time_dim``. The result is *added* to the time embedding
+    by the caller — this preserves backward compatibility for callers
+    that do not pass a length.
+
+    Parameters
+    ----------
+    time_dim : int
+        Output dimensionality (matches the time embedding of the
+        backbone diffusion model).
+    embed_dim : int, optional
+        Internal embedding dimensionality used for the sinusoidal
+        encoding. Defaults to ``time_dim``.
+    max_period : float, default 10000.0
+        Sinusoidal frequency parameter.
+    """
+
+    def __init__(self,
+                 time_dim: int,
+                 embed_dim: Optional[int] = None,
+                 max_period: float = 10000.0) -> None:
+        super().__init__()
+        if embed_dim is None:
+            embed_dim = time_dim
+        if embed_dim % 2 != 0:
+            raise ValueError('embed_dim must be even.')
+        self.embed_dim = int(embed_dim)
+        self.max_period = float(max_period)
+        self.mlp = nn.Sequential(
+            nn.Linear(self.embed_dim, time_dim),
+            nn.SiLU(),
+            nn.Linear(time_dim, time_dim),
+        )
+
+    def forward(self, length: torch.Tensor) -> torch.Tensor:
+        """Return the length-conditioned addend of shape ``(B, time_dim)``."""
+        embed = sinusoidal_length_embedding(
+            length, self.embed_dim, max_period=self.max_period)
+        return self.mlp(embed)
+
+
+class BinderCrossAttention(nn.Module):
+    """Multi-head cross-attention from generated chain to a frozen binder.
+
+    The target (binder) representation is processed through fixed key /
+    value projections whose parameters are flagged ``requires_grad=False``
+    and therefore *do not receive gradient updates*. The generated
+    chain serves as the query. A residual + LayerNorm is applied around
+    the attention block.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Dimensionality of both query and target representations.
+    num_heads : int, default 4
+        Number of attention heads. ``embed_dim`` must be divisible by
+        ``num_heads``.
+    dropout : float, default 0.0
+        Attention dropout probability.
+
+    Notes
+    -----
+    "Frozen target" here means the projection layers applied to the
+    target are non-trainable. Callers may additionally detach the target
+    tensor itself prior to passing it in to fully cut off the gradient
+    flow.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 num_heads: int = 4,
+                 dropout: float = 0.0) -> None:
+        super().__init__()
+        if embed_dim % num_heads != 0:
+            raise ValueError('embed_dim must be divisible by num_heads.')
+        self.embed_dim = int(embed_dim)
+        self.num_heads = int(num_heads)
+        self.head_dim = self.embed_dim // self.num_heads
+        self.dropout = float(dropout)
+        self.norm_q = nn.LayerNorm(embed_dim)
+        self.norm_kv = nn.LayerNorm(embed_dim)
+        self.q_proj = nn.Linear(embed_dim, embed_dim)
+        self.k_proj = nn.Linear(embed_dim, embed_dim)
+        self.v_proj = nn.Linear(embed_dim, embed_dim)
+        self.out_proj = nn.Linear(embed_dim, embed_dim)
+        # Freeze the key and value projections — they act on the binder
+        # which is treated as a fixed conditioning signal.
+        for param in self.k_proj.parameters():
+            param.requires_grad = False
+        for param in self.v_proj.parameters():
+            param.requires_grad = False
+        # Zero-initialise the output projection so the module is the
+        # identity at initialisation (drop-in compatible with the
+        # existing diffusion transformer stack).
+        nn.init.zeros_(self.out_proj.weight)
+        nn.init.zeros_(self.out_proj.bias)
+
+    def forward(self,
+                query: torch.Tensor,
+                target: torch.Tensor,
+                target_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Apply cross-attention from ``query`` to ``target``.
+
+        Parameters
+        ----------
+        query : torch.Tensor
+            Generated-chain features of shape ``(B, L_q, embed_dim)``.
+        target : torch.Tensor
+            Binder features of shape ``(B, L_k, embed_dim)``. Pass
+            ``target.detach()`` to additionally block gradient flow
+            into the upstream binder encoder.
+        target_mask : torch.Tensor, optional
+            Boolean mask of shape ``(B, L_k)``; ``True`` for valid
+            positions.
+
+        Returns
+        -------
+        torch.Tensor
+            Attended features of shape ``(B, L_q, embed_dim)``.
+        """
+        if query.ndim != 3 or target.ndim != 3:
+            raise ValueError('query and target must be 3-D tensors.')
+        if query.shape[-1] != self.embed_dim:
+            raise ValueError('query last dim must match embed_dim.')
+        batch_size, len_q, _ = query.shape
+        len_k = target.shape[1]
+        q = self.q_proj(self.norm_q(query))
+        k = self.k_proj(self.norm_kv(target))
+        v = self.v_proj(self.norm_kv(target))
+        # Split heads.
+        q = q.view(batch_size, len_q, self.num_heads, self.head_dim).transpose(1, 2)
+        k = k.view(batch_size, len_k, self.num_heads, self.head_dim).transpose(1, 2)
+        v = v.view(batch_size, len_k, self.num_heads, self.head_dim).transpose(1, 2)
+        scale = 1.0 / math.sqrt(self.head_dim)
+        logits = torch.matmul(q, k.transpose(-1, -2)) * scale
+        if target_mask is not None:
+            if target_mask.shape != (batch_size, len_k):
+                raise ValueError('target_mask must be (B, L_k).')
+            additive = torch.where(
+                target_mask.unsqueeze(1).unsqueeze(1),
+                torch.zeros_like(logits),
+                torch.full_like(logits, float('-inf')))
+            logits = logits + additive
+        attn = torch.softmax(logits, dim=-1)
+        if self.training and self.dropout > 0.0:
+            attn = F.dropout(attn, p=self.dropout)
+        out = torch.matmul(attn, v)  # (B, H, L_q, D)
+        out = out.transpose(1, 2).reshape(batch_size, len_q, self.embed_dim)
+        return query + self.out_proj(out)

--- a/deepchem/models/torch_models/rfdiffusion_losses.py
+++ b/deepchem/models/torch_models/rfdiffusion_losses.py
@@ -1,0 +1,298 @@
+"""Losses for RFDiffusion training and evaluation.
+
+This module ships three losses used by the RFDiffusion pipeline
+[Watson2023]_:
+
+* :func:`backbone_fape_loss` — Frame-Aligned Point Error on the
+  backbone N / CA / C atoms following AlphaFold2 [Jumper2021]_, with the
+  standard 10 Å clamp.
+* :func:`chi_angle_loss` — periodic ℓ² loss on the side-chain χ-angles
+  computed via ``1 − cos(Δχ)`` so that the loss is differentiable and
+  periodic.
+* :func:`ligand_contact_loss` — Huber-style attraction term encouraging
+  specified protein residues to make close contact with a ligand point
+  cloud.
+
+All losses accept boolean masks and zero out gradient contributions of
+masked elements exactly (i.e. masked-atom gradient must be identically
+zero).
+
+Developer-facing summary
+------------------------
+``backbone_fape_loss`` is the main geometry-alignment loss for frame and
+backbone supervision. ``chi_angle_loss`` and ``all_atom_l2_loss`` are
+for finer-grained atom / torsion supervision, and
+``ligand_contact_loss`` is the contact-style auxiliary term for
+ligand-conditioned generation.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+.. [Jumper2021] Jumper et al. "Highly accurate protein structure
+   prediction with AlphaFold." Nature 596 (2021) 583-589.
+"""
+
+import math
+from typing import Optional
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_losses requires PyTorch to be installed.')
+
+__all__ = [
+    'backbone_fape_loss',
+    'chi_angle_loss',
+    'ligand_contact_loss',
+    'all_atom_l2_loss',
+]
+
+
+def _apply_inverse_rigid(points: torch.Tensor,
+                         rotations: torch.Tensor,
+                         translations: torch.Tensor) -> torch.Tensor:
+    """Apply the inverse rigid transform ``Rᵀ (x − t)`` to a point cloud.
+
+    Parameters
+    ----------
+    points : torch.Tensor
+        Point cloud of shape ``(..., N, 3)``.
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+    translations : torch.Tensor
+        Translation vectors of shape ``(..., 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Points expressed in the local frame, shape ``(..., N, 3)``.
+    """
+    centred = points - translations.unsqueeze(-2)
+    # x_local = (Rᵀ)·(x − t) — written as a batched matmul.
+    return torch.einsum('...ij,...nj->...ni', rotations.transpose(-1, -2),
+                        centred)
+
+
+def backbone_fape_loss(pred_rotations: torch.Tensor,
+                       pred_translations: torch.Tensor,
+                       true_rotations: torch.Tensor,
+                       true_translations: torch.Tensor,
+                       pred_atoms: torch.Tensor,
+                       true_atoms: torch.Tensor,
+                       mask: Optional[torch.Tensor] = None,
+                       clamp_distance: float = 10.0,
+                       length_scale: float = 10.0,
+                       eps: float = 1e-4) -> torch.Tensor:
+    """Backbone Frame-Aligned Point Error (FAPE).
+
+    For every frame ``T_i = (R_i, t_i)`` we compute the predicted and
+    true positions of every backbone atom expressed in the *local*
+    frame of ``T_i``, take the L₂ distance between them, clamp it to
+    ``clamp_distance`` (default 10 Å) and average over the i × j pairs.
+
+    Mathematically the per-pair contribution is
+
+    .. math::
+
+        \\ell_{ij}
+        = \\min\\!\\big(d_{ij},\\, d_{\\mathrm{clamp}}\\big),\\quad
+        d_{ij} = \\| R_i^{\\top}(\\hat x_j - \\hat t_i)
+                    - R_i^{*\\top}(x_j^{*} - t_i^{*})\\|_{2}.
+
+    The final loss is the mean of ``ℓ_{ij}`` over unmasked pairs,
+    divided by ``length_scale`` so the value is roughly dimensionless.
+
+    Parameters
+    ----------
+    pred_rotations : torch.Tensor
+        Predicted rotation matrices of shape ``(B, L, 3, 3)``.
+    pred_translations : torch.Tensor
+        Predicted translations of shape ``(B, L, 3)``.
+    true_rotations : torch.Tensor
+        Ground-truth rotation matrices of the same shape.
+    true_translations : torch.Tensor
+        Ground-truth translations of the same shape.
+    pred_atoms : torch.Tensor
+        Predicted backbone atom coordinates of shape ``(B, L, A, 3)``.
+    true_atoms : torch.Tensor
+        Ground-truth atom coordinates of the same shape.
+    mask : torch.Tensor, optional
+        Boolean mask of shape ``(B, L)`` flagging valid residues.
+    clamp_distance : float, default 10.0
+        Distance clamp d_clamp.
+    length_scale : float, default 10.0
+        Divisor used to scale the averaged distance.
+    eps : float, default 1e-4
+        Small constant inside the square root for numerical stability.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar FAPE loss.
+    """
+    if pred_rotations.shape != true_rotations.shape:
+        raise ValueError('Rotation shape mismatch.')
+    if pred_translations.shape != true_translations.shape:
+        raise ValueError('Translation shape mismatch.')
+    if pred_atoms.shape != true_atoms.shape:
+        raise ValueError('Atom shape mismatch.')
+    if pred_atoms.ndim != 4:
+        raise ValueError('pred_atoms must have shape (B, L, A, 3).')
+    batch, length, num_atoms, _ = pred_atoms.shape
+    # Flatten atoms to a single point cloud per residue (per frame).
+    pred_flat = pred_atoms.reshape(batch, length * num_atoms, 3)
+    true_flat = true_atoms.reshape(batch, length * num_atoms, 3)
+    # Compute local-frame coordinates for every (i, j) pair.
+    pred_local = _apply_inverse_rigid(
+        pred_flat.unsqueeze(1).expand(-1, length, -1, -1),
+        pred_rotations, pred_translations)
+    true_local = _apply_inverse_rigid(
+        true_flat.unsqueeze(1).expand(-1, length, -1, -1),
+        true_rotations, true_translations)
+    diff = pred_local - true_local
+    dist = torch.sqrt((diff * diff).sum(-1) + eps)  # (B, L, L*A)
+    dist = torch.clamp(dist, max=clamp_distance)
+    if mask is not None:
+        # Per-frame mask broadcast against (L, A) atom mask.
+        frame_mask = mask.unsqueeze(-1)  # (B, L, 1)
+        atom_mask = mask.unsqueeze(-1).expand(-1, -1, num_atoms).reshape(
+            batch, length * num_atoms).unsqueeze(1)  # (B, 1, L*A)
+        pair_mask = frame_mask * atom_mask
+        dist = dist * pair_mask
+        denom = pair_mask.sum().clamp(min=1.0)
+        return (dist.sum() / denom) / length_scale
+    return dist.mean() / length_scale
+
+
+def chi_angle_loss(pred_chi: torch.Tensor,
+                   true_chi: torch.Tensor,
+                   chi_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """Periodic loss on side-chain χ-angles.
+
+    Computes ``mean(1 − cos(χ_pred − χ_true))`` over valid entries,
+    giving a smooth periodic loss with minimum 0 when angles agree.
+
+    Parameters
+    ----------
+    pred_chi : torch.Tensor
+        Predicted angles in radians; shape ``(..., 4)``.
+    true_chi : torch.Tensor
+        Ground-truth angles in radians; shape ``(..., 4)``.
+    chi_mask : torch.Tensor, optional
+        Boolean mask of the same shape flagging valid χ entries.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar loss in [0, 2].
+    """
+    if pred_chi.shape != true_chi.shape:
+        raise ValueError('χ-angle shape mismatch.')
+    residual = 1.0 - torch.cos(pred_chi - true_chi)
+    if chi_mask is not None:
+        if chi_mask.shape != pred_chi.shape:
+            raise ValueError('chi_mask shape mismatch.')
+        residual = residual * chi_mask
+        denom = chi_mask.sum().clamp(min=1.0)
+        return residual.sum() / denom
+    return residual.mean()
+
+
+def ligand_contact_loss(protein_ca: torch.Tensor,
+                        ligand_coords: torch.Tensor,
+                        contact_mask: torch.Tensor,
+                        contact_distance: float = 6.0,
+                        slope: float = 1.0) -> torch.Tensor:
+    """Soft attraction term toward a ligand point cloud.
+
+    For each residue flagged in ``contact_mask`` the loss is
+
+    .. math::
+
+        \\ell_i = \\max\\!\\big(0,
+              \\min_a \\| x_i^{C\\alpha} - y_a \\|_2 - d_{\\rm contact}
+        \\big)
+
+    multiplied by ``slope``. The total loss is the mean over the
+    flagged residues. Residues outside the mask contribute exactly
+    zero (verified by the gradient-flow tests).
+
+    Parameters
+    ----------
+    protein_ca : torch.Tensor
+        Protein Cα coordinates of shape ``(L, 3)`` or ``(B, L, 3)``.
+    ligand_coords : torch.Tensor
+        Ligand atom coordinates of shape ``(N, 3)`` or ``(B, N, 3)``.
+    contact_mask : torch.Tensor
+        Boolean mask of shape ``(L,)`` or ``(B, L)`` flagging residues
+        that must contact the ligand.
+    contact_distance : float, default 6.0
+        Distance d_contact at which the loss reaches zero.
+    slope : float, default 1.0
+        Multiplicative slope ``λ``.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar contact loss.
+    """
+    if protein_ca.ndim == 2:
+        protein_ca = protein_ca.unsqueeze(0)
+        ligand_coords = ligand_coords.unsqueeze(0)
+        contact_mask = contact_mask.unsqueeze(0)
+    if protein_ca.ndim != 3 or ligand_coords.ndim != 3:
+        raise ValueError(
+            'protein_ca and ligand_coords must be 2-D or 3-D tensors.')
+    if contact_mask.shape != protein_ca.shape[:2]:
+        raise ValueError('contact_mask must have shape (B, L).')
+    diff = protein_ca.unsqueeze(2) - ligand_coords.unsqueeze(1)
+    dist = torch.sqrt((diff * diff).sum(-1) + 1e-4)  # (B, L, N)
+    nearest = dist.min(dim=-1).values  # (B, L)
+    excess = torch.clamp(nearest - contact_distance, min=0.0)
+    mask_f = contact_mask.to(excess.dtype)
+    weighted = slope * excess * mask_f
+    denom = mask_f.sum().clamp(min=1.0)
+    return weighted.sum() / denom
+
+
+def all_atom_l2_loss(pred_coords: torch.Tensor,
+                     true_coords: torch.Tensor,
+                     atom_mask: torch.Tensor) -> torch.Tensor:
+    """Per-atom L₂ loss with strict atom-mask honouring.
+
+    Computes ``mean( ||pred − true||²_2 )`` over atoms whose
+    ``atom_mask`` is True. Masked atoms contribute *exactly* zero — the
+    test suite asserts gradient sparsity at the granularity of single
+    atoms (no information leak via the mean reduction).
+
+    Parameters
+    ----------
+    pred_coords : torch.Tensor
+        Predicted coordinates of shape ``(..., A, 3)``.
+    true_coords : torch.Tensor
+        Ground-truth coordinates of the same shape.
+    atom_mask : torch.Tensor
+        Boolean mask of shape ``(..., A)``. Masked atoms (``False``)
+        receive zero gradient.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar L₂ loss averaged over unmasked atoms.
+    """
+    if pred_coords.shape != true_coords.shape:
+        raise ValueError('Coordinate shape mismatch.')
+    if atom_mask.shape != pred_coords.shape[:-1]:
+        raise ValueError(
+            f'atom_mask shape {atom_mask.shape} does not match '
+            f'coords {pred_coords.shape}.')
+    mask = atom_mask.to(pred_coords.dtype).unsqueeze(-1)
+    diff = (pred_coords - true_coords) * mask
+    sq = (diff * diff).sum(-1)
+    denom = atom_mask.to(pred_coords.dtype).sum().clamp(min=1.0)
+    return sq.sum() / denom
+
+
+# Expose math.tau so doctest writers do not have to recompute it.
+_PI: float = math.pi

--- a/deepchem/models/torch_models/rfdiffusion_symmetry.py
+++ b/deepchem/models/torch_models/rfdiffusion_symmetry.py
@@ -1,0 +1,315 @@
+"""Symmetry helpers for RFDiffusion: enforcing Cₙ, Dₙ, T, O, I groups.
+
+RFDiffusion enforces point-group symmetry on generated assemblies by
+projecting per-residue updates (frames or coordinates) onto the
+symmetric subspace defined by a group ``G`` [Watson2023]_. Concretely,
+if ``L`` residues form ``|G|`` copies of an asymmetric unit of size
+``L / |G|``, we average the per-update gradients across the orbit of
+every residue under ``G`` so that all copies remain related by the
+same rigid motion.
+
+Notation
+--------
+* ``G`` — point group of order ``|G|``.
+* ``U`` — asymmetric-unit size, with ``L = |G| · U``.
+* Residue ``(g, u)`` denotes the ``u``-th residue of the ``g``-th
+  copy. Indexing convention: ``index(g, u) = g · U + u``.
+
+Implementation notes
+--------------------
+The orbit of residue ``u`` is the set ``{(0, u), (1, u), …, (|G|−1, u)}``.
+The symmetric-projection operator ``Π`` averages per-orbit translations
+and rotations *expressed in a common reference frame*, then re-applies
+the group element to obtain each copy.
+
+Developer-facing summary
+------------------------
+The group-construction helpers build canonical rotation sets such as
+``cyclic_group(n)`` or ``dihedral_group(n)``. During generation, call
+``symmetrise_coords`` or ``symmetrise_frames`` after each update step
+to keep all copies of the asymmetric unit locked to the same symmetry.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+"""
+
+import math
+from typing import Iterable, List
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError(
+        'rfdiffusion_symmetry requires PyTorch to be installed.')
+
+__all__ = [
+    'cyclic_group',
+    'dihedral_group',
+    'tetrahedral_group',
+    'octahedral_group',
+    'icosahedral_group',
+    'symmetrise_frames',
+    'symmetrise_coords',
+]
+
+
+# ---------------------------------------------------------------------
+# Group generators
+# ---------------------------------------------------------------------
+def _axis_rotation(axis: torch.Tensor, angle: float) -> torch.Tensor:
+    """Build a rotation matrix from an axis and angle (Rodrigues)."""
+    axis = axis / axis.norm()
+    x, y, z = axis.tolist()
+    c = math.cos(angle)
+    s = math.sin(angle)
+    one_minus_c = 1.0 - c
+    return torch.tensor([
+        [c + x * x * one_minus_c, x * y * one_minus_c - z * s,
+         x * z * one_minus_c + y * s],
+        [y * x * one_minus_c + z * s, c + y * y * one_minus_c,
+         y * z * one_minus_c - x * s],
+        [z * x * one_minus_c - y * s, z * y * one_minus_c + x * s,
+         c + z * z * one_minus_c],
+    ], dtype=torch.float64)
+
+
+def _close_group(generators: Iterable[torch.Tensor],
+                 max_order: int = 128,
+                 tol: float = 1e-8) -> List[torch.Tensor]:
+    """Close a set of rotation generators into a finite group.
+
+    Repeatedly composes the current set with the generators until no
+    new elements are discovered or ``max_order`` is reached.
+    """
+    group: List[torch.Tensor] = []
+
+    def _add(g: torch.Tensor) -> bool:
+        for existing in group:
+            if (g - existing).abs().max().item() < tol:
+                return False
+        group.append(g)
+        return True
+
+    eye = torch.eye(3, dtype=torch.float64)
+    _add(eye)
+    pending = list(generators)
+    for gen in pending:
+        _add(gen)
+    changed = True
+    while changed:
+        changed = False
+        for h in list(group):
+            for g in pending:
+                product = g @ h
+                if _add(product):
+                    changed = True
+                    if len(group) > max_order:
+                        raise RuntimeError(
+                            f'Group exceeded max_order {max_order}.')
+    return group
+
+
+def cyclic_group(n: int) -> torch.Tensor:
+    """Cyclic group :math:`C_n` of rotations about the z-axis.
+
+    Parameters
+    ----------
+    n : int
+        Order of the cyclic group (n ≥ 1).
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(n, 3, 3)`` containing all elements of
+        :math:`C_n`.
+    """
+    if n < 1:
+        raise ValueError('Cyclic order must be >= 1.')
+    z = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float64)
+    elements = [_axis_rotation(z, 2.0 * math.pi * k / n) for k in range(n)]
+    return torch.stack(elements, dim=0)
+
+
+def dihedral_group(n: int) -> torch.Tensor:
+    """Dihedral group :math:`D_n`: ``C_n`` plus n perpendicular C₂ axes.
+
+    Parameters
+    ----------
+    n : int
+        Order parameter (n ≥ 2). The full group has order 2n.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(2n, 3, 3)``.
+    """
+    if n < 2:
+        raise ValueError('Dihedral order must be >= 2.')
+    z = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float64)
+    x = torch.tensor([1.0, 0.0, 0.0], dtype=torch.float64)
+    generators = [_axis_rotation(z, 2.0 * math.pi / n),
+                  _axis_rotation(x, math.pi)]
+    group = _close_group(generators, max_order=4 * n)
+    return torch.stack(group, dim=0)
+
+
+def tetrahedral_group() -> torch.Tensor:
+    """Rotational tetrahedral group T (order 12).
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(12, 3, 3)``.
+    """
+    # Generators: 3-fold about (1,1,1)/√3, 2-fold about z.
+    z = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float64)
+    diag = torch.tensor([1.0, 1.0, 1.0], dtype=torch.float64)
+    gens = [_axis_rotation(diag, 2.0 * math.pi / 3.0),
+            _axis_rotation(z, math.pi)]
+    group = _close_group(gens, max_order=24)
+    return torch.stack(group, dim=0)
+
+
+def octahedral_group() -> torch.Tensor:
+    """Rotational octahedral group O (order 24).
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(24, 3, 3)``.
+    """
+    z = torch.tensor([0.0, 0.0, 1.0], dtype=torch.float64)
+    diag = torch.tensor([1.0, 1.0, 1.0], dtype=torch.float64)
+    gens = [_axis_rotation(z, math.pi * 0.5),
+            _axis_rotation(diag, 2.0 * math.pi / 3.0)]
+    group = _close_group(gens, max_order=48)
+    return torch.stack(group, dim=0)
+
+
+def icosahedral_group() -> torch.Tensor:
+    """Rotational icosahedral group I (order 60).
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of shape ``(60, 3, 3)``.
+    """
+    phi = (1.0 + math.sqrt(5.0)) / 2.0
+    # 5-fold axis through (1, φ, 0) / norm.
+    five_fold = torch.tensor([1.0, phi, 0.0], dtype=torch.float64)
+    # 3-fold axis through (1, 1, 1).
+    three_fold = torch.tensor([1.0, 1.0, 1.0], dtype=torch.float64)
+    gens = [_axis_rotation(five_fold, 2.0 * math.pi / 5.0),
+            _axis_rotation(three_fold, 2.0 * math.pi / 3.0)]
+    group = _close_group(gens, max_order=120)
+    return torch.stack(group, dim=0)
+
+
+# ---------------------------------------------------------------------
+# Projection operators
+# ---------------------------------------------------------------------
+def _validate(group: torch.Tensor, frames_or_coords: torch.Tensor) -> int:
+    if group.ndim != 3 or group.shape[-2:] != (3, 3):
+        raise ValueError('group must have shape (|G|, 3, 3).')
+    g = int(group.shape[0])
+    length = frames_or_coords.shape[-2] if frames_or_coords.ndim >= 2 \
+        else frames_or_coords.shape[0]
+    if length % g != 0:
+        raise ValueError(
+            f'Sequence length {length} is not divisible by |G|={g}.')
+    return g
+
+
+def symmetrise_coords(coords: torch.Tensor,
+                      group: torch.Tensor) -> torch.Tensor:
+    """Project coordinates onto the symmetric subspace.
+
+    Each asymmetric-unit copy is forced to be the rigid image of the
+    same reference unit under the corresponding group element. The
+    returned coords satisfy
+
+    .. math::
+
+        x^{\\text{sym}}_{(g, u)} = R_g\\, \\bar x_u,
+        \\quad \\bar x_u = \\frac{1}{|G|}
+            \\sum_{g'} R_{g'}^{\\top}\\, x_{(g', u)}
+
+    Parameters
+    ----------
+    coords : torch.Tensor
+        Coordinates of shape ``(..., L, 3)`` where ``L = |G| · U``.
+    group : torch.Tensor
+        Rotation matrices of the group, shape ``(|G|, 3, 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Symmetrised coordinates of the same shape.
+    """
+    g = _validate(group, coords)
+    *batch_shape, length, dim = coords.shape
+    if dim != 3:
+        raise ValueError('coords last dim must be 3.')
+    unit = length // g
+    coords = coords.to(dtype=group.dtype if coords.dtype != group.dtype
+                       else coords.dtype)
+    grouped = coords.reshape(*batch_shape, g, unit, 3)
+    # Express every copy in the reference frame: x_ref_g = R_g^T x_g.
+    rgt = group.transpose(-1, -2)  # (G, 3, 3)
+    rotated_back = torch.einsum('gij,...guj->...gui', rgt, grouped)
+    averaged = rotated_back.mean(dim=-3, keepdim=True)  # (..., 1, U, 3)
+    # Re-apply each group element to the averaged unit.
+    out = torch.einsum('gij,...uj->...gui', group, averaged.squeeze(-3))
+    return out.reshape(*batch_shape, length, 3).to(dtype=coords.dtype)
+
+
+def symmetrise_frames(rotations: torch.Tensor,
+                      translations: torch.Tensor,
+                      group: torch.Tensor) -> 'tuple[torch.Tensor, torch.Tensor]':
+    """Project rigid frames onto the symmetric subspace.
+
+    The translations are averaged in the reference frame using
+    :func:`symmetrise_coords`; the rotations are projected onto SO(3)
+    by averaging the rotation matrices in the reference frame and
+    re-orthogonalising via SVD.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., L, 3, 3)``.
+    translations : torch.Tensor
+        Translation vectors of shape ``(..., L, 3)``.
+    group : torch.Tensor
+        Rotation matrices of the group, shape ``(|G|, 3, 3)``.
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        ``(R_sym, t_sym)`` of the same shapes as the inputs.
+    """
+    g = _validate(group, translations)
+    *batch_shape, length, _ = translations.shape
+    unit = length // g
+    rotations = rotations.to(dtype=group.dtype)
+    translations = translations.to(dtype=group.dtype)
+    # Translations: use the coordinate symmetriser.
+    t_sym = symmetrise_coords(translations, group)
+    # Rotations: average R_g^T R_{g,u} in the reference frame, then
+    # re-apply R_g and re-orthogonalise.
+    grouped = rotations.reshape(*batch_shape, g, unit, 3, 3)
+    rgt = group.transpose(-1, -2)
+    ref_rots = torch.einsum('gij,...gujk->...guik', rgt, grouped)
+    averaged = ref_rots.mean(dim=-4)  # (..., U, 3, 3)
+    # SVD-based projection onto SO(3): R = U diag(1,1,det) Vᵀ.
+    u_mat, _, v_mat = torch.linalg.svd(averaged)
+    det = torch.det(u_mat @ v_mat)
+    signs = torch.ones_like(det)
+    signs = signs * det.sign().where(det.abs() > 1e-8, torch.ones_like(det))
+    diag = torch.diag_embed(torch.stack(
+        [torch.ones_like(signs), torch.ones_like(signs), signs], dim=-1))
+    ref_rot = u_mat @ diag @ v_mat
+    out = torch.einsum('gij,...ujk->...guik', group, ref_rot)
+    r_sym = out.reshape(*batch_shape, length, 3, 3)
+    return r_sym.to(dtype=rotations.dtype), t_sym.to(dtype=translations.dtype)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_conditioning.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_conditioning.py
@@ -1,0 +1,112 @@
+"""Tests for binder cross-attention and length conditioning."""
+
+import math
+
+import pytest
+import torch
+
+from deepchem.models.torch_models.rfdiffusion_conditioning import (
+    BinderCrossAttention,
+    LengthConditioning,
+    sinusoidal_length_embedding,
+)
+
+
+class TestLengthEmbedding:
+
+    def test_shape_and_dtype(self):
+        lengths = torch.tensor([10, 25, 64, 128])
+        emb = sinusoidal_length_embedding(lengths, embed_dim=32)
+        assert emb.shape == (4, 32)
+        assert emb.dtype == torch.float32
+
+    def test_distinct_lengths_distinct_embeddings(self):
+        lengths = torch.tensor([10, 11])
+        emb = sinusoidal_length_embedding(lengths, embed_dim=64)
+        assert not torch.allclose(emb[0], emb[1])
+
+    def test_odd_embed_dim_rejected(self):
+        with pytest.raises(ValueError):
+            sinusoidal_length_embedding(torch.tensor([1]), embed_dim=31)
+
+
+class TestLengthConditioning:
+
+    def test_output_shape(self):
+        m = LengthConditioning(time_dim=64, embed_dim=32)
+        out = m(torch.tensor([10, 20, 30]))
+        assert out.shape == (3, 64)
+
+    def test_distinct_lengths_distinct_outputs(self):
+        torch.manual_seed(0)
+        m = LengthConditioning(time_dim=32)
+        out = m(torch.tensor([5, 15, 25]))
+        assert not torch.allclose(out[0], out[1])
+        assert not torch.allclose(out[1], out[2])
+
+    def test_gradient_flow(self):
+        m = LengthConditioning(time_dim=32)
+        out = m(torch.tensor([5]))
+        out.sum().backward()
+        for p in m.parameters():
+            assert p.grad is not None
+
+
+class TestBinderCrossAttention:
+
+    def _make(self, embed_dim=32, num_heads=4):
+        torch.manual_seed(0)
+        return BinderCrossAttention(embed_dim, num_heads=num_heads)
+
+    def test_construction_validation(self):
+        with pytest.raises(ValueError):
+            BinderCrossAttention(33, num_heads=4)
+
+    def test_zero_init_is_identity(self):
+        block = self._make()
+        q = torch.randn(2, 5, 32)
+        t = torch.randn(2, 4, 32)
+        out = block(q, t)
+        assert torch.allclose(out, q, atol=1e-6)
+
+    def test_target_kv_frozen(self):
+        block = self._make()
+        for p in block.k_proj.parameters():
+            assert not p.requires_grad
+        for p in block.v_proj.parameters():
+            assert not p.requires_grad
+
+    def test_no_grad_into_frozen_kv(self):
+        block = self._make()
+        # Randomise output projection so gradient is non-zero.
+        torch.nn.init.normal_(block.out_proj.weight, std=0.05)
+        q = torch.randn(1, 4, 32, requires_grad=True)
+        t = torch.randn(1, 3, 32)
+        out = block(q, t)
+        out.sum().backward()
+        for p in block.k_proj.parameters():
+            assert p.grad is None
+        for p in block.v_proj.parameters():
+            assert p.grad is None
+        # Query path still receives gradient.
+        assert q.grad is not None and torch.isfinite(q.grad).all()
+
+    def test_mask_blocks_invalid_target_positions(self):
+        block = self._make()
+        torch.nn.init.normal_(block.out_proj.weight, std=0.1)
+        q = torch.randn(1, 2, 32)
+        t = torch.randn(1, 4, 32)
+        full_mask = torch.ones(1, 4, dtype=torch.bool)
+        partial_mask = torch.tensor([[True, False, False, False]])
+        out_full = block(q, t, target_mask=full_mask)
+        out_partial = block(q, t, target_mask=partial_mask)
+        # The two outputs must differ because attention sees a different
+        # set of valid target keys.
+        assert not torch.allclose(out_full, out_partial, atol=1e-5)
+
+    def test_shape_validation(self):
+        block = self._make()
+        with pytest.raises(ValueError):
+            block(torch.zeros(2, 5), torch.zeros(2, 4, 32))
+        with pytest.raises(ValueError):
+            block(torch.zeros(2, 5, 16), torch.zeros(2, 4, 32))

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_losses.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_losses.py
@@ -1,0 +1,154 @@
+"""Tests for RFDiffusion losses (FAPE, χ-angle, ligand contact)."""
+
+import math
+
+import pytest
+import torch
+
+from deepchem.models.torch_models.rfdiffusion_losses import (
+    all_atom_l2_loss,
+    backbone_fape_loss,
+    chi_angle_loss,
+    ligand_contact_loss,
+)
+
+
+def _random_rotation(seed: int = 0) -> torch.Tensor:
+    g = torch.Generator().manual_seed(seed)
+    A = torch.randn(3, 3, generator=g)
+    Q, _ = torch.linalg.qr(A)
+    if torch.det(Q) < 0:
+        Q[:, 0] = -Q[:, 0]
+    return Q
+
+
+class TestBackboneFAPE:
+
+    def _make_frames(self, batch, length, seed=0):
+        torch.manual_seed(seed)
+        rots = torch.stack(
+            [_random_rotation(seed + i) for i in range(length)])
+        rots = rots.unsqueeze(0).expand(batch, -1, -1, -1).contiguous()
+        trans = torch.randn(batch, length, 3)
+        return rots, trans
+
+    def test_zero_when_pred_equals_true(self):
+        rots, trans = self._make_frames(2, 6)
+        atoms = torch.randn(2, 6, 3, 3)
+        loss = backbone_fape_loss(rots, trans, rots, trans, atoms, atoms)
+        # ε = 1e-4 floor inside sqrt yields ~1e-3 when difference is zero.
+        assert loss.item() < 5e-3
+
+    def test_positive_with_random_diff(self):
+        rots, trans = self._make_frames(2, 6)
+        rots2, trans2 = self._make_frames(2, 6, seed=99)
+        atoms = torch.randn(2, 6, 3, 3)
+        atoms2 = torch.randn(2, 6, 3, 3)
+        loss = backbone_fape_loss(rots, trans, rots2, trans2, atoms, atoms2)
+        assert loss.item() > 0
+
+    def test_clamp_caps_distance(self):
+        rots, trans = self._make_frames(1, 4)
+        atoms_true = torch.zeros(1, 4, 3, 3)
+        atoms_pred = atoms_true + 1000.0  # far away
+        loss_unclamped_proxy = backbone_fape_loss(
+            rots, trans, rots, trans, atoms_pred, atoms_true,
+            clamp_distance=10.0, length_scale=10.0)
+        # All distances clamped to 10 → loss ≈ 10/10 = 1.
+        assert 0.95 < loss_unclamped_proxy.item() <= 1.05
+
+    def test_mask_zeros_invalid(self):
+        rots, trans = self._make_frames(1, 4)
+        atoms = torch.randn(1, 4, 3, 3, requires_grad=True)
+        mask = torch.tensor([[True, True, False, False]])
+        loss = backbone_fape_loss(
+            rots, trans, rots, trans + 1.0,
+            atoms, atoms.detach(), mask=mask)
+        loss.backward()
+        # Gradient on masked atoms must be exactly zero.
+        assert torch.all(atoms.grad[:, 2:] == 0)
+        assert torch.any(atoms.grad[:, :2] != 0)
+
+    def test_shape_validation(self):
+        with pytest.raises(ValueError):
+            backbone_fape_loss(torch.zeros(1, 4, 3, 3),
+                               torch.zeros(1, 4, 3),
+                               torch.zeros(1, 5, 3, 3),
+                               torch.zeros(1, 5, 3),
+                               torch.zeros(1, 4, 3, 3),
+                               torch.zeros(1, 4, 3, 3))
+
+
+class TestChiAngleLoss:
+
+    def test_zero_when_equal(self):
+        a = torch.randn(2, 5, 4)
+        loss = chi_angle_loss(a, a)
+        assert loss.item() < 1e-7
+
+    def test_periodicity(self):
+        a = torch.zeros(1, 1, 4)
+        b = torch.full((1, 1, 4), 2 * math.pi)
+        loss = chi_angle_loss(a, b)
+        # 1 − cos(2π) = 0.
+        assert loss.item() < 1e-6
+
+    def test_max_at_pi(self):
+        a = torch.zeros(1, 1, 4)
+        b = torch.full((1, 1, 4), math.pi)
+        loss = chi_angle_loss(a, b)
+        # 1 − cos(π) = 2 exactly.
+        assert abs(loss.item() - 2.0) < 1e-6
+
+    def test_mask_excludes_entries(self):
+        a = torch.zeros(1, 1, 4)
+        b = torch.tensor([[[math.pi, 0.0, 0.0, 0.0]]])
+        m = torch.tensor([[[False, True, True, True]]])
+        loss = chi_angle_loss(a, b, m)
+        # All unmasked χ are equal → loss zero.
+        assert loss.item() < 1e-6
+
+
+class TestLigandContact:
+
+    def test_zero_when_inside_contact(self):
+        ca = torch.zeros(3, 3)
+        lig = torch.zeros(5, 3)
+        mask = torch.ones(3, dtype=torch.bool)
+        loss = ligand_contact_loss(ca, lig, mask, contact_distance=6.0)
+        assert loss.item() < 1e-6
+
+    def test_positive_when_far(self):
+        ca = torch.tensor([[100.0, 0.0, 0.0]])
+        lig = torch.tensor([[0.0, 0.0, 0.0]])
+        mask = torch.ones(1, dtype=torch.bool)
+        loss = ligand_contact_loss(ca, lig, mask, contact_distance=6.0)
+        assert loss.item() > 90.0
+
+    def test_masked_residues_contribute_nothing(self):
+        ca = torch.tensor([[100.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+        lig = torch.tensor([[0.0, 0.0, 0.0]])
+        mask = torch.tensor([False, True])
+        loss = ligand_contact_loss(ca, lig, mask)
+        assert loss.item() < 1e-6
+
+
+class TestAllAtomL2:
+
+    def test_masked_atoms_zero_gradient(self):
+        pred = torch.randn(4, 14, 3, requires_grad=True)
+        true = torch.randn(4, 14, 3)
+        mask = torch.zeros(4, 14, dtype=torch.bool)
+        mask[:, :5] = True  # only first five atoms valid.
+        loss = all_atom_l2_loss(pred, true, mask)
+        loss.backward()
+        # Strict: masked-atom gradient is *exactly* zero.
+        assert torch.all(pred.grad[:, 5:] == 0)
+        # Unmasked atoms should have gradient.
+        assert torch.any(pred.grad[:, :5] != 0)
+
+    def test_zero_loss_when_pred_equals_true(self):
+        x = torch.randn(2, 14, 3)
+        mask = torch.ones(2, 14, dtype=torch.bool)
+        loss = all_atom_l2_loss(x, x, mask)
+        assert loss.item() < 1e-9

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_symmetry.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_symmetry.py
@@ -1,0 +1,133 @@
+"""Tests for the point-group symmetry helpers."""
+
+import math
+
+import pytest
+import torch
+
+from deepchem.models.torch_models.rfdiffusion_symmetry import (
+    cyclic_group,
+    dihedral_group,
+    icosahedral_group,
+    octahedral_group,
+    symmetrise_coords,
+    symmetrise_frames,
+    tetrahedral_group,
+)
+
+
+def _is_rotation(R, tol=1e-6):
+    eye = torch.eye(3, dtype=R.dtype)
+    err = (R @ R.transpose(-1, -2) - eye).abs().max()
+    det = torch.det(R)
+    return float(err) < tol and float((det - 1).abs().max()) < tol
+
+
+class TestGroupConstruction:
+
+    @pytest.mark.parametrize('n', [1, 2, 3, 4, 5, 6, 12])
+    def test_cyclic_order(self, n):
+        g = cyclic_group(n)
+        assert g.shape == (n, 3, 3)
+        for R in g:
+            assert _is_rotation(R)
+
+    @pytest.mark.parametrize('n', [2, 3, 4, 5])
+    def test_dihedral_order(self, n):
+        g = dihedral_group(n)
+        assert g.shape == (2 * n, 3, 3)
+
+    def test_tetrahedral(self):
+        g = tetrahedral_group()
+        assert g.shape == (12, 3, 3)
+
+    def test_octahedral(self):
+        g = octahedral_group()
+        assert g.shape == (24, 3, 3)
+
+    def test_icosahedral(self):
+        g = icosahedral_group()
+        assert g.shape == (60, 3, 3)
+
+    def test_group_contains_identity(self):
+        for g in [cyclic_group(4), dihedral_group(3), tetrahedral_group(),
+                  octahedral_group(), icosahedral_group()]:
+            eye = torch.eye(3, dtype=g.dtype)
+            diffs = (g - eye).reshape(g.shape[0], -1).abs().sum(-1)
+            assert diffs.min() < 1e-8
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            cyclic_group(0)
+        with pytest.raises(ValueError):
+            dihedral_group(1)
+
+
+class TestSymmetrise:
+
+    def test_coords_match_under_group_action(self):
+        n = 4
+        g = cyclic_group(n)
+        unit = 5
+        coords = torch.randn(g.shape[0] * unit, 3, dtype=torch.float64) * 2.0
+        sym = symmetrise_coords(coords, g)
+        # The symmetric image must satisfy x_g = R_g · x_0.
+        reshaped = sym.view(n, unit, 3)
+        for k in range(n):
+            expected = torch.einsum('ij,uj->ui', g[k], reshaped[0])
+            err = (reshaped[k] - expected).abs().max()
+            assert err < 1e-8
+
+    def test_rmsd_between_units_below_tolerance(self):
+        """RMSD between copies after applying inverse group action
+        must be < 1e-5 Å."""
+        n = 6
+        g = cyclic_group(n)
+        unit = 7
+        torch.manual_seed(0)
+        coords = torch.randn(n * unit, 3, dtype=torch.float64)
+        sym = symmetrise_coords(coords, g).view(n, unit, 3)
+        ref = sym[0]
+        for k in range(1, n):
+            back = torch.einsum('ij,uj->ui', g[k].transpose(-1, -2), sym[k])
+            rmsd = (back - ref).pow(2).mean().sqrt()
+            assert rmsd < 1e-5
+
+    def test_frames_are_proper_rotations(self):
+        g = octahedral_group()
+        unit = 3
+        torch.manual_seed(1)
+        rots_raw = torch.randn(g.shape[0] * unit, 3, 3, dtype=torch.float64)
+        # Orthogonalise random matrices.
+        rots_raw, _ = torch.linalg.qr(rots_raw)
+        trans = torch.randn(g.shape[0] * unit, 3, dtype=torch.float64)
+        r_sym, _ = symmetrise_frames(rots_raw, trans, g)
+        for R in r_sym:
+            assert _is_rotation(R, tol=1e-6)
+
+    def test_frames_equivariant(self):
+        g = cyclic_group(3)
+        unit = 4
+        torch.manual_seed(2)
+        rots = torch.stack([
+            torch.linalg.qr(torch.randn(3, 3, dtype=torch.float64))[0]
+            for _ in range(g.shape[0] * unit)])
+        # Ensure proper rotations.
+        rots = rots * torch.det(rots).sign().view(-1, 1, 1)
+        trans = torch.randn(g.shape[0] * unit, 3, dtype=torch.float64)
+        r_sym, t_sym = symmetrise_frames(rots, trans, g)
+        r_sym = r_sym.view(3, unit, 3, 3)
+        t_sym = t_sym.view(3, unit, 3)
+        for k in range(1, 3):
+            # R_k = R_g_k · R_0
+            expected_r = torch.einsum('ij,ujk->uik', g[k], r_sym[0])
+            expected_t = torch.einsum('ij,uj->ui', g[k], t_sym[0])
+            assert (r_sym[k] - expected_r).abs().max() < 1e-6
+            assert (t_sym[k] - expected_t).abs().max() < 1e-6
+
+    def test_validation_rejects_bad_length(self):
+        with pytest.raises(ValueError):
+            symmetrise_coords(torch.zeros(5, 3), cyclic_group(2))
+        with pytest.raises(ValueError):
+            symmetrise_frames(torch.zeros(5, 3, 3), torch.zeros(5, 3),
+                              cyclic_group(2))

--- a/deepchem/utils/rfdiffusion_ligand.py
+++ b/deepchem/utils/rfdiffusion_ligand.py
@@ -1,0 +1,168 @@
+"""Minimal optional ligand parser for RFDiffusion-style conditioning.
+
+This utility reads an SDF / MOL file via RDKit and returns a
+``(num_atoms, 3)`` Cartesian point cloud plus per-atom integer atomic
+numbers. RDKit is imported lazily so the rest of the diffusion stack
+remains usable without it.
+
+Developer-facing summary
+------------------------
+Use ``parse_sdf`` to turn an on-disk ligand file into one or more
+``LigandPointCloud`` objects. Downstream code can then call
+``closest_distances`` or ``pairwise_distances`` to build residue-to-
+ligand geometry features without depending on RDKit after parsing.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+"""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+__all__ = [
+    'LigandPointCloud',
+    'parse_sdf',
+]
+
+
+class LigandPointCloud:
+    """Light-weight container for ligand point-cloud features.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray
+        Array of shape ``(N, 3)`` of atom Cartesian coordinates.
+    atomic_numbers : numpy.ndarray
+        Integer array of shape ``(N,)`` with atomic numbers.
+    name : str, optional
+        Human-readable ligand identifier.
+    """
+
+    __slots__ = ('coords', 'atomic_numbers', 'name')
+
+    def __init__(self,
+                 coords: np.ndarray,
+                 atomic_numbers: np.ndarray,
+                 name: Optional[str] = None) -> None:
+        coords = np.asarray(coords, dtype=np.float32)
+        atomic_numbers = np.asarray(atomic_numbers, dtype=np.int32)
+        if coords.ndim != 2 or coords.shape[-1] != 3:
+            raise ValueError(
+                f'coords must have shape (N, 3); got {coords.shape}.')
+        if atomic_numbers.shape != (coords.shape[0],):
+            raise ValueError(
+                'atomic_numbers must be of shape (N,) matching coords.')
+        self.coords = coords
+        self.atomic_numbers = atomic_numbers
+        self.name = name
+
+    @property
+    def num_atoms(self) -> int:
+        """Number of atoms in the ligand."""
+        return int(self.coords.shape[0])
+
+    def center(self) -> 'LigandPointCloud':
+        """Return a copy translated so the centroid is at the origin."""
+        coords = self.coords - self.coords.mean(axis=0, keepdims=True)
+        return LigandPointCloud(coords, self.atomic_numbers, self.name)
+
+
+def parse_sdf(path: str,
+              heavy_atoms_only: bool = True,
+              first_only: bool = True) -> List[LigandPointCloud]:
+    """Read an SDF file into ``LigandPointCloud`` objects.
+
+    Parameters
+    ----------
+    path : str
+        Path to the SDF / MOL file.
+    heavy_atoms_only : bool, default True
+        If ``True`` drop explicit hydrogens before extracting atoms.
+    first_only : bool, default True
+        If ``True`` parse only the first molecule in the file.
+
+    Returns
+    -------
+    list of LigandPointCloud
+        One entry per molecule successfully parsed.
+
+    Raises
+    ------
+    ImportError
+        If RDKit is not available.
+    """
+    try:
+        from rdkit import Chem
+    except ImportError as exc:  # pragma: no cover - exercised only without rdkit
+        raise ImportError(
+            'parse_sdf requires RDKit. Install with `pip install rdkit`.'
+        ) from exc
+    suppl = Chem.SDMolSupplier(path, removeHs=heavy_atoms_only)
+    clouds: List[LigandPointCloud] = []
+    for mol in suppl:
+        if mol is None:
+            continue
+        conf = mol.GetConformer() if mol.GetNumConformers() else None
+        if conf is None:
+            continue
+        coords = np.array([
+            [conf.GetAtomPosition(i).x,
+             conf.GetAtomPosition(i).y,
+             conf.GetAtomPosition(i).z]
+            for i in range(mol.GetNumAtoms())], dtype=np.float32)
+        atomic_numbers = np.array(
+            [a.GetAtomicNum() for a in mol.GetAtoms()], dtype=np.int32)
+        clouds.append(LigandPointCloud(
+            coords, atomic_numbers, name=mol.GetProp('_Name') or None))
+        if first_only:
+            break
+    return clouds
+
+
+def pairwise_distances(query: np.ndarray,
+                       target: np.ndarray) -> np.ndarray:
+    """Pairwise Euclidean distances between two point sets.
+
+    Parameters
+    ----------
+    query : numpy.ndarray
+        Array of shape ``(M, 3)``.
+    target : numpy.ndarray
+        Array of shape ``(N, 3)``.
+
+    Returns
+    -------
+    numpy.ndarray
+        Distance matrix of shape ``(M, N)``.
+    """
+    diff = query[:, None, :] - target[None, :, :]
+    return np.sqrt((diff * diff).sum(-1))
+
+
+def closest_distances(ligand: 'LigandPointCloud',
+                      protein_ca: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """Per-residue closest ligand-atom distance.
+
+    Parameters
+    ----------
+    ligand : LigandPointCloud
+        Ligand point cloud.
+    protein_ca : numpy.ndarray
+        Array of shape ``(L, 3)`` of protein Cα coordinates.
+
+    Returns
+    -------
+    distances : numpy.ndarray
+        Array of shape ``(L,)`` with the distance from each Cα to its
+        nearest ligand atom.
+    nearest_atom : numpy.ndarray
+        Integer array of shape ``(L,)`` with the index of the nearest
+        ligand atom for each residue.
+    """
+    dmat = pairwise_distances(protein_ca, ligand.coords)
+    nearest_atom = np.argmin(dmat, axis=1).astype(np.int32)
+    distances = dmat[np.arange(dmat.shape[0]), nearest_atom]
+    return distances, nearest_atom

--- a/deepchem/utils/test/test_rfdiffusion_ligand.py
+++ b/deepchem/utils/test/test_rfdiffusion_ligand.py
@@ -1,0 +1,93 @@
+"""Tests for the lightweight SDF/MOL ligand point-cloud parser."""
+
+import numpy as np
+import pytest
+
+from deepchem.utils.rfdiffusion_ligand import (
+    LigandPointCloud,
+    closest_distances,
+    pairwise_distances,
+)
+
+
+class TestLigandPointCloud:
+
+    def test_construction_and_shape(self):
+        coords = np.zeros((4, 3))
+        nums = np.array([6, 7, 8, 1])
+        lp = LigandPointCloud(coords=coords, atomic_numbers=nums, name='X')
+        assert lp.num_atoms == 4
+        assert lp.name == 'X'
+
+    def test_center_zero_centroid(self):
+        coords = np.array([[1.0, 1.0, 1.0],
+                           [-1.0, -1.0, -1.0],
+                           [2.0, 0.0, 0.0],
+                           [-2.0, 0.0, 0.0]])
+        lp = LigandPointCloud(coords=coords,
+                              atomic_numbers=np.array([6, 6, 6, 6]))
+        centred = lp.center()
+        assert np.allclose(centred.coords.mean(axis=0), 0.0, atol=1e-10)
+
+    def test_shape_validation(self):
+        with pytest.raises(ValueError):
+            LigandPointCloud(coords=np.zeros((3, 2)),
+                             atomic_numbers=np.array([1, 1, 1]))
+        with pytest.raises(ValueError):
+            LigandPointCloud(coords=np.zeros((3, 3)),
+                             atomic_numbers=np.array([1, 1]))
+
+
+class TestDistances:
+
+    def test_pairwise_known_values(self):
+        a = np.array([[0.0, 0.0, 0.0]])
+        b = np.array([[3.0, 4.0, 0.0]])
+        d = pairwise_distances(a, b)
+        assert d.shape == (1, 1)
+        assert abs(d[0, 0] - 5.0) < 1e-12
+
+    def test_closest_distances(self):
+        ca = np.array([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+        lig = LigandPointCloud(
+            coords=np.array([[1.0, 0.0, 0.0], [11.0, 0.0, 0.0]]),
+            atomic_numbers=np.array([6, 6]))
+        d, idx = closest_distances(lig, ca)
+        assert d.shape == (2,) and idx.shape == (2,)
+        assert abs(d[0] - 1.0) < 1e-12
+        assert abs(d[1] - 1.0) < 1e-12
+        assert idx.tolist() == [0, 1]
+
+    def test_validation(self):
+        with pytest.raises(ValueError):
+            pairwise_distances(np.zeros((3, 2)), np.zeros((3, 3)))
+
+
+# Optional RDKit-dependent tests below.
+try:
+    from rdkit import Chem  # noqa: F401
+    has_rdkit = True
+except ImportError:
+    has_rdkit = False
+
+
+@pytest.mark.skipif(not has_rdkit, reason='RDKit not installed.')
+class TestSDFParsing:
+
+    def test_parse_methane(self, tmp_path):
+        # Build a one-atom SDF (carbon) directly via RDKit.
+        from rdkit import Chem
+        from rdkit.Chem import AllChem
+        mol = Chem.MolFromSmiles('C')
+        mol = Chem.AddHs(mol)
+        AllChem.EmbedMolecule(mol, randomSeed=0)
+        path = tmp_path / 'methane.sdf'
+        writer = Chem.SDWriter(str(path))
+        writer.write(mol)
+        writer.close()
+        from deepchem.utils.rfdiffusion_ligand import parse_sdf
+        clouds = parse_sdf(str(path), heavy_atoms_only=True)
+        assert isinstance(clouds, list) and len(clouds) == 1
+        lp = clouds[0]
+        assert lp.num_atoms == 1
+        assert lp.atomic_numbers[0] == 6


### PR DESCRIPTION
## Summary
- add symmetry helpers for keeping generated coordinates and frames on a prescribed point group
- add length-conditioning, binder cross-attention, and the main RFDiffusion training losses
- add ligand point-cloud parsing utilities and focused tests for the full interface surface

> This is a Draft PR pushed to establish the core RFDiffusion architecture foundation for the RF Antibody extensions. This code will be further formatted, modularly tested, and split into smaller, independent PRs for official review in the coming weeks.

## Notes for RF Antibodies Extension
- `rfdiffusion_conditioning.py` is the primary antibody hook: `BinderCrossAttention` is the intended interface for conditioning a generated chain on a frozen partner representation.
- `rfdiffusion_losses.py` contains the supervision surface to reuse when antibody-specific heads still need frame, torsion, contact, or atom-level losses.
- `rfdiffusion_symmetry.py` is available if the antibody workflow later needs symmetric assemblies, and `rfdiffusion_ligand.py` is the optional point-cloud bridge for any future antigen or small-molecule conditioning experiments.
