### PR TITLE
docs: minor docstring clarification

### DIFF
--- a/deepchem/utils/sequence_utils.py
+++ b/deepchem/utils/sequence_utils.py
@@ -38,7 +38,7 @@ def hhblits(dataset_path,
         E-value cutoff.
     num_iterations: int
         Number of iterations.
-    num_threads: int
+    num_threads: int, default 4
         Number of threads.
 
     Returns


### PR DESCRIPTION
Adding a minor docstring clarification. (Opened as a simple PR to establish CI permissions as discussed with mentors).
