### PR TITLE
Fixed Typos in DeepChem Repository

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -24,7 +24,7 @@ class HuggingFaceModel(TorchModel):
     r"""Wrapper class that wraps HuggingFace models as DeepChem models
 
     The class provides a wrapper for wrapping models from HuggingFace
-    ecosystem in DeepChem and training it via DeepChem's api. The reason
+    ecosystem in DeepChem and training it via DeepChem's API. The reason
     for this might be that you might want to do an apples-to-apples comparison
     between HuggingFace from the transformers library and DeepChem library.
 
@@ -62,7 +62,7 @@ class HuggingFaceModel(TorchModel):
         `AutoModel` classes via `**kwargs` when loading from the hf_checkpoint. These parameters
         are typically used to customize the behavior and architecture of the underlying transformer
         model (e.g., number of layers, hidden size, dropout rates, etc.). When loading from pretrained
-        from hf_checkpoint, If any keys in `config` match configuration attributes supported by
+        from hf_checkpoint, if any keys in `config` match configuration attributes supported by
         the specific Hugging Face `AutoModel` being used, they will override the default settings
         for that model.
 


### PR DESCRIPTION
## Description
Fixed capitalization. For example, instead of DeepChem's api -> DeepChem's API, and If -> if since it was in a sentence. 
Fix #(issue)

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->


## Type of change
This was a documentation change, and it was important because documentation should have correct grammar. 




Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [X ] Documentations (modification for documents)


## Checklist

- [ X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
