### PR TITLE
Add RFDiffusion input embedding layers

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -53,6 +53,7 @@ class SinusoidalTimestepEmbedding(nn.Module):
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion import SinusoidalTimestepEmbedding
     >>> emb = SinusoidalTimestepEmbedding(64)
     >>> t = torch.tensor([0, 100, 500, 999])
     >>> output = emb(t)
@@ -102,6 +103,7 @@ class ResidueEmbedding(nn.Module):
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion import ResidueEmbedding
     >>> emb = ResidueEmbedding(9, 128)
     >>> x = torch.randn(2, 50, 9)
     >>> output = emb(x)
@@ -150,6 +152,7 @@ class PositionalEncoding(nn.Module):
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion import PositionalEncoding
     >>> pe = PositionalEncoding(128, max_len=256)
     >>> x = torch.randn(2, 50, 128)
     >>> output = pe(x)

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -80,8 +80,7 @@ class SinusoidalTimestepEmbedding(nn.Module):
         device = t.device
         half_dim = self.dim // 2
         log_scale: float = math.log(10000) / (half_dim - 1)
-        freq = torch.exp(
-            torch.arange(half_dim, device=device) * -log_scale)
+        freq = torch.exp(torch.arange(half_dim, device=device) * -log_scale)
         emb = t.float().unsqueeze(1) * freq.unsqueeze(0)
         emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
         return emb

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -1,0 +1,185 @@
+"""Input embedding layers for the RFDiffusion protein backbone model.
+
+This module adds three building-block layers that turn raw backbone
+coordinates and diffusion timesteps into feature vectors before the
+denoiser transformer sees them:
+
+- ``SinusoidalTimestepEmbedding`` — turns an integer timestep into a
+  sinusoidal vector so the network can tell how noisy the current input is.
+- ``ResidueEmbedding`` — projects the 9 raw backbone coordinates (N, CA, C
+  each with x, y, z) into a higher-dimensional space.
+- ``PositionalEncoding`` — adds sinusoidal position information so the
+  network knows where each residue sits in the chain.
+
+None of these have learnable parameters that depend on later modules, so
+they are shipped separately as the first small, reviewable PR.
+
+References
+----------
+.. [1] Watson, J. L., et al. "De novo design of protein structure and function
+   with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+.. [2] Vaswani, A., et al. "Attention is all you need." NeurIPS 2017.
+
+Notes
+-----
+This module requires PyTorch to be installed.
+"""
+
+import math
+
+try:
+    import torch
+    import torch.nn as nn
+except ModuleNotFoundError:
+    raise ImportError('These classes require PyTorch to be installed.')
+
+
+class SinusoidalTimestepEmbedding(nn.Module):
+    """Sinusoidal embedding for diffusion timesteps.
+
+    Maps integer timesteps to continuous vector representations using
+    sinusoidal functions, following the positional encoding scheme from
+    the Transformer architecture [1]_.
+
+    Parameters
+    ----------
+    dim : int
+        Dimensionality of the output embedding.
+
+    References
+    ----------
+    .. [1] Vaswani, A., et al. "Attention is all you need." NeurIPS 2017.
+
+    Examples
+    --------
+    >>> import torch
+    >>> emb = SinusoidalTimestepEmbedding(64)
+    >>> t = torch.tensor([0, 100, 500, 999])
+    >>> output = emb(t)
+    >>> output.shape
+    torch.Size([4, 64])
+    """
+
+    def __init__(self, dim: int) -> None:
+        super().__init__()
+        self.dim = dim
+
+    def forward(self, t: torch.Tensor) -> torch.Tensor:
+        """Compute timestep embeddings.
+
+        Parameters
+        ----------
+        t : torch.Tensor
+            Integer timesteps of shape ``(batch_size,)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embeddings of shape ``(batch_size, dim)``.
+        """
+        device = t.device
+        half_dim = self.dim // 2
+        log_scale: float = math.log(10000) / (half_dim - 1)
+        freq = torch.exp(
+            torch.arange(half_dim, device=device) * -log_scale)
+        emb = t.float().unsqueeze(1) * freq.unsqueeze(0)
+        emb = torch.cat([torch.sin(emb), torch.cos(emb)], dim=-1)
+        return emb
+
+
+class ResidueEmbedding(nn.Module):
+    """Embed per-residue backbone coordinates into feature vectors.
+
+    Each residue is represented by 9 values (N, CA, C atoms x 3 coordinates).
+    This module projects them into a higher-dimensional feature space.
+
+    Parameters
+    ----------
+    coord_dim : int, default 9
+        Input coordinate dimension (3 atoms * 3 xyz = 9).
+    embed_dim : int, default 256
+        Output embedding dimension.
+
+    Examples
+    --------
+    >>> import torch
+    >>> emb = ResidueEmbedding(9, 128)
+    >>> x = torch.randn(2, 50, 9)
+    >>> output = emb(x)
+    >>> output.shape
+    torch.Size([2, 50, 128])
+    """
+
+    def __init__(self, coord_dim: int = 9, embed_dim: int = 256) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(coord_dim, embed_dim),
+            nn.LayerNorm(embed_dim),
+            nn.GELU(),
+            nn.Linear(embed_dim, embed_dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Project coordinates to embeddings.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Backbone coordinates of shape ``(batch, num_residues, coord_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Embeddings of shape ``(batch, num_residues, embed_dim)``.
+        """
+        return self.net(x)
+
+
+class PositionalEncoding(nn.Module):
+    """Sinusoidal positional encoding for residue positions along the chain.
+
+    Injects information about relative position of each residue in the
+    protein sequence, following standard Transformer positional encoding.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Feature dimension.
+    max_len : int, default 512
+        Maximum supported sequence length.
+
+    Examples
+    --------
+    >>> import torch
+    >>> pe = PositionalEncoding(128, max_len=256)
+    >>> x = torch.randn(2, 50, 128)
+    >>> output = pe(x)
+    >>> output.shape
+    torch.Size([2, 50, 128])
+    """
+
+    def __init__(self, embed_dim: int, max_len: int = 512) -> None:
+        super().__init__()
+        pe = torch.zeros(max_len, embed_dim)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, embed_dim, 2).float() *
+            (-math.log(10000.0) / embed_dim))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        self.register_buffer('pe', pe.unsqueeze(0))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Add positional encoding to input features.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input of shape ``(batch, seq_len, embed_dim)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Input with positional encoding added, same shape.
+        """
+        return x + self.pe[:, :x.size(1), :]

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_embeddings.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_embeddings.py
@@ -2,17 +2,18 @@
 
 import pytest
 
-from deepchem.models.torch_models.rfdiffusion import (
-    PositionalEncoding,
-    ResidueEmbedding,
-    SinusoidalTimestepEmbedding,
-)
-
 try:
     import torch
     has_torch = True
 except ImportError:
     has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion import (
+        PositionalEncoding,
+        ResidueEmbedding,
+        SinusoidalTimestepEmbedding,
+    )
 
 
 @pytest.mark.torch

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_embeddings.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_embeddings.py
@@ -1,0 +1,101 @@
+"""Tests for the RFDiffusion input embedding layers."""
+
+import pytest
+
+from deepchem.models.torch_models.rfdiffusion import (
+    PositionalEncoding,
+    ResidueEmbedding,
+    SinusoidalTimestepEmbedding,
+)
+
+try:
+    import torch
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSinusoidalTimestepEmbedding:
+
+    def test_output_shape(self):
+        emb = SinusoidalTimestepEmbedding(64)
+        t = torch.tensor([0, 50, 100, 999])
+        assert emb(t).shape == (4, 64)
+
+    def test_different_timesteps_differ(self):
+        emb = SinusoidalTimestepEmbedding(64)
+        out = emb(torch.tensor([0, 500]))
+        assert not torch.allclose(out[0], out[1])
+
+    def test_not_all_zeros(self):
+        emb = SinusoidalTimestepEmbedding(32)
+        out = emb(torch.tensor([100]))
+        assert not torch.allclose(out, torch.zeros_like(out))
+
+    def test_gradient_flows(self):
+        # timestep embedding has no parameters, but input grad should work
+        emb = SinusoidalTimestepEmbedding(64)
+        t = torch.tensor([50])
+        out = emb(t)
+        # just checking no error is raised
+        assert out.shape == (1, 64)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestResidueEmbedding:
+
+    def test_output_shape(self):
+        emb = ResidueEmbedding(9, 128)
+        x = torch.randn(2, 50, 9)
+        assert emb(x).shape == (2, 50, 128)
+
+    def test_gradient_flow(self):
+        emb = ResidueEmbedding(9, 64)
+        x = torch.randn(1, 10, 9, requires_grad=True)
+        out = emb(x)
+        out.sum().backward()
+        assert x.grad is not None
+        assert x.grad.shape == x.shape
+
+    def test_zero_input_does_not_explode(self):
+        emb = ResidueEmbedding(9, 64)
+        x = torch.zeros(1, 5, 9)
+        out = emb(x)
+        assert torch.isfinite(out).all()
+
+    def test_custom_coord_dim(self):
+        emb = ResidueEmbedding(coord_dim=14, embed_dim=32)
+        x = torch.randn(1, 8, 14)
+        assert emb(x).shape == (1, 8, 32)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestPositionalEncoding:
+
+    def test_output_shape(self):
+        pe = PositionalEncoding(128, max_len=256)
+        x = torch.randn(2, 50, 128)
+        assert pe(x).shape == (2, 50, 128)
+
+    def test_adds_to_input(self):
+        pe = PositionalEncoding(64, max_len=100)
+        x = torch.zeros(1, 10, 64)
+        out = pe(x)
+        assert not torch.allclose(out, x)
+
+    def test_different_positions_differ(self):
+        pe = PositionalEncoding(64)
+        x = torch.zeros(1, 5, 64)
+        out = pe(x)
+        # each row should be different because positions differ
+        for i in range(4):
+            assert not torch.allclose(out[0, i], out[0, i + 1])
+
+    def test_preserves_shape_for_short_seq(self):
+        pe = PositionalEncoding(32, max_len=512)
+        x = torch.randn(4, 1, 32)
+        assert pe(x).shape == (4, 1, 32)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_embeddings.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_embeddings.py
@@ -4,16 +4,14 @@ import pytest
 
 try:
     import torch
-    has_torch = True
-except ImportError:
-    has_torch = False
-
-if has_torch:
     from deepchem.models.torch_models.rfdiffusion import (
         PositionalEncoding,
         ResidueEmbedding,
         SinusoidalTimestepEmbedding,
     )
+    has_torch = True
+except ImportError:
+    has_torch = False
 
 
 @pytest.mark.torch


### PR DESCRIPTION
## Description

Adds the three input embedding layers that the RFDiffusion denoiser uses to
convert raw backbone coordinates and timesteps into feature vectors:

- `SinusoidalTimestepEmbedding` – turns an integer diffusion timestep into a
  sinusoidal vector so the model knows how noisy the current input is.
- `ResidueEmbedding` – projects the 9 backbone coordinates (N, CA, C × xyz)
  into a higher-dimensional feature space before the transformer.
- `PositionalEncoding` – adds sinusoidal chain-position info so the model can
  tell residues apart by their order in the sequence.

This is PR A in a 4-part split. None of these classes import from later PRs so
they stand on their own. PR B (CosineSchedule) and PR C (BackboneDiffusion)
will build on top of this file.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
