### PR TITLE
Fix invalid escape sequence warnings in jacobian.py docstrings

### DIFF
--- a/deepchem/utils/differentiation_utils/optimize/jacobian.py
+++ b/deepchem/utils/differentiation_utils/optimize/jacobian.py
@@ -328,7 +328,7 @@ class LinearMixing(Jacobian):
 
 
 class LowRankMatrix(object):
-    """represents a matrix of `\alpha * I + \sum_n c_n d_n^T`
+    r"""represents a matrix of `\alpha * I + \sum_n c_n d_n^T`
 
     Examples
     --------
@@ -451,7 +451,7 @@ class LowRankMatrix(object):
 
 
 class FullRankMatrix(object):
-    """represents a full rank matrix of `\alpha * I + \sum_n c_n d_n^T`
+    r"""represents a full rank matrix of `\alpha * I + \sum_n c_n d_n^T`
 
     Examples
     --------


### PR DESCRIPTION
## Description
Related to #2989

Fixes invalid escape sequence DeprecationWarnings in `jacobian.py` by 
converting two docstrings to raw strings (adding `r` prefix).

The docstrings for `LowRankMatrix` and `FullRankMatrix` contain LaTeX 
notation (`\alpha`, `\sum`) which Python interprets as invalid escape 
sequences when the string is not declared as raw. This change has no 
functional impact — only removes the warning.

## Type of change
- [x] Documentations (modification for documents)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings