### PR TITLE
Fix invalid escape sequence warnings in attention.py docstrings

### DIFF
--- a/deepchem/models/torch_models/attention.py
+++ b/deepchem/models/torch_models/attention.py
@@ -59,7 +59,7 @@ class ScaledDotProductAttention(nn.Module):
 
 
 class SelfAttention(nn.Module):
-    """SelfAttention Layer
+    r"""SelfAttention Layer
 
     Given $X\in \mathbb{R}^{n \times in_feature}$, the attention is calculated by: $a=softmax(W_2tanh(W_1X))$, where
     $W_1 \in \mathbb{R}^{hidden \times in_feature}$, $W_2 \in \mathbb{R}^{out_feature \times hidden}$.
@@ -88,7 +88,7 @@ class SelfAttention(nn.Module):
         nn.init.xavier_normal_(self.w2)
 
     def forward(self, X):
-        """The forward function.
+        r"""The forward function.
 
         Parameters
         ----------


### PR DESCRIPTION
## Description
Related to #2989

Fixes invalid escape sequence DeprecationWarnings in `attention.py` by 
converting two docstrings to raw strings (adding `r` prefix).

The docstrings for the `SelfAttention` class and its `forward` method 
contain LaTeX/math notation (`\in`, `\mathbb`, `\times`) which Python 
interprets as invalid escape sequences when not declared as raw strings. 
This change has no functional impact — only removes the warnings.

## Type of change
- [x] Documentations (modification for documents)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings