### PR TITLE
Fix dropped samples in SingletaskStratifiedSplitter

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -775,7 +775,7 @@ class SingletaskStratifiedSplitter(Splitter):
 
         # Append remaining examples to train
         if sortidx.shape[0] > 0:
-            np.hstack([train_idx, sortidx])
+            train_idx = np.hstack([train_idx, sortidx])
 
         return (train_idx, valid_idx, test_idx)
 


### PR DESCRIPTION
Fixes #5008
## Descripion

This PR fixes a bug in `SingletaskStratifiedSplitter.split()` where the remaining samples that do not fit into a complete block are silently discarded.

The issue occurs because the result of `np.hstack([train_idx, sortidx])` is computed but never assigned back to `train_idx`. As a result, the remaining indices are omitted from all returned splits.

## Changes Made

In `splitters.py`, the following code:

```python
if sortidx.shape[0] > 0:
    np.hstack([train_idx, sortidx])
```

was changed to:

```python
if sortidx.shape[0] > 0:
    train_idx = np.hstack([train_idx, sortidx])
```

## Why This Change Is Needed

The original implementation computed the concatenation of the remaining samples with the training indices but discarded the returned array because it was not assigned back to any variable.

Since NumPy array operations are not performed in place, the remaining samples were never included in any split.

## Impact

This fix ensures that:

* No samples are silently dropped during splitting.
* Every sample from the original dataset is assigned to exactly one output split.
* The total number of samples across train, validation, and test splits matches the original dataset size.

## Verification

Using a dataset whose size is not divisible by 10:

```python
X = np.random.rand(95, 10)
y = np.random.rand(95, 1)

dataset = dc.data.NumpyDataset(X, y)
splitter = dc.splits.SingletaskStratifiedSplitter()
```

Before this fix:

```text
Original dataset size: 95
Split sizes - Train: 72 Valid: 9 Test: 9
Lost samples: 5
```

After this fix:

```text
Original dataset size: 95
Split sizes - Train: 77 Valid: 9 Test: 9
Lost samples: 0
```
### Verification Video


https://github.com/user-attachments/assets/a2c5a7fb-79bd-4b42-9dd9-7eb168a75f99



