### PR TITLE
Correct one-hot encoding generation for column-vector labels

### DIFF
--- a/deepchem/metrics/metric.py
+++ b/deepchem/metrics/metric.py
@@ -397,7 +397,7 @@ def to_one_hot(y: np.ndarray, n_classes: int = 2) -> np.ndarray:
         raise ValueError("y has more than n_class unique elements.")
     N = np.shape(y)[0]
     y_hot = np.zeros((N, n_classes))
-    y_hot[np.arange(N), y.astype(np.int64)] = 1
+    y_hot[np.arange(N), y.astype(np.int64).ravel()] = 1
     return y_hot
 
 


### PR DESCRIPTION
fixes #5010
## Description

This PR fixes an indexing issue in `deepchem.metrics.to_one_hot()` when labels are provided as a 2D column vector of shape `(N, 1)`.

The function documentation explicitly states that inputs of shape `(N,)` or `(N, 1)` are supported. However, when a `(N, 1)` array is passed, NumPy broadcasting during advanced indexing causes the generated one-hot encoding to be incorrect.

## Root Cause

The original implementation performed indexing using:

```python
y_hot[np.arange(N), y.astype(np.int64)] = 1
```

When `y` has shape `(N, 1)`, NumPy broadcasts the indexing arrays, resulting in assignments across unintended positions of the output matrix.

## Changes Made

Flattened the label array before indexing:

```python
y_hot[np.arange(N), y.astype(np.int64).ravel()] = 1
```

This ensures labels are treated as a one-dimensional index array regardless of whether the input shape is `(N,)` or `(N, 1)`.

## Validation

### Reproduction Case

Input:

```python
import numpy as np
from deepchem.metrics import to_one_hot

y = np.array([[0], [1], [0]])
print(to_one_hot(y))
```

Before fix:

```text
[[1. 1.]
 [1. 1.]
 [1. 1.]]
```

After fix:

```text
[[1. 0.]
 [0. 1.]
 [1. 0.]]
```

### Existing Tests

Verified that the existing test suite continues to pass:

```bash
pytest deepchem/metrics/tests/test_normalize.py
```

Result:

```text
18 passed
```

## Impact

This fix restores correct behavior for documented `(N, 1)` label inputs and prevents silent generation of invalid one-hot encodings that can affect classification metrics and downstream workflows.


## Verification Video

https://github.com/user-attachments/assets/ac963353-e7f1-409e-aec6-d5d6705c5a33