### PR TITLE
fix: correct ButinaSplitter logger format and typos in splitters.py (Fixes #5015)

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1235,13 +1235,13 @@ class ButinaSplitter(Splitter):
         except ModuleNotFoundError:
             raise ImportError("This function requires RDKit to be installed.")
 
-        logger.info("Performing butina clustering with cutoff of", self.cutoff)
+        logger.info("Performing butina clustering with cutoff of %s", self.cutoff)
         mols = []
         for ind, smiles in enumerate(dataset.ids):
             mols.append(Chem.MolFromSmiles(smiles))
         fps = [AllChem.GetMorganFingerprintAsBitVect(x, 2, 1024) for x in mols]
 
-        # calcaulate scaffold sets
+        # calculate scaffold sets
         # (ytz): this is directly copypasta'd from Greg Landrum's clustering example.
         dists = []
         nfps = len(fps)
@@ -1281,7 +1281,7 @@ def _generate_scaffold(smiles: str,
     They are essentially that part of the molecule consisting of
     rings and the linker atoms between them.
 
-    Paramters
+    Parameters
     ---------
     smiles: str
         SMILES
@@ -1483,7 +1483,7 @@ class ScaffoldSplitter(Splitter):
 
     Group  molecules  based on  the Bemis-Murcko scaffold representation, which identifies rings,
     linkers, frameworks (combinations between linkers and rings) and atomic properties  such as
-    atom type, hibridization and bond order in a dataset of molecules. Then split the groups by
+    atom type, hybridization and bond order in a dataset of molecules. Then split the groups by
     the number of molecules in each group in decreasing order.
 
     It is necessary to add the smiles representation in the ids field during the


### PR DESCRIPTION
Fixes #5015

## Problem

**Bug 1 — Logger ignores cutoff value (line 1238):**
`logger.info("Performing butina clustering with cutoff of", self.cutoff)`

Python's logging module uses %-style formatting. The format string has no `%s` placeholder, so `self.cutoff` is passed as a positional argument but silently ignored. The log message never shows the actual cutoff value.

**Bug 2 — Docstring typo (line 1284):**
`Paramters` → `Parameters`

**Bug 3 — Docstring typo (line 1486):**
`hibridization` → `hybridization`

**Bug 4 — Comment typo (line 1244):**
`calcaulate` → `calculate`

## Fix

1. Changed the logger call to use proper %-style formatting: `logger.info("Performing butina clustering with cutoff of %s", self.cutoff)`
2. Fixed all three typos in docstrings and comments.

## Verification

```bash
$ python3 -c "import ast; ast.parse(open('deepchem/splits/splitters.py').read()); print('Syntax OK')"
Syntax OK

$ grep -n "Performing butina" deepchem/splits/splitters.py
1238:        logger.info("Performing butina clustering with cutoff of %s", self.cutoff)

$ grep -n "Paramters\|hibridization\|calcaulate" deepchem/splits/splitters.py
(no output — all typos fixed)
```

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
