### PR TITLE
fix: DTNNEmbedding parameter misspelled (should be initializer) — Fixes #5020

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -3165,8 +3165,16 @@ class DTNNEmbedding(nn.Module):
     def __init__(self,
                  n_embedding: int = 30,
                  periodic_table_length: int = 30,
-                 initalizer: str = 'xavier_uniform_',
+                 initializer: str = 'xavier_uniform_',
                  **kwargs):
+        if 'initalizer' in kwargs:
+            import warnings
+            warnings.warn(
+                "The 'initalizer' parameter is deprecated. Use 'initializer' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            initializer = kwargs.pop('initalizer')
         """
         Parameters
         ----------
@@ -3174,7 +3182,7 @@ class DTNNEmbedding(nn.Module):
             Number of features for each atom
         periodic_table_length: int, optional
             Length of embedding, 83=Bi
-        initalizer: str, optional
+        initializer: str, optional
             Weight initialization for filters.
             Options: {xavier_uniform_, xavier_normal_, kaiming_uniform_, kaiming_normal_, trunc_normal_}
 
@@ -3182,9 +3190,9 @@ class DTNNEmbedding(nn.Module):
         super(DTNNEmbedding, self).__init__(**kwargs)
         self.n_embedding = n_embedding
         self.periodic_table_length = periodic_table_length
-        self.initalizer = initalizer  # Set weight initialization
+        self.initializer = initializer  # Set weight initialization
 
-        init_func: Callable = getattr(initializers, self.initalizer)
+        init_func: Callable = getattr(initializers, self.initializer)
         self.embedding_list: nn.Parameter = nn.Parameter(
             init_func(
                 torch.empty([self.periodic_table_length, self.n_embedding])))
@@ -3198,12 +3206,12 @@ class DTNNEmbedding(nn.Module):
             Number of features for each atom
         periodic_table_length: int, optional
             Length of embedding, 83=Bi
-        initalizer: str, optional
+        initializer: str, optional
             Weight initialization for filters.
             Options: {xavier_uniform_, xavier_normal_, kaiming_uniform_, kaiming_normal_, trunc_normal_}
 
         """
-        return f'{self.__class__.__name__}(n_embedding={self.n_embedding}, periodic_table_length={self.periodic_table_length}, initalizer={self.initalizer})'
+        return f'{self.__class__.__name__}(n_embedding={self.n_embedding}, periodic_table_length={self.periodic_table_length}, initializer={self.initializer})'
 
     def forward(self, inputs: torch.Tensor):
         """Returns Embeddings according to indices.


### PR DESCRIPTION
Rename `initalizer` → `initializer` in `DTNNEmbedding`, accept deprecated `'initalizer'` via `**kwargs` with a `DeprecationWarning`, and update docstrings and `__repr__`.

## Description

Fix typo in `DTNNEmbedding.__init__` parameter `initalizer` (missing second "i"). The correct spelling `initializer` is now used everywhere. The old misspelled name is still accepted via `**kwargs` with a `DeprecationWarning` for backwards compatibility.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings