### PR TITLE
Fix invalid escape sequence warnings in layers.py docstrings

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -1201,7 +1201,7 @@ class GraphNetwork(torch.nn.Module):
             edge_features: Tensor,
             global_features: Tensor,
             batch: Optional[Tensor] = None) -> Tuple[Tensor, Tensor, Tensor]:
-        """Output computation for a GraphNetwork
+        r"""Output computation for a GraphNetwork
         
         Parameters
         ----------
@@ -7722,7 +7722,7 @@ class SE3PairwiseConv(nn.Module):
 
 
 class SE3Sum(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Residual Sum Function (SE3Sum).
 
     This layer performs element-wise summation of SE(3)-equivariant
@@ -7819,7 +7819,7 @@ class SE3Sum(nn.Module):
 
 
 class SE3Cat(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Feature Concatenation (SE3Cat).
 
     This layer concatenates features from two SE(3)-equivariant fiber representations.
@@ -7909,7 +7909,7 @@ class SE3Cat(nn.Module):
 
 
 class SE3AvgPooling(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Average Pooling Module (SE3AvgPooling).
 
     This layer **performs average pooling over graph nodes while preserving SE(3) equivariance.
@@ -8013,7 +8013,7 @@ class SE3AvgPooling(nn.Module):
 
 
 class SE3MaxPooling(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Graph Max Pooling Module (SE3MaxPooling).
 
     This layer performs max pooling over graph nodes while preserving SE(3) equivariance.
@@ -8119,7 +8119,7 @@ class SE3MaxPooling(nn.Module):
 
 
 class SE3MultiHeadAttention(nn.Module):
-    """
+    r"""
     SE(3)-Equivariant Multi-Headed Self-Attention for Graph Neural Networks.
     This layer extends multi-head self-attention (MHA) to SE(3)-equivariant
     representations. Instead of using dot-product attention in standard Transformers,


### PR DESCRIPTION
## Description
Related to #2989

Fixes invalid escape sequence DeprecationWarnings in `layers.py` by 
converting six docstrings to raw strings (adding `r` prefix).

The affected classes are `GraphNetwork`, `SE3Sum`, `SE3Cat`, `SE3AvgPooling`, 
`SE3MaxPooling`, and `SE3MultiHeadAttention`. Their docstrings contain 
LaTeX/math notation (`\mathcal`, `\[`, `\(`, `\text`, etc.) which Python 
interprets as invalid escape sequences when not declared as raw strings. 
This change has no functional impact — only removes the warnings.

## Type of change
- [x] Documentations (modification for documents)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] Run `flake8 <modified file> --count` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
