### PR TITLE
docs: fix HingeLoss label values

### DIFF
--- a/deepchem/models/losses.py
+++ b/deepchem/models/losses.py
@@ -97,8 +97,8 @@ class L2Loss(Loss):
 class HingeLoss(Loss):
     """The hinge loss function.
 
-    The 'output' argument should contain logits, and all elements of 'labels'
-    should equal 0 or 1.
+    The ``output`` argument should contain logits, and all elements of ``labels``
+    should equal -1 or 1.
     """
 
     def _compute_tf_loss(self, output, labels):


### PR DESCRIPTION
## Description

Fixes #5017.

This updates the `HingeLoss` docstring to state that labels should be `-1` or `1`, matching the hinge-loss formulation used by the implementation.

No new dependencies are required.

## Type of change

Please check the option that is related to your PR.

* [ ] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

  * In this case, we recommend to discuss your modification on GitHub issues before creating the PR
* [x] Documentations (modification for documents)

## Checklist

* [x] My code follows [[the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)

  * [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  * [ ] Run `mypy -p deepchem` and check no errors
  * [ ] Run `flake8 <modified file> --count` and check no errors
  * [ ] Run `python -m doctest <modified file>` and check no errors
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas

  * Not applicable: this PR only updates an existing docstring.
* [x] I have made corresponding changes to the documentation
* [ ] I have added tests that prove my fix is effective or that my feature works

  * Not applicable: this is a documentation-only change.
* [ ] New unit tests pass locally with my changes

  * Not applicable: no unit tests were added for this documentation-only change.
* [x] I have checked my code and corrected any misspellings

Checked locally with:

```bash
python -m compileall deepchem/models/losses.py
```