### PR TITLE
Added task types that my olmo.py  will be using in prepare batch function otherwise my olmo.py won't work

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -311,13 +311,17 @@ class HuggingFaceModel(TorchModel):
                 'labels': labels
             }
             return inputs, None, w
-        elif self.task in ['single-task-regression', 'single-task-classification', 'mtr' , 'multi-task-classification']:
+        elif self.task in [
+                'single-task-regression', 'single-task-classification', 'mtr',
+                'multi-task-classification'
+        ]:
             if y is not None:
                 # y is None during predict
                 y = torch.from_numpy(y[0])
-                if self.task in ('single-task-regression' , 'mtr'):
+                if self.task in ('single-task-regression', 'mtr'):
                     y = y.float().to(self.device)
-                elif self.task in ('single-task-classification' , 'multi-task-classification'):
+                elif self.task in ('single-task-classification',
+                                   'multi-task-classification'):
                     y = y.float().to(self.device)
             for key, value in tokens.items():
                 tokens[key] = value.to(self.device)

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -311,14 +311,14 @@ class HuggingFaceModel(TorchModel):
                 'labels': labels
             }
             return inputs, None, w
-        elif self.task in ['regression', 'classification', 'mtr']:
+        elif self.task in ['single-task-regression', 'single-task-classification', 'mtr' , 'multi-task-classification']:
             if y is not None:
                 # y is None during predict
                 y = torch.from_numpy(y[0])
-                if self.task == 'regression' or self.task == 'mtr':
+                if self.task in ('single-task-regression' , 'mtr'):
                     y = y.float().to(self.device)
-                elif self.task == 'classification':
-                    y = y.long().to(self.device)
+                elif self.task in ('single-task-classification' , 'multi-task-classification'):
+                    y = y.float().to(self.device)
             for key, value in tokens.items():
                 tokens[key] = value.to(self.device)
 


### PR DESCRIPTION
## Description

Fix #(issue)

My olmo.py needs single-task-classification, multi-task-classification and single-task-regression, however the prepare batch function only allows just regular regression, classification, and mtr. I'm adding this fix so that my olmo.py which is a class that handles single task classification, multi-task-classiification, mtr, and single-task-regression will work. 


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [X] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [X] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
