### PR TITLE
Add float() because olmo loading is quite memory intensive so loading with bfloat16 will help with using less memory

### DIFF
--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -535,7 +535,9 @@ class HuggingFaceModel(TorchModel):
 
             if isinstance(output_values, torch.Tensor):
                 output_values = [output_values]
-            output_values = [t.float().detach().cpu().numpy() for t in output_values]
+            output_values = [
+                t.float().detach().cpu().numpy() for t in output_values
+            ]
             # Apply tranformers and record results.
             if uncertainty:
                 var = [output_values[i] for i in self._variance_outputs]

--- a/deepchem/models/torch_models/hf_models.py
+++ b/deepchem/models/torch_models/hf_models.py
@@ -535,7 +535,7 @@ class HuggingFaceModel(TorchModel):
 
             if isinstance(output_values, torch.Tensor):
                 output_values = [output_values]
-            output_values = [t.detach().cpu().numpy() for t in output_values]
+            output_values = [t.float().detach().cpu().numpy() for t in output_values]
             # Apply tranformers and record results.
             if uncertainty:
                 var = [output_values[i] for i in self._variance_outputs]


### PR DESCRIPTION
## Description

Fix #(issue)
For my olmo.py, I don't want to load the entire model since it's memory intensive. Loading with bfloat16 will help with loading the olmo model but hf_models.py doesn't support that, so I've added a float() to help with that. 


## Type of change

Please check the option that is related to your PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [X] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [ ] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [ ] Run `mypy -p deepchem` and check no errors
  - [ ] Run `flake8 <modified file> --count` and check no errors
  - [ ] Run `python -m doctest <modified file>` and check no errors
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings
