### PR TITLE
Update MoleculeNet dataset URLs to current S3 endpoint format

### DIFF
--- a/deepchem/molnet/load_function/bace_datasets.py
+++ b/deepchem/molnet/load_function/bace_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-BACE_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/bace.csv"
+BACE_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/bace.csv"
 BACE_REGRESSION_TASKS = ["pIC50"]
 BACE_CLASSIFICATION_TASKS = ["Class"]
 

--- a/deepchem/molnet/load_function/bbbp_datasets.py
+++ b/deepchem/molnet/load_function/bbbp_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-BBBP_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/BBBP.csv"
+BBBP_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/BBBP.csv"
 BBBP_TASKS = ["p_np"]
 
 

--- a/deepchem/molnet/load_function/chembl25_datasets.py
+++ b/deepchem/molnet/load_function/chembl25_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-CHEMBL25_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_25.csv.gz"
+CHEMBL25_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/chembl_25.csv.gz"
 CHEMBL25_TASKS = [
     "MolWt", "HeavyAtomMolWt", "MolLogP", "MolMR", "TPSA", "LabuteASA",
     "HeavyAtomCount", "NHOHCount", "NOCount", "NumHAcceptors", "NumHDonors",

--- a/deepchem/molnet/load_function/chembl_datasets.py
+++ b/deepchem/molnet/load_function/chembl_datasets.py
@@ -9,7 +9,7 @@ from deepchem.molnet.load_function.chembl_tasks import chembl_tasks
 
 from typing import List, Optional, Tuple, Union
 
-CHEMBL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/chembl_%s.csv.gz"
+CHEMBL_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/chembl_%s.csv.gz"
 
 
 class _ChemblLoader(_MolnetLoader):

--- a/deepchem/molnet/load_function/clearance_datasets.py
+++ b/deepchem/molnet/load_function/clearance_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-CLEARANCE_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/clearance.csv"
+CLEARANCE_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/clearance.csv"
 CLEARANCE_TASKS = ['target']
 
 

--- a/deepchem/molnet/load_function/clintox_datasets.py
+++ b/deepchem/molnet/load_function/clintox_datasets.py
@@ -8,7 +8,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-CLINTOX_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/clintox.csv.gz"
+CLINTOX_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/clintox.csv.gz"
 CLINTOX_TASKS = ['FDA_APPROVED', 'CT_TOX']
 
 

--- a/deepchem/molnet/load_function/delaney_datasets.py
+++ b/deepchem/molnet/load_function/delaney_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-DELANEY_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/delaney-processed.csv"
+DELANEY_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/delaney-processed.csv"
 DELANEY_TASKS = ['measured log solubility in mols per litre']
 
 

--- a/deepchem/molnet/load_function/factors_datasets.py
+++ b/deepchem/molnet/load_function/factors_datasets.py
@@ -11,9 +11,9 @@ from deepchem.utils import remove_missing_entries
 
 logger = logging.getLogger(__name__)
 
-TRAIN_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/FACTORS_training_disguised_combined_full.csv.gz"
-VALID_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/FACTORS_test1_disguised_combined_full.csv.gz"
-TEST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/FACTORS_test2_disguised_combined_full.csv.gz"
+TRAIN_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/FACTORS_training_disguised_combined_full.csv.gz"
+VALID_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/FACTORS_test1_disguised_combined_full.csv.gz"
+TEST_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/FACTORS_test2_disguised_combined_full.csv.gz"
 
 TRAIN_FILENAME = "FACTORS_training_disguised_combined_full.csv.gz"
 VALID_FILENAME = "FACTORS_test1_disguised_combined_full.csv.gz"

--- a/deepchem/molnet/load_function/hiv_datasets.py
+++ b/deepchem/molnet/load_function/hiv_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-HIV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/HIV.csv"
+HIV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/HIV.csv"
 HIV_TASKS = ["HIV_active"]
 
 

--- a/deepchem/molnet/load_function/hopv_datasets.py
+++ b/deepchem/molnet/load_function/hopv_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-HOPV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/hopv.tar.gz"
+HOPV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/hopv.tar.gz"
 HOPV_TASKS = [
     'HOMO', 'LUMO', 'electrochemical_gap', 'optical_gap', 'PCE', 'V_OC', 'J_SC',
     'fill_factor'

--- a/deepchem/molnet/load_function/hppb_datasets.py
+++ b/deepchem/molnet/load_function/hppb_datasets.py
@@ -8,7 +8,7 @@ from deepchem.data import Dataset
 from deepchem.utils import remove_missing_entries
 from typing import List, Optional, Tuple, Union
 
-HPPB_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/hppb.csv"
+HPPB_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/hppb.csv"
 HPPB_TASKS = ["target"]  # Task is solubility in pH 7.4 buffer
 
 

--- a/deepchem/molnet/load_function/kaggle_datasets.py
+++ b/deepchem/molnet/load_function/kaggle_datasets.py
@@ -42,13 +42,13 @@ def gen_kaggle(KAGGLE_tasks,
                               "KAGGLE_test2_disguised_combined_full.csv.gz")
     if not os.path.exists(train_files):
         deepchem.utils.data_utils.download_url(
-            "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz",
+            "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/KAGGLE_training_disguised_combined_full.csv.gz",
             dest_dir=data_dir)
         deepchem.utils.data_utils.download_url(
-            "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz",
+            "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/KAGGLE_test1_disguised_combined_full.csv.gz",
             dest_dir=data_dir)
         deepchem.utils.data_utils.download_url(
-            "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz",
+            "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/KAGGLE_test2_disguised_combined_full.csv.gz",
             dest_dir=data_dir)
 
     # Featurize KAGGLE dataset

--- a/deepchem/molnet/load_function/kinase_datasets.py
+++ b/deepchem/molnet/load_function/kinase_datasets.py
@@ -9,9 +9,9 @@ import deepchem
 from deepchem.molnet.load_function.kaggle_features import merck_descriptors
 from deepchem.utils import remove_missing_entries
 
-TRAIN_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KINASE_training_disguised_combined_full.csv.gz"
-VALID_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KINASE_test1_disguised_combined_full.csv.gz"
-TEST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/KINASE_test2_disguised_combined_full.csv.gz"
+TRAIN_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/KINASE_training_disguised_combined_full.csv.gz"
+VALID_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/KINASE_test1_disguised_combined_full.csv.gz"
+TEST_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/KINASE_test2_disguised_combined_full.csv.gz"
 
 TRAIN_FILENAME = "KINASE_training_disguised_combined_full.csv.gz"
 VALID_FILENAME = "KINASE_test1_disguised_combined_full.csv.gz"

--- a/deepchem/molnet/load_function/lipo_datasets.py
+++ b/deepchem/molnet/load_function/lipo_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-LIPO_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/Lipophilicity.csv"
+LIPO_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/Lipophilicity.csv"
 LIPO_TASKS = ['exp']
 
 

--- a/deepchem/molnet/load_function/load_dataset_template.py
+++ b/deepchem/molnet/load_function/load_dataset_template.py
@@ -14,8 +14,8 @@ from typing import List, Tuple, Dict, Optional
 logger = logging.getLogger(__name__)
 
 DEFAULT_DIR = deepchem.utils.data_utils.get_data_dir()
-MYDATASET_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/mydataset.tar.gz"
-MYDATASET_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/mydataset.csv"
+MYDATASET_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/mydataset.tar.gz"
+MYDATASET_CSV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/mydataset.csv"
 
 # dict of accepted featurizers for this dataset
 # modify the returned dicts for your dataset

--- a/deepchem/molnet/load_function/material_datasets/load_Pt_NO_surface_adsorbate_energy.py
+++ b/deepchem/molnet/load_function/material_datasets/load_Pt_NO_surface_adsorbate_energy.py
@@ -8,7 +8,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-PLATINUM_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/Platinum_adsorption.tar.gz"
+PLATINUM_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/Platinum_adsorption.tar.gz"
 PLATINUM_TASKS = ["Formation Energy"]
 PRIMITIVE_CELL = {
     "lattice": [[2.818528, 0.0, 0.0], [-1.409264, 2.440917, 0.0],

--- a/deepchem/molnet/load_function/material_datasets/load_bandgap.py
+++ b/deepchem/molnet/load_function/material_datasets/load_bandgap.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-BANDGAP_URL = 'https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/expt_gap.tar.gz'
+BANDGAP_URL = 'https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/expt_gap.tar.gz'
 BANDGAP_TASKS = ['experimental_bandgap']
 
 

--- a/deepchem/molnet/load_function/material_datasets/load_mp_formation_energy.py
+++ b/deepchem/molnet/load_function/material_datasets/load_mp_formation_energy.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-MPFORME_URL = 'https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/mp_formation_energy.tar.gz'
+MPFORME_URL = 'https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/mp_formation_energy.tar.gz'
 MPFORME_TASKS = ['formation_energy']
 
 

--- a/deepchem/molnet/load_function/material_datasets/load_mp_metallicity.py
+++ b/deepchem/molnet/load_function/material_datasets/load_mp_metallicity.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-MPMETAL_URL = 'https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/mp_is_metal.tar.gz'
+MPMETAL_URL = 'https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/mp_is_metal.tar.gz'
 MPMETAL_TASKS = ['is_metal']
 
 

--- a/deepchem/molnet/load_function/material_datasets/load_perovskite.py
+++ b/deepchem/molnet/load_function/material_datasets/load_perovskite.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-PEROVSKITE_URL = 'https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/perovskite.tar.gz'
+PEROVSKITE_URL = 'https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/perovskite.tar.gz'
 PEROVSKITE_TASKS = ['formation_energy']
 
 

--- a/deepchem/molnet/load_function/muv_datasets.py
+++ b/deepchem/molnet/load_function/muv_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-MUV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/muv.csv.gz"
+MUV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/muv.csv.gz"
 MUV_TASKS = sorted([
     'MUV-692', 'MUV-689', 'MUV-846', 'MUV-859', 'MUV-644', 'MUV-548', 'MUV-852',
     'MUV-600', 'MUV-810', 'MUV-712', 'MUV-737', 'MUV-858', 'MUV-713', 'MUV-733',

--- a/deepchem/molnet/load_function/nci_datasets.py
+++ b/deepchem/molnet/load_function/nci_datasets.py
@@ -9,7 +9,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-NCI_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/nci_unique.csv"
+NCI_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/nci_unique.csv"
 NCI_TASKS = [
     'CCRF-CEM', 'HL-60(TB)', 'K-562', 'MOLT-4', 'RPMI-8226', 'SR', 'A549/ATCC',
     'EKVX', 'HOP-62', 'HOP-92', 'NCI-H226', 'NCI-H23', 'NCI-H322M', 'NCI-H460',

--- a/deepchem/molnet/load_function/pcba_datasets.py
+++ b/deepchem/molnet/load_function/pcba_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-PCBA_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/%s"
+PCBA_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/%s"
 PCBA_TASKS = [
     'PCBA-1030', 'PCBA-1379', 'PCBA-1452', 'PCBA-1454', 'PCBA-1457',
     'PCBA-1458', 'PCBA-1460', 'PCBA-1461', 'PCBA-1468', 'PCBA-1469',

--- a/deepchem/molnet/load_function/pdbbind_datasets.py
+++ b/deepchem/molnet/load_function/pdbbind_datasets.py
@@ -10,7 +10,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-DATASETS_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/"
+DATASETS_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/"
 PDBBIND_URL = DATASETS_URL + "pdbbindv2019/"
 PDBBIND_TASKS = ['-logKd/Ki']
 

--- a/deepchem/molnet/load_function/ppb_datasets.py
+++ b/deepchem/molnet/load_function/ppb_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-PPB_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/PPB.csv"
+PPB_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/PPB.csv"
 PPB_TASKS = ['exp']
 
 

--- a/deepchem/molnet/load_function/qm7_datasets.py
+++ b/deepchem/molnet/load_function/qm7_datasets.py
@@ -7,10 +7,10 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-QM7_MAT_UTL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm7.mat"
-QM7_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm7.csv"
-QM7B_MAT_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm7b.mat"
-GDB7_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb7.tar.gz"
+QM7_MAT_UTL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/qm7.mat"
+QM7_CSV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/qm7.csv"
+QM7B_MAT_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/qm7b.mat"
+GDB7_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/gdb7.tar.gz"
 GDB7_V2_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/gdb7_v2.tar.gz"
 QM7_TASKS = ["u0_atom"]
 

--- a/deepchem/molnet/load_function/qm8_datasets.py
+++ b/deepchem/molnet/load_function/qm8_datasets.py
@@ -7,8 +7,8 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-GDB8_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb8.tar.gz"
-QM8_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm8.csv"
+GDB8_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/gdb8.tar.gz"
+QM8_CSV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/qm8.csv"
 QM8_TASKS = [
     "E1-CC2", "E2-CC2", "f1-CC2", "f2-CC2", "E1-PBE0", "E2-PBE0", "f1-PBE0",
     "f2-PBE0", "E1-PBE0", "E2-PBE0", "f1-PBE0", "f2-PBE0", "E1-CAM", "E2-CAM",

--- a/deepchem/molnet/load_function/qm9_datasets.py
+++ b/deepchem/molnet/load_function/qm9_datasets.py
@@ -7,8 +7,8 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-GDB9_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb9.tar.gz"
-QM9_CSV_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/qm9.csv"
+GDB9_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/gdb9.tar.gz"
+QM9_CSV_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/qm9.csv"
 QM9_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/qm9.tar.gz"
 QM9_TASKS = [
     "mu", "alpha", "homo", "lumo", "gap", "r2", "zpve", "cv", "u0", "u298",

--- a/deepchem/molnet/load_function/sampl_datasets.py
+++ b/deepchem/molnet/load_function/sampl_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-SAMPL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/SAMPL.csv"
+SAMPL_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/SAMPL.csv"
 SAMPL_TASKS = ['expt']
 
 

--- a/deepchem/molnet/load_function/sider_datasets.py
+++ b/deepchem/molnet/load_function/sider_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-SIDER_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/sider.csv.gz"
+SIDER_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/sider.csv.gz"
 SIDER_TASKS = [
     'Hepatobiliary disorders', 'Metabolism and nutrition disorders',
     'Product issues', 'Eye disorders', 'Investigations',

--- a/deepchem/molnet/load_function/sweetlead_datasets.py
+++ b/deepchem/molnet/load_function/sweetlead_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-SWEETLEAD_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/sweet.csv.gz"
+SWEETLEAD_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/sweet.csv.gz"
 SWEETLEAD_TASKS = ["task"]
 
 

--- a/deepchem/molnet/load_function/thermosol_datasets.py
+++ b/deepchem/molnet/load_function/thermosol_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-THERMOSOL_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/thermosol.csv"
+THERMOSOL_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/thermosol.csv"
 THERMOSOL_TASKS = ["target"]  # Task is solubility in pH 7.4 buffer
 
 

--- a/deepchem/molnet/load_function/tox21_datasets.py
+++ b/deepchem/molnet/load_function/tox21_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-TOX21_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/tox21.csv.gz"
+TOX21_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/tox21.csv.gz"
 TOX21_TASKS = [
     'NR-AR', 'NR-AR-LBD', 'NR-AhR', 'NR-Aromatase', 'NR-ER', 'NR-ER-LBD',
     'NR-PPAR-gamma', 'SR-ARE', 'SR-ATAD5', 'SR-HSE', 'SR-MMP', 'SR-p53'

--- a/deepchem/molnet/load_function/toxcast_datasets.py
+++ b/deepchem/molnet/load_function/toxcast_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-TOXCAST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/toxcast_data.csv.gz"
+TOXCAST_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/toxcast_data.csv.gz"
 TOXCAST_TASKS = [
     'ACEA_T47D_80hr_Negative', 'ACEA_T47D_80hr_Positive',
     'APR_HepG2_CellCycleArrest_24h_dn', 'APR_HepG2_CellCycleArrest_24h_up',

--- a/deepchem/molnet/load_function/uv_datasets.py
+++ b/deepchem/molnet/load_function/uv_datasets.py
@@ -12,9 +12,9 @@ from deepchem.utils import remove_missing_entries
 
 logger = logging.getLogger(__name__)
 
-TRAIN_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/UV_training_disguised_combined_full.csv.gz"
-VALID_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/UV_test1_disguised_combined_full.csv.gz"
-TEST_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/UV_test2_disguised_combined_full.csv.gz"
+TRAIN_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/UV_training_disguised_combined_full.csv.gz"
+VALID_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/UV_test1_disguised_combined_full.csv.gz"
+TEST_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/UV_test2_disguised_combined_full.csv.gz"
 
 TRAIN_FILENAME = "UV_training_disguised_combined_full.csv.gz"
 VALID_FILENAME = "UV_test1_disguised_combined_full.csv.gz"

--- a/deepchem/molnet/load_function/zinc15_datasets.py
+++ b/deepchem/molnet/load_function/zinc15_datasets.py
@@ -7,7 +7,7 @@ from deepchem.molnet.load_function.molnet_loader import TransformerGenerator, _M
 from deepchem.data import Dataset
 from typing import List, Optional, Tuple, Union
 
-ZINC15_URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/"
+ZINC15_URL = "https://deepchemdata.s3.us-west-1.amazonaws.com/datasets/"
 ZINC15_TASKS = ['mwt', 'logp', 'reactive']
 
 


### PR DESCRIPTION
## Description

Fixes #5034.

This PR updates MoleculeNet loader constants from the legacy S3 endpoint format:

`https://deepchemdata.s3-us-west-1.amazonaws.com/...`

to the virtual-hosted regional endpoint already used by newer loaders such as
QM7/QM9:

`https://deepchemdata.s3.us-west-1.amazonaws.com/...`

The object keys are unchanged. This keeps existing dataset locations the same
while using a more current endpoint style consistently across loaders.

## Why

Some environments can fail TLS negotiation or HTTP handling against older S3
endpoint spellings. DeepChem already uses the
`s3.us-west-1.amazonaws.com` format for newer dataset constants such as
`GDB7_V2_URL` and `QM9_URL`; this PR applies the same endpoint format to the
remaining MoleculeNet loader constants.

## Validation

- Updated 36 loader files under `deepchem/molnet/load_function`.
- Verified that the patch applies cleanly with `git apply --check`.
- Extracted 51 DeepChem S3 URL constants from the patched files.
- Sent HEAD requests for 46 concrete URLs after excluding template/base URLs
  such as `%s`, `/datasets/`, and `mydataset`.
- All 46 checked URLs returned HTTP 200.
- Ran `git diff --check`.
- Verified that no `deepchemdata.s3-us-west-1.amazonaws.com` strings remain
  under `deepchem/molnet/load_function`.

No dataset object names or loader behavior were changed.
