### PR TITLE
Fix incorrect parameter names in docstrings

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1629,7 +1629,7 @@ class DiskDataset(Dataset):
         batch_size: int, optional (default None)
             Number of elements in a batch. If None, then it yields batches
             with size equal to the size of each individual shard.
-        epoch: int, default 1
+        epochs: int, default 1
             Number of epochs to walk over dataset
         deterministic: bool, default False
             Whether or not we should should shuffle each shard before

--- a/deepchem/feat/smiles_tokenizer.py
+++ b/deepchem/feat/smiles_tokenizer.py
@@ -299,7 +299,7 @@ class BasicSmilesTokenizer(object):
 
         Parameters
         ----------
-        regex: string
+        regex_pattern: string
             SMILES token regex
         """
         self.regex_pattern = regex_pattern

--- a/deepchem/utils/geometry_utils.py
+++ b/deepchem/utils/geometry_utils.py
@@ -158,7 +158,7 @@ def is_angle_within_cutoff(vector_i: np.ndarray, vector_j: np.ndarray,
         A numpy array of shape (3,)`, where `3` is (x,y,z).
     vector_j: np.ndarray
         A numpy array of shape `(3,)`, where `3` is (x,y,z).
-    cutoff: float
+    angle_cutoff: float
         The deviation from 180 (in degrees)
 
     Returns

--- a/deepchem/utils/noncovalent_utils.py
+++ b/deepchem/utils/noncovalent_utils.py
@@ -126,7 +126,7 @@ def compute_hbonds_in_range(frag1, frag2, pairwise_distances, hbond_dist_bin,
         Matrix of shape `(N, M)` with pairwise distances between frag1/frag2.
     hbond_dist_bin: tuple
         Tuple of floats `(min_dist, max_dist)` in angstroms.
-    hbond_angle_cutoffs: list[float]
+    hbond_angle_cutoff: list[float]
         List of angles of deviances allowed for hbonds
     """
 

--- a/deepchem/utils/pdbqt_utils.py
+++ b/deepchem/utils/pdbqt_utils.py
@@ -274,7 +274,7 @@ def _dfs(used_partitions: Set[int], current_partition: int,
 
     Parameters
     ----------
-    used_partions: Set[int]
+    used_partitions: Set[int]
         Partitions which have already been used
     current_partition: int
         The current partition to expand
@@ -324,7 +324,7 @@ def _valid_bond(used_partitions: Set[int], bond: Tuple[int, int],
 
     Parameters
     ----------
-    used_partions: Set[int]
+    used_partitions: Set[int]
         Partitions which have already been used
     bond: Tuple[int, int]
         The bond to check if it goes to an unexplored partition.


### PR DESCRIPTION
## Description

Several docstrings in `deepchem` document parameter names that do not match their function signatures. This corrects them so the docs match the code:

| Function | File | Docstring | Signature |
|---|---|---|---|
| `DiskDataset.iterbatches` | `data/datasets.py` | `epoch` | `epochs` |
| `BasicSMILESTokenizer.__init__` | `feat/smiles_tokenizer.py` | `regex` | `regex_pattern` |
| `is_angle_within_cutoff` | `utils/geometry_utils.py` | `cutoff` | `angle_cutoff` |
| `compute_hbonds_in_range` | `utils/noncovalent_utils.py` | `hbond_angle_cutoffs` | `hbond_angle_cutoff` |
| `_dfs`, `_valid_bond` | `utils/pdbqt_utils.py` | `used_partions` | `used_partitions` |

Note: `compute_hydrogen_bonds` genuinely takes a plural `hbond_angle_cutoffs`, so that docstring is intentionally left unchanged.

Documentation-only change; no runtime behavior is affected.

## Type of change

- [x] Documentation update
