### PR TITLE
Fix seed parameter in ScaffoldSplitter and resolve type issues

### DIFF
--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1552,7 +1552,9 @@ class ScaffoldSplitter(Splitter):
             Each indices is a list of integers.
         """
         np.testing.assert_almost_equal(frac_train + frac_valid + frac_test, 1.)
-        scaffold_sets = self.generate_scaffolds(dataset)
+        scaffold_sets = self.generate_scaffolds(
+            dataset,
+            log_every_n=log_every_n if log_every_n is not None else 1000)
 
         from collections import defaultdict
         size_to_group_idxs = defaultdict(list)

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1555,14 +1555,16 @@ class ScaffoldSplitter(Splitter):
         scaffold_sets = self.generate_scaffolds(dataset)
 
         from collections import defaultdict
-        rng = np.random.RandomState(seed)
         size_to_group_idxs = defaultdict(list)
         for i, group in enumerate(scaffold_sets):
             size_to_group_idxs[len(group)].append(i)
-        for idxs in size_to_group_idxs.values():
-            rng.shuffle(idxs)
 
         ordered_sizes = sorted(size_to_group_idxs.keys(), reverse=True)
+        if seed is not None:
+            rng = np.random.RandomState(seed)
+            for size in ordered_sizes:
+                rng.shuffle(size_to_group_idxs[size])
+
         scaffold_sets = [
             scaffold_sets[i]
             for size in ordered_sizes

--- a/deepchem/splits/splitters.py
+++ b/deepchem/splits/splitters.py
@@ -1442,8 +1442,8 @@ def _split_fingerprints(fps: List, size1: int,
     remaining_fp = fps[1:]
     remaining_indices = list(range(1, len(fps)))
     max_similarity_to_group = [
-        DataStructs.BulkTanimotoSimilarity(fps[0], remaining_fp),
-        [0] * len(remaining_fp)
+        np.array(DataStructs.BulkTanimotoSimilarity(fps[0], remaining_fp)),
+        np.zeros(len(remaining_fp))
     ]
     # Return identity if no tuple to split to
     if size2 == 0:
@@ -1539,7 +1539,8 @@ class ScaffoldSplitter(Splitter):
         frac_test: float, optional (default 0.1)
             The fraction of data to be used for the test split.
         seed: int, optional (default None)
-            Random seed to use.
+            Random seed to use for tie-breaking shuffling among equal-sized
+            scaffold groups.
         log_every_n: int, optional (default 1000)
             Controls the logger by dictating how often logger outputs
             will be produced.
@@ -1552,6 +1553,21 @@ class ScaffoldSplitter(Splitter):
         """
         np.testing.assert_almost_equal(frac_train + frac_valid + frac_test, 1.)
         scaffold_sets = self.generate_scaffolds(dataset)
+
+        from collections import defaultdict
+        rng = np.random.RandomState(seed)
+        size_to_group_idxs = defaultdict(list)
+        for i, group in enumerate(scaffold_sets):
+            size_to_group_idxs[len(group)].append(i)
+        for idxs in size_to_group_idxs.values():
+            rng.shuffle(idxs)
+
+        ordered_sizes = sorted(size_to_group_idxs.keys(), reverse=True)
+        scaffold_sets = [
+            scaffold_sets[i]
+            for size in ordered_sizes
+            for i in size_to_group_idxs[size]
+        ]
 
         train_cutoff = frac_train * len(dataset)
         valid_cutoff = (frac_train + frac_valid) * len(dataset)

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -620,18 +620,30 @@ class TestSplitter(unittest.TestCase):
         # Use a NumpyDataset and stub generate_scaffolds to return known
         # equal-sized scaffold groups, making the test deterministic and
         # independent of RDKit scaffold generation across versions.
+        # The lambda signature matches the real generate_scaffolds signature:
+        # (self, dataset, log_every_n=1000) -> List[List[int]]
+        # When assigned to an instance, self is not passed, so we take
+        # (dataset, log_every_n=1000).
         dataset = dc.data.NumpyDataset(X=np.zeros(8), y=np.ones(8))
         splitter = dc.splits.ScaffoldSplitter()
-        splitter.generate_scaffolds = lambda _: [
-            [i] for i in range(len(dataset))
-        ]  # type: ignore[method-assign]
+        splitter.generate_scaffolds = (  # type: ignore[method-assign]
+            lambda dataset, log_every_n=1000: [[i] for i in range(len(dataset))]
+        )
 
-        # Same seed twice -> identical splits
+        # seed=42: verify exact deterministic split order matches
+        # np.random.RandomState(42) shuffle of [0..7].
         train1, valid1, test1 = splitter.split(dataset,
                                                frac_train=0.5,
                                                frac_valid=0.25,
                                                frac_test=0.25,
                                                seed=42)
+        expected_42 = list(range(8))
+        np.random.RandomState(42).shuffle(expected_42)
+        assert train1 == expected_42[:4]
+        assert valid1 == expected_42[4:6]
+        assert test1 == expected_42[6:]
+
+        # Same seed twice -> identical splits
         train2, valid2, test2 = splitter.split(dataset,
                                                frac_train=0.5,
                                                frac_valid=0.25,
@@ -641,23 +653,36 @@ class TestSplitter(unittest.TestCase):
         assert valid1 == valid2
         assert test1 == test2
 
-        # Different seeds -> different splits (all groups are size 1 so
-        # tie-breaking order determines the split)
+        # seed=43: verify exact deterministic split order (non-flaky)
         train3, valid3, test3 = splitter.split(dataset,
                                                frac_train=0.5,
                                                frac_valid=0.25,
                                                frac_test=0.25,
                                                seed=43)
-        assert train1 != train3 or valid1 != valid3 or test1 != test3
+        expected_43 = list(range(8))
+        np.random.RandomState(43).shuffle(expected_43)
+        assert train3 == expected_43[:4]
+        assert valid3 == expected_43[4:6]
+        assert test3 == expected_43[6:]
 
-        # seed=None -> runs without error, splits respect fractions,
-        # and behaviour remains deterministic (no shuffling applied)
+        # seed=None -> no tie-breaking shuffle; preserves deterministic
+        # insertion order (0..7) and two calls produce the same result.
         train_none, valid_none, test_none = splitter.split(dataset,
                                                            frac_train=0.5,
                                                            frac_valid=0.25,
                                                            frac_test=0.25,
                                                            seed=None)
-        assert len(train_none) == 4
-        assert len(valid_none) == 2
-        assert len(test_none) == 2
+        assert train_none == [0, 1, 2, 3]
+        assert valid_none == [4, 5]
+        assert test_none == [6, 7]
+
+        train_none2, valid_none2, test_none2 = splitter.split(dataset,
+                                                              frac_train=0.5,
+                                                              frac_valid=0.25,
+                                                              frac_test=0.25,
+                                                              seed=None)
+        assert train_none == train_none2
+        assert valid_none == valid_none2
+        assert test_none == test_none2
+
 

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -617,15 +617,14 @@ class TestSplitter(unittest.TestCase):
 
     def test_scaffold_splitter_seed(self):
         """Test that ScaffoldSplitter seed works for tie-breaking shuffling."""
-        smiles = [
-            'C1CCCCC1', 'c1ccccc1', 'C1COCCN1', 'c1ncncn1', 'c1ccccc1CC',
-            'C1CCCCCC1', 'c1cc[nH]c1', 'C1CSCCS1'
-        ]
-        dataset = dc.data.DiskDataset.from_numpy(X=np.zeros(8),
-                                                 y=np.ones(8),
-                                                 w=np.zeros(8),
-                                                 ids=smiles)
+        # Use a NumpyDataset and stub generate_scaffolds to return known
+        # equal-sized scaffold groups, making the test deterministic and
+        # independent of RDKit scaffold generation across versions.
+        dataset = dc.data.NumpyDataset(X=np.zeros(8), y=np.ones(8))
         splitter = dc.splits.ScaffoldSplitter()
+        splitter.generate_scaffolds = lambda _: [
+            [i] for i in range(len(dataset))
+        ]  # type: ignore[method-assign]
 
         # Same seed twice -> identical splits
         train1, valid1, test1 = splitter.split(dataset,
@@ -642,7 +641,8 @@ class TestSplitter(unittest.TestCase):
         assert valid1 == valid2
         assert test1 == test2
 
-        # Different seeds -> different splits (since we have multiple size 1 scaffold groups)
+        # Different seeds -> different splits (all groups are size 1 so
+        # tie-breaking order determines the split)
         train3, valid3, test3 = splitter.split(dataset,
                                                frac_train=0.5,
                                                frac_valid=0.25,
@@ -650,7 +650,8 @@ class TestSplitter(unittest.TestCase):
                                                seed=43)
         assert train1 != train3 or valid1 != valid3 or test1 != test3
 
-        # seed=None -> runs without error and splits respect fractions
+        # seed=None -> runs without error, splits respect fractions,
+        # and behaviour remains deterministic (no shuffling applied)
         train_none, valid_none, test_none = splitter.split(dataset,
                                                            frac_train=0.5,
                                                            frac_valid=0.25,
@@ -659,3 +660,4 @@ class TestSplitter(unittest.TestCase):
         assert len(train_none) == 4
         assert len(valid_none) == 2
         assert len(test_none) == 2
+

--- a/deepchem/splits/tests/test_splitter.py
+++ b/deepchem/splits/tests/test_splitter.py
@@ -614,3 +614,48 @@ class TestSplitter(unittest.TestCase):
             cv_folds[1][1])
         assert len(multitask_dataset) == len(cv_folds[2][0]) + len(
             cv_folds[2][1])
+
+    def test_scaffold_splitter_seed(self):
+        """Test that ScaffoldSplitter seed works for tie-breaking shuffling."""
+        smiles = [
+            'C1CCCCC1', 'c1ccccc1', 'C1COCCN1', 'c1ncncn1', 'c1ccccc1CC',
+            'C1CCCCCC1', 'c1cc[nH]c1', 'C1CSCCS1'
+        ]
+        dataset = dc.data.DiskDataset.from_numpy(X=np.zeros(8),
+                                                 y=np.ones(8),
+                                                 w=np.zeros(8),
+                                                 ids=smiles)
+        splitter = dc.splits.ScaffoldSplitter()
+
+        # Same seed twice -> identical splits
+        train1, valid1, test1 = splitter.split(dataset,
+                                               frac_train=0.5,
+                                               frac_valid=0.25,
+                                               frac_test=0.25,
+                                               seed=42)
+        train2, valid2, test2 = splitter.split(dataset,
+                                               frac_train=0.5,
+                                               frac_valid=0.25,
+                                               frac_test=0.25,
+                                               seed=42)
+        assert train1 == train2
+        assert valid1 == valid2
+        assert test1 == test2
+
+        # Different seeds -> different splits (since we have multiple size 1 scaffold groups)
+        train3, valid3, test3 = splitter.split(dataset,
+                                               frac_train=0.5,
+                                               frac_valid=0.25,
+                                               frac_test=0.25,
+                                               seed=43)
+        assert train1 != train3 or valid1 != valid3 or test1 != test3
+
+        # seed=None -> runs without error and splits respect fractions
+        train_none, valid_none, test_none = splitter.split(dataset,
+                                                           frac_train=0.5,
+                                                           frac_valid=0.25,
+                                                           frac_test=0.25,
+                                                           seed=None)
+        assert len(train_none) == 4
+        assert len(valid_none) == 2
+        assert len(test_none) == 2


### PR DESCRIPTION
## Summary

This PR fixes an issue where the `seed` parameter passed to `ScaffoldSplitter.split()` was accepted but never used.

Previously, scaffold groups were sorted only by size. When multiple scaffold groups had the same number of molecules, ties were always resolved in the same order, producing identical splits regardless of the provided seed.

This change introduces deterministic tie-breaking by shuffling scaffold groups of equal size using a random number generator initialized with the user-provided seed. As a result:

- The same seed always produces the same scaffold split.
- Different seeds can produce different, yet reproducible, scaffold splits when equal-sized scaffold groups are present.
- Existing scaffold-based splitting logic remains unchanged apart from tie resolution.

Fixes #5043

---

## Changes Made

### `deepchem/splits/splitters.py`

- Group scaffold sets by their size using `collections.defaultdict`.
- Use `np.random.RandomState(seed)` to deterministically shuffle scaffold groups within each size bucket.
- Preserve the existing greedy scaffold assignment algorithm after tie-breaking.

---

## Type of Change

- [x] Bug fix (non-breaking change)

---

## Testing

The change was verified by running the existing splitter test suite.

- ✅ `pytest splits/tests/test_scaffold_splitter.py`
- ✅ `pytest splits/tests/test_splitter.py`
- ✅ `mypy splits/splitters.py`

All tests passed successfully with no type checking issues.

**Test Results**

<img width="937" height="355" alt="Screenshot 2026-07-06 232542" src="https://github.com/user-attachments/assets/7de570bb-1a49-4491-bd16-508114a9cbcf" />
<img width="943" height="285" alt="Screenshot 2026-07-06 232631" src="https://github.com/user-attachments/assets/f9a542be-df2d-4993-b11a-29ca08f17069" />


## Notes

This change only affects the ordering of scaffold groups with identical sizes during splitting. It does not modify the overall scaffold splitting strategy or change behavior for scaffold groups with unique sizes.