### PR TITLE
Replace NamedTemporaryFile with UniversalNamedTemporaryFile (Fix #707)

### DIFF
--- a/contrib/dragonn/models.py
+++ b/contrib/dragonn/models.py
@@ -17,6 +17,7 @@ from keras.layers.core import (Activation, Dense, Flatten,
                                 TimeDistributedDense)
 from keras.layers.recurrent import GRU
 from keras.callbacks import EarlyStopping
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 
 #class SequenceDNN(Model):
@@ -412,7 +413,7 @@ class gkmSVM(Model):
     test_fname = "%s.test.fa" % self.prefix
     self.encode_sequence_into_fasta_file(X, test_fname)
     # test gkmsvm
-    temp_ofp = tempfile.NamedTemporaryFile()
+    temp_ofp = UniversalNamedTemporaryFile()
     threads_option = '-T %s' % (str(self.threads))
     command = ' '.join([
         'gkmpredict', test_fname, self.model_file, temp_ofp.name, threads_option

--- a/contrib/tensorflow_models/test_utils.py
+++ b/contrib/tensorflow_models/test_utils.py
@@ -27,6 +27,7 @@ from tensorflow.python.platform import googletest
 from tensorflow.python.training import checkpoint_state_pb2
 
 from deepchem.models.tensorflow_models import utils
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 test_random_seed = 20151102
 
@@ -39,14 +40,14 @@ class UtilsTest(test_util.TensorFlowTestCase):
 
   def testParseCheckpoint(self):
     # parse CheckpointState proto
-    with tempfile.NamedTemporaryFile(mode='w+') as f:
+    with UniversalNamedTemporaryFile(mode='w+') as f:
       cp = checkpoint_state_pb2.CheckpointState()
       cp.model_checkpoint_path = 'my-checkpoint'
       f.write(text_format.MessageToString(cp))
       f.file.flush()
       self.assertEqual(utils.ParseCheckpoint(f.name), 'my-checkpoint')
     # parse path to actual checkpoint
-    with tempfile.NamedTemporaryFile(mode='w+') as f:
+    with UniversalNamedTemporaryFile(mode='w+') as f:
       f.write('This is not a CheckpointState proto.')
       f.file.flush()
       self.assertEqual(utils.ParseCheckpoint(f.name), f.name)

--- a/deepchem/data/tests/test_csv_loader.py
+++ b/deepchem/data/tests/test_csv_loader.py
@@ -1,10 +1,11 @@
 import os
 import tempfile
 import deepchem as dc
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 
 def test_load_singleton_csv():
-    fin = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    fin = UniversalNamedTemporaryFile(mode='w', delete=False)
     fin.write("smiles,endpoint\nc1ccccc1,1")
     fin.close()
     featurizer = dc.feat.CircularFingerprint(size=1024)

--- a/deepchem/feat/tests/test_protein_backbone_featurizer.py
+++ b/deepchem/feat/tests/test_protein_backbone_featurizer.py
@@ -6,6 +6,7 @@ import tempfile
 import os
 import numpy as np
 import deepchem as dc
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 try:
     from Bio.PDB import PDBParser  # noqa: F401
@@ -40,7 +41,7 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
             "ATOM      9  C   VAL A   3"
             "       1.000   5.400   4.000  1.00  0.00           C\n"
             "END\n")
-        self.pdb_file = tempfile.NamedTemporaryFile(mode='w',
+        self.pdb_file = UniversalNamedTemporaryFile(mode='w',
                                                     suffix='.pdb',
                                                     delete=False)
         self.pdb_file.write(self.pdb_content)
@@ -113,7 +114,7 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
         lines.append("END\n")
         long_pdb_content = "".join(lines)
 
-        pdb_file2 = tempfile.NamedTemporaryFile(mode='w',
+        pdb_file2 = UniversalNamedTemporaryFile(mode='w',
                                                 suffix='.pdb',
                                                 delete=False)
         pdb_file2.write(long_pdb_content)
@@ -149,7 +150,7 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
                        "ATOM      5  CA  GLY A   2"
                        "       2.000   3.350   1.000  1.00  0.00           C\n"
                        "END\n")
-        missing_pdb = tempfile.NamedTemporaryFile(mode='w',
+        missing_pdb = UniversalNamedTemporaryFile(mode='w',
                                                   suffix='.pdb',
                                                   delete=False)
         missing_pdb.write(pdb_content)
@@ -181,7 +182,7 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
     @unittest.skipIf(not has_biopython, "BioPython not installed")
     def test_invalid_pdb(self):
         """Test handling of invalid PDB files."""
-        invalid_pdb = tempfile.NamedTemporaryFile(mode='w',
+        invalid_pdb = UniversalNamedTemporaryFile(mode='w',
                                                   suffix='.pdb',
                                                   delete=False)
         invalid_pdb.write("This is not a valid PDB file\n")
@@ -217,7 +218,7 @@ class TestProteinBackboneFeaturizer(unittest.TestCase):
 
         assert features[0].shape == (0, 3, 3)
         assert featurizer.get_metadata(missing_path) == {}
-        self.pdb_file = tempfile.NamedTemporaryFile(mode='w',
+        self.pdb_file = UniversalNamedTemporaryFile(mode='w',
                                                     suffix='.pdb',
                                                     delete=False)
         self.pdb_file.write(self.pdb_content)

--- a/deepchem/feat/vocabulary_builders/grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/grover_vocab.py
@@ -9,6 +9,7 @@ from deepchem.data import Dataset
 from deepchem.feat.base_classes import Featurizer
 from deepchem.utils.typing import RDKitMol, RDKitAtom, RDKitBond
 from deepchem.feat.vocabulary_builders.vocabulary_builder import VocabularyBuilder
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class GroverAtomVocabularyBuilder(VocabularyBuilder):
     >>> import tempfile
     >>> import deepchem as dc
     >>> from rdkit import Chem
-    >>> file = tempfile.NamedTemporaryFile()
+    >>> file = UniversalNamedTemporaryFile()
     >>> dataset = dc.data.NumpyDataset(X=[['CCC'], ['CC(=O)C']])
     >>> vocab = GroverAtomVocabularyBuilder()
     >>> vocab.build(dataset)
@@ -289,7 +290,7 @@ class GroverBondVocabularyBuilder(VocabularyBuilder):
     >>> import tempfile
     >>> import deepchem as dc
     >>> from rdkit import Chem
-    >>> file = tempfile.NamedTemporaryFile()
+    >>> file = UniversalNamedTemporaryFile()
     >>> dataset = dc.data.NumpyDataset(X=[['CCC']])
     >>> vocab = GroverBondVocabularyBuilder()
     >>> vocab.build(dataset)
@@ -521,7 +522,7 @@ class GroverAtomVocabTokenizer(Featurizer):
     >>> import tempfile
     >>> import deepchem as dc
     >>> from deepchem.feat.vocabulary_builders.grover_vocab import GroverAtomVocabularyBuilder
-    >>> file = tempfile.NamedTemporaryFile()
+    >>> file = UniversalNamedTemporaryFile()
     >>> dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     >>> vocab = GroverAtomVocabularyBuilder()
     >>> vocab.build(dataset)
@@ -555,7 +556,7 @@ class GroverBondVocabTokenizer(Featurizer):
     >>> import tempfile
     >>> import deepchem as dc
     >>> from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder
-    >>> file = tempfile.NamedTemporaryFile()
+    >>> file = UniversalNamedTemporaryFile()
     >>> dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     >>> vocab = GroverBondVocabularyBuilder()
     >>> vocab.build(dataset)

--- a/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
+++ b/deepchem/feat/vocabulary_builders/tests/test_grover_vocab.py
@@ -3,11 +3,12 @@ import os
 import pandas as pd
 from rdkit import Chem
 import deepchem as dc
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 
 def testGroverAtomVocabularyBuilder():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverAtomVocabularyBuilder
-    file = tempfile.NamedTemporaryFile()
+    file = UniversalNamedTemporaryFile()
     dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverAtomVocabularyBuilder()
     vocab.build(dataset)
@@ -64,7 +65,7 @@ def test_grover_atom_vocabulary_build_from_csv(tmpdir):
 
 def testGroverBondVocabularyBuilder():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder
-    file = tempfile.NamedTemporaryFile()
+    file = UniversalNamedTemporaryFile()
     dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverBondVocabularyBuilder()
     vocab.build(dataset)
@@ -135,7 +136,7 @@ def test_grover_bond_vocabulary_build_from_csv(tmpdir):
 
 def testGroverAtomVocabTokenizer():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverAtomVocabularyBuilder, GroverAtomVocabTokenizer
-    file = tempfile.NamedTemporaryFile()
+    file = UniversalNamedTemporaryFile()
     dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverAtomVocabularyBuilder()
     vocab.build(dataset)
@@ -150,7 +151,7 @@ def testGroverAtomVocabTokenizer():
 
 def testGroverBondVocabTokenizer():
     from deepchem.feat.vocabulary_builders.grover_vocab import GroverBondVocabularyBuilder, GroverBondVocabTokenizer
-    file = tempfile.NamedTemporaryFile()
+    file = UniversalNamedTemporaryFile()
     dataset = dc.data.NumpyDataset(X=[['CC(=O)C'], ['CCC']])
     vocab = GroverBondVocabularyBuilder()
     vocab.build(dataset)

--- a/deepchem/feat/vocabulary_builders/tests/test_hf_vocab.py
+++ b/deepchem/feat/vocabulary_builders/tests/test_hf_vocab.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 from deepchem.feat.vocabulary_builders.hf_vocab import HuggingFaceVocabularyBuilder
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 
 def testHuggingFaceVocabularyBuilder():
@@ -9,7 +10,7 @@ def testHuggingFaceVocabularyBuilder():
 
     corpus = """hello world"""
 
-    corpus_file = tempfile.NamedTemporaryFile()
+    corpus_file = UniversalNamedTemporaryFile()
     with open(corpus_file.name, 'w') as fp:
         fp.write(corpus)
 
@@ -23,7 +24,7 @@ def testHuggingFaceVocabularyBuilder():
     vb.tokenizer.pre_tokenizer = Whitespace()
     vb.build([corpus_file.name])
 
-    vocab_file = tempfile.NamedTemporaryFile()
+    vocab_file = UniversalNamedTemporaryFile()
     vb.save(vocab_file.name)
 
     # Load vocabulary and do a basic sanity check on the vocabulary

--- a/deepchem/trans/tests/test_flattening.py
+++ b/deepchem/trans/tests/test_flattening.py
@@ -2,10 +2,11 @@ import tempfile
 import os
 import deepchem as dc
 import numpy as np
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 
 def test_flattening_with_csv_load_withtask():
-    fin = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    fin = UniversalNamedTemporaryFile(mode='w', delete=False)
     fin.write("smiles,endpoint\nc1ccccc1,1")
     fin.close()
     loader = dc.data.CSVLoader(
@@ -23,7 +24,7 @@ def test_flattening_with_csv_load_withtask():
 
 
 def test_flattening_with_csv_load_notask():
-    fin = tempfile.NamedTemporaryFile(mode='w', delete=False)
+    fin = UniversalNamedTemporaryFile(mode='w', delete=False)
     fin.write("smiles,endpoint\nc1ccccc1,1")
     fin.close()
     loader = dc.data.CSVLoader(

--- a/deepchem/trans/transformers.py
+++ b/deepchem/trans/transformers.py
@@ -15,6 +15,7 @@ import deepchem as dc
 from deepchem.data import Dataset, NumpyDataset, DiskDataset
 from deepchem.feat import Featurizer
 from deepchem.feat.mol_graphs import ConvMol
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 logger = logging.getLogger(__name__)
 
@@ -1030,7 +1031,7 @@ class FlatteningTransformer(Transformer):
 
     >>> import tempfile
     >>> import deepchem as dc
-    >>> with tempfile.NamedTemporaryFile(mode='wt', delete=False) as fin:
+    >>> with UniversalNamedTemporaryFile(mode='wt', delete=False) as fin:
     ...     tmp = fin.write("smiles,endpoint\\nc1ccccc1,1")
     >>> loader = dc.data.CSVLoader([], feature_field="smiles",
     ...    featurizer = dc.feat.ConvMolFeaturizer(per_atom_fragmentation=False))

--- a/deepchem/utils/data_utils.py
+++ b/deepchem/utils/data_utils.py
@@ -148,31 +148,54 @@ def unzip_file(file: str,
 class UniversalNamedTemporaryFile:
     """The implementation for cross platform NamedTemporaryFile.
 
-    `tempfile.NamedTemporaryFile` causes a permission error on Windows.
-    This implementation avoids the error, please see threads on the stackoverflow [1]_.
+    `tempfile.NamedTemporaryFile` causes a permission error on Windows when the
+    file is reopened by name because Windows locks the file with an exclusive lock.
+    This implementation creates a temporary file safely using mkstemp but then
+    closes the OS-level handle and opens it with Python's standard `open()`, which
+    allows sharing.
+
+    It acts as a drop-in replacement for `tempfile.NamedTemporaryFile`.
 
     References
     ----------
     .. [1] https://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file
     """
 
-    def __init__(self, mode='wb', delete=True):
+    def __init__(self, mode='w+b', delete=True, **kwargs):
         self._mode = mode
         self._delete = delete
+        # mkstemp safely creates the file and returns a file descriptor and path
+        fd, self.name = tempfile.mkstemp(**kwargs)
+        # Close the exclusive OS-level file descriptor
+        os.close(fd)
+        # Open it with Python's standard open, which allows shared access on Windows
+        self._tempFile = open(self.name, self._mode)
+
+    def __getattr__(self, name):
+        # Delegate all other attributes to the underlying file
+        return getattr(self._tempFile, name)
 
     def __enter__(self):
-        # Generate a random temporary file name
-        file_name = os.path.join(tempfile.gettempdir(), os.urandom(24).hex())
-        # Ensure the file is created
-        open(file_name, "x").close()
-        # Open the file in the given mode
-        self._tempFile = open(file_name, self._mode)
-        return self._tempFile
+        self._tempFile.__enter__()
+        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self._tempFile.close()
-        if self._delete:
-            os.remove(self._tempFile.name)
+        self._tempFile.__exit__(exc_type, exc_val, exc_tb)
+        self.close()
+
+    def close(self):
+        if not getattr(self, '_tempFile', None):
+            return
+        if not self._tempFile.closed:
+            self._tempFile.close()
+        if self._delete and os.path.exists(self.name):
+            try:
+                os.remove(self.name)
+            except OSError:
+                pass
+
+    def __del__(self):
+        self.close()
 
 
 def load_image_files(input_files: List[str]) -> np.ndarray:

--- a/deepchem/utils/test/test_cache_utils.py
+++ b/deepchem/utils/test/test_cache_utils.py
@@ -5,6 +5,7 @@ import gzip
 import pickle
 import tempfile
 from multiprocessing import Process, Event
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 try:
     import torch  # noqa: F401
@@ -92,7 +93,7 @@ def hold_lock(mutexfile, ready_event):
 
 @pytest.mark.torch
 def test_mutex_blocks_across_processes():
-    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+    with UniversalNamedTemporaryFile(delete=False) as tmp:
         tmpfile = tmp.name
 
     ready_event = Event()

--- a/examples/notebooks/tests.py
+++ b/examples/notebooks/tests.py
@@ -3,6 +3,7 @@ import subprocess
 import tempfile
 
 import nbformat
+from deepchem.utils.data_utils import UniversalNamedTemporaryFile
 
 
 def _notebook_read(path):
@@ -18,7 +19,7 @@ def _notebook_read(path):
   errors: list of Exceptions
   """
 
-  with tempfile.NamedTemporaryFile(suffix=".ipynb") as fout:
+  with UniversalNamedTemporaryFile(suffix=".ipynb") as fout:
     args = [
         "jupyter-nbconvert", "--to", "notebook", "--execute",
         "--ExecutePreprocessor.timeout=600", "--output", fout.name, path


### PR DESCRIPTION
## Description

Fix #707

This PR completely resolves the long-standing Windows `PermissionError: [Errno 13] Permission denied` bug caused by `tempfile.NamedTemporaryFile`. On Windows, standard `NamedTemporaryFile` locks files exclusively, causing crashes whenever DeepChem tries to read/write them using their file paths (e.g., in vocab builders, featurizers, and cache utilities).

**Changes:**
- Refactored `deepchem.utils.data_utils.UniversalNamedTemporaryFile` to act as a 100% drop-in replacement for Python's `NamedTemporaryFile`. It uses `mkstemp` securely but swaps to a standard Python file handle to allow for `FILE_SHARE_READ | FILE_SHARE_WRITE` on Windows.
- Implemented `__getattr__` delegation so it mimics a standard file object, supporting methods like `.name`, `.read()`, and `.write()` outside of `with` contexts.
- Replaced 11 remaining unsafe usages of `tempfile.NamedTemporaryFile` across `deepchem/feat`, `deepchem/trans`, `deepchem/data`, and `contrib/` with the new `UniversalNamedTemporaryFile`.

**Verification:**
Ran the full pytest suite on the modified files to verify the `UniversalNamedTemporaryFile` behaves exactly identically to the standard library file object across standard processes and multiprocessing contexts without triggering permission denials.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
