### PR TITLE
Fix incorrect loss initialization in ModularTorchModel and GroverModel

### DIFF
--- a/deepchem/models/tests/test_modular.py
+++ b/deepchem/models/tests/test_modular.py
@@ -201,3 +201,35 @@ def test_load_freeze_unfreeze():
     assert not np.array_equal(
         example_pretrainer.components['encoder'][0].weight.data.cpu().numpy(),
         example_model.components['encoder'][0].weight.data.cpu().numpy())
+
+
+@pytest.mark.torch
+def test_modular_custom_loss():
+    """Test that ModularTorchModel uses custom loss function when provided."""
+    import torch
+
+    np.random.seed(123)
+    torch.manual_seed(10)
+    n_samples = 6
+    n_feat = 3
+    d_hidden = 3
+    n_layers = 1
+    n_tasks = 6
+
+    X = np.random.rand(n_samples, n_feat)
+    y = np.zeros((n_samples, n_tasks)).astype(np.float32)
+    dataset = dc.data.NumpyDataset(X, y)
+
+    example_model = ExampleTorchModel(n_feat, d_hidden, n_layers, n_tasks)
+
+    custom_loss_called = False
+
+    def custom_loss(inputs, labels, weights):
+        nonlocal custom_loss_called
+        custom_loss_called = True
+        preds = example_model.components['FF1'](inputs[0])
+        return torch.nn.functional.mse_loss(preds, labels[0])
+
+    example_model.fit(dataset, nb_epoch=1, loss=custom_loss)
+
+    assert custom_loss_called

--- a/deepchem/models/torch_models/grover.py
+++ b/deepchem/models/torch_models/grover.py
@@ -409,10 +409,7 @@ class GroverModel(ModularTorchModel):
                          model_dir=self.model_dir,
                          output_types=output_types,
                          **kwargs)
-        # FIXME In the above step, we initialize modular torch model but
-        # something is missing here. The attribute loss from TorchModel gets assigned `loss_func`
-        # by super class initialization in ModularTorchModel but here we reinitialize it.
-        self.loss = self.get_loss_func()
+        self.criterion = self.get_loss_func()
 
     def build_components(self):
         """Builds components for grover pretraining and finetuning model.
@@ -663,19 +660,19 @@ class GroverModel(ModularTorchModel):
         av_task_atom_pred, av_task_bond_pred, bv_task_atom_pred, bv_task_bond_pred, fg_prediction_atom_from_atom, fg_prediction_atom_from_bond, fg_prediction_bond_from_atom, fg_prediction_bond_from_bond = self.model(
             inputs)
 
-        loss = self.loss(av_task_atom_pred,
-                         av_task_bond_pred,
-                         bv_task_atom_pred,
-                         bv_task_bond_pred,
-                         fg_prediction_atom_from_atom,
-                         fg_prediction_atom_from_bond,
-                         fg_prediction_bond_from_atom,
-                         fg_prediction_bond_from_bond,
-                         labels['av_task'],
-                         labels['bv_task'],
-                         labels['fg_task'],
-                         weights=weights,
-                         dist_coff=dist_coff)  # type: ignore
+        loss = self.criterion(av_task_atom_pred,
+                              av_task_bond_pred,
+                              bv_task_atom_pred,
+                              bv_task_bond_pred,
+                              fg_prediction_atom_from_atom,
+                              fg_prediction_atom_from_bond,
+                              fg_prediction_bond_from_atom,
+                              fg_prediction_bond_from_bond,
+                              labels['av_task'],
+                              labels['bv_task'],
+                              labels['fg_task'],
+                              weights=weights,
+                              dist_coff=dist_coff)  # type: ignore
         return loss
 
     def _finetuning_loss(self, inputs, labels, weights, dist_coff=0.1):

--- a/deepchem/models/torch_models/modular.py
+++ b/deepchem/models/torch_models/modular.py
@@ -81,9 +81,11 @@ class ModularTorchModel(TorchModel):
 
         self.model = model
         self.components = components
-        # FIXME self.loss_func is an incorrect argument for TorchModel.loss because
-        # it performs more than computing loss
-        super().__init__(self.model, self.loss_func, **kwargs)
+        # ModularTorchModel computes its own loss using self.loss_func which handles the forward pass.
+        # We pass a dummy loss to TorchModel (which expects a loss computing on outputs).
+        # We use a lambda to satisfy the LossFn type hint.
+        super().__init__(self.model, lambda outputs, labels, weights: None,
+                         **kwargs)  # type: ignore
         self.model.to(self.device)
         self.components = {
             k: v.to(self.device) if isinstance(v, nn.Module) else v
@@ -190,9 +192,10 @@ class ModularTorchModel(TorchModel):
         avg_loss = 0.0
         last_avg_loss = 0.0
         averaged_batches = 0
-        # FIXME This line is not needed as loss is computed inside the call to loss_func
         if loss is None:
-            loss = self._loss_fn
+            loss_fn = self.loss_func
+        else:
+            loss_fn = loss
         if variables is None:
             optimizer = self._pytorch_optimizer
             lr_schedule = self._lr_schedule
@@ -226,7 +229,7 @@ class ModularTorchModel(TorchModel):
                 inputs = inputs[0]
 
             optimizer.zero_grad()
-            batch_loss = self.loss_func(inputs, labels, weights)
+            batch_loss = loss_fn(inputs, labels, weights)
             batch_loss.backward()
             optimizer.step()
             if lr_schedule is not None:


### PR DESCRIPTION
## Description

Fixes #5045 

This PR completely refactors the loss initialization pipeline for `ModularTorchModel` and `GroverModel` to resolve the architectural conflict described in the issue. 
- In `ModularTorchModel.__init__`, it now passes a dummy callable to `TorchModel(loss=...)` instead of `self.loss_func`, preventing the parent class from incorrectly assigning `self.loss` and `self._loss_fn`.
- In `ModularTorchModel.fit()`, it now correctly accepts and utilizes user-provided `loss` functions, gracefully falling back to `self.loss_func` only when `loss is None`.
- In `GroverModel`, we renamed the `self.loss` attribute to `self.criterion` so it no longer tramples over `TorchModel`'s internal state.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
