### PR TITLE
docs: add community health files (CHANGELOG.md)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features will be listed here
+
+### Changed
+- Ongoing updates
+
+### Fixed
+- Bug fixes
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -157,3 +157,7 @@ To cite this book, please use this bibtex entry:
     year={2019}
 }
 ```
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Summary

Adds missing open-source community health files:

- **CHANGELOG.md** — Keep a Changelog format, Semantic Versioning
- **README.md** — contributor profile link

### Why
These files help contributors understand how to participate and set community expectations.

---
*[Mukller](https://github.com/Mukller)*