### PR TITLE
Fix for the Docs build CI failure (3.11)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@ scikit-learn
 sphinx==7.2.6
 sphinx_rtd_theme>=1.0
 tensorflow==2.15.0
-transformers>=4.34.1
+transformers==4.51.3
 torch==2.2.1 --extra-index-url https://download.pytorch.org/whl/cpu
 lightning
 jax==0.4.30


### PR DESCRIPTION
## Description

Fixes the docs-build 3.11 CI Failure. The core issue was that the CI env was using torch 2.2.1 which does not support the most recent Transformers version. Hence, the solution was to pin the transformers version to 4.51.3 to make sure this failure does not happen.

<!-- Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change. -->

Made a change in the transformers version in requirements.txt from transformers>=4.34.1 to 4.51.3.

## Type of change

Please check the option that is related to your PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [x] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
