### PR TITLE
Fix get_label_means and get_label_stds raising KeyError

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -2711,13 +2711,19 @@ class DiskDataset(Dataset):
             return tuple(X_shape), tuple(y_shape), tuple(w_shape), tuple(
                 ids_shape)
 
-    def get_label_means(self) -> pd.DataFrame:
-        """Return pandas series of label means."""
-        return self.metadata_df["y_means"]
+    def get_label_means(self) -> np.ndarray:
+        """Return the mean of each label (task) over the dataset."""
+        # The metadata no longer stores per-shard `y_means`; compute the label
+        # means from the data via `get_statistics`.
+        y_means, _ = self.get_statistics(X_stats=False, y_stats=True)
+        return y_means
 
-    def get_label_stds(self) -> pd.DataFrame:
-        """Return pandas series of label stds."""
-        return self.metadata_df["y_stds"]
+    def get_label_stds(self) -> np.ndarray:
+        """Return the standard deviation of each label (task) over the dataset."""
+        # The metadata no longer stores per-shard `y_stds`; compute the label
+        # standard deviations from the data via `get_statistics`.
+        _, y_stds = self.get_statistics(X_stats=False, y_stats=True)
+        return y_stds
 
 
 class ImageDataset(Dataset):

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -429,6 +429,16 @@ def test_get_statistics():
     np.testing.assert_allclose(comp_y_stds, y_stds)
 
 
+def test_get_label_means_and_stds():
+    """Test that get_label_means/get_label_stds return per-task label statistics."""
+    solubility_dataset = load_solubility_data()
+    y = solubility_dataset.y
+    np.testing.assert_allclose(solubility_dataset.get_label_means(),
+                               np.mean(y, axis=0))
+    np.testing.assert_allclose(solubility_dataset.get_label_stds(),
+                               np.std(y, axis=0))
+
+
 def test_disk_iterate_batch_size():
     solubility_dataset = load_solubility_data()
     X, y, _, _ = (solubility_dataset.X, solubility_dataset.y,


### PR DESCRIPTION
Fixes #3543

## The bug

`DiskDataset.get_label_means()` and `get_label_stds()` read the metadata columns `y_means` / `y_stds`:

```python
def get_label_means(self) -> pd.DataFrame:
    return self.metadata_df["y_means"]

def get_label_stds(self) -> pd.DataFrame:
    return self.metadata_df["y_stds"]
```

But those columns are no longer part of the metadata schema (`get_shard_ids`/metadata columns are `ids, X, y, w` + their shapes), so both methods raise `KeyError` on **every** `DiskDataset`:

```python
import deepchem as dc
import numpy as np

ds = dc.data.DiskDataset.from_numpy(X=np.random.randn(10, 5), y=np.random.randn(10, 1))
ds.get_label_means()   # KeyError: 'y_means'
```

## Fix

Compute the per-task label means and standard deviations from the data via the existing `get_statistics()` helper (which already streams over the shards with a numerically-stable online algorithm), instead of reading the removed metadata columns:

```python
def get_label_means(self) -> np.ndarray:
    y_means, _ = self.get_statistics(X_stats=False, y_stats=True)
    return y_means

def get_label_stds(self) -> np.ndarray:
    _, y_stds = self.get_statistics(X_stats=False, y_stats=True)
    return y_stds
```

(These methods have no callers inside the repo, so nothing else changes.)

## Testing

Added `test_get_label_means_and_stds`, asserting the returned values match `np.mean`/`np.std` of the labels. It fails before this change (`KeyError`) and passes after; the existing `test_get_statistics` still passes, and I verified correctness on both single- and multi-shard datasets. `yapf` and `flake8` are clean.