### PR TITLE
Align contributor editable-install instructions with the source installation guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,19 +65,19 @@ and then install the desired deep learning framework before installing DeepChem:
 - [pytorch](https://pytorch.org/get-started/locally/#start-locally)
 - [jax](https://github.com/google/jax#installation)
 
-3. Install DeepChem in `develop` mode
+3. Install DeepChem in editable mode
 
 ```bash
-python setup.py develop
+pip install -e .
 ```
 
-This mode will symlink the Python files from current local source tree into
-the Python install. Hence, if you modify a Python file, you do not need to
-reinstall DeepChem again and again.
+This mode will make the Python files from the current local source tree
+available in the Python environment. Hence, if you modify a Python file, you do
+not need to reinstall DeepChem again and again.
 
 In case you need to reinstall, uninstall DeepChem first by running
 `pip uninstall deepchem` until you see `Warning: Skipping deepchem
-as it is not installed`; run `python setup.py clean` and install in `develop` mode again.
+as it is not installed`; then run `pip install -e .` again.
 
 Some other tips:
 - Every contribution must pass the unit tests. Some tests are

--- a/docs/source/development_guide/coding.rst
+++ b/docs/source/development_guide/coding.rst
@@ -111,16 +111,16 @@ The full suite of slow tests can be run from the root directory of the source co
 
   pytest -v -m 'slow' deepchem
 
-To test your code locally, you will have to setup a symbolic link to your
-current development directory. To do this, simply run
+To test your code locally, you will have to install DeepChem in editable mode
+from your current development directory. To do this, simply run
 
 .. code-block:: bash
 
-  python setup.py develop
+  pip install -e .
 
-while installing the package from source. This will let you see changes that you
-make to the source code when you import the package and, in particular, it
-allows you to import the new classes/methods for unit tests.
+This will let you see changes that you make to the source code when you import
+the package and, in particular, it allows you to import the new classes/methods
+for unit tests.
 
 Ensure that the tests pass locally! Check this by running
 


### PR DESCRIPTION
## Description

Fixes #5059

Aligns `CONTRIBUTING.md` and `docs/source/development_guide/coding.rst` with the installation documentation by consistently recommending `pip install -e .`.

It also updates the related reinstall instructions to remove direct `setup.py` invocations while preserving the existing editable-install workflow.

## Type of change

- [x] Documentations (modification for documents)

## Testing

- `git diff --check`
- No code tests required because this is a documentation-only change.