### PR TITLE
Fix InfoMax3D classification loss for single-class batches

### DIFF
--- a/deepchem/models/tests/test_gnn3d.py
+++ b/deepchem/models/tests/test_gnn3d.py
@@ -198,6 +198,30 @@ def testInfoMax3DModularClassification():
 
 
 @pytest.mark.torch
+def testInfoMax3DModularClassificationSingleClassBatch():
+    import numpy as np
+    import torch
+    from deepchem.models.torch_models.gnn3d import InfoMax3DModular
+
+    data, _ = get_classification_dataset()
+    data = data.select([0, 1, 2, 3])
+    assert np.all(data.y == 0)
+
+    model = InfoMax3DModular(hidden_dim=128,
+                             aggregators=['sum', 'mean', 'max'],
+                             readout_aggregators=['sum', 'mean'],
+                             scalers=['identity'],
+                             task='classification',
+                             n_tasks=1,
+                             n_classes=2,
+                             batch_size=4,
+                             device=torch.device('cpu'))
+
+    loss = model.fit(data, nb_epoch=1)
+    assert np.isfinite(loss)
+
+
+@pytest.mark.torch
 def test_infomax3d_load_from_pretrained(tmpdir):
     import torch
     from deepchem.models.torch_models.gnn3d import InfoMax3DModular

--- a/deepchem/models/torch_models/gnn3d.py
+++ b/deepchem/models/torch_models/gnn3d.py
@@ -606,8 +606,8 @@ class InfoMax3DModular(ModularTorchModel):
             # torch's one-hot encoding works with integer data types.
             # We convert labels to integer, one-hot encode and convert it back to float
             # for making it suitable to loss function
-            labels = F.one_hot(labels.squeeze().type(torch.int64)).type(
-                torch.float32)
+            labels = F.one_hot(labels.squeeze().type(torch.int64),
+                               num_classes=self.n_classes).type(torch.float32)
             loss = F.binary_cross_entropy_with_logits(logits, labels)
         return loss
 


### PR DESCRIPTION
## Description

Fixes #4274.

## Problem

`InfoMax3DModular` allowed `F.one_hot()` to infer the number of classes from each batch. For batches containing only class 0, this produced labels with shape `(batch_size, 1)` instead of `(batch_size, 2)`.

## Changes

Pass the model's configured `n_classes` to `F.one_hot()` and add a regression test using a class-0-only batch.

No new dependencies are required.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Documentation changes are not required for this bug fix
- [x] I have added tests that prove my fix is effective
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings

Tested with:

`python -m pytest -v deepchem/models/tests/test_gnn3d.py -k "testInfoMax3DModularClassification"`