### PR TITLE
fix: correct DTNNEmbedding initializer typo

### DIFF
--- a/deepchem/models/tests/test_layers.py
+++ b/deepchem/models/tests/test_layers.py
@@ -1039,6 +1039,21 @@ def test_dtnn_embedding():
 
 
 @pytest.mark.torch
+def test_dtnn_embedding_initializer_keyword():
+    """Test DTNNEmbedding accepts initializer with backwards compatibility."""
+    embedding_layer_torch = torch_layers.DTNNEmbedding(
+        5, 5, initializer='xavier_uniform_')
+    assert embedding_layer_torch.initializer == 'xavier_uniform_'
+    assert 'initializer=xavier_uniform_' in repr(embedding_layer_torch)
+    assert 'initalizer=' not in repr(embedding_layer_torch)
+
+    with pytest.warns(DeprecationWarning):
+        deprecated_layer_torch = torch_layers.DTNNEmbedding(
+            5, 5, initalizer='xavier_uniform_')
+    assert deprecated_layer_torch.initializer == 'xavier_uniform_'
+
+
+@pytest.mark.torch
 def test_dtnn_step():
     """Test invoking the Torch Equivalent of DTNNEmbedding."""
     # Weights and Embeddings from Tensorflow implementation

--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from math import pi as PI
 import numpy as np
 import itertools
@@ -3165,7 +3166,7 @@ class DTNNEmbedding(nn.Module):
     def __init__(self,
                  n_embedding: int = 30,
                  periodic_table_length: int = 30,
-                 initalizer: str = 'xavier_uniform_',
+                 initializer: str = 'xavier_uniform_',
                  **kwargs):
         """
         Parameters
@@ -3174,17 +3175,24 @@ class DTNNEmbedding(nn.Module):
             Number of features for each atom
         periodic_table_length: int, optional
             Length of embedding, 83=Bi
-        initalizer: str, optional
+        initializer: str, optional
             Weight initialization for filters.
             Options: {xavier_uniform_, xavier_normal_, kaiming_uniform_, kaiming_normal_, trunc_normal_}
 
         """
+        if 'initalizer' in kwargs:
+            initializer = kwargs.pop('initalizer')
+            warnings.warn(
+                "'initalizer' is deprecated and will be removed in a future "
+                "release. Use 'initializer' instead.",
+                DeprecationWarning,
+                stacklevel=2)
         super(DTNNEmbedding, self).__init__(**kwargs)
         self.n_embedding = n_embedding
         self.periodic_table_length = periodic_table_length
-        self.initalizer = initalizer  # Set weight initialization
+        self.initializer = initializer  # Set weight initialization
 
-        init_func: Callable = getattr(initializers, self.initalizer)
+        init_func: Callable = getattr(initializers, self.initializer)
         self.embedding_list: nn.Parameter = nn.Parameter(
             init_func(
                 torch.empty([self.periodic_table_length, self.n_embedding])))
@@ -3198,12 +3206,12 @@ class DTNNEmbedding(nn.Module):
             Number of features for each atom
         periodic_table_length: int, optional
             Length of embedding, 83=Bi
-        initalizer: str, optional
+        initializer: str, optional
             Weight initialization for filters.
             Options: {xavier_uniform_, xavier_normal_, kaiming_uniform_, kaiming_normal_, trunc_normal_}
 
         """
-        return f'{self.__class__.__name__}(n_embedding={self.n_embedding}, periodic_table_length={self.periodic_table_length}, initalizer={self.initalizer})'
+        return f'{self.__class__.__name__}(n_embedding={self.n_embedding}, periodic_table_length={self.periodic_table_length}, initializer={self.initializer})'
 
     def forward(self, inputs: torch.Tensor):
         """Returns Embeddings according to indices.


### PR DESCRIPTION
## Description

Fixes #5021

Renames the misspelled `DTNNEmbedding` parameter `initalizer` to `initializer`.

The old `initalizer` keyword is still accepted through `**kwargs` for backwards compatibility and emits a `DeprecationWarning`.

## Changes

- Renamed `DTNNEmbedding` constructor parameter to `initializer`
- Added backwards compatibility for deprecated `initalizer`
- Updated `__repr__` and docstrings
- Added tests for both the corrected and deprecated keyword paths

## Tests

```bash
python -m pytest deepchem/models/tests/test_layers.py -k "dtnn_embedding" -v
```

Result:

```text
2 passed
```