### PR TITLE
Warn when create_dataset is called on a non-empty directory

### DIFF
--- a/deepchem/data/datasets.py
+++ b/deepchem/data/datasets.py
@@ -1266,6 +1266,13 @@ class DiskDataset(Dataset):
             data_dir = tempfile.mkdtemp()
         elif not os.path.exists(data_dir):
             os.makedirs(data_dir)
+        else:
+            existing_files = os.listdir(data_dir)
+            if existing_files:
+                logger.warning(
+                    "The directory %s already contains %d file(s): %s. "
+                    "Saving to this directory will overwrite existing data.",
+                    data_dir, len(existing_files), existing_files)
 
         metadata_rows = []
         time1 = time.time()

--- a/deepchem/data/tests/test_datasets.py
+++ b/deepchem/data/tests/test_datasets.py
@@ -908,3 +908,42 @@ class TestDatasets(unittest.TestCase):
         """Test creating a PyTorch Dataset from a DiskDataset."""
         dataset = load_solubility_data()
         _validate_pytorch_dataset(dataset)
+
+
+def test_create_dataset_warns_on_existing_files():
+    """Test that create_dataset logs a warning when saving to a non-empty directory."""
+    import logging
+    import tempfile
+
+    X = np.random.random((4, 5))
+    y = np.random.random((4, 1))
+    w = np.ones((4, 1))
+    ids = np.arange(4)
+
+    with tempfile.TemporaryDirectory() as data_dir:
+        # Populate the directory with an initial dataset.
+        dc.data.DiskDataset.create_dataset([(X, y, w, ids)], data_dir=data_dir)
+
+        # Capture log output from the datasets module.
+        dc_logger = logging.getLogger("deepchem.data.datasets")
+        dc_logger.setLevel(logging.WARNING)
+
+        log_records = []
+
+        class _Capture(logging.Handler):
+
+            def emit(self, record):
+                log_records.append(record)
+
+        handler = _Capture()
+        dc_logger.addHandler(handler)
+        try:
+            dc.data.DiskDataset.create_dataset(
+                [(X, y, w, ids)], data_dir=data_dir)
+        finally:
+            dc_logger.removeHandler(handler)
+
+        messages = [r.getMessage() for r in log_records]
+        assert any("already contains" in m for m in messages), (
+            "Expected a warning about overwriting an existing directory, "
+            "but none was logged. Messages: %s" % messages)


### PR DESCRIPTION
Fixes #3402

`DiskDataset.create_dataset` now logs a warning when the target `data_dir`
already exists and has files in it. Before this, saving to a non-empty
directory would silently overwrite everything there.

The overwrite still proceeds so existing behaviour is unchanged. Added
`test_create_dataset_warns_on_existing_files` in `test_datasets.py` to
verify the warning is logged.