### PR TITLE
Fix misleading restore=False docstring in Model.fit (#1491)

### DIFF
--- a/deepchem/models/keras_model.py
+++ b/deepchem/models/keras_model.py
@@ -334,8 +334,14 @@ class KerasModel(Model):
             if True, the samples are processed in order.  If False, a different random
             order is used for each epoch.
         restore: bool
-            if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            if True, restore the model from the most recent checkpoint before
+            training and continue training from there.  If False (the default),
+            training continues from the model's current in-memory parameters
+            without reloading a checkpoint.  Note that restore=False does not
+            reinitialize the parameters: if the model has already been trained,
+            calling fit() again continues from the current weights rather than
+            from scratch.  To train from randomly initialized parameters, create
+            a new model instance.
         variables: list of tf.Variable
             the variables to train.  If None (the default), all trainable variables in
             the model are used.
@@ -385,8 +391,14 @@ class KerasModel(Model):
             the frequency at which to write checkpoints, measured in training steps.
             Set this to 0 to disable automatic checkpointing.
         restore: bool
-            if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            if True, restore the model from the most recent checkpoint before
+            training and continue training from there.  If False (the default),
+            training continues from the model's current in-memory parameters
+            without reloading a checkpoint.  Note that restore=False does not
+            reinitialize the parameters: if the model has already been trained,
+            calling fit() again continues from the current weights rather than
+            from scratch.  To train from randomly initialized parameters, create
+            a new model instance.
         variables: list of tf.Variable
             the variables to train.  If None (the default), all trainable variables in
             the model are used.

--- a/deepchem/models/tests/test_torch_model.py
+++ b/deepchem/models/tests/test_torch_model.py
@@ -197,6 +197,49 @@ def test_fit_restore():
 
 
 @pytest.mark.torch
+def test_fit_no_restore_does_not_reinitialize():
+    """Test that restore=False does not reinitialize the model parameters.
+
+    Regression test for https://github.com/deepchem/deepchem/issues/1491.  With
+    a persistent model object, restore=False does not reload a checkpoint or
+    reset the weights to their initial values; training simply continues from
+    the current in-memory parameters.  This test locks in that intentional
+    behavior (and matches the corrected fit() docstring).
+    """
+    n_data_points = 10
+    n_features = 2
+    X = np.random.rand(n_data_points, n_features)
+    y = (X[:, 0] > X[:, 1]).astype(np.float32)
+    dataset = dc.data.NumpyDataset(X, y)
+
+    pytorch_model = torch.nn.Sequential(torch.nn.Linear(2, 10), torch.nn.ReLU(),
+                                        torch.nn.Linear(10, 1),
+                                        torch.nn.Sigmoid())
+    model = dc.models.TorchModel(pytorch_model,
+                                 dc.models.losses.BinaryCrossEntropy(),
+                                 learning_rate=0.005)
+    model.fit(dataset, nb_epoch=100)
+
+    # Snapshot the trained parameters.
+    trained_params = [p.detach().clone() for p in model.model.parameters()]
+
+    # Calling fit() again with restore=False must not reset the parameters.  A
+    # fit with zero epochs performs no training steps, so the parameters should
+    # be preserved exactly rather than reinitialized to random values.
+    model.fit(dataset, nb_epoch=0, restore=False)
+    preserved_params = [p.detach().clone() for p in model.model.parameters()]
+    for trained, preserved in zip(trained_params, preserved_params):
+        assert torch.equal(trained, preserved)
+
+    # Continuing to train with restore=False updates the existing weights
+    # (continues from where it left off) rather than starting from scratch.
+    model.fit(dataset, nb_epoch=100, restore=False)
+    continued_params = [p.detach().clone() for p in model.model.parameters()]
+    assert any(not torch.equal(trained, continued)
+               for trained, continued in zip(trained_params, continued_params))
+
+
+@pytest.mark.torch
 def test_uncertainty():
     """Test estimating uncertainty a TorchModel."""
     n_samples = 30

--- a/deepchem/models/torch_models/torch_model.py
+++ b/deepchem/models/torch_models/torch_model.py
@@ -314,8 +314,14 @@ class TorchModel(Model):
             if True, the samples are processed in order.  If False, a different random
             order is used for each epoch.
         restore: bool
-            if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            if True, restore the model from the most recent checkpoint before
+            training and continue training from there.  If False (the default),
+            training continues from the model's current in-memory parameters
+            without reloading a checkpoint.  Note that restore=False does not
+            reinitialize the parameters: if the model has already been trained,
+            calling fit() again continues from the current weights rather than
+            from scratch.  To train from randomly initialized parameters, create
+            a new model instance.
         variables: list of torch.nn.Parameter
             the variables to train.  If None (the default), all trainable variables in
             the model are used.
@@ -365,8 +371,14 @@ class TorchModel(Model):
             the frequency at which to write checkpoints, measured in training steps.
             Set this to 0 to disable automatic checkpointing.
         restore: bool
-            if True, restore the model from the most recent checkpoint and continue training
-            from there.  If False, retrain the model from scratch.
+            if True, restore the model from the most recent checkpoint before
+            training and continue training from there.  If False (the default),
+            training continues from the model's current in-memory parameters
+            without reloading a checkpoint.  Note that restore=False does not
+            reinitialize the parameters: if the model has already been trained,
+            calling fit() again continues from the current weights rather than
+            from scratch.  To train from randomly initialized parameters, create
+            a new model instance.
         variables: list of torch.nn.Parameter or torch.nn.ParameterList
             the variables to train.  If None (the default), all trainable variables in
             the model are used.


### PR DESCRIPTION
## Description

Fixes #1491.

The `fit()` / `fit_generator()` docstrings claim that `restore=False` will
"retrain the model from scratch", which implies the parameters are
reinitialized to random values. That is not what happens. With a persistent
model object, `restore=False` simply does not reload a checkpoint — training
continues from the model's current in-memory parameters. If the model has
already been trained, calling `fit(..., restore=False)` continues from the
current weights, giving it a "head start" rather than starting over.

As @peastman noted in the issue, this is intended behavior: *"this is an error
in the docs. It used to work that way, back when it constructed a new Session
for every call. The behavior changed when we switched to using a persistent
Session, but the method description missed getting updated."* So the correct
fix is to update the documentation to match the (intentional) behavior, not to
change the behavior.

### Changes
- Corrected the `restore` parameter docstring in `TorchModel.fit` /
  `fit_generator` and `KerasModel.fit` / `fit_generator` to describe the actual
  behavior, and to point out that training from randomly initialized parameters
  requires creating a new model instance.
- Added a regression test (`test_fit_no_restore_does_not_reinitialize`) that
  locks in the intended behavior: after training, calling `fit(restore=False)`
  does not reset the parameters, and continued training updates the existing
  weights.

## Type of change

- [x] Documentations (modification for documents)
- [x] Bug fix (non-breaking change) — adds a regression test for the documented behavior

## Checklist

- [x] `yapf -i <modified files>` (yapf 0.32.0) — no diff
- [x] `flake8 <modified files> --count` — 0
- [x] New test passes locally: `pytest deepchem/models/tests/test_torch_model.py -k "restore"` → 2 passed (~8s, torch CPU)
- [x] Self-review performed; corrected misspellings
