### PR TITLE
Add HyperoptHyperparamOpt hyperparameter tuner (#2684)

### DIFF
--- a/deepchem/hyper/__init__.py
+++ b/deepchem/hyper/__init__.py
@@ -3,3 +3,4 @@ from deepchem.hyper.base_classes import HyperparamOpt
 from deepchem.hyper.grid_search import GridHyperparamOpt
 from deepchem.hyper.gaussian_process import GaussianProcessHyperparamOpt
 from deepchem.hyper.random_search import RandomHyperparamOpt
+from deepchem.hyper.hyperopt import HyperoptHyperparamOpt

--- a/deepchem/hyper/hyperopt.py
+++ b/deepchem/hyper/hyperopt.py
@@ -1,0 +1,250 @@
+"""
+Contains class for hyperparameter optimization using the hyperopt library.
+"""
+import os
+import tempfile
+import logging
+from typing import Dict, List, Optional, Tuple, Any, Callable
+
+import numpy as np
+
+from deepchem.data import Dataset
+from deepchem.trans import Transformer
+from deepchem.models import Model
+from deepchem.metrics import Metric
+from deepchem.hyper.base_classes import HyperparamOpt
+from deepchem.hyper.base_classes import _convert_hyperparam_dict_to_filename
+
+logger = logging.getLogger(__name__)
+
+
+class HyperoptHyperparamOpt(HyperparamOpt):
+    """Provides hyperparameter search using the hyperopt library.
+
+    This class uses the Tree-structured Parzen Estimator (TPE) algorithm from
+    the `hyperopt <https://github.com/hyperopt/hyperopt>`_ library to perform a
+    guided (Bayesian) search over the hyperparameter space. Unlike
+    `GridHyperparamOpt` (which searches exhaustively) or `RandomHyperparamOpt`
+    (which samples independently), this optimizer uses the results of previous
+    evaluations to decide which hyperparameters to try next, which is often much
+    more sample efficient for expensive-to-train models.
+
+    The search space is specified using hyperopt's expression objects (for
+    example `hyperopt.hp.uniform` for continuous ranges and `hyperopt.hp.choice`
+    for a discrete set of options). See the hyperopt documentation for the full
+    list of available expressions.
+
+    Note that this class requires hyperopt to be installed.
+
+    Examples
+    --------
+    This example shows the type of constructor function this class expects.
+
+    >>> import deepchem as dc
+    >>> import numpy as np
+    >>> from sklearn.ensemble import RandomForestRegressor as RF
+    >>> from hyperopt import hp
+    >>> # generating data
+    >>> X = np.random.rand(50, 5)
+    >>> y = np.random.rand(50, 1)
+    >>> dataset = dc.data.NumpyDataset(X, y)
+    >>> # splitting dataset into train and validation
+    >>> splitter = dc.splits.RandomSplitter()
+    >>> train_dataset, valid_dataset = splitter.train_test_split(dataset)
+    >>> # metric to evaluate a set of parameters
+    >>> metric = dc.metrics.Metric(dc.metrics.pearson_r2_score)
+    >>> # defining `model_builder`
+    >>> def model_builder(**model_params):
+    ...   n_estimators = model_params['n_estimators']
+    ...   model_dir = model_params['model_dir']
+    ...   rf = RF(n_estimators=n_estimators)
+    ...   return dc.models.SklearnModel(rf, model_dir)
+    >>> # the search space, specified using hyperopt expressions
+    >>> params_dict = {'n_estimators': hp.choice('n_estimators', [10, 100])}
+    >>> # creating optimizer and searching over hyperparameters
+    >>> optimizer = dc.hyper.HyperoptHyperparamOpt(model_builder, max_evals=5)
+    >>> best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
+    ...     params_dict, train_dataset, valid_dataset, metric)  # doctest: +SKIP
+
+    Parameters
+    ----------
+    model_builder: constructor function.
+        This parameter must be constructor function which returns an
+        object which is an instance of `dc.models.Model`. This function
+        must accept two arguments, `model_params` of type `dict` and
+        `model_dir`, a string specifying a path to a model directory.
+    max_evals: int, (default 10)
+        The maximum number of parameter settings (model trainings) that
+        hyperopt is allowed to evaluate during the search.
+    """
+
+    def __init__(self,
+                 model_builder: Callable[..., Model],
+                 max_evals: int = 10):
+        super(HyperoptHyperparamOpt, self).__init__(model_builder=model_builder)
+        self.max_evals = max_evals
+
+    def hyperparam_search(
+        self,
+        params_dict: Dict,
+        train_dataset: Dataset,
+        valid_dataset: Dataset,
+        metric: Metric,
+        output_transformers: List[Transformer] = [],
+        nb_epoch: int = 10,
+        use_max: bool = True,
+        logfile: str = 'results.txt',
+        logdir: Optional[str] = None,
+        **kwargs,
+    ) -> Tuple[Model, Dict[str, Any], Dict[str, Any]]:
+        """Perform hyperparameter search using hyperopt.
+
+        Parameters
+        ----------
+        params_dict: Dict
+            Maps each hyperparameter name (string) to a hyperopt search
+            expression describing the values to search over, for example
+            ``{'learning_rate': hp.uniform('learning_rate', 1e-4, 1e-1)}``.
+        train_dataset: Dataset
+            dataset used for training
+        valid_dataset: Dataset
+            dataset used for validation (optimization on valid scores)
+        metric: Metric
+            metric used for evaluation
+        output_transformers: list[Transformer]
+            Transformers for evaluation. This argument is needed since
+            `train_dataset` and `valid_dataset` may have been transformed
+            for learning and need the transform to be inverted before
+            the metric can be evaluated on a model.
+        nb_epoch: int, (default 10)
+            Specifies the number of training epochs during each iteration of
+            optimization. Not used by all model types.
+        use_max: bool, optional
+            If True, return the model with the highest score. Else return
+            model with the minimum score. Since hyperopt always minimizes its
+            objective, the validation score is negated internally when
+            `use_max` is True.
+        logdir: str, optional
+            The directory in which to store created models. If not set, will
+            use a temporary directory.
+        logfile: str, optional (default `results.txt`)
+            Name of logfile to write results to. If specified, this must
+            be a valid file name. If not specified, results of hyperparameter
+            search will be written to `logdir/results.txt`.
+
+        Returns
+        -------
+        Tuple[`best_model`, `best_hyperparams`, `all_scores`]
+            `(best_model, best_hyperparams, all_scores)` where `best_model` is
+            an instance of `dc.models.Model`, `best_hyperparams` is a
+            dictionary of parameters, and `all_scores` is a dictionary mapping
+            string representations of hyperparameter sets to validation
+            scores.
+        """
+        try:
+            from hyperopt import fmin, tpe, Trials, STATUS_OK
+        except ModuleNotFoundError:
+            raise ImportError("This class requires hyperopt to be installed.")
+
+        if logdir is not None:
+            if not os.path.exists(logdir):
+                os.makedirs(logdir, exist_ok=True)
+            log_file = os.path.join(logdir, logfile)
+
+        all_scores: Dict[str, Any] = {}
+        # Track the best result across trials. hyperopt's `fmin` only returns the
+        # best hyperparameters (and, for hp.choice, as indices rather than
+        # values), so we keep track of the actual best model ourselves.
+        best: Dict[str, Any] = {
+            'score': -np.inf if use_max else np.inf,
+            'model': None,
+            'hyperparams': None,
+        }
+
+        def objective(model_params: Dict) -> Dict[str, Any]:
+            model_params = dict(model_params)
+            hp_str = _convert_hyperparam_dict_to_filename(model_params)
+            logger.info("Fitting model with hyperparameters: %s" %
+                        str(model_params))
+
+            if logdir is not None:
+                model_dir = os.path.join(logdir, hp_str)
+                try:
+                    os.makedirs(model_dir)
+                except OSError:
+                    if not os.path.isdir(model_dir):
+                        logger.info(
+                            "Error creating model_dir, using tempfile directory"
+                        )
+                        model_dir = tempfile.mkdtemp()
+            else:
+                model_dir = tempfile.mkdtemp()
+
+            model_params['model_dir'] = model_dir
+            model = self.model_builder(**model_params)
+
+            # mypy test throws error, so ignoring it in try
+            try:
+                model.fit(train_dataset, nb_epoch=nb_epoch)  # type: ignore
+            # Not all models have nb_epoch
+            except TypeError:
+                model.fit(train_dataset)
+            try:
+                model.save()
+            # Some models autosave
+            except NotImplementedError:
+                pass
+
+            multitask_scores = model.evaluate(valid_dataset, [metric],
+                                              output_transformers)
+            valid_score = multitask_scores[metric.name]
+            all_scores[hp_str] = valid_score
+
+            if (use_max and valid_score >= best['score']) or (
+                    not use_max and valid_score <= best['score']):
+                best['score'] = valid_score
+                best['model'] = model
+                best['hyperparams'] = model_params
+
+            logger.info("Model %s, Validation set score: %f" %
+                        (hp_str, valid_score))
+            logger.info("\tbest_validation_score so far: %f" % best['score'])
+
+            # hyperopt always minimizes, so negate the score when maximizing.
+            loss = -valid_score if use_max else valid_score
+            return {'loss': loss, 'status': STATUS_OK}
+
+        trials = Trials()
+        fmin(objective,
+             space=params_dict,
+             algo=tpe.suggest,
+             max_evals=self.max_evals,
+             trials=trials)
+
+        best_model = best['model']
+        best_hyperparams = best['hyperparams']
+
+        if best_model is None:
+            logger.info("No models trained correctly.")
+            if logdir is not None:
+                with open(log_file, 'w+') as f:
+                    f.write(
+                        "No model trained correctly. Arbitrary models returned")
+            # mypy: best_model is narrowed to None here, but the declared return
+            # type is Model; this defensive branch mirrors the other optimizers.
+            return best_model, best_hyperparams, all_scores  # type: ignore
+
+        multitask_scores = best_model.evaluate(train_dataset, [metric],
+                                               output_transformers)
+        train_score = multitask_scores[metric.name]
+        logger.info("Best hyperparameters: %s" % str(best_hyperparams))
+        logger.info("best train_score: %f" % train_score)
+        logger.info("best validation_score: %f" % best['score'])
+
+        if logdir is not None:
+            with open(log_file, 'w+') as f:
+                f.write("Best Hyperparameters dictionary %s\n" %
+                        str(best_hyperparams))
+                f.write("Best validation score %f\n" % best['score'])
+                f.write("Best train_score: %f\n" % train_score)
+        return best_model, best_hyperparams, all_scores

--- a/deepchem/hyper/tests/test_hyperopt_hyperparam_opt.py
+++ b/deepchem/hyper/tests/test_hyperopt_hyperparam_opt.py
@@ -1,0 +1,146 @@
+"""
+Tests for hyperopt based hyperparameter optimization.
+"""
+import unittest
+import tempfile
+import os
+import numpy as np
+import pytest
+import sklearn
+import sklearn.ensemble
+import deepchem as dc
+
+try:
+    from hyperopt import hp
+    has_hyperopt = True
+except ModuleNotFoundError:
+    has_hyperopt = False
+
+
+@unittest.skipIf(not has_hyperopt, "hyperopt is not installed")
+class TestHyperoptHyperparamOpt(unittest.TestCase):
+    """
+    Test hyperopt based hyperparameter optimization API.
+    """
+
+    def setUp(self):
+        """Set up common resources."""
+
+        def rf_model_builder(**model_params):
+            rf_params = {
+                k: v for (k, v) in model_params.items() if k != 'model_dir'
+            }
+            model_dir = model_params['model_dir']
+            # Fix random_state so that a given set of hyperparameters always
+            # yields the same score. This makes the "best model" selection
+            # deterministic and the assertions below well defined.
+            sklearn_model = sklearn.ensemble.RandomForestRegressor(
+                random_state=0, **rf_params)
+            return dc.models.SklearnModel(sklearn_model, model_dir)
+
+        self.rf_model_builder = rf_model_builder
+        self.max_evals = 5
+        self.train_dataset = dc.data.NumpyDataset(X=np.random.rand(50, 5),
+                                                  y=np.random.rand(50, 1))
+        self.valid_dataset = dc.data.NumpyDataset(X=np.random.rand(20, 5),
+                                                  y=np.random.rand(20, 1))
+
+    def test_rf_hyperparam(self):
+        """Test of hyperparam_opt with singletask RF regression API (maximize)."""
+        optimizer = dc.hyper.HyperoptHyperparamOpt(self.rf_model_builder,
+                                                   max_evals=self.max_evals)
+        params_dict = {"n_estimators": hp.choice("n_estimators", [10, 100])}
+        transformers = []
+        metric = dc.metrics.Metric(dc.metrics.pearson_r2_score)
+
+        best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
+            params_dict, self.train_dataset, self.valid_dataset, metric,
+            transformers)
+        valid_score = best_model.evaluate(self.valid_dataset, [metric],
+                                          transformers)
+
+        # The returned best model must be the one with the highest score.
+        assert valid_score["pearson_r2_score"] == max(all_results.values())
+        assert isinstance(best_model, dc.models.SklearnModel)
+        assert "n_estimators" in best_hyperparams
+
+    def test_rf_hyperparam_min(self):
+        """Test of hyperparam_opt with singletask RF regression API (minimize)."""
+        optimizer = dc.hyper.HyperoptHyperparamOpt(self.rf_model_builder,
+                                                   max_evals=self.max_evals)
+        params_dict = {"n_estimators": hp.choice("n_estimators", [10, 100])}
+        transformers = []
+        metric = dc.metrics.Metric(dc.metrics.pearson_r2_score)
+
+        best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
+            params_dict,
+            self.train_dataset,
+            self.valid_dataset,
+            metric,
+            transformers,
+            use_max=False)
+        valid_score = best_model.evaluate(self.valid_dataset, [metric],
+                                          transformers)
+
+        # The returned best model must be the one with the lowest score.
+        assert valid_score["pearson_r2_score"] == min(all_results.values())
+
+    def test_rf_with_logdir(self):
+        """Test that using a logdir can work correctly."""
+        optimizer = dc.hyper.HyperoptHyperparamOpt(self.rf_model_builder,
+                                                   max_evals=self.max_evals)
+        params_dict = {"n_estimators": hp.choice("n_estimators", [10, 100])}
+        transformers = []
+        metric = dc.metrics.Metric(dc.metrics.pearson_r2_score)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
+                params_dict,
+                self.train_dataset,
+                self.valid_dataset,
+                metric,
+                transformers,
+                logdir=tmpdirname)
+            # A results.txt log file and at least one model directory should be
+            # written. (hyperopt may re-sample the same discrete value, so the
+            # number of unique model directories can be fewer than max_evals.)
+            contents = os.listdir(tmpdirname)
+            assert "results.txt" in contents
+            assert len(contents) >= 2
+
+    @pytest.mark.torch
+    def test_multitask_example(self):
+        """Test optimizing a multitask torch model with hyperopt."""
+        np.random.seed(123)
+        train_dataset = dc.data.NumpyDataset(np.random.rand(10, 3),
+                                             np.zeros((10, 2)), np.ones(
+                                                 (10, 2)), np.arange(10))
+        valid_dataset = dc.data.NumpyDataset(np.random.rand(5, 3),
+                                             np.zeros((5, 2)), np.ones((5, 2)),
+                                             np.arange(5))
+
+        optimizer = dc.hyper.HyperoptHyperparamOpt(
+            lambda **params: dc.models.MultitaskRegressor(
+                n_tasks=2,
+                n_features=3,
+                dropouts=[0.],
+                weight_init_stddevs=[np.sqrt(6) / np.sqrt(1000)],
+                learning_rate=0.003,
+                **params),
+            max_evals=self.max_evals)
+
+        params_dict = {"batch_size": hp.choice("batch_size", [10, 20])}
+        transformers = []
+        metric = dc.metrics.Metric(dc.metrics.mean_squared_error,
+                                   task_averager=np.mean)
+        best_model, best_hyperparams, all_results = optimizer.hyperparam_search(
+            params_dict,
+            train_dataset,
+            valid_dataset,
+            metric,
+            transformers,
+            use_max=False)
+
+        assert best_model is not None
+        assert len(all_results) > 0
+        assert "batch_size" in best_hyperparams

--- a/docs/source/api_reference/hyper.rst
+++ b/docs/source/api_reference/hyper.rst
@@ -37,4 +37,24 @@ Gaussian Process Hyperparameter Optimization
 .. autoclass:: deepchem.hyper.GaussianProcessHyperparamOpt
   :members:
 
+Random Hyperparameter Optimization
+----------------------------------
+
+This class performs a random search over the specified hyperparameter
+space, sampling hyperparameter combinations at random.
+
+.. autoclass:: deepchem.hyper.RandomHyperparamOpt
+  :members:
+
+Hyperopt Hyperparameter Optimization
+------------------------------------
+
+This class uses the `hyperopt <https://github.com/hyperopt/hyperopt>`_
+library to perform a guided (Bayesian) search over the hyperparameter
+space using the Tree-structured Parzen Estimator (TPE) algorithm. It
+requires hyperopt to be installed.
+
+.. autoclass:: deepchem.hyper.HyperoptHyperparamOpt
+  :members:
+
 

--- a/requirements/env_common.yml
+++ b/requirements/env_common.yml
@@ -14,6 +14,7 @@ dependencies:
     - pre-commit
     - biopython
     - dgllife
+    - hyperopt
     - lightgbm
     - matminer
     - mordred

--- a/requirements/env_common_3_8.yml
+++ b/requirements/env_common_3_8.yml
@@ -13,6 +13,7 @@ dependencies:
     - pre-commit
     - biopython
     - dgllife
+    - hyperopt
     - lightgbm
     - matminer
     - mordred


### PR DESCRIPTION
## Description

Fixes #2684.

DeepChem's hyperparameter optimizers currently cover exhaustive grid search
(`GridHyperparamOpt`), random search (`RandomHyperparamOpt`), and a
Gaussian-process Bayesian search (`GaussianProcessHyperparamOpt`, via pyGPGO).
This PR adds a tuner backed by the [hyperopt](https://github.com/hyperopt/hyperopt)
library, which the [MoleculeNet benchmarking code already uses](https://github.com/deepchem/moleculenet/blob/master/examples/gnn.py#L136).

`HyperoptHyperparamOpt` uses hyperopt's Tree-structured Parzen Estimator (TPE)
to perform a guided Bayesian search. The search space is expressed with hyperopt
expressions (`hp.uniform`, `hp.choice`, ...), and the class follows the same
`HyperparamOpt` API as the existing optimizers so it is a drop-in alternative:

```python
from hyperopt import hp
params_dict = {'learning_rate': hp.uniform('learning_rate', 1e-4, 1e-1)}
optimizer = dc.hyper.HyperoptHyperparamOpt(model_builder, max_evals=20)
best_model, best_hyperparams, all_scores = optimizer.hyperparam_search(
    params_dict, train_dataset, valid_dataset, metric)
```

### Changes
- `deepchem/hyper/hyperopt.py`: new `HyperoptHyperparamOpt`. `hyperparam_search`
  returns `(best_model, best_hyperparams, all_scores)` and supports `use_max`,
  `nb_epoch`, and `logdir`/`logfile`, mirroring the other optimizers. hyperopt
  is imported lazily and raises a clear `ImportError` if it isn't installed.
- Exported from `deepchem.hyper` and documented in the hyper API reference.
- Added `hyperopt` to the common conda environments (next to `pyGPGO`).
- Tests mirror the existing per-backend test pattern (RF regression for the
  maximize and minimize cases, a `logdir` test, and a torch multitask model);
  they skip cleanly when hyperopt is not installed.

### Note on scope / design
@rbharath, in the issue thread you suggested proposing a design and discussing
on a developer call first, since a full hyperopt tuner can grow large. I kept
this deliberately bounded to a single backend that matches the existing
`HyperparamOpt` interface (no new public API surface beyond the class), so it
composes with the current optimizers. Happy to bring it to a dev call and
extend it (e.g. richer search-space helpers, ATPE, parallel trials) based on
your feedback.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] `yapf -i <modified files>` (yapf 0.32.0) — no diff
- [x] `flake8 <modified files> --count` — 0
- [x] `mypy` — no new errors in `deepchem/hyper/hyperopt.py`
- [x] `pytest --doctest-modules deepchem/hyper/hyperopt.py` — passes
- [x] New tests pass locally: `pytest deepchem/hyper/tests/test_hyperopt_hyperparam_opt.py` → 4 passed (~6s, torch CPU, hyperopt 0.2.7)
- [x] Added tests and documentation
