### PR TITLE
Add RFDiffusion SO(3) rotation diffusion utilities

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -1,0 +1,610 @@
+"""SO(3) diffusion utilities for RFDiffusion.
+
+This module implements the rotational component of the RFDiffusion noise
+process [Watson2023]_: an IGSO(3) (Isotropic Gaussian on SO(3)) diffusion
+with a logarithmic variance schedule and a reverse-time Euler-Maruyama
+integrator on the so(3) tangent space [Leach2022]_, [Yim2023]_.
+
+Conventions
+-----------
+* Rotations are represented as ``(..., 3, 3)`` proper rotation matrices
+  R in SO(3) with det(R) = +1.
+* A rotation is parameterised on the tangent space so(3) =~ R^3 by a
+  rotation vector tau = omega * u where omega in [0, pi] is the rotation angle
+  (geodesic distance from the identity) and u in S^2 is the rotation axis.
+* The matrix exponential of a tangent vector uses Rodrigues' formula
+  R = I + sin(omega) [u]_x + (1 - cos(omega)) [u]_x^2 where [u]_x is the
+  skew-symmetric matrix associated with u.
+
+Mathematical reference
+----------------------
+The IGSO(3) density on the rotation angle omega is
+
+.. math::
+
+    f(\\omega; \\sigma) = \\sum_{l=0}^{\\infty}
+        (2l+1)\\,
+        \\exp\\!\\left(-\\tfrac{l(l+1)}{2}\\sigma^{2}\\right)\\,
+        \\frac{\\sin\\!\\big((l+\\tfrac{1}{2})\\omega\\big)}
+             {\\sin(\\omega/2)}
+
+and the marginal density on omega in [0, pi] is
+
+.. math::
+
+    p(\\omega; \\sigma) = \\frac{1 - \\cos \\omega}{\\pi}\\, f(\\omega; \\sigma).
+
+The score on the rotation angle is
+
+.. math::
+
+    s(\\omega; \\sigma) = \\partial_{\\omega}\\log f(\\omega; \\sigma)
+
+and the score on so(3) - used as the drift term in the reverse SDE -
+points along the geodesic from the identity to R with magnitude
+``s(omega; sigma)``.
+
+Developer-facing summary
+------------------------
+This file is the rotation-noise backend for RFDiffusion. Use
+``so3_exp_map`` and ``so3_log_map`` to move between tangent vectors and
+rotation matrices, build an ``IGSO3`` table once for cached score /
+sampling queries, and call ``so3_reverse_step`` during sampling to move
+one denoising step from ``R_t`` to ``R_{t-1}``.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+.. [Leach2022] Leach et al. "Denoising Diffusion Probabilistic Models on
+   SO(3) for Rotational Alignment." ICLR Workshop on Geometric and
+   Topological Representation Learning (2022).
+.. [Yim2023] Yim et al. "SE(3) Diffusion Model with Application to Protein
+   Backbone Generation." ICML (2023).
+"""
+
+import math
+from typing import Optional, Tuple
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_so3 requires PyTorch to be installed.')
+
+__all__ = [
+    'IGSO3',
+    'log_beta_schedule',
+    'so3_log_map',
+    'so3_exp_map',
+    'so3_reverse_step',
+]
+
+# Threshold below which series expansions are used instead of the closed
+# form to preserve numerical stability.
+_SMALL_OMEGA: float = 1e-4
+_SMALL_SIGMA: float = 5e-2
+
+
+def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
+    """Return ``sin(x) / x`` with a stable Taylor series near zero.
+
+    Computes the second-order Taylor expansion ``1 - x^2/6`` when
+    |x| < ``_SMALL_OMEGA`` and the closed-form expression elsewhere.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of arbitrary shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x`` containing ``sin(x) / x``.
+    """
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
+
+
+def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
+    """Return ``(1 - cos x) / x^2`` with a Taylor series near zero.
+
+    Computes ``1/2 - x^2/24`` when |x| < ``_SMALL_OMEGA`` and the closed
+    form ``(1 - cos x) / x^2`` elsewhere.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of arbitrary shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x``.
+    """
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)
+    series = 0.5 - x * x / 24.0
+    return torch.where(small, series, closed)
+
+
+def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
+    """Map a tangent vector in so(3) =~ R^3 to a rotation matrix.
+
+    Implements Rodrigues' rotation formula
+
+    .. math::
+
+        R = I + \\frac{\\sin\\omega}{\\omega}\\,[\\tau]_{\\times}
+            + \\frac{1 - \\cos\\omega}{\\omega^{2}}\\,[\\tau]_{\\times}^{2}
+
+    where omega = ||tau|| and [tau]_x is the skew-symmetric matrix of tau. Small-omega
+    Taylor expansions are used to maintain numerical stability.
+
+    Parameters
+    ----------
+    tangent : torch.Tensor
+        Tangent vector(s) of shape ``(..., 3)`` representing rotation
+        vectors tau = omega * u.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import so3_exp_map
+    >>> R = so3_exp_map(torch.zeros(1, 3))
+    >>> bool(torch.allclose(R, torch.eye(3).unsqueeze(0)))
+    True
+    """
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)  # (..., 1)
+    # Build the skew matrix [tau]_x.
+    zeros = torch.zeros_like(tangent[..., 0])
+    tx, ty, tz = tangent[..., 0], tangent[..., 1], tangent[..., 2]
+    skew = torch.stack([
+        torch.stack([zeros, -tz, ty], dim=-1),
+        torch.stack([tz, zeros, -tx], dim=-1),
+        torch.stack([-ty, tx, zeros], dim=-1),
+    ],
+                       dim=-2)  # (..., 3, 3)
+    eye = torch.eye(3, dtype=tangent.dtype, device=tangent.device)
+    sin_coeff = _safe_sin_div_x(omega).unsqueeze(-1)  # (..., 1, 1)
+    cos_coeff = _safe_one_minus_cos_div_x_sq(omega).unsqueeze(-1)
+    skew_sq = torch.matmul(skew, skew)
+    return eye + sin_coeff * skew + cos_coeff * skew_sq
+
+
+def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
+    """Map rotation matrices to tangent vectors on the principal branch.
+
+    The rotation is converted to a unit quaternion first and then to an
+    axis-angle vector. Routing through the quaternion keeps the result
+    stable for rotations near ``pi``, where reading the angle straight from
+    the trace loses accuracy because ``sin(omega)`` goes to zero.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Tangent vectors of shape ``(..., 3)`` whose norm lies in
+        ``[0, pi]``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     so3_exp_map, so3_log_map)
+    >>> tangent = torch.tensor([[0.3, -0.4, 1.2]])
+    >>> recovered = so3_log_map(so3_exp_map(tangent))
+    >>> bool(torch.allclose(recovered, tangent, atol=1e-5))
+    True
+    """
+    m00 = rotations[..., 0, 0]
+    m11 = rotations[..., 1, 1]
+    m22 = rotations[..., 2, 2]
+    trace = m00 + m11 + m22
+
+    # Read the unit quaternion from the rotation matrix. Each component
+    # magnitude comes from the diagonal and its sign from the skew part.
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
+    qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
+    qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
+
+    quat_vec = torch.stack([qx, qy, qz], dim=-1)
+    sin_half = quat_vec.norm(dim=-1)
+    cos_half = qw.clamp(-1.0, 1.0)
+    omega = 2.0 * torch.atan2(sin_half, cos_half)
+
+    small = sin_half < _SMALL_OMEGA
+    safe_sin_half = torch.where(small, torch.ones_like(sin_half), sin_half)
+    unit_axis = quat_vec / safe_sin_half.unsqueeze(-1)
+    # Near zero rotation the axis is ill-defined; there the tangent vector
+    # is approximately 2 * (qx, qy, qz).
+    return torch.where(small.unsqueeze(-1), 2.0 * quat_vec,
+                       omega.unsqueeze(-1) * unit_axis)
+
+
+def log_beta_schedule(num_steps: int,
+                      beta_min: float = 0.1,
+                      beta_max: float = 1.5) -> torch.Tensor:
+    """Logarithmic variance schedule for IGSO(3) diffusion.
+
+    Returns sigma_t = exp(linear(log beta_min, log beta_max)) for t = 1 .. T. This
+    is the schedule used by [Watson2023]_ and [Yim2023]_ for rotational
+    diffusion. The schedule is **monotonically increasing** in t.
+
+    Parameters
+    ----------
+    num_steps : int
+        Number of diffusion steps T (must be >= 2).
+    beta_min : float, default 0.1
+        Smallest sigma value (at t = 1).
+    beta_max : float, default 1.5
+        Largest sigma value (at t = T).
+
+    Returns
+    -------
+    torch.Tensor
+        Schedule tensor of shape ``(num_steps,)`` containing sigma_t values.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     log_beta_schedule)
+    >>> sigmas = log_beta_schedule(5, beta_min=0.1, beta_max=1.5)
+    >>> sigmas.shape
+    torch.Size([5])
+    >>> bool((sigmas[1:] > sigmas[:-1]).all())
+    True
+    """
+    if num_steps < 2:
+        raise ValueError('num_steps must be >= 2.')
+    if beta_min <= 0 or beta_max <= 0 or beta_max <= beta_min:
+        raise ValueError('Require 0 < beta_min < beta_max; got '
+                         f'beta_min={beta_min}, beta_max={beta_max}.')
+    log_min = math.log(beta_min)
+    log_max = math.log(beta_max)
+    return torch.exp(torch.linspace(log_min, log_max, num_steps))
+
+
+class IGSO3:
+    """Isotropic Gaussian distribution on SO(3).
+
+    The IGSO(3) density on the rotation angle omega in [0, pi] is the heat
+    kernel of the Laplace-Beltrami operator on SO(3) evaluated at
+    rotations whose geodesic distance from the identity is omega
+    [Nikolayev1997]_, [Leach2022]_.
+
+    The class caches a discretised PDF / CDF over a ``num_omega`` grid
+    for the supplied ``sigma`` values so that ``sample`` and ``score``
+    queries are fast.
+
+    Parameters
+    ----------
+    sigmas : torch.Tensor
+        1-D tensor of strictly positive sigma values (one per discrete
+        diffusion step).
+    num_omega : int, default 1024
+        Number of grid points used to discretise omega in (0, pi).
+    lmax : int, default 1999
+        Maximum degree retained in the infinite-series PDF. This gives
+        2000 terms, matching upstream RFdiffusion's default truncation
+        level.
+    cache : bool, default True
+        If ``True`` precompute and cache the discretised PDF / CDF for
+        each sigma in ``sigmas``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import IGSO3
+    >>> sigmas = torch.tensor([0.5])
+    >>> dist = IGSO3(sigmas, num_omega=256)
+    >>> samples = dist.sample(sigma_index=0, shape=(8,))
+    >>> samples.shape
+    torch.Size([8, 3, 3])
+
+    References
+    ----------
+    .. [Nikolayev1997] Nikolayev, D. I. & Savyolov, T. I. "Normal
+       distribution on the rotation group SO(3)." Textures and
+       Microstructures 29 (1997) 201-233.
+    """
+
+    def __init__(self,
+                 sigmas: torch.Tensor,
+                 num_omega: int = 1024,
+                 lmax: int = 1999,
+                 cache: bool = True) -> None:
+        if sigmas.ndim != 1:
+            raise ValueError('sigmas must be a 1-D tensor.')
+        if (sigmas <= 0).any():
+            raise ValueError('sigmas must be strictly positive.')
+        if num_omega < 64:
+            raise ValueError('num_omega must be at least 64.')
+        if lmax < 1:
+            raise ValueError('lmax must be at least 1.')
+        self.sigmas = sigmas.to(dtype=torch.float64)
+        self.num_omega = int(num_omega)
+        self.lmax = int(lmax)
+        # Upstream RFdiffusion discretises omega as linspace(0, pi, N+1)[1:]:
+        # zero is skipped, pi is included.
+        self.omegas = torch.linspace(0.0,
+                                     math.pi,
+                                     self.num_omega + 1,
+                                     dtype=torch.float64)[1:]
+        self.domega = float(self.omegas[1] - self.omegas[0])
+        self._pdf: Optional[torch.Tensor] = None
+        self._cdf: Optional[torch.Tensor] = None
+        self._score: Optional[torch.Tensor] = None
+        if cache:
+            self._compute_tables()
+
+    # ------------------------------------------------------------------
+    # PDF / CDF / score on the rotation angle omega
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _f_omega(omega: torch.Tensor, sigma: torch.Tensor,
+                 lmax: int) -> torch.Tensor:
+        """Evaluate the heat-kernel series f(omega; sigma).
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of shape ``(N,)`` containing rotation angles omega.
+        sigma : torch.Tensor
+            Tensor of shape ``(M,)`` containing sigma values.
+        lmax : int
+            Truncation degree of the series.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(M, N)`` with ``f(omega_n; sigma_m)``.
+        """
+        l_values = torch.arange(lmax + 1, device=omega.device)[None]
+        omega_col = omega[:, None]
+        rows = []
+        for sigma_i in sigma:
+            sigma_sq = float(sigma_i.detach().cpu().item()**2)
+            terms = ((2 * l_values + 1) *
+                     torch.exp(-l_values * (l_values + 1) * sigma_sq / 2) *
+                     torch.sin(omega_col *
+                               (l_values + 0.5)) / torch.sin(omega_col / 2))
+            rows.append(terms.sum(dim=-1))
+        return torch.stack(rows, dim=0)
+
+    @staticmethod
+    def _score_omega(omega: torch.Tensor, sigma: torch.Tensor,
+                     lmax: int) -> torch.Tensor:
+        """Evaluate domega log f(omega; sigma) using upstream-style autograd."""
+        with torch.enable_grad():
+            omega_var = omega.detach().clone().requires_grad_(True)
+            f = IGSO3._f_omega(omega_var, sigma.detach(), lmax)
+            scores = []
+            for row in f:
+                log_f = torch.log(row)
+                grad = torch.autograd.grad(log_f.sum(),
+                                           omega_var,
+                                           retain_graph=True)[0]
+                scores.append(grad.detach())
+        return torch.stack(scores, dim=0)
+
+    def _compute_tables(self) -> None:
+        """Populate the PDF / CDF / score caches."""
+        f = self._f_omega(self.omegas, self.sigmas, self.lmax)  # (M, N)
+        # Marginal density on omega: p(omega) = (1 - cos omega)/pi * f(omega).
+        prefactor = (1.0 - torch.cos(self.omegas)) / math.pi  # (N,)
+        pdf = prefactor[None, :] * f
+        cdf = torch.cumsum(pdf, dim=-1) * self.domega
+        # Score s(omega; sigma) = domega log f(omega; sigma), matching the upstream
+        # autograd derivative of the truncated heat-kernel series.
+        score = self._score_omega(self.omegas, self.sigmas, self.lmax)
+        self._pdf = pdf
+        self._cdf = cdf
+        self._score = score
+
+    def pdf(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached PDF at the supplied angles.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles omega in (0, pi) of arbitrary shape.
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` whose PDF to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            PDF evaluated at the supplied angles.
+        """
+        if self._pdf is None:
+            self._compute_tables()
+        assert self._pdf is not None
+        return self._interp(omega, self._pdf[sigma_index])
+
+    def cdf(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached CDF at the supplied angles."""
+        if self._cdf is None:
+            self._compute_tables()
+        assert self._cdf is not None
+        return self._interp(omega, self._cdf[sigma_index])
+
+    def score(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached score s(omega; sigma) at the supplied angles.
+
+        For small sigma the IGSO(3) collapses to a wrapped Gaussian on
+        so(3); the score is then approximately -omega / sigma^2. The cached
+        table already encodes this limit, so no special branch is
+        required at query time.
+        """
+        if self._score is None:
+            self._compute_tables()
+        assert self._score is not None
+        return self._interp(omega, self._score[sigma_index])
+
+    def _interp(self, omega: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+        """Linear interpolation of a 1-D cached table on the omega grid."""
+        omega = omega.to(dtype=torch.float64)
+        x = (omega - self.omegas[0]) / self.domega
+        x = x.clamp(0.0, float(self.num_omega - 1))
+        lo = x.floor().long()
+        hi = (lo + 1).clamp(max=self.num_omega - 1)
+        frac = (x - lo.to(x.dtype))
+        return (1.0 - frac) * table[lo] + frac * table[hi]
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+    def sample_angle(
+            self,
+            sigma_index: int,
+            shape: Tuple[int, ...],
+            generator: Optional[torch.Generator] = None) -> torch.Tensor:
+        """Sample rotation angles omega from IGSO(3) by inverse CDF."""
+        if self._cdf is None:
+            self._compute_tables()
+        assert self._cdf is not None
+        cdf = self._cdf[sigma_index]
+        u = torch.rand(shape, dtype=torch.float64, generator=generator)
+        idx = torch.searchsorted(cdf, u.flatten()).clamp(max=self.num_omega - 1)
+        return self.omegas[idx].reshape(shape)
+
+    def sample(self,
+               sigma_index: int,
+               shape: Tuple[int, ...],
+               generator: Optional[torch.Generator] = None) -> torch.Tensor:
+        """Sample rotation matrices from IGSO(3, sigma).
+
+        Sampling proceeds by:
+
+        1. drawing omega ~ p(omega; sigma) via inverse CDF;
+        2. drawing a uniform axis u in S^2 (rejection-free);
+        3. mapping tau = omega * u through Rodrigues' formula.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of sigma in ``self.sigmas``.
+        shape : tuple of int
+            Output batch shape; the returned tensor has shape
+            ``shape + (3, 3)``.
+        generator : torch.Generator, optional
+            PyTorch random generator for reproducibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Sampled rotation matrices of shape ``shape + (3, 3)`` in
+            ``torch.float32``.
+        """
+        omega = self.sample_angle(sigma_index, shape, generator=generator)
+        # Uniform axis on S^2 via standard normal normalisation.
+        axis = torch.randn(shape + (3,),
+                           dtype=torch.float64,
+                           generator=generator)
+        axis = axis / axis.norm(dim=-1, keepdim=True).clamp(min=1e-12)
+        tangent = (omega.unsqueeze(-1) * axis).to(dtype=torch.float32)
+        return so3_exp_map(tangent)
+
+    # ------------------------------------------------------------------
+    # Discrete normalisation check
+    # ------------------------------------------------------------------
+    def normalisation_error(self, sigma_index: int) -> float:
+        """Return |integralp(omega;sigma) domega - 1| on the cached grid.
+
+        This mirrors the upstream RFdiffusion Riemann-sum check; the
+        table is not renormalised after truncation.
+        """
+        if self._pdf is None:
+            self._compute_tables()
+        assert self._pdf is not None
+        total = float(self._pdf[sigma_index].sum() * self.domega)
+        return abs(total - 1.0)
+
+
+def so3_reverse_step(rotations: torch.Tensor,
+                     score: torch.Tensor,
+                     sigma_t: float,
+                     sigma_t_minus_1: float,
+                     noise: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """Single reverse-time Euler-Maruyama step on SO(3).
+
+    Implements the discretisation [Yim2023]_
+
+    .. math::
+
+        \\tau_{t-1} = (\\sigma_{t-1}^{2}/\\sigma_{t}^{2})\\,\\tau_{t}
+                    + (\\sigma_{t}^{2} - \\sigma_{t-1}^{2})\\,
+                      s(\\omega_t; \\sigma_t)\\,
+                      \\frac{\\tau_t}{\\omega_t}
+                    + \\sqrt{\\sigma_{t-1}^{2}\\,
+                            (1 - \\sigma_{t-1}^{2}/\\sigma_{t}^{2})}\\,
+                      \\xi
+
+    where xi ~ N(0, I3), tau_t = log(R_t) and the resulting tau_{t-1} is
+    re-exponentiated via Rodrigues' formula to give R_{t-1}.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Current rotation matrices of shape ``(..., 3, 3)``.
+    score : torch.Tensor
+        Score s(omega_t; sigma_t) evaluated at the current rotation angles,
+        broadcastable to the leading dimensions of ``rotations``.
+    sigma_t : float
+        Noise level at the current step.
+    sigma_t_minus_1 : float
+        Noise level at the previous step (must be < sigma_t).
+    noise : torch.Tensor, optional
+        Standard normal noise of shape ``rotations.shape[:-2] + (3,)``.
+        If ``None`` a fresh sample is drawn.
+
+    Returns
+    -------
+    torch.Tensor
+        Updated rotation matrices of shape ``(..., 3, 3)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     so3_exp_map, so3_reverse_step)
+    >>> R_t = so3_exp_map(torch.tensor([[0.0, 0.0, 2.0]]))
+    >>> R_prev = so3_reverse_step(R_t, torch.tensor([-1.0]), sigma_t=1.0,
+    ...                           sigma_t_minus_1=0.9,
+    ...                           noise=torch.zeros(1, 3))
+    >>> R_prev.shape
+    torch.Size([1, 3, 3])
+    """
+    if sigma_t <= 0 or sigma_t_minus_1 <= 0:
+        raise ValueError('sigma values must be strictly positive.')
+    if sigma_t_minus_1 >= sigma_t:
+        raise ValueError('Reverse step requires sigma_t_minus_1 < sigma_t; got '
+                         f'{sigma_t_minus_1} >= {sigma_t}.')
+    tau_t = so3_log_map(rotations)
+    omega = tau_t.norm(dim=-1, keepdim=True).clamp(min=_SMALL_OMEGA)
+    direction = tau_t / omega
+    score = score.unsqueeze(-1) if score.dim() == tau_t.dim() - 1 else score
+    ratio = (sigma_t_minus_1 / sigma_t)**2
+    drift = ratio * tau_t + (sigma_t**2 - sigma_t_minus_1**2) * (score *
+                                                                 direction)
+    diffusion_std = math.sqrt(max(0.0, sigma_t_minus_1**2 * (1.0 - ratio)))
+    if noise is None:
+        noise = torch.randn_like(tau_t)
+    tau_prev = drift + diffusion_std * noise
+    return so3_exp_map(tau_prev)

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -208,10 +208,17 @@ def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
 
     # Read the unit quaternion from the rotation matrix. Each component
     # magnitude comes from the diagonal and its sign from the skew part.
-    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
-    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
-    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
-    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    # The clamp floor is a small positive epsilon rather than 0: torch.sqrt
+    # has an infinite gradient exactly at 0, which this component reaches
+    # whenever the corresponding quaternion axis is (near) zero -- e.g. for
+    # any rotation close to the identity. Training a model that predicts
+    # rotations close to their target hits this constantly, so a hard
+    # min=0.0 clamp turns into NaN gradients partway through optimization.
+    _sqrt_eps = 1e-12
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=_sqrt_eps))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=_sqrt_eps))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=_sqrt_eps))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=_sqrt_eps))
     qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
     qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
     qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
@@ -453,13 +460,24 @@ class IGSO3:
 
     def _interp(self, omega: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
         """Linear interpolation of a 1-D cached table on the omega grid."""
-        omega = omega.to(dtype=torch.float64)
+        original_device = omega.device
+        # The cached tables are float64 for interpolation accuracy, but
+        # some backends (e.g. Apple's MPS) do not support float64 tensors
+        # at all -- not even as a transient step of a combined device+dtype
+        # .to() call -- so the move to CPU and the cast to float64 have to
+        # happen as two separate steps.
+        omega = omega.to(device='cpu').to(dtype=torch.float64)
         x = (omega - self.omegas[0]) / self.domega
         x = x.clamp(0.0, float(self.num_omega - 1))
         lo = x.floor().long()
         hi = (lo + 1).clamp(max=self.num_omega - 1)
         frac = (x - lo.to(x.dtype))
-        return (1.0 - frac) * table[lo] + frac * table[hi]
+        result = (1.0 - frac) * table[lo] + frac * table[hi]
+        # MPS has no float64 support, so results headed back there are
+        # downcast to float32; other devices keep full precision.
+        result_dtype = (torch.float32
+                        if original_device.type == 'mps' else torch.float64)
+        return result.to(device=original_device, dtype=result_dtype)
 
     # ------------------------------------------------------------------
     # Sampling

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -260,6 +260,12 @@ def log_beta_schedule(num_steps: int,
     torch.Tensor
         Schedule tensor of shape ``(num_steps,)`` containing sigma_t values.
 
+    Raises
+    ------
+    ValueError
+        If `num_steps < 2` or `beta_min`/`beta_max` are not `0 < beta_min
+        < beta_max`.
+
     Examples
     --------
     >>> import torch
@@ -307,6 +313,12 @@ class IGSO3:
     cache : bool, default True
         If ``True`` precompute and cache the discretised PDF / CDF for
         each sigma in ``sigmas``.
+
+    Raises
+    ------
+    ValueError
+        If `sigmas` is not 1-D or not strictly positive, if `num_omega
+        < 64`, or if `lmax < 1`.
 
     Examples
     --------
@@ -408,6 +420,22 @@ class IGSO3:
         backward call, since independent leaves have no cross-row terms
         to sum over. This is the same closed-form formula as
         ``_f_omega``, just batched over sigma instead of looped.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of shape ``(N,)`` containing rotation angles omega.
+        sigma : torch.Tensor
+            Tensor of shape ``(M,)`` containing sigma values.
+        lmax : int
+            Truncation degree of the series.
+        chunk_size : int, default 32
+            Number of sigma rows processed per backward call.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(M, N)`` with domega log f(omega_n; sigma_m).
         """
         num_sigma = sigma.shape[0]
         l_values = torch.arange(lmax + 1, device=omega.device)[None, None, :]
@@ -465,7 +493,20 @@ class IGSO3:
         return self._interp(omega, self._pdf[sigma_index])
 
     def cdf(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
-        """Interpolate the cached CDF at the supplied angles."""
+        """Interpolate the cached CDF at the supplied angles.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles omega in (0, pi) of arbitrary shape.
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` whose CDF to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            CDF evaluated at the supplied angles.
+        """
         if self._cdf is None:
             self._compute_tables()
         assert self._cdf is not None
@@ -478,6 +519,18 @@ class IGSO3:
         so(3); the score is then approximately -omega / sigma^2. The cached
         table already encodes this limit, so no special branch is
         required at query time.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles omega in (0, pi) of arbitrary shape.
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` whose score to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            Score s(omega; sigma) evaluated at the supplied angles.
         """
         if self._score is None:
             self._compute_tables()
@@ -485,7 +538,22 @@ class IGSO3:
         return self._interp(omega, self._score[sigma_index])
 
     def _interp(self, omega: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
-        """Linear interpolation of a 1-D cached table on the omega grid."""
+        """Linear interpolation of a 1-D cached table on the omega grid.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Query angles, arbitrary shape, on any device/dtype.
+        table : torch.Tensor
+            1-D cached table of shape ``(num_omega,)`` (e.g. `self._pdf`,
+            `self._cdf`, or `self._score`, indexed by sigma) to interpolate.
+
+        Returns
+        -------
+        torch.Tensor
+            Interpolated values, same shape as `omega`, on `omega`'s
+            original device.
+        """
         original_device = omega.device
         # The cached tables are float64 for interpolation accuracy, but
         # some backends (e.g. Apple's MPS) do not support float64 tensors
@@ -513,7 +581,22 @@ class IGSO3:
             sigma_index: int,
             shape: Tuple[int, ...],
             generator: Optional[torch.Generator] = None) -> torch.Tensor:
-        """Sample rotation angles omega from IGSO(3) by inverse CDF."""
+        """Sample rotation angles omega from IGSO(3) by inverse CDF.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of sigma in ``self.sigmas``.
+        shape : tuple of int
+            Output batch shape for the sampled angles.
+        generator : torch.Generator, optional
+            PyTorch random generator for reproducibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Sampled angles omega of shape ``shape``, in ``torch.float64``.
+        """
         if self._cdf is None:
             self._compute_tables()
         assert self._cdf is not None
@@ -567,6 +650,17 @@ class IGSO3:
 
         This mirrors the upstream RFdiffusion Riemann-sum check; the
         table is not renormalised after truncation.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` to check.
+
+        Returns
+        -------
+        float
+            Absolute deviation of the cached PDF's Riemann sum from 1.
+            Should be small for a well-resolved grid (see `num_omega`).
         """
         if self._pdf is None:
             self._compute_tables()
@@ -616,6 +710,12 @@ def so3_reverse_step(rotations: torch.Tensor,
     -------
     torch.Tensor
         Updated rotation matrices of shape ``(..., 3, 3)``.
+
+    Raises
+    ------
+    ValueError
+        If `sigma_t` or `sigma_t_minus_1` is not strictly positive, or
+        if `sigma_t_minus_1 >= sigma_t`.
 
     Examples
     --------

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -389,20 +389,46 @@ class IGSO3:
         return torch.stack(rows, dim=0)
 
     @staticmethod
-    def _score_omega(omega: torch.Tensor, sigma: torch.Tensor,
-                     lmax: int) -> torch.Tensor:
-        """Evaluate domega log f(omega; sigma) using upstream-style autograd."""
-        with torch.enable_grad():
-            omega_var = omega.detach().clone().requires_grad_(True)
-            f = IGSO3._f_omega(omega_var, sigma.detach(), lmax)
-            scores = []
-            for row in f:
-                log_f = torch.log(row)
-                grad = torch.autograd.grad(log_f.sum(),
-                                           omega_var,
-                                           retain_graph=True)[0]
-                scores.append(grad.detach())
-        return torch.stack(scores, dim=0)
+    def _score_omega(omega: torch.Tensor,
+                     sigma: torch.Tensor,
+                     lmax: int,
+                     chunk_size: int = 32) -> torch.Tensor:
+        """Evaluate domega log f(omega; sigma) using batched autograd.
+
+        Calling ``torch.autograd.grad`` once per sigma row with
+        ``retain_graph=True`` (as a naive per-row loop would) keeps the
+        whole shared computation graph alive across every call, which
+        makes the cost grow quadratically in the number of sigmas --
+        completely impractical at the ``num_diffusion_steps`` ~ 1000
+        scale this class is normally used at. Instead, sigmas are
+        processed in chunks: within a chunk, every row gets its own
+        independent leaf tensor (via ``.clone()``), so ``f`` for the whole
+        chunk can be computed with one vectorized (chunk, N, L) batched
+        expression and its per-row gradients recovered with a *single*
+        backward call, since independent leaves have no cross-row terms
+        to sum over. This is the same closed-form formula as
+        ``_f_omega``, just batched over sigma instead of looped.
+        """
+        num_sigma = sigma.shape[0]
+        l_values = torch.arange(lmax + 1, device=omega.device)[None, None, :]
+        scores = []
+        for start in range(0, num_sigma, chunk_size):
+            sigma_chunk = sigma[start:start + chunk_size].detach()
+            chunk = sigma_chunk.shape[0]
+            with torch.enable_grad():
+                omega_var = omega[None, :].expand(chunk, omega.shape[0]).clone()
+                omega_var.requires_grad_(True)
+                sigma_sq = (sigma_chunk**2)[:, None, None]
+                omega_col = omega_var[:, :, None]
+                terms = ((2 * l_values + 1) *
+                         torch.exp(-l_values * (l_values + 1) * sigma_sq / 2) *
+                         torch.sin(omega_col *
+                                   (l_values + 0.5)) / torch.sin(omega_col / 2))
+                f_chunk = terms.sum(dim=-1)  # (chunk, N)
+                log_f = torch.log(f_chunk)
+                grad = torch.autograd.grad(log_f.sum(), omega_var)[0]
+            scores.append(grad.detach())
+        return torch.cat(scores, dim=0)
 
     def _compute_tables(self) -> None:
         """Populate the PDF / CDF / score caches."""

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -71,16 +71,10 @@ try:
 except ModuleNotFoundError:
     raise ImportError('rfdiffusion_so3 requires PyTorch to be installed.')
 
-__all__ = [
-    'IGSO3',
-    'log_beta_schedule',
-    'so3_log_map',
-    'so3_exp_map',
-    'so3_reverse_step',
-]
-
-# Threshold below which series expansions are used instead of the closed
-# form to preserve numerical stability.
+# Threshold for small-angle Taylor expansions.
+# For rotation angles theta < 1e-4, sin(theta)/theta ~ 1 - theta^2/6 and
+# (1 - cos(theta))/theta^2 ~ 1/2 - theta^2/24. This avoids division-by-zero
+# and float32 precision loss near the identity (Grassia, 1998).
 _SMALL_OMEGA: float = 1e-4
 _SMALL_SIGMA: float = 5e-2
 

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_so3.py
@@ -1,0 +1,223 @@
+"""Tests for the RFDiffusion SO(3) diffusion utilities."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    from deepchem.models.torch_models.rfdiffusion_so3 import (
+        IGSO3,
+        log_beta_schedule,
+        so3_exp_map,
+        so3_log_map,
+        so3_reverse_step,
+    )
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3Maps:
+    """Exponential and logarithm maps between so(3) and SO(3)."""
+
+    def test_exp_zero_is_identity(self):
+        """A zero tangent vector maps to the identity rotation."""
+        rotations = so3_exp_map(torch.zeros(4, 3))
+        assert torch.allclose(rotations,
+                              torch.eye(3).expand(4, 3, 3),
+                              atol=1e-6)
+
+    def test_exp_is_valid_rotation(self):
+        """Exp-map outputs are orthogonal with determinant +1."""
+        torch.manual_seed(0)
+        rotations = so3_exp_map(torch.randn(16, 3))
+        eye = torch.eye(3).expand(16, 3, 3)
+        assert torch.allclose(rotations @ rotations.transpose(-1, -2),
+                              eye,
+                              atol=1e-5)
+        assert torch.allclose(torch.det(rotations), torch.ones(16), atol=1e-5)
+
+    def test_exp_known_rotation_about_z(self):
+        """A pi/2 rotation about z matches the closed-form matrix."""
+        rotation = so3_exp_map(torch.tensor([[0.0, 0.0, math.pi / 2]]))[0]
+        expected = torch.tensor([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0],
+                                 [0.0, 0.0, 1.0]])
+        assert torch.allclose(rotation, expected, atol=1e-6)
+
+    def test_log_is_inverse_of_exp(self):
+        """log(exp(tau)) recovers tau for angles across (0, pi)."""
+        torch.manual_seed(1)
+        axis = torch.randn(32, 3)
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        for angle in [0.05, 1.0, 2.5, math.pi - 0.05]:
+            tangent = angle * axis
+            recovered = so3_log_map(so3_exp_map(tangent))
+            assert torch.allclose(recovered, tangent, atol=1e-3)
+
+    def test_log_near_pi_is_stable(self):
+        """The log map stays accurate for rotations very close to pi.
+
+        The quaternion route keeps the error small where reading the angle
+        from the trace would lose precision (``sin(omega) -> 0``).
+        """
+        axis = torch.tensor([[0.3, -0.5, 0.8]])
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        rotation = so3_exp_map((math.pi - 1e-3) * axis)
+        # Compare rotations, avoiding the axis-sign ambiguity at pi.
+        recovered = so3_exp_map(so3_log_map(rotation))
+        assert torch.allclose(rotation, recovered, atol=1e-3)
+
+    def test_log_identity_is_zero(self):
+        """The log of the identity rotation is the zero tangent vector."""
+        identity = torch.eye(3).unsqueeze(0)
+        assert torch.allclose(so3_log_map(identity),
+                              torch.zeros(1, 3),
+                              atol=1e-6)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestLogBetaSchedule:
+    """Logarithmic sigma schedule for rotational diffusion."""
+
+    def test_shape_and_endpoints(self):
+        """The schedule has the requested length and hits both endpoints."""
+        sigmas = log_beta_schedule(10, beta_min=0.1, beta_max=1.5)
+        assert sigmas.shape == (10,)
+        assert math.isclose(sigmas[0].item(), 0.1, rel_tol=1e-6)
+        assert math.isclose(sigmas[-1].item(), 1.5, rel_tol=1e-6)
+
+    def test_monotonic_increasing(self):
+        """Sigma increases monotonically with the step index."""
+        sigmas = log_beta_schedule(50)
+        assert bool((sigmas[1:] > sigmas[:-1]).all())
+
+    def test_linear_in_log_space(self):
+        """Successive log-sigma differences are constant."""
+        sigmas = log_beta_schedule(7, beta_min=0.2, beta_max=2.0)
+        diffs = torch.log(sigmas)[1:] - torch.log(sigmas)[:-1]
+        assert torch.allclose(diffs, diffs[0].expand_as(diffs), atol=1e-6)
+
+    def test_invalid_args_raise(self):
+        """Bad step counts and beta ranges raise ValueError."""
+        with pytest.raises(ValueError):
+            log_beta_schedule(1)
+        with pytest.raises(ValueError):
+            log_beta_schedule(10, beta_min=1.0, beta_max=0.5)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestIGSO3:
+    """IGSO(3) density, score, and sampling."""
+
+    def test_pdf_normalised(self):
+        """The discretised marginal density integrates to approximately 1."""
+        dist = IGSO3(torch.tensor([0.3, 0.8, 1.5]), num_omega=512)
+        for index in range(3):
+            assert dist.normalisation_error(index) < 1e-2
+
+    def test_cdf_monotonic_and_bounded(self):
+        """The CDF increases monotonically and reaches ~1 at pi."""
+        dist = IGSO3(torch.tensor([0.7]), num_omega=512)
+        cdf = dist._cdf[0]
+        assert bool((cdf[1:] >= cdf[:-1] - 1e-9).all())
+        assert abs(cdf[-1].item() - 1.0) < 1e-2
+
+    def test_score_matches_finite_difference(self):
+        """The autograd score equals a finite-difference of log f(omega)."""
+        sigma = torch.tensor([0.9]).double()
+        lmax = 500
+        omega = torch.tensor([0.5, 1.0, 2.0], dtype=torch.float64)
+        analytic = IGSO3._score_omega(omega, sigma, lmax)[0]
+        eps = 1e-4
+        fp = torch.log(IGSO3._f_omega(omega + eps, sigma, lmax))[0]
+        fm = torch.log(IGSO3._f_omega(omega - eps, sigma, lmax))[0]
+        finite_diff = (fp - fm) / (2 * eps)
+        assert torch.allclose(analytic, finite_diff, atol=1e-3)
+
+    def test_sample_shape_and_valid(self):
+        """Samples have the requested batch shape and are valid rotations."""
+        dist = IGSO3(torch.tensor([0.6]), num_omega=256)
+        generator = torch.Generator().manual_seed(0)
+        rotations = dist.sample(0, (5, 4), generator=generator)
+        assert rotations.shape == (5, 4, 3, 3)
+        eye = torch.eye(3).expand(5, 4, 3, 3)
+        assert torch.allclose(rotations @ rotations.transpose(-1, -2),
+                              eye,
+                              atol=1e-4)
+
+    def test_sample_angle_in_range(self):
+        """Sampled rotation angles lie within (0, pi]."""
+        dist = IGSO3(torch.tensor([1.0]), num_omega=256)
+        generator = torch.Generator().manual_seed(0)
+        angles = dist.sample_angle(0, (1000,), generator=generator)
+        assert bool((angles > 0).all())
+        assert bool((angles <= math.pi + 1e-6).all())
+
+    def test_larger_sigma_gives_larger_mean_angle(self):
+        """A larger sigma produces a larger mean sampled angle."""
+        dist = IGSO3(torch.tensor([0.3, 1.5]), num_omega=512)
+        generator = torch.Generator().manual_seed(0)
+        small = dist.sample_angle(0, (4000,), generator=generator).mean()
+        large = dist.sample_angle(1, (4000,), generator=generator).mean()
+        assert large > small
+
+    def test_invalid_construction_raises(self):
+        """Invalid sigmas or grid sizes raise ValueError."""
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([[0.5]]))
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([-0.5]))
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([0.5]), num_omega=8)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3ReverseStep:
+    """Reverse-time Euler-Maruyama integrator on SO(3)."""
+
+    def test_output_shape_and_valid(self):
+        """A reverse step returns valid rotations of the input shape."""
+        torch.manual_seed(0)
+        rotations = so3_exp_map(torch.randn(6, 3))
+        score = torch.full((6,), -0.5)
+        updated = so3_reverse_step(rotations,
+                                   score,
+                                   1.0,
+                                   0.9,
+                                   noise=torch.zeros(6, 3))
+        assert updated.shape == (6, 3, 3)
+        eye = torch.eye(3).expand(6, 3, 3)
+        assert torch.allclose(updated @ updated.transpose(-1, -2),
+                              eye,
+                              atol=1e-5)
+
+    def test_deterministic_without_noise(self):
+        """With zero noise the reverse step is deterministic."""
+        rotations = so3_exp_map(torch.tensor([[0.0, 0.0, 2.0]]))
+        score = torch.tensor([-1.0])
+        first = so3_reverse_step(rotations,
+                                 score,
+                                 1.0,
+                                 0.8,
+                                 noise=torch.zeros(1, 3))
+        second = so3_reverse_step(rotations,
+                                  score,
+                                  1.0,
+                                  0.8,
+                                  noise=torch.zeros(1, 3))
+        assert torch.allclose(first, second)
+
+    def test_invalid_sigmas_raise(self):
+        """Non-decreasing or non-positive sigma values raise ValueError."""
+        rotations = so3_exp_map(torch.zeros(1, 3))
+        score = torch.tensor([0.0])
+        with pytest.raises(ValueError):
+            so3_reverse_step(rotations, score, 1.0, 1.0)
+        with pytest.raises(ValueError):
+            so3_reverse_step(rotations, score, -1.0, 0.5)


### PR DESCRIPTION
This adds the rotational part of the RFDiffusion noise process as a new
self-contained module, `rfdiffusion_so3.py`. It only depends on torch.

What it adds:

- `so3_exp_map` / `so3_log_map` - Rodrigues exponential and a
  quaternion-based logarithm. Routing the log map through a quaternion keeps
  it stable for rotations near `pi`, where reading the angle straight from
  the trace loses precision.
- `log_beta_schedule` - the log-linear sigma schedule used for rotational
  diffusion.
- `IGSO3` - the isotropic Gaussian on SO(3). It caches the PDF, CDF, and
  score over an omega grid and samples rotations by inverse CDF. The
  truncated heat-kernel series (2000 terms), the omega grid
  (`linspace(0, pi, N+1)[1:]`), and the autograd score all match upstream
  RFdiffusion's defaults.
- `so3_reverse_step` - one reverse-time Euler-Maruyama step on SO(3).

Testing:

- Exp/log roundtrip across angles, including close to `pi`.
- Schedule shape, endpoints, and monotonicity.
- IGSO(3) normalisation, CDF monotonicity, and the score checked against a
  finite difference of `log f(omega)`.
- Sampling shapes, valid rotation outputs, and angle statistics.
- Reverse-step shape, determinism, and input validation.

Doctests and the test module both pass locally, and the module is
flake8/yapf clean.

Part of the RFDiffusion series. The module is standalone, so it can be
reviewed on its own.
