### PR TITLE
Initial Functions and Classes for ProteinMPNN Model

### DIFF
--- a/deepchem/models/torch_models/ProteinMPNN.py
+++ b/deepchem/models/torch_models/ProteinMPNN.py
@@ -1,0 +1,274 @@
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.utils.ProteinMPNN_utils import gather_edges
+
+
+class PositionalEncodings(nn.Module):
+    """Relative positional encodings for residue pairs in the kNN graph.
+
+    Encodes relative sequence offsets and chain membership between residue
+    pairs into edge features used by the ProteinMPNN encoder.
+
+    Parameters
+    ----------
+    num_embeddings : int
+        Output dimension of the positional encoding.
+    max_relative_feature : int, optional (default 32)
+        Maximum absolute relative residue offset to encode.
+
+    References
+    ----------
+    .. [1] Dauparas, J., et al. "Robust deep learning-based protein sequence
+       design using ProteinMPNN." Science 378.6615 (2022): 49-56.
+       https://doi.org/10.1126/science.add2187
+    """
+
+    def __init__(self, num_embeddings: int, max_relative_feature: int = 32):
+        super().__init__()
+        self.num_embeddings = num_embeddings
+        self.max_relative_feature = max_relative_feature
+        self.linear = nn.Linear(2 * max_relative_feature + 2, num_embeddings)
+
+    def forward(self, offset, mask):
+        """Compute positional encodings for edge features.
+
+        Parameters
+        ----------
+        offset : torch.Tensor
+            Relative residue index offsets of shape
+            ``(batch, num_nodes, k)``.
+        mask : torch.Tensor
+            Binary mask indicating same-chain residue pairs, of shape
+            ``(batch, num_nodes, k)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Positional edge embeddings of shape
+            ``(batch, num_nodes, k, num_embeddings)``.
+        """
+        d = torch.clip(offset + self.max_relative_feature, 0,
+                       2 * self.max_relative_feature) * mask + (1 - mask) * (
+                           2 * self.max_relative_feature + 1)
+        d_onehot = F.one_hot(d.long(), 2 * self.max_relative_feature + 2)
+        return self.linear(d_onehot.float())
+
+
+class ProteinFeaturesLayer(nn.Module):
+    """Extract k-nearest-neighbor graph edge features from backbone coordinates.
+
+    This layer constructs a kNN graph from C-alpha distances and computes
+    edge features from pairwise radial basis function (RBF) distances and
+    relative positional encodings. These edge features are consumed by the
+    ProteinMPNN encoder during message passing.
+
+    Parameters
+    ----------
+    edge_features : int
+        Output dimension of the edge feature embedding.
+    num_positional_embeddings : int, optional (default 16)
+        Dimension of relative positional encodings.
+    num_rbf : int, optional (default 16)
+        Number of radial basis functions used to encode distances.
+    top_k : int, optional (default 30)
+        Number of nearest neighbors per residue in the kNN graph.
+    augment_eps : float, optional (default 0.0)
+        Standard deviation of Gaussian noise added to coordinates during
+        training. No augmentation is applied when set to 0.0.
+
+    References
+    ----------
+    .. [1] Dauparas, J., et al. "Robust deep learning-based protein sequence
+       design using ProteinMPNN." Science 378.6615 (2022): 49-56.
+       https://doi.org/10.1126/science.add2187
+
+    Examples
+    --------
+    >>> import torch
+    >>> layer = ProteinFeaturesLayer(edge_features=128)
+    >>> X = torch.randn(1, 10, 4, 3)
+    >>> mask = torch.ones(1, 10)
+    >>> residue_idx = torch.arange(10).unsqueeze(0)
+    >>> chain_labels = torch.ones(1, 10)
+    >>> E, E_idx = layer(X, mask, residue_idx, chain_labels)
+    >>> E.shape[0]
+    1
+    """
+
+    def __init__(self,
+                 edge_features: int,
+                 num_positional_embeddings: int = 16,
+                 num_rbf: int = 16,
+                 top_k: int = 30,
+                 augment_eps: float = 0.0):
+        super().__init__()
+        self.edge_features = edge_features
+        self.top_k = top_k
+        self.augment_eps = augment_eps
+        self.num_rbf = num_rbf
+        self.embeddings = PositionalEncodings(num_positional_embeddings)
+        edge_in = num_positional_embeddings + num_rbf * 25
+        self.edge_embedding = nn.Linear(edge_in, edge_features, bias=False)
+        self.norm_edges = nn.LayerNorm(edge_features)
+
+    def dist(self, X, mask, eps: float = 1e-6):
+        """
+        Compute pairwise C-alpha distances and k-nearest neighbor indices.
+        The C-alpha distances are computed using the backbone coordinates.
+        The k-nearest neighbors are computed using the C-alpha distances.
+        The k-nearest neighbor indices are returned along with the C-alpha distances.
+
+        Parameters
+        ----------
+        X : torch.Tensor
+            C-alpha coordinates of shape ``(batch, num_nodes, 3)``.
+        mask : torch.Tensor
+            Validity mask of shape ``(batch, num_nodes)``.
+        eps : float, optional (default 1e-6)
+            Small constant added for numerical stability in distance computation.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            - D_neighbors: k-nearest neighbor distances of shape
+              ``(batch, num_nodes, k)``.
+            - E_idx: k-nearest neighbor indices of shape
+              ``(batch, num_nodes, k)``.
+        """
+        mask_2D = mask.unsqueeze(1) * mask.unsqueeze(2)
+        dX = X.unsqueeze(1) - X.unsqueeze(2)
+        D = mask_2D * torch.sqrt(torch.sum(dX**2, dim=3) + eps)
+        D_max, _ = torch.max(D, dim=-1, keepdim=True)
+        D_adjust = D + (1.0 - mask_2D) * D_max
+        k = min(self.top_k, X.shape[1])
+        D_neighbors, E_idx = torch.topk(D_adjust, k, dim=-1, largest=False)
+        return D_neighbors, E_idx
+
+    def rbf(self, D):
+        """
+        The distances are encoded using the radial basis functions.
+        The encoded distances are returned.
+
+        Parameters
+        ----------
+        D : torch.Tensor
+            Pairwise distances of shape ``(batch, num_nodes, k)``.
+
+        Returns
+        -------
+        torch.Tensor
+            RBF-encoded distances of shape
+            ``(batch, num_nodes, k, num_rbf)``.
+        """
+        D_min, D_max = 2.0, 22.0
+        D_mu = torch.linspace(D_min, D_max, self.num_rbf, device=D.device)
+        D_mu = D_mu.view(1, 1, 1, -1)
+        D_sigma = (D_max - D_min) / self.num_rbf
+        RBF = torch.exp(-((D.unsqueeze(-1) - D_mu) / D_sigma)**2)
+        return RBF
+
+    def get_rbf(self, A, B, E_idx):
+        """
+        Computes the RBF features for atom pairs at neighbor edges.
+
+        Parameters
+        ----------
+        A : torch.Tensor
+            Coordinates of the first atom type, shape ``(batch, num_nodes, 3)``.
+        B : torch.Tensor
+            Coordinates of the second atom type, shape ``(batch, num_nodes, 3)``.
+        E_idx : torch.Tensor
+            k-nearest neighbor index tensor of shape ``(batch, num_nodes, k)``.
+
+        Returns
+        -------
+        torch.Tensor
+            RBF-encoded pairwise distances of shape
+            ``(batch, num_nodes, k, num_rbf)``.
+        """
+        D_A_B = torch.sqrt(
+            torch.sum((A[:, :, None, :] - B[:, None, :, :])**2, dim=-1) + 1e-6)
+        D_neighbors = gather_edges(D_A_B[:, :, :, None], E_idx)[:, :, :, 0]
+        return self.rbf(D_neighbors)
+
+    def forward(self, X, mask, residue_idx, chain_labels):
+        """
+        Builds the kNN graph and computes the edge features from the backbone coordinates.
+        The backbone coordinates are used to compute the C-alpha distances and the k-nearest neighbors.
+        The edge features are computed using the RBF features and the relative positional encodings.
+        The edge features are then normalized and embedded using a linear layer.
+        The edge features are returned along with the k-nearest neighbor indices.
+
+        Parameters
+        ----------
+        X : torch.Tensor
+            Backbone coordinates of shape ``(batch, num_nodes, 4, 3)`` for
+            atoms N, CA, C, and O.
+        mask : torch.Tensor
+            Validity mask of shape ``(batch, num_nodes)``.
+        residue_idx : torch.Tensor
+            Residue index tensor of shape ``(batch, num_nodes)``.
+        chain_labels : torch.Tensor
+            Chain identifier tensor of shape ``(batch, num_nodes)``.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            - E: Edge feature tensor of shape
+              ``(batch, num_nodes, k, edge_features)``.
+            - E_idx: k-nearest neighbor index tensor of shape
+              ``(batch, num_nodes, k)``.
+
+        Examples
+        --------
+        >>> import torch
+        >>> layer = ProteinFeaturesLayer(edge_features=128)
+        >>> X = torch.randn(1, 10, 4, 3)
+        >>> mask = torch.ones(1, 10)
+        >>> residue_idx = torch.arange(10).unsqueeze(0)
+        >>> chain_labels = torch.ones(1, 10)
+        >>> E, E_idx = layer(X, mask, residue_idx, chain_labels)
+        >>> len(E.shape)
+        4
+        """
+        if self.augment_eps > 0 and self.training:
+            X = X + self.augment_eps * torch.randn_like(X)
+
+        N = X[:, :, 0, :]
+        Ca = X[:, :, 1, :]
+        C = X[:, :, 2, :]
+        O_atom = X[:, :, 3, :]
+
+        b = C - Ca
+        c = N - Ca
+        a = torch.cross(b, c, dim=-1)
+        Cb = -0.58273431 * a + 0.56802827 * b - 0.54067466 * c + Ca
+
+        D_neighbors, E_idx = self.dist(Ca, mask)
+
+        atom_pairs = [(Ca, Ca), (N, N), (C, C), (O_atom, O_atom), (Cb, Cb),
+                      (Ca, N), (Ca, C), (Ca, O_atom), (Ca, Cb), (N, C),
+                      (N, O_atom), (N, Cb), (Cb, C), (Cb, O_atom), (O_atom, C),
+                      (N, Ca), (C, Ca), (O_atom, Ca), (Cb, Ca), (C, N),
+                      (O_atom, N), (Cb, N), (C, Cb), (O_atom, Cb), (C, O_atom)]
+        RBF_list = [self.rbf(D_neighbors)]
+        for A, B in atom_pairs[1:]:
+            RBF_list.append(self.get_rbf(A, B, E_idx))
+        RBF_all = torch.cat(RBF_list, dim=-1)
+
+        offset = residue_idx[:, :, None] - residue_idx[:, None, :]
+        offset = gather_edges(offset[:, :, :, None], E_idx)[:, :, :, 0]
+        d_chains = ((chain_labels[:, :, None] -
+                     chain_labels[:, None, :]) == 0).long()
+        E_chains = gather_edges(d_chains[:, :, :, None], E_idx)[:, :, :, 0]
+        E_positional = self.embeddings(offset.long(), E_chains)
+        E = torch.cat((E_positional, RBF_all), dim=-1)
+        E = self.norm_edges(self.edge_embedding(E))
+        return E, E_idx

--- a/deepchem/models/torch_models/ProteinMPNN.py
+++ b/deepchem/models/torch_models/ProteinMPNN.py
@@ -28,6 +28,17 @@ class PositionalEncodings(nn.Module):
     .. [1] Dauparas, J., et al. "Robust deep learning-based protein sequence
        design using ProteinMPNN." Science 378.6615 (2022): 49-56.
        https://doi.org/10.1126/science.add2187
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.ProteinMPNN import PositionalEncodings
+    >>> layer = PositionalEncodings(num_embeddings=16, max_relative_feature=8)
+    >>> offset = torch.randint(-10, 11, (2, 5, 3))
+    >>> mask = torch.ones(2, 5, 3)
+    >>> output = layer(offset, mask)
+    >>> output.shape
+    torch.Size([2, 5, 3, 16])
     """
 
     def __init__(self, num_embeddings: int, max_relative_feature: int = 32):

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -57,6 +57,7 @@ from deepchem.models.torch_models.layers import ResidueEmbedding
 from deepchem.models.torch_models.layers import PositionalEncoding
 from deepchem.models.torch_models.layers import CosineSchedule
 from deepchem.models.torch_models.layers import BackboneDiffusion
+from deepchem.models.torch_models.ProteinMPNN import PositionalEncodings, ProteinFeaturesLayer
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel

--- a/deepchem/models/torch_models/tests/test_ProteinMPNN.py
+++ b/deepchem/models/torch_models/tests/test_ProteinMPNN.py
@@ -19,37 +19,6 @@ if has_torch:
         _MapperProteinMPNN,
     )
 
-    from deepchem.utils.ProteinMPNN_utils import gather_edges
-
-
-@pytest.mark.torch
-def test_gather_edges_output_shape():
-    """Test that _gather_edges returns a tensor with the correct shape."""
-    batch, num_nodes, k, edge_features = 2, 5, 3, 16
-    edges = torch.rand(batch, num_nodes, num_nodes, edge_features)
-    neighbor_idx = torch.randint(0, num_nodes, (batch, num_nodes, k))
-
-    out = gather_edges(edges, neighbor_idx)
-
-    assert isinstance(out, torch.Tensor)
-    assert out.shape == torch.Size([batch, num_nodes, k, edge_features])
-
-
-@pytest.mark.torch
-def test_gather_edges_values():
-    """Test that _gather_edges gathers the correct edge feature vectors."""
-    edges = torch.tensor([[[[0., 1.], [10., 11.], [20., 21.]],
-                           [[100., 101.], [110., 111.], [120., 121.]],
-                           [[200., 201.], [210., 211.], [220., 221.]]]])
-    neighbor_idx = torch.tensor([[[1, 2], [0, 2], [0, 1]]])
-
-    out = gather_edges(edges, neighbor_idx)
-
-    assert torch.allclose(out[0, 0, 0], torch.tensor([10., 11.]))
-    assert torch.allclose(out[0, 0, 1], torch.tensor([20., 21.]))
-    assert torch.allclose(out[0, 1, 0], torch.tensor([100., 101.]))
-    assert torch.allclose(out[0, 2, 1], torch.tensor([210., 211.]))
-
 
 @pytest.mark.torch
 def test_positional_encodings_init():
@@ -87,25 +56,6 @@ def test_positional_encodings_output_shape():
 
 
 @pytest.mark.torch
-def test_positional_encodings_cross_chain_bucket():
-    """Test that cross-chain residue pairs use the dedicated encoding bucket.
-
-    For the same sequence offset, embeddings should differ when residues are on
-    different chains versus the same chain.
-    """
-    layer = PositionalEncodings(num_embeddings=4, max_relative_feature=2)
-
-    offset = torch.tensor([[[0]]])
-    same_chain = torch.tensor([[[1.]]])
-    diff_chain = torch.tensor([[[0.]]])
-
-    same_chain_out = layer(offset, same_chain)
-    diff_chain_out = layer(offset, diff_chain)
-
-    assert not torch.allclose(same_chain_out, diff_chain_out)
-
-
-@pytest.mark.torch
 def test_protein_features_layer_init():
     """Test that ProteinFeaturesLayer initializes its submodules correctly."""
     edge_features = 64
@@ -128,19 +78,6 @@ def test_protein_features_layer_init():
     assert isinstance(layer.embeddings, PositionalEncodings)
     assert layer.edge_embedding.in_features == num_positional_embeddings + num_rbf * 25
     assert layer.edge_embedding.out_features == edge_features
-
-
-@pytest.mark.torch
-def test_protein_features_layer_dist_output_shape():
-    """Test that dist() returns neighbor distances and indices with correct shape."""
-    layer = ProteinFeaturesLayer(edge_features=32, top_k=3)
-    Ca = torch.rand(2, 5, 3)
-    mask = torch.ones(2, 5)
-
-    D_neighbors, E_idx = layer.dist(Ca, mask)
-
-    assert D_neighbors.shape == torch.Size([2, 5, 3])
-    assert E_idx.shape == torch.Size([2, 5, 3])
 
 
 @pytest.mark.torch
@@ -192,17 +129,6 @@ def test_protein_features_layer_dist_masked_residues():
 
     for node in [0, 2, 3]:
         assert 1 not in E_idx[0, node].tolist()
-
-
-@pytest.mark.torch
-def test_protein_features_layer_rbf_output_shape():
-    """Test that rbf() encodes distances to the expected number of bins."""
-    layer = ProteinFeaturesLayer(edge_features=32, num_rbf=8, top_k=4)
-    D = torch.rand(2, 6, 4)
-
-    out = layer.rbf(D)
-
-    assert out.shape == torch.Size([2, 6, 4, 8])
 
 
 @pytest.mark.torch

--- a/deepchem/models/torch_models/tests/test_ProteinMPNN.py
+++ b/deepchem/models/torch_models/tests/test_ProteinMPNN.py
@@ -6,10 +6,6 @@ torch = pytest.importorskip("torch")
 try:
     import torch
     has_torch = True
-except ModuleNotFoundError:
-    has_torch = False
-
-if has_torch:
     from deepchem.models.torch_models.ProteinMPNN import (
         PositionalEncodings,
         ProteinFeaturesLayer,
@@ -18,6 +14,8 @@ if has_torch:
         ProteinStructureData,
         _MapperProteinMPNN,
     )
+except ImportError:
+    has_torch = False
 
 
 @pytest.mark.torch

--- a/deepchem/models/torch_models/tests/test_ProteinMPNN.py
+++ b/deepchem/models/torch_models/tests/test_ProteinMPNN.py
@@ -1,0 +1,335 @@
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+try:
+    import torch
+    has_torch = True
+except ModuleNotFoundError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.ProteinMPNN import (
+        PositionalEncodings,
+        ProteinFeaturesLayer,
+    )
+    from deepchem.feat.ProteinMPNN_featurizer import (
+        ProteinStructureData,
+        _MapperProteinMPNN,
+    )
+
+    from deepchem.utils.ProteinMPNN_utils import gather_edges
+
+
+@pytest.mark.torch
+def test_gather_edges_output_shape():
+    """Test that _gather_edges returns a tensor with the correct shape."""
+    batch, num_nodes, k, edge_features = 2, 5, 3, 16
+    edges = torch.rand(batch, num_nodes, num_nodes, edge_features)
+    neighbor_idx = torch.randint(0, num_nodes, (batch, num_nodes, k))
+
+    out = gather_edges(edges, neighbor_idx)
+
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == torch.Size([batch, num_nodes, k, edge_features])
+
+
+@pytest.mark.torch
+def test_gather_edges_values():
+    """Test that _gather_edges gathers the correct edge feature vectors."""
+    edges = torch.tensor([[[[0., 1.], [10., 11.], [20., 21.]],
+                           [[100., 101.], [110., 111.], [120., 121.]],
+                           [[200., 201.], [210., 211.], [220., 221.]]]])
+    neighbor_idx = torch.tensor([[[1, 2], [0, 2], [0, 1]]])
+
+    out = gather_edges(edges, neighbor_idx)
+
+    assert torch.allclose(out[0, 0, 0], torch.tensor([10., 11.]))
+    assert torch.allclose(out[0, 0, 1], torch.tensor([20., 21.]))
+    assert torch.allclose(out[0, 1, 0], torch.tensor([100., 101.]))
+    assert torch.allclose(out[0, 2, 1], torch.tensor([210., 211.]))
+
+
+@pytest.mark.torch
+def test_positional_encodings_init():
+    """Test that PositionalEncodings initializes its linear layer correctly."""
+    num_embeddings = 8
+    max_relative_feature = 4
+
+    layer = PositionalEncodings(num_embeddings=num_embeddings,
+                                max_relative_feature=max_relative_feature)
+
+    assert layer.num_embeddings == num_embeddings
+    assert layer.max_relative_feature == max_relative_feature
+    assert layer.linear.in_features == 2 * max_relative_feature + 2
+    assert layer.linear.out_features == num_embeddings
+
+
+@pytest.mark.torch
+def test_positional_encodings_output_shape():
+    """Test that PositionalEncodings returns embeddings with the correct shape.
+
+    Given offset and mask tensors of shape ``(batch, num_nodes, k)``, the
+    output should have shape ``(batch, num_nodes, k, num_embeddings)``.
+    """
+    batch, num_nodes, k = 2, 6, 4
+    num_embeddings = 16
+
+    layer = PositionalEncodings(num_embeddings=num_embeddings)
+    offset = torch.randint(-5, 6, (batch, num_nodes, k))
+    mask = torch.ones(batch, num_nodes, k)
+
+    out = layer(offset, mask)
+
+    assert isinstance(out, torch.Tensor)
+    assert out.shape == torch.Size([batch, num_nodes, k, num_embeddings])
+
+
+@pytest.mark.torch
+def test_positional_encodings_cross_chain_bucket():
+    """Test that cross-chain residue pairs use the dedicated encoding bucket.
+
+    For the same sequence offset, embeddings should differ when residues are on
+    different chains versus the same chain.
+    """
+    layer = PositionalEncodings(num_embeddings=4, max_relative_feature=2)
+
+    offset = torch.tensor([[[0]]])
+    same_chain = torch.tensor([[[1.]]])
+    diff_chain = torch.tensor([[[0.]]])
+
+    same_chain_out = layer(offset, same_chain)
+    diff_chain_out = layer(offset, diff_chain)
+
+    assert not torch.allclose(same_chain_out, diff_chain_out)
+
+
+@pytest.mark.torch
+def test_protein_features_layer_init():
+    """Test that ProteinFeaturesLayer initializes its submodules correctly."""
+    edge_features = 64
+    num_positional_embeddings = 8
+    num_rbf = 4
+    top_k = 10
+    augment_eps = 0.1
+
+    layer = ProteinFeaturesLayer(
+        edge_features=edge_features,
+        num_positional_embeddings=num_positional_embeddings,
+        num_rbf=num_rbf,
+        top_k=top_k,
+        augment_eps=augment_eps)
+
+    assert layer.edge_features == edge_features
+    assert layer.top_k == top_k
+    assert layer.augment_eps == augment_eps
+    assert layer.num_rbf == num_rbf
+    assert isinstance(layer.embeddings, PositionalEncodings)
+    assert layer.edge_embedding.in_features == num_positional_embeddings + num_rbf * 25
+    assert layer.edge_embedding.out_features == edge_features
+
+
+@pytest.mark.torch
+def test_protein_features_layer_dist_output_shape():
+    """Test that dist() returns neighbor distances and indices with correct shape."""
+    layer = ProteinFeaturesLayer(edge_features=32, top_k=3)
+    Ca = torch.rand(2, 5, 3)
+    mask = torch.ones(2, 5)
+
+    D_neighbors, E_idx = layer.dist(Ca, mask)
+
+    assert D_neighbors.shape == torch.Size([2, 5, 3])
+    assert E_idx.shape == torch.Size([2, 5, 3])
+
+
+@pytest.mark.torch
+def test_protein_features_layer_dist_clips_top_k():
+    """Test that dist() clips k when the number of residues is less than top_k."""
+    layer = ProteinFeaturesLayer(edge_features=32, top_k=10)
+    num_nodes = 4
+    Ca = torch.rand(1, num_nodes, 3)
+    mask = torch.ones(1, num_nodes)
+
+    D_neighbors, E_idx = layer.dist(Ca, mask)
+
+    assert D_neighbors.shape == torch.Size([1, num_nodes, num_nodes])
+    assert E_idx.shape == torch.Size([1, num_nodes, num_nodes])
+
+
+@pytest.mark.torch
+def test_protein_features_layer_dist_neighbors():
+    """Test that dist() selects spatially close residues as neighbors.
+
+    Constructs residues on a line and verifies that a query residue prefers
+    nearby indices over a distant one.
+    """
+    layer = ProteinFeaturesLayer(edge_features=32, top_k=3)
+    Ca = torch.tensor([[[0., 0., 0.], [1., 0., 0.], [2., 0., 0.], [10., 0.,
+                                                                   0.]]])
+    mask = torch.ones(1, 4)
+
+    _, E_idx = layer.dist(Ca, mask)
+
+    assert 1 in E_idx[0, 0].tolist()
+    assert 2 in E_idx[0, 0].tolist()
+    assert 3 not in E_idx[0, 0].tolist()
+
+
+@pytest.mark.torch
+def test_protein_features_layer_dist_masked_residues():
+    """Test that dist() excludes masked residues from neighbor selection.
+
+    Verifies that masked residues are not selected as neighbors for valid
+    query residues.
+    """
+    layer = ProteinFeaturesLayer(edge_features=32, top_k=2)
+    Ca = torch.tensor([[[0., 0., 0.], [1., 0., 0.], [5., 0., 0.], [6., 0.,
+                                                                   0.]]])
+    mask = torch.tensor([[1., 0., 1., 1.]])
+
+    _, E_idx = layer.dist(Ca, mask)
+
+    for node in [0, 2, 3]:
+        assert 1 not in E_idx[0, node].tolist()
+
+
+@pytest.mark.torch
+def test_protein_features_layer_rbf_output_shape():
+    """Test that rbf() encodes distances to the expected number of bins."""
+    layer = ProteinFeaturesLayer(edge_features=32, num_rbf=8, top_k=4)
+    D = torch.rand(2, 6, 4)
+
+    out = layer.rbf(D)
+
+    assert out.shape == torch.Size([2, 6, 4, 8])
+
+
+@pytest.mark.torch
+def test_protein_features_layer_rbf_peak_near_center():
+    """Test that rbf() assigns the largest response near the matching center."""
+    layer = ProteinFeaturesLayer(edge_features=32, num_rbf=4, top_k=1)
+    D = torch.tensor([[[[2.0]]]])
+
+    out = layer.rbf(D)
+
+    assert out.argmax(dim=-1).item() == 0
+
+
+@pytest.mark.torch
+def test_protein_features_layer_get_rbf_output_shape():
+    """Test that get_rbf() returns gathered pairwise RBF features."""
+    layer = ProteinFeaturesLayer(edge_features=32, num_rbf=8, top_k=3)
+    A = torch.rand(1, 5, 3)
+    B = torch.rand(1, 5, 3)
+    E_idx = torch.randint(0, 5, (1, 5, 3))
+
+    out = layer.get_rbf(A, B, E_idx)
+
+    assert out.shape == torch.Size([1, 5, 3, 8])
+
+
+@pytest.mark.torch
+def test_protein_features_layer_get_rbf_values():
+    """Test that get_rbf() matches rbf() on manually gathered distances."""
+    layer = ProteinFeaturesLayer(edge_features=32, num_rbf=4, top_k=2)
+    A = torch.tensor([[[0., 0., 0.], [3., 0., 0.], [6., 0., 0.]]])
+    B = torch.tensor([[[0., 0., 0.], [4., 0., 0.], [6., 0., 0.]]])
+    E_idx = torch.tensor([[[1, 2], [0, 2], [0, 1]]])
+
+    out = layer.get_rbf(A, B, E_idx)
+
+    # Node 0, neighbor 1: distance between A[0] and B[1] is 4.0
+    assert torch.allclose(out[0, 0, 0],
+                          layer.rbf(torch.tensor([[[4.0]]]))[0, 0, 0])
+    # Node 0, neighbor 2: distance between A[0] and B[2] is 6.0
+    assert torch.allclose(out[0, 0, 1],
+                          layer.rbf(torch.tensor([[[6.0]]]))[0, 0, 0])
+
+
+@pytest.mark.torch
+def test_protein_features_layer_forward_output_shape():
+    """Test that forward() returns edge features and neighbor indices."""
+    batch, num_nodes = 2, 12
+    edge_features = 64
+    top_k = 5
+
+    layer = ProteinFeaturesLayer(edge_features=edge_features, top_k=top_k)
+    X, mask, residue_idx, chain_labels = _make_structure_inputs(
+        batch, num_nodes)
+
+    E, E_idx = layer(X, mask, residue_idx, chain_labels)
+
+    assert E.shape == torch.Size([batch, num_nodes, top_k, edge_features])
+    assert E_idx.shape == torch.Size([batch, num_nodes, top_k])
+    assert torch.isfinite(E).all()
+
+
+@pytest.mark.torch
+def test_protein_features_layer_forward_batched():
+    """Test that forward() handles independent batch elements correctly."""
+    batch, num_nodes = 3, 8
+    layer = ProteinFeaturesLayer(edge_features=32, top_k=4)
+
+    X, mask, residue_idx, chain_labels = _make_structure_inputs(
+        batch, num_nodes)
+    E, E_idx = layer(X, mask, residue_idx, chain_labels)
+
+    assert E.shape[0] == batch
+    assert E_idx.shape[0] == batch
+
+
+@pytest.mark.torch
+def test_protein_features_layer_forward_augmentation():
+    """Test that coordinate augmentation is applied only during training."""
+    torch.manual_seed(0)
+    layer = ProteinFeaturesLayer(edge_features=32, top_k=4, augment_eps=0.5)
+    X, mask, residue_idx, chain_labels = _make_structure_inputs(1, 10)
+
+    layer.eval()
+    E_eval_1, _ = layer(X, mask, residue_idx, chain_labels)
+    E_eval_2, _ = layer(X, mask, residue_idx, chain_labels)
+    assert torch.allclose(E_eval_1, E_eval_2)
+
+    layer.train()
+    E_train_1, _ = layer(X, mask, residue_idx, chain_labels)
+    E_train_2, _ = layer(X, mask, residue_idx, chain_labels)
+    assert not torch.allclose(E_train_1, E_train_2)
+
+
+@pytest.mark.torch
+def test_protein_features_layer_forward_with_featurizer_output():
+    """Test forward() with tensors derived from the ProteinMPNN featurizer."""
+    coords = np.array(
+        [
+            [[0.000, 0.000, 0.000], [1.458, 0.000, 0.000],
+             [2.009, 1.424, 0.000], [1.319, 2.441, 0.000]],
+            [[3.326, 1.488, 0.000], [4.015, 2.766, 0.000],
+             [5.516, 2.517, 0.000], [6.155, 3.421, 0.000]],
+        ],
+        dtype=np.float32,
+    )
+    structure = ProteinStructureData(backbone_coords=coords, sequence='AG')
+    mapper = _MapperProteinMPNN(structure)
+    X_np, _, mask_np, _, residue_idx_np, chain_encoding_np = mapper.values
+
+    X = torch.from_numpy(X_np).float().unsqueeze(0)
+    mask = torch.from_numpy(mask_np).float().unsqueeze(0)
+    residue_idx = torch.from_numpy(residue_idx_np).unsqueeze(0)
+    chain_labels = torch.from_numpy(chain_encoding_np).float().unsqueeze(0)
+
+    layer = ProteinFeaturesLayer(edge_features=128, top_k=2)
+    E, E_idx = layer(X, mask, residue_idx, chain_labels)
+
+    assert E.shape == torch.Size([1, 2, 2, 128])
+    assert E_idx.shape == torch.Size([1, 2, 2])
+    assert torch.isfinite(E).all()
+
+
+def _make_structure_inputs(batch: int, num_nodes: int):
+    """Helper to create random protein structure tensors for model tests."""
+    X = torch.randn(batch, num_nodes, 4, 3)
+    mask = torch.ones(batch, num_nodes)
+    residue_idx = torch.arange(num_nodes).unsqueeze(0).expand(batch, -1)
+    chain_labels = torch.ones(batch, num_nodes)
+    return X, mask, residue_idx, chain_labels

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -303,7 +303,7 @@ Torch Layers
 
 .. autoclass:: deepchem.models.torch_models.layers.SpectralConv
   :members:
-  
+
 .. autoclass:: deepchem.models.torch_models.chemnet_layers.Stem
   :members:
 
@@ -314,7 +314,7 @@ Torch Layers
   :members:
 
 .. autoclass:: deepchem.models.torch_models.fno.FNOBlock
-  :members:  
+  :members:
 
 .. autoclass:: deepchem.models.torch_models.chemnet_layers.InceptionResnetC
   :members:
@@ -545,4 +545,10 @@ RFDiffusion Layers
    :members:
 
 .. autoclass:: deepchem.models.torch_models.layers.BackboneDiffusion
+   :members:
+
+ProteinMPNN Layers
+------------------
+
+.. autoclass:: deepchem.models.torch_models.ProteinMPNN.ProteinFeaturesLayer
    :members:


### PR DESCRIPTION
## Description

Fix #(issue)

This PR adds the first PyTorch model components for ProteinMPNN in DeepChem, laying the groundwork for structure-conditioned protein sequence design based on Dauparas et al. The implementation follows the reference architecture’s feature-extraction stage and integrates with existing DeepChem ProteinMPNN support. The two classes introduced in this PR are as follows:

- PositionalEncodings: Encodes relative residue offsets and same-chain membership for kNN graph edges into learnable edge features used by the ProteinMPNN encoder.
- ProteinFeaturesLayer: Builds a k-nearest-neighbor graph from backbone coordinates and computes normalized edge embeddings from RBF-encoded distances across 25 backbone atom pairs (including virtual Cβ), combined with the positional encodings above.

Unit tests cover layer initialization, kNN neighbor selection, masking behavior, RBF encoding, training-time coordinate augmentation, batched forward passes, and end-to-end compatibility with featurizer output.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings
