### PR TITLE
Fix AtomicConv applying dropout during eval

### DIFF
--- a/deepchem/models/torch_models/layers.py
+++ b/deepchem/models/torch_models/layers.py
@@ -2801,7 +2801,7 @@ class AtomicConv(nn.Module):
             x = layer(inputs_x)
 
             if dropout > 0:
-                x = F.dropout(x, dropout)
+                x = F.dropout(x, dropout, training=self.training)
 
             if activation_fn is not None:
                 x = activation_fn(x)

--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -175,8 +175,7 @@ def test_atomic_convolution_module_eval_dropout():
                              size=(batch_size, num_atoms, max_num_neighbors))
         nbrs_z = torch.randint(1,
                                10,
-                               size=(batch_size, num_atoms,
-                                     max_num_neighbors))
+                               size=(batch_size, num_atoms, max_num_neighbors))
         return coords, nbrs, nbrs_z
 
     frag1 = _frag(frag1_num_atoms)

--- a/deepchem/models/torch_models/tests/test_acnn.py
+++ b/deepchem/models/torch_models/tests/test_acnn.py
@@ -147,3 +147,51 @@ def test_atomic_convolution_model_variable():
     preds = atomic_convnet.predict(train)
     assert preds.shape == (1, 1)
     assert np.count_nonzero(preds) > 0
+
+
+@pytest.mark.torch
+def test_atomic_convolution_module_eval_dropout():
+    """AtomicConv must not apply dropout once the module is in eval mode."""
+    import torch
+    from deepchem.models.torch_models.layers import AtomicConv
+
+    frag1_num_atoms = 4
+    frag2_num_atoms = 6
+    max_num_neighbors = 3
+    batch_size = 2
+
+    acm = AtomicConv(n_tasks=1,
+                     frag1_num_atoms=frag1_num_atoms,
+                     frag2_num_atoms=frag2_num_atoms,
+                     complex_num_atoms=frag1_num_atoms + frag2_num_atoms,
+                     max_num_neighbors=max_num_neighbors,
+                     batch_size=batch_size,
+                     layer_sizes=[10],
+                     dropouts=0.5)
+
+    def _frag(num_atoms):
+        coords = torch.rand(batch_size, num_atoms, 3)
+        nbrs = torch.randint(num_atoms,
+                             size=(batch_size, num_atoms, max_num_neighbors))
+        nbrs_z = torch.randint(1,
+                               10,
+                               size=(batch_size, num_atoms,
+                                     max_num_neighbors))
+        return coords, nbrs, nbrs_z
+
+    frag1 = _frag(frag1_num_atoms)
+    frag2 = _frag(frag2_num_atoms)
+    complex_ = _frag(frag1_num_atoms + frag2_num_atoms)
+    inputs = [
+        frag1[0], frag1[1], frag1[2], None, frag2[0], frag2[1], frag2[2], None,
+        complex_[0], complex_[1], complex_[2]
+    ]
+
+    acm.eval()
+    with torch.no_grad():
+        first = acm(inputs)[0]
+        second = acm(inputs)[0]
+
+    assert torch.equal(
+        first,
+        second), "eval() output must be deterministic, dropout is still active"


### PR DESCRIPTION
`AtomicConv.forward` calls `F.dropout(x, dropout)` without passing `training`. `F.dropout` defaults to `training=True`, so dropout stays active after `model.eval()`. `dropouts` defaults to `0.5` and `AtomConvModel.predict()` runs through this path, so repeated predictions on the same input differ.

Other modules already guard this. `fcnet.py` uses `if dropout > 0.0 and self.training`, and the uncertainty path uses an explicit `dropout_switch`. `AtomicConv` had neither.

Passes `training=self.training` so `eval()` disables dropout, and adds a test that runs two forward passes under `eval()` on the same input and asserts the outputs are identical.

Closes #5092.