### PR TITLE
Add NequIP model skeleton

### DIFF
--- a/deepchem/data/__init__.py
+++ b/deepchem/data/__init__.py
@@ -21,6 +21,7 @@ from deepchem.data.data_loader import CSVLoader
 from deepchem.data.data_loader import UserCSVLoader
 from deepchem.data.data_loader import JsonLoader
 from deepchem.data.data_loader import SDFLoader
+from deepchem.data.data_loader import MaterialsLoader
 from deepchem.data.data_loader import FASTALoader
 from deepchem.data.data_loader import FASTQLoader
 from deepchem.data.data_loader import ImageLoader

--- a/deepchem/data/data_loader.py
+++ b/deepchem/data/data_loader.py
@@ -1807,6 +1807,209 @@ class InMemoryLoader(DataLoader):
         return X, np.array(labels), np.array(weights), np.array(ids)
 
 
+class MaterialsLoader(DataLoader):
+    """Creates ``Dataset`` objects from ASE-readable atomistic files.
+
+    This loader streams ``ase.Atoms`` frames from one or more ASE-readable
+    files, featurizes each frame, and stores the results in a ``DiskDataset``.
+    Each frame becomes one datapoint in the output dataset.
+
+    Examples
+    --------
+    >>> import deepchem as dc
+    >>> featurizer = dc.feat.AtomisticRadiusGraphFeaturizer(cutoff=2.5)  # doctest: +SKIP
+    >>> loader = dc.data.MaterialsLoader(tasks=["energy"], featurizer=featurizer)  # doctest: +SKIP
+    >>> dataset = loader.create_dataset("molecule.extxyz")  # doctest: +SKIP
+
+    Notes
+    -----
+    This loader requires ASE to be installed. Requested labels are extracted
+    from ``atoms.info`` for energy and ``atoms.arrays`` for forces.
+
+    Parameters
+    ----------
+    tasks: List[str]
+        List of task names to extract. Supported values are ``"energy"`` and
+        ``"forces"``.
+    featurizer: Featurizer
+        Featurizer to use for each ``ase.Atoms`` frame.
+    energy_key: str, default "energy"
+        Key to read from ``atoms.info`` for energy labels.
+    forces_key: str, default "forces"
+        Key to read from ``atoms.arrays`` for force labels.
+    log_every_n: int, default 1000
+        Writes a logging statement this often.
+    """
+
+    _ALLOWED_TASKS: Tuple[str, str] = ("energy", "forces")
+
+    def __init__(self,
+                 tasks: List[str],
+                 featurizer: Featurizer,
+                 energy_key: str = "energy",
+                 forces_key: str = "forces",
+                 log_every_n: int = 1000) -> None:
+        """Initializes MaterialsLoader.
+
+        Parameters
+        ----------
+        tasks: List[str]
+            List of task names to extract. Supported values are ``"energy"`` and
+            ``"forces"``.
+        featurizer: Featurizer
+            Featurizer to use to process each ``ase.Atoms`` frame.
+        energy_key: str, optional (default "energy")
+            Key to read from ``atoms.info`` for energy labels.
+        forces_key: str, optional (default "forces")
+            Key to read from ``atoms.arrays`` for force labels.
+        log_every_n: int, optional (default 1000)
+            Writes a logging statement this often.
+        """
+        self._validate_tasks(tasks)
+        super().__init__(tasks=tasks,
+                         featurizer=featurizer,
+                         id_field=None,
+                         log_every_n=log_every_n)
+        self.energy_key = energy_key
+        self.forces_key = forces_key
+
+    def _validate_tasks(self, tasks: List[str]) -> None:
+        invalid_tasks = [
+            task for task in tasks if task not in self._ALLOWED_TASKS
+        ]
+        if invalid_tasks:
+            raise ValueError("Unsupported tasks: %s. Supported tasks are %s." %
+                             (invalid_tasks, list(self._ALLOWED_TASKS)))
+
+    def _process_inputs(self, inputs: OneOrMany[str]) -> List[str]:
+        if isinstance(inputs, str):
+            return [inputs]
+        try:
+            input_paths = list(inputs)
+        except TypeError:
+            raise ValueError(
+                "MaterialsLoader inputs must be a path string or an iterable "
+                "of path strings.")
+        if not all(isinstance(path, str) for path in input_paths):
+            raise ValueError(
+                "MaterialsLoader inputs must contain only path strings.")
+        return input_paths
+
+    def _extract_labels(self, atoms: Any, input_path: str,
+                        frame_index: int) -> np.ndarray:
+        labels = np.empty((len(self.tasks),), dtype=object)
+        for task_index, task in enumerate(self.tasks):
+            if task == "energy":
+                if self.energy_key not in atoms.info:
+                    raise ValueError(
+                        "Missing requested label for task 'energy' with key "
+                        "'%s' in file '%s' frame %d." %
+                        (self.energy_key, input_path, frame_index))
+                labels[task_index] = atoms.info[self.energy_key]
+            elif task == "forces":
+                if self.forces_key not in atoms.arrays:
+                    raise ValueError(
+                        "Missing requested label for task 'forces' with key "
+                        "'%s' in file '%s' frame %d." %
+                        (self.forces_key, input_path, frame_index))
+                forces = np.asarray(atoms.arrays[self.forces_key],
+                                    dtype=np.float32)
+                if forces.shape != (len(atoms), 3):
+                    raise ValueError(
+                        "Invalid forces shape %s for task 'forces' with key "
+                        "'%s' in file '%s' frame %d. Expected (%d, 3)." %
+                        (forces.shape, self.forces_key, input_path, frame_index,
+                         len(atoms)))
+                labels[task_index] = forces
+        return labels
+
+    def create_dataset(self,
+                       inputs: OneOrMany[str],
+                       data_dir: Optional[str] = None,
+                       shard_size: Optional[int] = 8192) -> DiskDataset:
+        """Creates a ``Dataset`` from ASE-readable input files.
+
+        Parameters
+        ----------
+        inputs: OneOrMany[str]
+            One filename or a list/tuple of filenames understood by ASE.
+            Each ``ase.Atoms`` frame becomes one datapoint in the output
+            dataset.
+        data_dir: str, optional (default None)
+            Directory to store featurized dataset.
+        shard_size: int, optional (default 8192)
+            Number of examples stored in each shard.
+
+        Returns
+        -------
+        DiskDataset
+            A ``DiskDataset`` object containing the featurized atomic frames
+            from ``inputs``.
+        """
+        try:
+            from ase.io import iread
+        except ImportError:
+            raise ImportError("This class requires ASE to be installed.")
+
+        input_files = self._process_inputs(inputs)
+        logger.info("Loading raw samples now.")
+        logger.info("shard_size: %s" % str(shard_size))
+
+        def shard_generator():
+            features: List[Any] = []
+            labels: List[np.ndarray] = []
+            ids: List[str] = []
+
+            def finalize_shard():
+                X = np.asarray(features, dtype=object)
+                ids_array = np.asarray(ids, dtype=object)
+                if len(self.tasks) == 0:
+                    return X, None, None, ids_array
+                y = np.empty((len(labels), len(self.tasks)), dtype=object)
+                for sample_index, sample_labels in enumerate(labels):
+                    y[sample_index, :] = sample_labels
+                w = np.ones((len(labels), len(self.tasks)), dtype=np.float32)
+                return X, y, w, ids_array
+
+            for input_path in input_files:
+                for frame_index, atoms in enumerate(iread(input_path,
+                                                          index=":")):
+                    if len(ids) % self.log_every_n == 0:
+                        logger.info("Featurizing frame %d from %s", frame_index,
+                                    input_path)
+                    frame_features = self.featurizer.featurize(
+                        [atoms], log_every_n=self.log_every_n)
+                    if len(frame_features) != 1:
+                        raise ValueError(
+                            "Featurizer returned %d outputs for file '%s' "
+                            "frame %d. Expected exactly 1." %
+                            (len(frame_features), input_path, frame_index))
+                    feature = frame_features[0]
+                    if isinstance(feature, np.ndarray) and feature.size == 0:
+                        raise ValueError(
+                            "Failed to featurize file '%s' frame %d." %
+                            (input_path, frame_index))
+                    features.append(feature)
+                    ids.append(f"{input_path}:{frame_index}")
+                    if len(self.tasks) > 0:
+                        labels.append(
+                            self._extract_labels(atoms, input_path,
+                                                 frame_index))
+
+                    if shard_size is not None and len(features) >= shard_size:
+                        yield finalize_shard()
+                        features = []
+                        labels = []
+                        ids = []
+
+            if features:
+                yield finalize_shard()
+
+        return DiskDataset.create_dataset(shard_generator(),
+                                          data_dir=data_dir,
+                                          tasks=self.tasks)
+
+
 class DFTYamlLoader(DataLoader):
     """
     Creates a `Dataset` object from YAML input files.

--- a/deepchem/data/tests/materials_loader_energy_forces.extxyz
+++ b/deepchem/data/tests/materials_loader_energy_forces.extxyz
@@ -1,0 +1,9 @@
+2
+Properties=species:S:1:pos:R:3:my_forces:R:3 my_energy=1.5
+H 0.0 0.0 0.0 0.1 0.0 0.0
+O 1.0 0.0 0.0 -0.1 0.0 0.0
+3
+Properties=species:S:1:pos:R:3:my_forces:R:3 my_energy=-2.0
+C 0.0 0.0 0.0 0.2 0.0 0.0
+H 0.8 0.0 0.0 0.0 0.2 0.0
+H -0.8 0.0 0.0 0.0 0.0 0.2

--- a/deepchem/data/tests/materials_loader_unlabeled.xyz
+++ b/deepchem/data/tests/materials_loader_unlabeled.xyz
@@ -1,0 +1,9 @@
+2
+water-like frame
+H 0.0 0.0 0.0
+O 1.0 0.0 0.0
+3
+small hydrocarbon-like frame
+C 0.0 0.0 0.0
+H 0.8 0.0 0.0
+H -0.8 0.0 0.0

--- a/deepchem/data/tests/test_materials_loader.py
+++ b/deepchem/data/tests/test_materials_loader.py
@@ -1,0 +1,136 @@
+import os
+
+import numpy as np
+import pytest
+
+import deepchem as dc
+
+pytest.importorskip("ase")
+
+
+def _asset_path(filename):
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    return os.path.join(current_dir, filename)
+
+
+def _make_loader(tasks):
+    featurizer = dc.feat.AtomisticRadiusGraphFeaturizer(cutoff=2.5)
+    return dc.data.MaterialsLoader(tasks=tasks,
+                                   featurizer=featurizer,
+                                   energy_key="my_energy",
+                                   forces_key="my_forces")
+
+
+def test_materials_loader_energy_from_asset():
+    input_file = _asset_path("materials_loader_energy_forces.extxyz")
+
+    dataset = _make_loader(["energy"]).create_dataset(input_file, shard_size=1)
+
+    assert len(dataset) == 2
+    assert dataset.y.shape == (2, 1)
+    assert dataset.w.shape == (2, 1)
+    assert float(dataset.y[0, 0]) == pytest.approx(1.5)
+    assert float(dataset.y[1, 0]) == pytest.approx(-2.0)
+
+
+def test_materials_loader_forces_variable_atom_counts_from_asset():
+    input_file = _asset_path("materials_loader_energy_forces.extxyz")
+
+    dataset = _make_loader(["forces"]).create_dataset(input_file)
+
+    assert len(dataset) == 2
+    assert dataset.y.shape == (2, 1)
+    assert dataset.y[0, 0].shape == (2, 3)
+    assert dataset.y[1, 0].shape == (3, 3)
+    np.testing.assert_allclose(
+        dataset.y[0, 0],
+        np.array([[0.1, 0.0, 0.0], [-0.1, 0.0, 0.0]], dtype=np.float32))
+    assert dataset.y[0, 0].dtype == np.float32
+
+
+def test_materials_loader_energy_and_forces_task_layout_from_asset():
+    input_file = _asset_path("materials_loader_energy_forces.extxyz")
+
+    dataset = _make_loader(["energy", "forces"]).create_dataset(input_file)
+
+    assert dataset.y.shape == (2, 2)
+    assert float(dataset.y[0, 0]) == pytest.approx(1.5)
+    assert dataset.y[0, 1].shape == (2, 3)
+    assert float(dataset.y[1, 0]) == pytest.approx(-2.0)
+    assert dataset.y[1, 1].shape == (3, 3)
+    np.testing.assert_array_equal(dataset.w, np.ones((2, 2), dtype=np.float32))
+
+
+def test_materials_loader_unlabeled_tasks_empty_from_xyz_asset():
+    input_file = _asset_path("materials_loader_unlabeled.xyz")
+
+    dataset = _make_loader([]).create_dataset(input_file)
+
+    assert len(dataset) == 2
+    assert len(dataset.get_task_names()) == 0
+    X, y, w, ids = dataset.get_shard(0)
+    assert len(X) == 2
+    assert y is None
+    assert w is None
+    assert list(ids) == [f"{input_file}:0", f"{input_file}:1"]
+
+
+def test_materials_loader_missing_requested_label_raises():
+    input_file = _asset_path("materials_loader_unlabeled.xyz")
+
+    with pytest.raises(
+            ValueError,
+            match=
+            "task 'energy'.*key 'my_energy'.*materials_loader_unlabeled.xyz.*frame 0"
+    ):
+        _make_loader(["energy"]).create_dataset(input_file)
+
+
+def test_materials_loader_invalid_forces_shape_raises(tmp_path):
+    input_file = tmp_path / "bad_forces.extxyz"
+    input_file.write_text(
+        "2\n"
+        "Properties=species:S:1:pos:R:3:my_forces:R:2 my_energy=1.0\n"
+        "H 0.0 0.0 0.0 0.1 0.0\n"
+        "O 1.0 0.0 0.0 -0.1 0.0\n")
+
+    with pytest.raises(
+            ValueError,
+            match="task 'forces'.*key 'my_forces'.*bad_forces.extxyz.*frame 0"):
+        _make_loader(["forces"]).create_dataset(str(input_file))
+
+
+def test_materials_loader_multiple_input_files_order_from_asset():
+    input_file = _asset_path("materials_loader_energy_forces.extxyz")
+
+    dataset = _make_loader(["energy"]).create_dataset([input_file, input_file],
+                                                      shard_size=2)
+
+    assert len(dataset) == 4
+    assert [float(value) for value in dataset.y[:, 0]] == [1.5, -2.0, 1.5, -2.0]
+    assert list(dataset.ids) == [
+        f"{input_file}:0", f"{input_file}:1", f"{input_file}:0",
+        f"{input_file}:1"
+    ]
+
+
+def test_materials_loader_graphdata_features_from_asset():
+    input_file = _asset_path("materials_loader_energy_forces.extxyz")
+
+    dataset = _make_loader(["energy"]).create_dataset(input_file)
+
+    assert isinstance(dataset.X[0], dc.feat.GraphData)
+    assert hasattr(dataset.X[0], "node_features")
+    assert hasattr(dataset.X[0], "edge_index")
+
+
+def test_materials_loader_invalid_task_raises():
+    featurizer = dc.feat.AtomisticRadiusGraphFeaturizer(cutoff=2.5)
+    with pytest.raises(ValueError, match="Unsupported tasks"):
+        dc.data.MaterialsLoader(tasks=["dipole"], featurizer=featurizer)
+
+
+@pytest.mark.parametrize("inputs", [5, ["frames.extxyz", 5]])
+def test_materials_loader_invalid_inputs_raise(inputs):
+    with pytest.raises(ValueError, match="MaterialsLoader"):
+        _make_loader([]).create_dataset(inputs)

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -57,6 +57,7 @@ from deepchem.models.torch_models.layers import ResidueEmbedding
 from deepchem.models.torch_models.layers import PositionalEncoding
 from deepchem.models.torch_models.layers import CosineSchedule
 from deepchem.models.torch_models.layers import BackboneDiffusion
+from deepchem.models.torch_models.nequip import NequIPModel
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel

--- a/deepchem/models/torch_models/nequip.py
+++ b/deepchem/models/torch_models/nequip.py
@@ -1,0 +1,205 @@
+"""DeepChem batching scaffold for future NequIP models."""
+
+from typing import Any, Iterable, List, Sequence, Tuple, Union
+
+import numpy as np
+import torch
+
+from deepchem.data import Dataset
+from deepchem.feat.graph_data import BatchGraphData, GraphData
+from deepchem.models.optimizers import LearningRateSchedule
+from deepchem.models.torch_models.torch_model import TorchModel
+from deepchem.utils.typing import LossFn
+
+
+class NequIPModel(TorchModel):
+    """Prepare variable-size atomistic batches for a future NequIP backbone.
+
+    This class is the DeepChem integration scaffold for NequIP-style models. It
+    batches :class:`GraphData` samples, preserves the requested task ordering,
+    and prepares graph-level energies and atom-level forces. It does not
+    implement the NequIP architecture or a physical loss.
+
+    Parameters
+    ----------
+    tasks : sequence of str
+        Any non-duplicated ordering of ``"energy"`` and ``"forces"``. An
+        empty sequence is supported for unlabeled prediction datasets.
+    model : torch.nn.Module
+        The atomistic model to receive a torch-converted
+        :class:`BatchGraphData`. Until the native NequIP backbone is added,
+        callers must supply this module.
+    loss : callable
+        A custom TorchModel loss callable accepting ``(outputs, labels,
+        weights)``. Labels and weights are lists in ``tasks`` order.
+    batch_size : int, default 100
+        Number of structures per batch. Final batches are never padded.
+    learning_rate : float or LearningRateSchedule, default 0.001
+        Learning rate passed to :class:`TorchModel`.
+    **kwargs
+        Additional arguments for :class:`TorchModel`.
+
+    Notes
+    -----
+    Energy tensors have shape ``(B, 1)``. Force tensors are concatenated in
+    graph order and have shape ``(N_total, 3)``; force weights have shape
+    ``(N_total, 1)``. Unlabeled batches return empty label and weight lists.
+    Backend conversion and all NequIP mathematics belong to later work.
+    """
+
+    _SUPPORTED_TASKS = {"energy", "forces"}
+
+    def __init__(self,
+                 tasks: Sequence[str],
+                 model: torch.nn.Module,
+                 loss: LossFn,
+                 batch_size: int = 100,
+                 learning_rate: Union[float, LearningRateSchedule] = 0.001,
+                 **kwargs: Any) -> None:
+        if isinstance(tasks, str):
+            raise ValueError("tasks must be a sequence of task names")
+        self.tasks: List[str] = list(tasks)
+        unsupported = [
+            task for task in self.tasks if task not in self._SUPPORTED_TASKS
+        ]
+        if unsupported:
+            raise ValueError(
+                "Unsupported NequIPModel tasks: %s. Supported tasks are %s." %
+                (unsupported, sorted(self._SUPPORTED_TASKS)))
+        if len(set(self.tasks)) != len(self.tasks):
+            raise ValueError("NequIPModel tasks must not contain duplicates.")
+        if not isinstance(model, torch.nn.Module):
+            raise TypeError("model must be a torch.nn.Module")
+        if not callable(loss):
+            raise TypeError("loss must be a custom callable")
+
+        self.task_to_index = {
+            task: index for index, task in enumerate(self.tasks)
+        }
+        output_types = kwargs.pop("output_types", ["prediction"])
+        super().__init__(model,
+                         loss=loss,
+                         output_types=output_types,
+                         batch_size=batch_size,
+                         learning_rate=learning_rate,
+                         **kwargs)
+
+    def default_generator(
+        self,
+        dataset: Dataset,
+        epochs: int = 1,
+        mode: str = "fit",
+        deterministic: bool = True,
+        pad_batches: bool = True
+    ) -> Iterable[Tuple[List[Any], List[Any], List[Any]]]:
+        """Iterate over structures without padding the final graph batch."""
+        del mode, pad_batches
+        for _ in range(epochs):
+            for X_b, y_b, w_b, _ in dataset.iterbatches(
+                    batch_size=self.batch_size,
+                    deterministic=deterministic,
+                    pad_batches=False):
+                yield [X_b], [y_b], [w_b]
+
+    def _prepare_batch(
+        self, batch: Tuple[Any, Any, Any]
+    ) -> Tuple[BatchGraphData, List[torch.Tensor], List[torch.Tensor]]:
+        """Batch graphs and prepare targets and weights in ``tasks`` order."""
+        inputs, labels, weights = batch
+        if inputs is None or len(inputs) != 1:
+            raise ValueError("inputs must contain one GraphData batch")
+        graphs = list(inputs[0])
+        if not graphs or not all(
+                isinstance(graph, GraphData) for graph in graphs):
+            raise ValueError(
+                "inputs must contain at least one GraphData sample")
+        graph_batch = BatchGraphData(graphs).numpy_to_torch(self.device)
+
+        if not self.tasks or self._is_missing(labels):
+            return graph_batch, [], []
+
+        label_array = np.asarray(labels[0], dtype=object)
+        expected_layout = (len(graphs), len(self.tasks))
+        if label_array.shape != expected_layout:
+            raise ValueError(
+                "Label array has shape %s. Expected %s for tasks %s." %
+                (label_array.shape, expected_layout, self.tasks))
+
+        if self._is_missing(weights):
+            weight_array = np.ones(expected_layout, dtype=np.float32)
+        else:
+            try:
+                weight_array = np.asarray(weights[0], dtype=np.float32)
+            except (TypeError, ValueError) as error:
+                raise ValueError(
+                    "Weights must be numeric structure/task values") from error
+            if weight_array.shape != expected_layout:
+                raise ValueError("Weight array has shape %s. Expected %s." %
+                                 (weight_array.shape, expected_layout))
+            if not np.isfinite(weight_array).all():
+                raise ValueError("Weights must be finite")
+
+        prepared_labels: List[torch.Tensor] = []
+        prepared_weights: List[torch.Tensor] = []
+        for task in self.tasks:
+            task_index = self.task_to_index[task]
+            if task == "energy":
+                energies = []
+                for sample_index in range(len(graphs)):
+                    try:
+                        energy = np.asarray(label_array[sample_index,
+                                                        task_index],
+                                            dtype=np.float32)
+                    except (TypeError, ValueError) as error:
+                        raise ValueError(
+                            "Energy label for sample %d must be a numeric scalar"
+                            % sample_index) from error
+                    if energy.shape != () or not np.isfinite(energy).item():
+                        raise ValueError(
+                            "Energy label for sample %d must be a finite scalar"
+                            % sample_index)
+                    energies.append(energy.item())
+                task_labels = torch.tensor(energies,
+                                           dtype=torch.float32,
+                                           device=self.device).view(-1, 1)
+                task_weights = torch.as_tensor(weight_array[:, task_index,
+                                                            None],
+                                               device=self.device)
+            else:
+                force_labels = []
+                force_weights = []
+                for sample_index, graph in enumerate(graphs):
+                    try:
+                        forces = np.asarray(label_array[sample_index,
+                                                        task_index],
+                                            dtype=np.float32)
+                    except (TypeError, ValueError) as error:
+                        raise ValueError(
+                            "Force labels for sample %d must be numeric" %
+                            sample_index) from error
+                    expected_shape = (graph.num_nodes, 3)
+                    if forces.shape != expected_shape:
+                        raise ValueError(
+                            "Force labels for sample %d have shape %s. Expected %s."
+                            % (sample_index, forces.shape, expected_shape))
+                    if not np.isfinite(forces).all():
+                        raise ValueError(
+                            "Force labels for sample %d must be finite" %
+                            sample_index)
+                    force_labels.append(forces)
+                    force_weights.append(
+                        np.full((graph.num_nodes, 1),
+                                weight_array[sample_index, task_index],
+                                dtype=np.float32))
+                task_labels = torch.as_tensor(np.concatenate(force_labels),
+                                              device=self.device)
+                task_weights = torch.as_tensor(np.concatenate(force_weights),
+                                               device=self.device)
+            prepared_labels.append(task_labels)
+            prepared_weights.append(task_weights)
+
+        return graph_batch, prepared_labels, prepared_weights
+
+    @staticmethod
+    def _is_missing(values: Any) -> bool:
+        return values is None or len(values) == 0 or values[0] is None

--- a/deepchem/models/torch_models/tests/test_nequip.py
+++ b/deepchem/models/torch_models/tests/test_nequip.py
@@ -1,0 +1,250 @@
+"""Tests for the NequIP DeepChem integration scaffold."""
+
+import numpy as np
+import pytest
+import torch
+
+from deepchem.data import DiskDataset
+from deepchem.feat.graph_data import BatchGraphData, GraphData
+from deepchem.models.torch_models.nequip import NequIPModel
+
+pytestmark = pytest.mark.torch
+
+
+class _DummyModule(torch.nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.value = torch.nn.Parameter(torch.zeros(1))
+
+    def forward(self, graph):
+        batch_size = int(graph.graph_index.max().item()) + 1
+        return self.value.expand(batch_size, 1)
+
+
+def _dummy_loss(outputs, labels, weights):
+    difference = outputs[0] - labels[0]
+    return torch.mean(weights[0] * difference**2)
+
+
+def _model(tasks, **kwargs):
+    return NequIPModel(tasks=tasks,
+                       model=_DummyModule(),
+                       loss=_dummy_loss,
+                       **kwargs)
+
+
+def _graphs():
+    graph_a = GraphData(node_features=np.array([[1], [8]], dtype=np.float32),
+                        edge_index=np.array([[0, 1], [1, 0]], dtype=np.int64),
+                        edge_features=np.array([[1, 0, 0], [-1, 0, 0]],
+                                               dtype=np.float32),
+                        node_pos_features=np.array([[0, 0, 0], [1, 0, 0]],
+                                                   dtype=np.float32),
+                        edge_distances=np.ones((2, 1), dtype=np.float32))
+    graph_b = GraphData(node_features=np.array([[6], [1], [1]],
+                                               dtype=np.float32),
+                        edge_index=np.array([[0, 1, 2], [1, 2, 0]],
+                                            dtype=np.int64),
+                        edge_features=np.ones((3, 3), dtype=np.float32),
+                        node_pos_features=np.array(
+                            [[0, 0, 0], [0.8, 0, 0], [-0.8, 0, 0]],
+                            dtype=np.float32),
+                        edge_distances=np.ones((3, 1), dtype=np.float32))
+    return [graph_a, graph_b]
+
+
+def _forces():
+    return [
+        np.array([[0.1, 0, 0], [-0.1, 0, 0]], dtype=np.float32),
+        np.array([[0.2, 0, 0], [0, 0.2, 0], [0, 0, 0.2]], dtype=np.float32)
+    ]
+
+
+def _labels(tasks):
+    values = {"energy": [1.5, -2.0], "forces": _forces()}
+    labels = np.empty((2, len(tasks)), dtype=object)
+    for task_index, task in enumerate(tasks):
+        labels[:, task_index] = values[task]
+    return labels
+
+
+def _prepare(tasks, weights):
+    model = _model(tasks)
+    return model._prepare_batch(([_graphs()], [_labels(tasks)], [weights]))
+
+
+def _energy_dataset():
+    graphs = np.asarray(_graphs(), dtype=object)
+    return DiskDataset.create_dataset(iter([
+        (graphs, _labels(["energy"]), np.ones(
+            (2, 1), dtype=np.float32), np.array(["a", "b"]))
+    ]),
+                                      tasks=["energy"])
+
+
+@pytest.mark.parametrize(
+    "tasks",
+    [["energy"], ["forces"], ["energy", "forces"], ["forces", "energy"]])
+def test_task_order_is_supported_and_preserved(tasks):
+    model = _model(tasks)
+    assert model.tasks == tasks
+    assert model.task_to_index == {
+        task: index for index, task in enumerate(tasks)
+    }
+
+
+@pytest.mark.parametrize("tasks", [["energy", "energy"], ["dipole"]])
+def test_invalid_tasks_are_rejected(tasks):
+    with pytest.raises(ValueError):
+        _model(tasks)
+
+
+@pytest.mark.parametrize("model, loss", [(object(), _dummy_loss),
+                                         (_DummyModule(), None)])
+def test_injected_model_and_loss_are_validated(model, loss):
+    with pytest.raises(TypeError):
+        NequIPModel(tasks=["energy"], model=model, loss=loss)
+
+
+def test_differently_sized_graphs_are_batched():
+    graph, _, _ = _prepare(["energy"], np.ones((2, 1), dtype=np.float32))
+    assert isinstance(graph, BatchGraphData)
+    assert graph.node_features.shape == (5, 1)
+    assert graph.node_pos_features.shape == (5, 3)
+    assert graph.edge_index.shape == (2, 5)
+    assert graph.edge_features.shape == (5, 3)
+    assert graph.edge_distances.shape == (5, 1)
+    assert graph.graph_index.tolist() == [0, 0, 1, 1, 1]
+    assert graph.node_features.dtype == torch.float32
+    assert graph.graph_index.dtype == torch.long
+
+
+def test_energy_only_preparation():
+    _, labels, weights = _prepare(["energy"],
+                                  np.array([[0.5], [0.25]], dtype=np.float32))
+    torch.testing.assert_close(labels[0], torch.tensor([[1.5], [-2.0]]))
+    torch.testing.assert_close(weights[0], torch.tensor([[0.5], [0.25]]))
+    assert labels[0].shape == (2, 1)
+    assert weights[0].shape == (2, 1)
+    assert labels[0].dtype == torch.float32
+    assert weights[0].dtype == torch.float32
+
+
+def test_force_only_preparation_and_weight_expansion():
+    _, labels, weights = _prepare(["forces"],
+                                  np.array([[0.3], [0.4]], dtype=np.float32))
+    expected_forces = torch.tensor([[0.1, 0, 0], [-0.1, 0, 0], [0.2, 0, 0],
+                                    [0, 0.2, 0], [0, 0, 0.2]])
+    torch.testing.assert_close(labels[0], expected_forces)
+    torch.testing.assert_close(
+        weights[0], torch.tensor([[0.3], [0.3], [0.4], [0.4], [0.4]]))
+    assert labels[0].shape == (5, 3)
+    assert weights[0].shape == (5, 1)
+    assert labels[0].dtype == torch.float32
+    assert weights[0].dtype == torch.float32
+
+
+def test_energy_and_forces_are_prepared_together():
+    _, labels, weights = _prepare(["energy", "forces"],
+                                  np.array([[0.5, 0.3], [0.25, 0.4]],
+                                           dtype=np.float32))
+    torch.testing.assert_close(labels[0], torch.tensor([[1.5], [-2.0]]))
+    torch.testing.assert_close(labels[1][:2],
+                               torch.tensor([[0.1, 0, 0], [-0.1, 0, 0]]))
+    assert labels[0].shape == (2, 1)
+    assert labels[1].shape == (5, 3)
+    assert weights[0].shape == (2, 1)
+    assert weights[1].shape == (5, 1)
+
+
+def test_reversed_task_order_uses_correct_columns():
+    _, labels, weights = _prepare(["forces", "energy"],
+                                  np.array([[0.3, 0.5], [0.4, 0.25]],
+                                           dtype=np.float32))
+    torch.testing.assert_close(labels[0][:2],
+                               torch.tensor([[0.1, 0, 0], [-0.1, 0, 0]]))
+    torch.testing.assert_close(labels[1], torch.tensor([[1.5], [-2.0]]))
+    torch.testing.assert_close(
+        weights[0], torch.tensor([[0.3], [0.3], [0.4], [0.4], [0.4]]))
+    torch.testing.assert_close(weights[1], torch.tensor([[0.5], [0.25]]))
+
+
+def test_invalid_force_shape_identifies_sample_and_expected_shape():
+    labels = _labels(["forces"])
+    labels[1, 0] = np.zeros((2, 3), dtype=np.float32)
+    with pytest.raises(ValueError,
+                       match=r"sample 1.*shape \(2, 3\).*Expected \(3, 3\)"):
+        _model(["forces"])._prepare_batch(
+            ([_graphs()], [labels], [np.ones((2, 1), dtype=np.float32)]))
+
+
+def test_non_scalar_energy_is_rejected():
+    labels = _labels(["energy"])
+    labels[1, 0] = np.array([-2.0], dtype=np.float32)
+    with pytest.raises(ValueError, match="Energy label for sample 1.*scalar"):
+        _model(["energy"])._prepare_batch(
+            ([_graphs()], [labels], [np.ones((2, 1), dtype=np.float32)]))
+
+
+def test_default_generator_never_pads_final_graph_batch():
+    dataset = _energy_dataset()
+    inputs, labels, weights = next(
+        _model(["energy"], batch_size=4).default_generator(dataset,
+                                                           pad_batches=True))
+    assert len(inputs[0]) == 2
+    assert labels[0].shape == (2, 1)
+    assert weights[0].shape == (2, 1)
+
+
+def test_unlabeled_diskdataset_batch_is_prepared_without_properties():
+    graphs = np.asarray(_graphs(), dtype=object)
+    dataset = DiskDataset.create_dataset(iter([(graphs, None, None,
+                                                np.array(["a", "b"]))]),
+                                         tasks=[])
+    generated_batch = next(_model([], batch_size=4).default_generator(dataset))
+    graph, labels, weights = _model([])._prepare_batch(generated_batch)
+    assert graph.graph_index.tolist() == [0, 0, 1, 1, 1]
+    assert generated_batch[1] == [None]
+    assert generated_batch[2] == [None]
+    assert labels == []
+    assert weights == []
+
+
+def test_prepared_values_use_model_device():
+    model = _model(["energy"], device=torch.device("cpu"))
+    graph, labels, weights = model._prepare_batch(
+        ([_graphs()], [_labels(["energy"])],
+         [np.ones((2, 1), dtype=np.float32)]))
+    assert graph.node_features.device.type == "cpu"
+    assert graph.node_pos_features.device.type == "cpu"
+    assert labels[0].device.type == "cpu"
+    assert weights[0].device.type == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_cuda_batch_preparation():
+    model = _model(["forces"], device=torch.device("cuda"))
+    graph, labels, weights = model._prepare_batch(
+        ([_graphs()], [_labels(["forces"])],
+         [np.ones((2, 1), dtype=np.float32)]))
+    assert graph.node_features.device.type == "cuda"
+    assert labels[0].device.type == "cuda"
+    assert weights[0].device.type == "cuda"
+
+
+def test_energy_fit_runs_through_torchmodel():
+    model = _model(["energy"], batch_size=4, learning_rate=0.1)
+    initial_value = model.model.value.detach().clone()
+    loss = model.fit(_energy_dataset(),
+                     nb_epoch=1,
+                     checkpoint_interval=0,
+                     deterministic=True)
+    assert np.isfinite(loss)
+    assert not torch.equal(model.model.value.detach(), initial_value)
+
+
+def test_public_export():
+    from deepchem.models.torch_models import NequIPModel as ExportedNequIPModel
+
+    assert ExportedNequIPModel is NequIPModel

--- a/docs/source/api_reference/data.rst
+++ b/docs/source/api_reference/data.rst
@@ -98,6 +98,12 @@ SDFLoader
 .. autoclass:: deepchem.data.SDFLoader
   :members: __init__, create_dataset
 
+MaterialsLoader
+^^^^^^^^^^^^^^^
+
+.. autoclass:: deepchem.data.MaterialsLoader
+  :members: __init__, create_dataset
+
 FASTALoader
 ^^^^^^^^^^^
 

--- a/docs/source/api_reference/models.rst
+++ b/docs/source/api_reference/models.rst
@@ -680,6 +680,11 @@ TFNModel
 --------------------
 .. autoclass:: deepchem.models.torch_models.TFNModel
   :members:
+
+NequIPModel
+--------------------
+.. autoclass:: deepchem.models.torch_models.NequIPModel
+  :members:
   
 ChemCeptionLayer
 ----------------


### PR DESCRIPTION
## Description

This PR adds the basic model skeleton for NequIP.

The main additions include:
- Batching of variable-sized atomistic graphs into BatchGraphData
- Concatenation of variable-sized force targets into atom-level tensors.
- Expansion of structure-level force weights to atom-level weights.
- Integration with the existing TorchModel.fit() workflow.

This PR is only the skeleton and the main architecture for the model will be implemented in the next few PRs. 

## Type of change

Please check the option that is related to your PR.

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

  * In this case, we recommend to discuss your modification on GitHub issues before creating the PR
* [ ] Documentations (modification for documents)

## Checklist

* [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)

  * [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be  0.32.0**)
  * [x] Run `mypy -p deepchem` and check no errors
  * [x] Run `flake8 <modified file> --count` and check no errors
  * [x] Run `python -m doctest <modified file>` and check no errors
* [x] I have performed a self-review of my own code
* [x] I have commented my code, particularly in hard-to-understand areas
* [x] I have made corresponding changes to the documentation
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] New unit tests pass locally with my changes
* [x] I have checked my code and corrected any misspellings