### PR TITLE
Fix PyG radius dependency and add skip guard in MXMNet test

### DIFF
--- a/deepchem/models/tests/test_mxmnet.py
+++ b/deepchem/models/tests/test_mxmnet.py
@@ -7,18 +7,28 @@ from deepchem.feat.molecule_featurizers import MXMNetFeaturizer
 
 try:
     import torch
+    import torch_geometric
     from deepchem.models.torch_models.mxmnet import MXMNet
     has_torch = True
-except:
+    has_pyg_radius = bool(
+        getattr(torch_geometric.typing, 'WITH_TORCH_CLUSTER', False) or
+        getattr(torch_geometric.typing, 'WITH_PYG_LIB', False))
+except Exception:
     has_torch = False
+    has_pyg_radius = False
 
 QM9_TASKS = [
     "mu", "alpha", "homo", "lumo", "gap", "r2", "zpve", "cv", "u0", "u298",
     "h298", "g298"
 ]
 
+_SKIP_REASON = (
+    "MXMNet test requires PyTorch Geometric with torch-cluster or pyg-lib installed."
+)
+
 
 @pytest.mark.torch
+@pytest.mark.skipif(not (has_torch and has_pyg_radius), reason=_SKIP_REASON)
 def test_mxmnet_regression():
     """
     Test MXMNet class for regression
@@ -26,8 +36,7 @@ def test_mxmnet_regression():
     try:
         from torch_geometric.data import Batch
     except ModuleNotFoundError:
-        raise ImportError(
-            "This test requires PyTorch Geometric to be installed.")
+        pytest.skip("This test requires PyTorch Geometric to be installed.")
 
     seed = 123
     torch.backends.cudnn.deterministic = True

--- a/requirements/torch/env_torch.cpu.yml
+++ b/requirements/torch/env_torch.cpu.yml
@@ -9,6 +9,7 @@ dependencies:
     - lightning
     - pydantic
     - -f https://data.pyg.org/whl/torch-2.2.1+cpu.html
+    - torch-cluster
     - git+https://github.com/diffqc/dqclibs.git
     - git+https://gitlab.com/libxc/libxc.git
     - basis-set-exchange


### PR DESCRIPTION
## Description

Fixes the recurring `test_mxmnet.py` failure in `torch-tests` CI (`ImportError: 'radius' requires 'pyg-lib' / 'torch-cluster'`).

1. Added `torch-cluster` to `requirements/torch/env_torch.cpu.yml` under the PyG wheels link.
2. Added a `@pytest.mark.skipif` guard in `test_mxmnet.py` to check for `torch_geometric` and its radius backend (`WITH_TORCH_CLUSTER` or `WITH_PYG_LIB`), so the test skips gracefully if the compiled extension is unavailable on a runner.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
  - [x] Run yapf -i and check no errors (yapf version 0.32.0)
  - [x] Run flake8 and check no errors
  - [x] Run pytest on modified test file
- [x] I have performed a self-review of my own code