### PR TITLE
Connect frames, IPA, pair/sequence tracks, and IGSO(3) into RFDiffusionModel

### DIFF
--- a/deepchem/models/__init__.py
+++ b/deepchem/models/__init__.py
@@ -52,6 +52,7 @@ try:
     from deepchem.models.torch_models import PositionalEncoding
     from deepchem.models.torch_models import CosineSchedule
     from deepchem.models.torch_models import BackboneDiffusion
+    from deepchem.models.torch_models import RFDiffusionMultiTrackDenoiser
     from deepchem.models.torch_models import RFDiffusionModel
     from deepchem.models.torch_models import ScaledDotProductAttention, SelfAttention
     from deepchem.models.torch_models import GroverReadout

--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -57,6 +57,7 @@ from deepchem.models.torch_models.layers import ResidueEmbedding
 from deepchem.models.torch_models.layers import PositionalEncoding
 from deepchem.models.torch_models.layers import CosineSchedule
 from deepchem.models.torch_models.layers import BackboneDiffusion
+from deepchem.models.torch_models.rfdiffusion_multitrack import RFDiffusionMultiTrackDenoiser
 from deepchem.models.torch_models.rfdiffusion import RFDiffusionModel
 
 try:

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -5,18 +5,16 @@ you train and sample protein backbone structures using standard DeepChem
 workflows. Two denoiser architectures are available, selected with the
 ``architecture`` argument:
 
-- ``'multitrack'`` -- the actual RFdiffusion architecture: rigid backbone
-  frames, Invariant Point Attention, the pair track, and the
+- ``'multitrack'`` (default) -- the actual RFdiffusion architecture: rigid
+  backbone frames, Invariant Point Attention, the pair track, and the
   sequence/structure track (``RFDiffusionMultiTrackStack``), combined with
   IGSO(3) rotational diffusion and Gaussian translational diffusion. This
   is the scientifically faithful path, and the only one that supports
   contig/motif conditioning.
-- ``'transformer'`` (default) -- the lightweight ``BackboneDiffusion``
-  baseline: a plain Transformer denoiser trained with translation-only
-  DDPM on flat ``(N, CA, C)`` coordinates. This stays the default so
-  existing code built against the earlier, transformer-only version of
-  this class keeps working unchanged; pass ``architecture='multitrack'``
-  to use the real network.
+- ``'transformer'`` -- the lightweight ``BackboneDiffusion`` baseline: a
+  plain Transformer denoiser trained with translation-only DDPM on flat
+  ``(N, CA, C)`` coordinates. Kept as a cheap, quick-to-train fallback;
+  pass ``architecture='transformer'`` to use it.
 
 The building-block layers (``SinusoidalTimestepEmbedding``,
 ``ResidueEmbedding``, ``PositionalEncoding``, ``CosineSchedule``,
@@ -122,7 +120,7 @@ class RFDiffusionModel(TorchModel):
     structures with ``model.generate()``. Two denoisers are available via
     ``architecture``:
 
-    - ``'multitrack'``: the real RFdiffusion network
+    - ``'multitrack'`` (default): the real RFdiffusion network
       (``RFDiffusionMultiTrackDenoiser``), trained to predict the denoised
       backbone frame (rotation + translation) directly at every step.
       Rotations are diffused with IGSO(3) and translations with a
@@ -130,12 +128,12 @@ class RFDiffusionModel(TorchModel):
       rotation loss plus a masked translation MSE
       (``multitrack_frame_loss``). This is the only architecture that
       supports contig/motif conditioning in ``generate()``.
-    - ``'transformer'`` (default): the lightweight ``BackboneDiffusion``
-      baseline. Training uses the standard DDPM noise-prediction
-      objective: at each step a random timestep is sampled, Gaussian
-      noise is added to the clean coordinates with
-      ``CosineSchedule.q_sample``, and the model learns to predict the
-      added noise via an MSE loss.
+    - ``'transformer'``: the lightweight ``BackboneDiffusion`` baseline.
+      Training uses the standard DDPM noise-prediction objective: at each
+      step a random timestep is sampled, Gaussian noise is added to the
+      clean coordinates with ``CosineSchedule.q_sample``, and the model
+      learns to predict the added noise via an MSE loss. Cheaper to train
+      than ``'multitrack'``, useful for quick experimentation.
 
     Coordinates are center-normalized before being fed to the model and
     denormalized when samples are returned from ``generate()``.
@@ -164,8 +162,8 @@ class RFDiffusionModel(TorchModel):
     device : torch.device, optional
         Device to train and sample on. Defaults to GPU if available,
         otherwise CPU.
-    architecture : str, default 'transformer'
-        Either ``'transformer'`` or ``'multitrack'``.
+    architecture : str, default 'multitrack'
+        Either ``'multitrack'`` or ``'transformer'``.
     pair_dim : int, default 64
         Pair-track channel size. Only used when
         ``architecture='multitrack'``.
@@ -197,22 +195,21 @@ class RFDiffusionModel(TorchModel):
     ...     X[i] = p
     >>> dataset = dc.data.NumpyDataset(X=X, y=np.zeros((6, 1), dtype=np.float32))
     >>> model = dc.models.RFDiffusionModel(
-    ...     embed_dim=64, num_layers=2, num_heads=4,
-    ...     num_diffusion_steps=50, batch_size=2)
+    ...     embed_dim=32, pair_dim=16, num_blocks=1, num_heads=4,
+    ...     pair_num_heads=2, num_diffusion_steps=20, batch_size=2)
     >>> loss = model.fit(dataset, nb_epoch=1)
     >>> samples = model.generate(num_samples=2, seq_length=20)
     >>> samples.shape
     (2, 20, 9)
 
-    The real RFdiffusion architecture is used the same way, by passing
-    ``architecture='multitrack'``:
+    The lightweight Transformer baseline is used the same way, by passing
+    ``architecture='transformer'``:
 
-    >>> mt_model = dc.models.RFDiffusionModel(
-    ...     architecture='multitrack', embed_dim=32, pair_dim=16,
-    ...     num_blocks=1, num_heads=4, pair_num_heads=2,
-    ...     num_diffusion_steps=20, batch_size=2)
-    >>> loss = mt_model.fit(dataset, nb_epoch=1)
-    >>> samples = mt_model.generate(num_samples=2, seq_length=20)
+    >>> baseline_model = dc.models.RFDiffusionModel(
+    ...     architecture='transformer', embed_dim=64, num_layers=2,
+    ...     num_heads=4, num_diffusion_steps=50, batch_size=2)
+    >>> loss = baseline_model.fit(dataset, nb_epoch=1)
+    >>> samples = baseline_model.generate(num_samples=2, seq_length=20)
     >>> samples.shape
     (2, 20, 9)
 
@@ -233,7 +230,7 @@ class RFDiffusionModel(TorchModel):
                  batch_size: int = 4,
                  learning_rate: float = 1e-4,
                  device: Optional[torch.device] = None,
-                 architecture: str = 'transformer',
+                 architecture: str = 'multitrack',
                  pair_dim: int = 64,
                  num_blocks: int = 2,
                  pair_num_heads: int = 4,
@@ -345,7 +342,9 @@ class RFDiffusionModel(TorchModel):
         --------
         >>> import numpy as np
         >>> import deepchem as dc
-        >>> model = dc.models.RFDiffusionModel()
+        >>> model = dc.models.RFDiffusionModel(
+        ...     embed_dim=32, pair_dim=16, num_blocks=1,
+        ...     num_diffusion_steps=10)
         >>> coords_33 = np.random.randn(10, 3, 3).astype(np.float32)
         >>> out = model._normalize_coords(coords_33)
         >>> out.shape
@@ -400,7 +399,9 @@ class RFDiffusionModel(TorchModel):
         --------
         >>> import numpy as np
         >>> import deepchem as dc
-        >>> model = dc.models.RFDiffusionModel()
+        >>> model = dc.models.RFDiffusionModel(
+        ...     embed_dim=32, pair_dim=16, num_blocks=1,
+        ...     num_diffusion_steps=10)
         >>> coords = np.random.randn(5, 9).astype(np.float32)
         >>> padded, orig_len = model._pad_coords(coords, 10)
         >>> padded.shape
@@ -425,15 +426,22 @@ class RFDiffusionModel(TorchModel):
             pad_batches: bool = True) -> Iterable[Tuple[List, List, List]]:
         """Yield diffusion training batches from a DeepChem dataset.
 
-        For each mini-batch this method:
+        For each mini-batch this method normalizes each protein's
+        coordinates with ``_normalize_coords``, pads them to a common
+        length with ``_pad_coords``, and samples random diffusion
+        timesteps uniformly from ``[0, num_diffusion_steps)``. What gets
+        yielded after that depends on ``architecture``:
 
-        1. Normalizes each protein's coordinates with ``_normalize_coords``.
-        2. Pads them to a common length with ``_pad_coords``.
-        3. Samples random diffusion timesteps uniformly from
-           ``[0, num_diffusion_steps)``.
-        4. Adds noise with ``CosineSchedule.q_sample``.
-        5. Yields ``([noisy_coords, timesteps, mask], [noise], [weights])``
-           where ``mask`` is a float array marking valid (non-padded) positions.
+        - ``'transformer'``: adds noise with ``CosineSchedule.q_sample``
+          and yields ``([noisy_coords, timesteps, mask], [noise],
+          [weights])``, where ``mask`` is a float array marking valid
+          (non-padded) positions.
+        - ``'multitrack'``: builds ground-truth rigid frames from the
+          padded coordinates with ``build_backbone_frames``, diffuses them
+          with ``sample_noisy_frames`` (IGSO(3) for rotations,
+          ``CosineSchedule.q_sample`` for translations), and yields
+          ``([noisy_coords, noisy_rotations, noisy_translations,
+          timesteps, mask], [rotations0, translations0], [weights])``.
 
         Running statistics for CA-centroid and coordinate std are updated
         each batch and used by ``generate()`` to denormalize samples.
@@ -455,18 +463,15 @@ class RFDiffusionModel(TorchModel):
         Yields
         ------
         tuple
-            ``([noisy_coords, timesteps, mask], [noise], [weights])``
-
-            - ``noisy_coords``: ``np.ndarray`` of shape
-              ``(batch, max_len, 9)``.
-            - ``timesteps``: ``np.ndarray`` of shape ``(batch,)``,
-              dtype int64.
-            - ``mask``: ``np.ndarray`` of shape ``(batch, max_len)``,
-              dtype float32; 1.0 for valid positions, 0.0 for padding.
-            - ``noise``: ``np.ndarray`` of shape ``(batch, max_len, 9)``.
-            - ``weights``: ``np.ndarray`` of shape
-              ``(batch, max_len, 9)``; combines positional mask with
-              per-sample weights.
+            See the architecture-dependent formats described above.
+            Shapes shared by both: ``noisy_coords`` is ``(batch, max_len,
+            9)``; ``timesteps`` is ``(batch,)`` int64; ``mask`` is
+            ``(batch, max_len)`` float32 (1.0 for valid positions, 0.0 for
+            padding). For ``'transformer'``, ``noise`` and ``weights`` are
+            ``(batch, max_len, 9)``. For ``'multitrack'``,
+            ``noisy_rotations`` / ``rotations0`` are ``(batch, max_len, 3,
+            3)``; ``noisy_translations`` / ``translations0`` are ``(batch,
+            max_len, 3)``; ``weights`` is ``(batch, max_len)``.
 
         Raises
         ------
@@ -686,19 +691,19 @@ class RFDiffusionModel(TorchModel):
         >>> import numpy as np
         >>> import deepchem as dc
         >>> model = dc.models.RFDiffusionModel(
-        ...     embed_dim=32, num_layers=1, num_heads=4,
-        ...     num_diffusion_steps=10)
+        ...     embed_dim=32, pair_dim=16, num_blocks=1, num_heads=4,
+        ...     pair_num_heads=2, num_diffusion_steps=10)
         >>> samples = model.generate(num_samples=2, seq_length=15)
         >>> samples.shape
         (2, 15, 9)
         >>> bool(np.isfinite(samples).all())
         True
 
-        Motif-conditioned generation with the multi-track architecture
-        holds a reference sub-structure fixed while the rest is generated:
+        Motif-conditioned generation holds a reference sub-structure fixed
+        while the rest is generated:
 
         >>> mt_model = dc.models.RFDiffusionModel(
-        ...     architecture='multitrack', embed_dim=32, pair_dim=16,
+        ...     embed_dim=32, pair_dim=16,
         ...     num_blocks=1, num_heads=4, pair_num_heads=2,
         ...     num_diffusion_steps=10)
         >>> mask = np.zeros(12, dtype=bool)

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -185,6 +185,13 @@ class RFDiffusionModel(TorchModel):
     **kwargs
         Additional keyword arguments forwarded to ``TorchModel``.
 
+    Raises
+    ------
+    ValueError
+        If `embed_dim`, `time_dim`, `num_layers`, `num_heads`,
+        `num_diffusion_steps`, or `max_seq_len` is not positive, or if
+        `architecture` is not `'transformer'` or `'multitrack'`.
+
     Examples
     --------
     >>> import numpy as np

--- a/deepchem/models/torch_models/rfdiffusion.py
+++ b/deepchem/models/torch_models/rfdiffusion.py
@@ -1,14 +1,29 @@
 """RFDiffusionModel: TorchModel wrapper for protein backbone diffusion.
 
-This module adds ``RFDiffusionModel``, a DeepChem ``TorchModel`` that wraps
-the ``BackboneDiffusion`` denoiser from ``deepchem.models.torch_models.layers``
-and lets you train and sample protein backbone structures using standard
-DeepChem workflows.
+This module adds ``RFDiffusionModel``, a DeepChem ``TorchModel`` that lets
+you train and sample protein backbone structures using standard DeepChem
+workflows. Two denoiser architectures are available, selected with the
+``architecture`` argument:
+
+- ``'multitrack'`` -- the actual RFdiffusion architecture: rigid backbone
+  frames, Invariant Point Attention, the pair track, and the
+  sequence/structure track (``RFDiffusionMultiTrackStack``), combined with
+  IGSO(3) rotational diffusion and Gaussian translational diffusion. This
+  is the scientifically faithful path, and the only one that supports
+  contig/motif conditioning.
+- ``'transformer'`` (default) -- the lightweight ``BackboneDiffusion``
+  baseline: a plain Transformer denoiser trained with translation-only
+  DDPM on flat ``(N, CA, C)`` coordinates. This stays the default so
+  existing code built against the earlier, transformer-only version of
+  this class keeps working unchanged; pass ``architecture='multitrack'``
+  to use the real network.
 
 The building-block layers (``SinusoidalTimestepEmbedding``,
 ``ResidueEmbedding``, ``PositionalEncoding``, ``CosineSchedule``,
 ``DiffusionTransformerBlock``, ``BackboneDiffusion``) live in
-``deepchem.models.torch_models.layers``.
+``deepchem.models.torch_models.layers``. The multi-track pieces
+(``RFDiffusionMultiTrackDenoiser`` and the diffusion helpers around it)
+live in ``deepchem.models.torch_models.rfdiffusion_multitrack``.
 
 Classes
 -------
@@ -42,6 +57,17 @@ except ModuleNotFoundError:
 
 from deepchem.data import Dataset
 from deepchem.models.torch_models.layers import BackboneDiffusion, CosineSchedule
+from deepchem.models.torch_models.rfdiffusion_frames import (
+    build_backbone_frames,)
+from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    RFDiffusionMultiTrackDenoiser,
+    backbone_coords_from_frames,
+    multitrack_frame_loss,
+    sample_noisy_frames,
+    so3_x0_reverse_step,
+    translation_posterior_step,
+)
+from deepchem.models.torch_models.rfdiffusion_so3 import IGSO3, log_beta_schedule
 from deepchem.models.torch_models.torch_model import TorchModel
 
 logger = logging.getLogger(__name__)
@@ -91,14 +117,25 @@ def _diffusion_loss(outputs: List[torch.Tensor], labels: List[torch.Tensor],
 class RFDiffusionModel(TorchModel):
     """TorchModel wrapper for the RFDiffusion protein backbone model.
 
-    Wraps ``BackboneDiffusion`` in DeepChem's ``TorchModel`` interface so
-    you can train with ``model.fit(dataset)`` and generate new backbone
-    structures with ``model.generate()``.
+    Wraps a backbone denoiser in DeepChem's ``TorchModel`` interface so you
+    can train with ``model.fit(dataset)`` and generate new backbone
+    structures with ``model.generate()``. Two denoisers are available via
+    ``architecture``:
 
-    Training uses the standard DDPM noise-prediction objective: at each step
-    a random timestep is sampled, Gaussian noise is added to the clean
-    coordinates with ``CosineSchedule.q_sample``, and the model learns to
-    predict the added noise via an MSE loss.
+    - ``'multitrack'``: the real RFdiffusion network
+      (``RFDiffusionMultiTrackDenoiser``), trained to predict the denoised
+      backbone frame (rotation + translation) directly at every step.
+      Rotations are diffused with IGSO(3) and translations with a
+      Gaussian DDPM process; the training loss is a masked geodesic
+      rotation loss plus a masked translation MSE
+      (``multitrack_frame_loss``). This is the only architecture that
+      supports contig/motif conditioning in ``generate()``.
+    - ``'transformer'`` (default): the lightweight ``BackboneDiffusion``
+      baseline. Training uses the standard DDPM noise-prediction
+      objective: at each step a random timestep is sampled, Gaussian
+      noise is added to the clean coordinates with
+      ``CosineSchedule.q_sample``, and the model learns to predict the
+      added noise via an MSE loss.
 
     Coordinates are center-normalized before being fed to the model and
     denormalized when samples are returned from ``generate()``.
@@ -106,19 +143,20 @@ class RFDiffusionModel(TorchModel):
     Parameters
     ----------
     embed_dim : int, default 256
-        Hidden dimension for the Transformer backbone.
+        Hidden (single-track) dimension for the denoiser.
     time_dim : int, default 128
         Dimension of the sinusoidal timestep embedding.
     num_layers : int, default 8
-        Number of ``DiffusionTransformerBlock`` layers in the denoiser.
+        Number of ``DiffusionTransformerBlock`` layers. Only used when
+        ``architecture='transformer'``.
     num_heads : int, default 8
-        Number of attention heads per Transformer block.
+        Number of attention heads per block.
     num_diffusion_steps : int, default 1000
         Total number of diffusion timesteps T.
     max_seq_len : int, default 512
         Maximum protein length in residues the model can handle.
     dropout : float, default 0.1
-        Dropout probability used in the Transformer blocks.
+        Dropout probability used in the denoiser blocks.
     batch_size : int, default 4
         Number of proteins per training batch.
     learning_rate : float, default 1e-4
@@ -126,6 +164,26 @@ class RFDiffusionModel(TorchModel):
     device : torch.device, optional
         Device to train and sample on. Defaults to GPU if available,
         otherwise CPU.
+    architecture : str, default 'transformer'
+        Either ``'transformer'`` or ``'multitrack'``.
+    pair_dim : int, default 64
+        Pair-track channel size. Only used when
+        ``architecture='multitrack'``.
+    num_blocks : int, default 2
+        Number of stacked multi-track blocks. Only used when
+        ``architecture='multitrack'``.
+    pair_num_heads : int, default 4
+        Attention heads for triangular self-attention. Only used when
+        ``architecture='multitrack'``.
+    rotation_weight : float, default 1.0
+        Weight on the rotation term of the multi-track training loss.
+        Only used when ``architecture='multitrack'``.
+    so3_beta_min : float, default 0.1
+        Smallest IGSO(3) sigma (at t=1). Only used when
+        ``architecture='multitrack'``.
+    so3_beta_max : float, default 1.5
+        Largest IGSO(3) sigma (at t=T). Only used when
+        ``architecture='multitrack'``.
     **kwargs
         Additional keyword arguments forwarded to ``TorchModel``.
 
@@ -146,6 +204,18 @@ class RFDiffusionModel(TorchModel):
     >>> samples.shape
     (2, 20, 9)
 
+    The real RFdiffusion architecture is used the same way, by passing
+    ``architecture='multitrack'``:
+
+    >>> mt_model = dc.models.RFDiffusionModel(
+    ...     architecture='multitrack', embed_dim=32, pair_dim=16,
+    ...     num_blocks=1, num_heads=4, pair_num_heads=2,
+    ...     num_diffusion_steps=20, batch_size=2)
+    >>> loss = mt_model.fit(dataset, nb_epoch=1)
+    >>> samples = mt_model.generate(num_samples=2, seq_length=20)
+    >>> samples.shape
+    (2, 20, 9)
+
     References
     ----------
     .. [1] Watson, J. L., et al. "De novo design of protein structure and
@@ -163,6 +233,13 @@ class RFDiffusionModel(TorchModel):
                  batch_size: int = 4,
                  learning_rate: float = 1e-4,
                  device: Optional[torch.device] = None,
+                 architecture: str = 'transformer',
+                 pair_dim: int = 64,
+                 num_blocks: int = 2,
+                 pair_num_heads: int = 4,
+                 rotation_weight: float = 1.0,
+                 so3_beta_min: float = 0.1,
+                 so3_beta_max: float = 1.5,
                  **kwargs) -> None:
         if embed_dim <= 0:
             raise ValueError('embed_dim must be positive.')
@@ -172,6 +249,10 @@ class RFDiffusionModel(TorchModel):
             raise ValueError('num_layers must be positive.')
         if num_heads <= 0:
             raise ValueError('num_heads must be positive.')
+        if architecture not in ('transformer', 'multitrack'):
+            raise ValueError(
+                f"architecture must be 'transformer' or 'multitrack', got "
+                f"{architecture!r}.")
         if num_diffusion_steps <= 0:
             raise ValueError('num_diffusion_steps must be positive.')
         if max_seq_len <= 0:
@@ -180,24 +261,53 @@ class RFDiffusionModel(TorchModel):
         self.num_diffusion_steps = num_diffusion_steps
         self.max_seq_len = max_seq_len
         self.coord_dim = 9
+        self.architecture = architecture
+        self.rotation_weight = rotation_weight
         self._train_mean: Optional[np.ndarray] = None
         self._train_std: Optional[float] = None
 
         self.schedule = CosineSchedule(num_timesteps=num_diffusion_steps)
-        backbone = BackboneDiffusion(
-            coord_dim=self.coord_dim,
-            embed_dim=embed_dim,
-            time_dim=time_dim,
-            num_layers=num_layers,
-            num_heads=num_heads,
-            max_seq_len=max_seq_len,
-            dropout=dropout,
-        )
+
+        if architecture == 'transformer':
+            self.igso3: Optional[IGSO3] = None
+            backbone: torch.nn.Module = BackboneDiffusion(
+                coord_dim=self.coord_dim,
+                embed_dim=embed_dim,
+                time_dim=time_dim,
+                num_layers=num_layers,
+                num_heads=num_heads,
+                max_seq_len=max_seq_len,
+                dropout=dropout,
+            )
+            loss_fn = _diffusion_loss
+        else:
+            self.igso3 = IGSO3(
+                log_beta_schedule(num_diffusion_steps,
+                                  beta_min=so3_beta_min,
+                                  beta_max=so3_beta_max))
+            backbone = RFDiffusionMultiTrackDenoiser(
+                embed_dim=embed_dim,
+                pair_dim=pair_dim,
+                time_dim=time_dim,
+                num_blocks=num_blocks,
+                num_heads=num_heads,
+                pair_num_heads=pair_num_heads,
+                max_seq_len=max_seq_len,
+                dropout=dropout,
+            )
+
+            def loss_fn(outputs: List[torch.Tensor], labels: List[torch.Tensor],
+                        weights: List[torch.Tensor]) -> torch.Tensor:
+                return multitrack_frame_loss(outputs,
+                                             labels,
+                                             weights,
+                                             rotation_weight=rotation_weight)
+
         # Attach schedule so it moves with the model when .to(device) is called
         backbone.schedule = self.schedule
 
         super(RFDiffusionModel, self).__init__(backbone,
-                                               loss=_diffusion_loss,
+                                               loss=loss_fn,
                                                batch_size=batch_size,
                                                learning_rate=learning_rate,
                                                device=device,
@@ -462,26 +572,78 @@ class RFDiffusionModel(TorchModel):
                                       size=(batch_size,))
                 coords_tensor = torch.tensor(coords_batch, dtype=torch.float32)
                 t_tensor = torch.tensor(t, dtype=torch.long)
-                noisy_coords, noise = self.schedule.q_sample(
-                    coords_tensor, t_tensor)
 
-                noisy_np = noisy_coords.numpy()
-                noise_np = noise.numpy()
-                t_np = t.astype(np.int64)
-                weights = (mask_batch[:, :, None].astype(np.float32) *
-                           sample_weights[:, None, None])
+                if self.architecture == 'transformer':
+                    noisy_coords, noise = self.schedule.q_sample(
+                        coords_tensor, t_tensor)
 
-                yield ([noisy_np, t_np, mask_batch], [noise_np], [weights])
+                    noisy_np = noisy_coords.numpy()
+                    noise_np = noise.numpy()
+                    t_np = t.astype(np.int64)
+                    weights = (mask_batch[:, :, None].astype(np.float32) *
+                               sample_weights[:, None, None])
+
+                    yield ([noisy_np, t_np, mask_batch], [noise_np], [weights])
+                else:
+                    mask_tensor = torch.tensor(mask_batch, dtype=torch.float32)
+                    rotations0, translations0 = build_backbone_frames(
+                        coords_tensor.reshape(batch_size, max_len, 3, 3))
+                    # Padded positions have all-zero (N, CA, C) coordinates,
+                    # which build_backbone_frames cannot turn into a valid
+                    # orthonormal frame. Replace those with an identity
+                    # frame so they cannot introduce NaNs into the network
+                    # before the loss masks them out.
+                    identity = torch.eye(
+                        3, dtype=rotations0.dtype).expand_as(rotations0)
+                    valid = mask_tensor.bool()
+                    rotations0 = torch.where(valid[..., None, None], rotations0,
+                                             identity)
+                    translations0 = translations0 * mask_tensor[..., None]
+
+                    assert self.igso3 is not None
+                    noisy_rotations, noisy_translations = sample_noisy_frames(
+                        self.igso3, self.schedule, rotations0, translations0,
+                        t_tensor)
+                    noisy_coords_9 = backbone_coords_from_frames(
+                        noisy_rotations,
+                        noisy_translations).reshape(batch_size, max_len, 9)
+
+                    weights_mask = mask_batch * sample_weights[:, None]
+
+                    yield ([
+                        noisy_coords_9.numpy(),
+                        noisy_rotations.numpy(),
+                        noisy_translations.numpy(),
+                        t.astype(np.int64), mask_batch
+                    ], [rotations0.numpy(),
+                        translations0.numpy()], [weights_mask])
 
     def generate(self,
                  num_samples: int = 1,
                  seq_length: int = 50,
-                 device: Optional[torch.device] = None) -> np.ndarray:
+                 device: Optional[torch.device] = None,
+                 motif_mask: Optional[np.ndarray] = None,
+                 motif_coords: Optional[np.ndarray] = None) -> np.ndarray:
         """Generate new protein backbone structures by running reverse diffusion.
 
-        Starts from pure Gaussian noise of shape
-        ``(num_samples, seq_length, 9)`` and iteratively denoises it
-        over ``num_diffusion_steps`` steps using ``CosineSchedule.sample``.
+        With ``architecture='transformer'``, starts from pure Gaussian noise
+        of shape ``(num_samples, seq_length, 9)`` and iteratively denoises
+        it over ``num_diffusion_steps`` steps using ``CosineSchedule.sample``.
+
+        With ``architecture='multitrack'``, starts from an IGSO(3) sample
+        for the rotations and Gaussian noise for the translations, and
+        alternates ``so3_x0_reverse_step`` / ``translation_posterior_step``
+        using the network's per-step frame prediction, following
+        RFdiffusion's own reverse sampling process. This is also the only
+        architecture that supports motif conditioning via ``motif_mask`` /
+        ``motif_coords``: positions flagged in ``motif_mask`` are held at
+        their reference frame throughout sampling, matching the
+        ``diffusion_mask`` behavior in the original ``Diffuser.diffuse_pose``.
+        Use :func:`~deepchem.utils.rfdiffusion_contigs.parse_contig_string`
+        and :func:`~deepchem.utils.rfdiffusion_contigs.build_motif_mask` to
+        build ``motif_mask`` / ``motif_coords`` from a contig string and a
+        reference structure.
+
         If the model has been trained, the output is denormalized using the
         running CA-centroid and coordinate std tracked during training.
 
@@ -493,6 +655,15 @@ class RFDiffusionModel(TorchModel):
             Number of residues in each generated structure.
         device : torch.device, optional
             Device to run sampling on. Defaults to the model's current device.
+        motif_mask : np.ndarray, optional
+            Boolean array of shape ``(seq_length,)``; ``True`` marks
+            positions held fixed at ``motif_coords`` throughout sampling.
+            Only valid with ``architecture='multitrack'``, and the same
+            mask/coords are applied to every sample in the batch.
+        motif_coords : np.ndarray, optional
+            Reference ``(N, CA, C)`` coordinates of shape
+            ``(seq_length, 3, 3)`` used at the positions flagged by
+            ``motif_mask``. Must be passed together with ``motif_mask``.
 
         Returns
         -------
@@ -504,8 +675,11 @@ class RFDiffusionModel(TorchModel):
         Raises
         ------
         ValueError
-            If ``num_samples <= 0``, ``seq_length <= 0``, or
-            ``seq_length > max_seq_len``.
+            If ``num_samples <= 0``, ``seq_length <= 0``,
+            ``seq_length > max_seq_len``, if only one of ``motif_mask`` /
+            ``motif_coords`` is given, if their shapes are inconsistent
+            with ``seq_length``, or if motif conditioning is requested
+            with ``architecture='transformer'``.
 
         Examples
         --------
@@ -519,6 +693,21 @@ class RFDiffusionModel(TorchModel):
         (2, 15, 9)
         >>> bool(np.isfinite(samples).all())
         True
+
+        Motif-conditioned generation with the multi-track architecture
+        holds a reference sub-structure fixed while the rest is generated:
+
+        >>> mt_model = dc.models.RFDiffusionModel(
+        ...     architecture='multitrack', embed_dim=32, pair_dim=16,
+        ...     num_blocks=1, num_heads=4, pair_num_heads=2,
+        ...     num_diffusion_steps=10)
+        >>> mask = np.zeros(12, dtype=bool)
+        >>> mask[4:8] = True
+        >>> ref = np.random.randn(12, 3, 3).astype(np.float32)
+        >>> samples = mt_model.generate(num_samples=1, seq_length=12,
+        ...                             motif_mask=mask, motif_coords=ref)
+        >>> samples.shape
+        (1, 12, 9)
         """
         if num_samples <= 0:
             raise ValueError('num_samples must be positive.')
@@ -528,13 +717,34 @@ class RFDiffusionModel(TorchModel):
             raise ValueError(
                 f'seq_length {seq_length} exceeds max_seq_len {self.max_seq_len}.'
             )
+        if (motif_mask is None) != (motif_coords is None):
+            raise ValueError(
+                'motif_mask and motif_coords must be provided together.')
+        if motif_mask is not None:
+            if self.architecture != 'multitrack':
+                raise ValueError(
+                    "motif conditioning requires architecture='multitrack'.")
+            if motif_mask.shape != (seq_length,):
+                raise ValueError(
+                    f'motif_mask must have shape ({seq_length},), got '
+                    f'{motif_mask.shape}.')
+            assert motif_coords is not None
+            if motif_coords.shape != (seq_length, 3, 3):
+                raise ValueError(
+                    f'motif_coords must have shape ({seq_length}, 3, 3), '
+                    f'got {motif_coords.shape}.')
         if device is None:
             device = self.device
 
         was_training = self.model.training
-        shape = (num_samples, seq_length, self.coord_dim)
         try:
-            samples = self.schedule.sample(self.model, shape, device)
+            if self.architecture == 'transformer':
+                shape = (num_samples, seq_length, self.coord_dim)
+                samples = self.schedule.sample(self.model, shape, device)
+            else:
+                samples = self._generate_multitrack(num_samples, seq_length,
+                                                    device, motif_mask,
+                                                    motif_coords)
         finally:
             self.model.train(was_training)
 
@@ -544,6 +754,92 @@ class RFDiffusionModel(TorchModel):
         if self._train_mean is not None:
             result = result + np.tile(self._train_mean, 3)
         return result
+
+    def _generate_multitrack(
+            self, num_samples: int, seq_length: int, device: torch.device,
+            motif_mask: Optional[np.ndarray],
+            motif_coords: Optional[np.ndarray]) -> torch.Tensor:
+        """Run the combined SO(3) + translation reverse diffusion loop.
+
+        Parameters
+        ----------
+        num_samples : int
+            Number of backbone structures to generate.
+        seq_length : int
+            Number of residues in each generated structure.
+        device : torch.device
+            Device to run sampling on.
+        motif_mask : np.ndarray, optional
+            Boolean array of shape ``(seq_length,)`` flagging fixed motif
+            positions, shared across the whole batch.
+        motif_coords : np.ndarray, optional
+            Reference ``(N, CA, C)`` coordinates of shape
+            ``(seq_length, 3, 3)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Generated ``(N, CA, C)`` coordinates flattened to shape
+            ``(num_samples, seq_length, 9)``.
+        """
+        assert self.igso3 is not None
+        self.model.eval()
+        with torch.no_grad():
+            rotations = self.igso3.sample(
+                sigma_index=self.num_diffusion_steps - 1,
+                shape=(num_samples, seq_length)).to(device)
+            translations = torch.randn(num_samples,
+                                       seq_length,
+                                       3,
+                                       device=device)
+            mask = torch.ones(num_samples, seq_length, device=device)
+
+            fixed = None
+            motif_rotations = motif_translations = None
+            if motif_mask is not None:
+                assert motif_coords is not None
+                fixed = torch.tensor(motif_mask,
+                                     dtype=torch.bool,
+                                     device=device).expand(
+                                         num_samples, seq_length)
+                ref = torch.tensor(motif_coords,
+                                   dtype=torch.float32,
+                                   device=device)
+                m_r, m_t = build_backbone_frames(ref)
+                motif_rotations = m_r.expand(num_samples, seq_length, 3, 3)
+                motif_translations = m_t.expand(num_samples, seq_length, 3)
+                rotations = torch.where(fixed[..., None, None], motif_rotations,
+                                        rotations)
+                translations = torch.where(fixed[..., None], motif_translations,
+                                           translations)
+
+            for step in reversed(range(self.num_diffusion_steps)):
+                t_batch = torch.full((num_samples,),
+                                     step,
+                                     dtype=torch.long,
+                                     device=device)
+                noisy_coords = backbone_coords_from_frames(
+                    rotations, translations).reshape(num_samples, seq_length, 9)
+                pred_rotations, pred_translations = self.model(
+                    [noisy_coords, rotations, translations, t_batch, mask])
+                if step > 0:
+                    rotations = so3_x0_reverse_step(self.igso3, rotations,
+                                                    pred_rotations, step)
+                    translations = translation_posterior_step(
+                        self.schedule, pred_translations, translations, step)
+                else:
+                    rotations, translations = pred_rotations, pred_translations
+
+                if fixed is not None:
+                    assert (motif_rotations is not None and
+                            motif_translations is not None)
+                    rotations = torch.where(fixed[..., None, None],
+                                            motif_rotations, rotations)
+                    translations = torch.where(fixed[..., None],
+                                               motif_translations, translations)
+
+            return backbone_coords_from_frames(rotations, translations).reshape(
+                num_samples, seq_length, 9)
 
     def save_checkpoint(self,
                         max_checkpoints_to_keep: int = 5,

--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -1,0 +1,310 @@
+"""SE(3) rigid-frame math utilities for RFDiffusion.
+
+This module contains the non-learned geometric primitives used by the
+RFDiffusion stack:
+
+* residue-local frame construction from backbone atoms `(N, CA, C)`
+* rigid transform apply / inverse / invert / compose helpers
+* Rodrigues exp/log maps between so(3) vectors and SO(3) rotations
+
+The module is intentionally self-contained and depends only on PyTorch.
+"""
+
+from typing import Optional, Sequence, Tuple
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError("rfdiffusion_frames requires PyTorch to be installed.")
+
+__all__ = [
+    "apply_inverse_rigid",
+    "apply_rigid",
+    "build_backbone_frames",
+    "compose_rigids",
+    "invert_rigid",
+    "make_identity_rigid",
+    "so3_exp_map",
+    "so3_log_map",
+]
+
+_SMALL_OMEGA: float = 1e-4
+
+
+def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
+    """Normalize vectors with epsilon stabilization.
+
+    Parameters
+    ----------
+    vector : torch.Tensor
+        Tensor of shape `(..., 3)`.
+    eps : float
+        Positive epsilon added to the norm.
+
+    Returns
+    -------
+    torch.Tensor
+        Normalized vectors.
+    """
+    norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
+    return vector / (norm + eps)
+
+
+def build_backbone_frames(
+        backbone: torch.Tensor,
+        eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build residue-local frames from `(N, CA, C)` backbone coordinates.
+
+    Parameters
+    ----------
+    backbone : torch.Tensor
+        Backbone coordinates of shape `(..., 3, 3)` ordered as
+        `(N, CA, C)`.
+    eps : float, default 1e-8
+        Positive stabilization constant.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Frame origins of shape `(..., 3)`.
+    """
+    if backbone.shape[-2:] != (3, 3):
+        raise ValueError("backbone must have shape (..., 3, 3).")
+    if eps <= 0:
+        raise ValueError("eps must be positive.")
+
+    n_atom = backbone[..., 0, :]
+    ca_atom = backbone[..., 1, :]
+    c_atom = backbone[..., 2, :]
+
+    x_axis = _normalize(c_atom - ca_atom, eps)
+    n_direction = n_atom - ca_atom
+    y_axis = n_direction - (n_direction * x_axis).sum(dim=-1,
+                                                      keepdim=True) * x_axis
+    y_axis = _normalize(y_axis, eps)
+    z_axis = torch.linalg.cross(x_axis, y_axis, dim=-1)
+
+    rotations = torch.stack((x_axis, y_axis, z_axis), dim=-1)
+    return rotations, ca_atom
+
+
+def make_identity_rigid(
+        shape: Sequence[int],
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create identity rigid transforms `(I, 0)`.
+
+    Parameters
+    ----------
+    shape : sequence of int
+        Batch shape.
+    device : torch.device, optional
+        Device for returned tensors.
+    dtype : torch.dtype, optional
+        Tensor dtype.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Identity rotations of shape `(*shape, 3, 3)`.
+    translations : torch.Tensor
+        Zero translations of shape `(*shape, 3)`.
+    """
+    shape = tuple(shape)
+    rotation = torch.eye(3, device=device, dtype=dtype)
+    rotation = rotation.expand(*shape, 3, 3).contiguous().clone()
+    translation = torch.zeros(*shape, 3, device=device, dtype=dtype)
+    return rotation, translation
+
+
+def _expand_rigid_to_points(
+        rotations: torch.Tensor, translations: torch.Tensor,
+        points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Broadcast rigid transforms across extra point dimensions."""
+    extra_dims = points.dim() - translations.dim()
+    if extra_dims < 0:
+        raise ValueError(
+            "points must have at least the transform batch dimensions.")
+    for _ in range(extra_dims):
+        rotations = rotations.unsqueeze(-3)
+        translations = translations.unsqueeze(-2)
+    return rotations, translations
+
+
+def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                points: torch.Tensor) -> torch.Tensor:
+    """Apply rigid transforms `x -> x @ R.T + t`.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points of shape `(..., 3)` or with extra point axes.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points.
+    """
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    rotated = torch.matmul(points.unsqueeze(-2),
+                           rotations.transpose(-1, -2)).squeeze(-2)
+    return rotated + translations
+
+
+def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                        points: torch.Tensor) -> torch.Tensor:
+    """Apply inverse rigid transforms `y -> (y - t) @ R`."""
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    centered = points - translations
+    return torch.matmul(centered.unsqueeze(-2), rotations).squeeze(-2)
+
+
+def invert_rigid(
+        rotations: torch.Tensor,
+        translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Invert rigid transforms.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    inv_rotations : torch.Tensor
+        Transposed rotations.
+    inv_translations : torch.Tensor
+        Inverse translations.
+    """
+    inv_rotations = rotations.transpose(-1, -2)
+    inv_translations = -torch.matmul(translations.unsqueeze(-2),
+                                     rotations).squeeze(-2)
+    return inv_rotations, inv_translations
+
+
+def compose_rigids(
+        rotations_a: torch.Tensor, translations_a: torch.Tensor,
+        rotations_b: torch.Tensor,
+        translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compose two rigid transforms `T_a o T_b`.
+
+    Parameters
+    ----------
+    rotations_a, rotations_b : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations_a, translations_b : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Composite rotations.
+    translations : torch.Tensor
+        Composite translations.
+    """
+    rotations = torch.matmul(rotations_a, rotations_b)
+    translations = apply_rigid(rotations_a, translations_a, translations_b)
+    return rotations, translations
+
+
+def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
+    """Return `sin(x) / x` with a stable Taylor branch near zero."""
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
+
+
+def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
+    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch."""
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)
+    series = 0.5 - x * x / 24.0
+    return torch.where(small, series, closed)
+
+
+def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
+    """Map tangent vectors in so(3) to rotation matrices.
+
+    Parameters
+    ----------
+    tangent : torch.Tensor
+        Tangent vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    """
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)
+    zeros = torch.zeros_like(tangent[..., 0])
+    tx, ty, tz = tangent[..., 0], tangent[..., 1], tangent[..., 2]
+    skew = torch.stack([
+        torch.stack([zeros, -tz, ty], dim=-1),
+        torch.stack([tz, zeros, -tx], dim=-1),
+        torch.stack([-ty, tx, zeros], dim=-1),
+    ],
+                       dim=-2)
+    eye = torch.eye(3, dtype=tangent.dtype, device=tangent.device)
+    sin_coeff = _safe_sin_div_x(omega).unsqueeze(-1)
+    cos_coeff = _safe_one_minus_cos_div_x_sq(omega).unsqueeze(-1)
+    skew_sq = torch.matmul(skew, skew)
+    return eye + sin_coeff * skew + cos_coeff * skew_sq
+
+
+def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
+    """Map rotation matrices to tangent vectors on the principal branch.
+
+    The rotation is converted to a unit quaternion first and then to an
+    axis-angle vector. Routing through the quaternion keeps the result stable
+    for rotations near ``pi``, where reading the angle straight from the trace
+    loses accuracy because ``sin(omega)`` goes to zero.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Tangent vectors of shape `(..., 3)` whose norm lies in ``[0, pi]``.
+    """
+    m00 = rotations[..., 0, 0]
+    m11 = rotations[..., 1, 1]
+    m22 = rotations[..., 2, 2]
+    trace = m00 + m11 + m22
+
+    # Read the unit quaternion from the rotation matrix. Each component
+    # magnitude comes from the diagonal and its sign from the skew part.
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
+    qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
+    qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
+
+    quat_vec = torch.stack([qx, qy, qz], dim=-1)
+    sin_half = quat_vec.norm(dim=-1)
+    cos_half = qw.clamp(-1.0, 1.0)
+    omega = 2.0 * torch.atan2(sin_half, cos_half)
+
+    small = sin_half < _SMALL_OMEGA
+    safe_sin_half = torch.where(small, torch.ones_like(sin_half), sin_half)
+    unit_axis = quat_vec / safe_sin_half.unsqueeze(-1)
+    # Near zero rotation the axis is ill-defined; there the tangent vector
+    # is approximately 2 * (qx, qy, qz).
+    return torch.where(small.unsqueeze(-1), 2.0 * quat_vec,
+                       omega.unsqueeze(-1) * unit_axis)

--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -1,11 +1,29 @@
 """SE(3) rigid-frame math utilities for RFDiffusion.
 
-This module contains the non-learned geometric primitives used by the
-RFDiffusion stack:
+RFDiffusion represents each residue as a rigid frame: a rotation matrix
+plus a translation, the same `(R, t)` convention AlphaFold2's structure
+module uses. `build_backbone_frames` builds one such frame per residue
+from its `(N, CA, C)` backbone atoms, and the rest of the module is the
+algebra needed to work with those frames:
 
-* residue-local frame construction from backbone atoms `(N, CA, C)`
-* rigid transform apply / inverse / invert / compose helpers
-* Rodrigues exp/log maps between so(3) vectors and SO(3) rotations
+* apply / inverse-apply / invert / compose helpers for moving points and
+  frames between global and residue-local coordinates
+* Rodrigues exp/log maps between so(3) tangent vectors and SO(3) rotations
+
+Downstream, the frames from `build_backbone_frames` feed the invariant
+point attention (IPA) block, and `so3_exp_map`/`so3_log_map` are what let
+the rotational diffusion process update and read back a residue's
+orientation at each denoising step.
+
+DeepChem's `equivariance_utils.py` already has SO(3)/SE(3) exp and log
+maps, but through a `LieGroup` class built for a different representation
+(homogeneous matrices and 6D Lie algebra vectors, used by the LieConv/TFN
+layers). Converting between that and the `(R, t)` frames used here on
+every call would add overhead without simplifying anything, so this
+module keeps its own copies tailored to the frame representation. The log
+map here also goes through a quaternion rather than the matrix trace,
+which stays accurate for rotations near pi where the trace-based form
+loses precision.
 
 The module is intentionally self-contained and depends only on PyTorch.
 """
@@ -42,6 +60,7 @@ def _normalize(vector: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import _normalize
     >>> v = torch.tensor([[3.0, 0.0, 0.0], [0.0, 4.0, 0.0]])
     >>> _normalize(v)
     tensor([[1., 0., 0.],
@@ -86,6 +105,7 @@ def build_backbone_frames(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import build_backbone_frames
     >>> n = torch.tensor([0.0, 1.0, 0.0])
     >>> ca = torch.tensor([0.0, 0.0, 0.0])
     >>> c = torch.tensor([1.0, 0.0, 0.0])
@@ -142,6 +162,7 @@ def make_identity_rigid(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
     >>> R, t = make_identity_rigid((2, 4))
     >>> R.shape
     torch.Size([2, 4, 3, 3])
@@ -175,6 +196,19 @@ def _expand_rigid_to_points(
         Rotations with unsqueezed singleton dimensions matching points.
     expanded_translations : torch.Tensor
         Translations with unsqueezed singleton dimensions matching points.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     make_identity_rigid, _expand_rigid_to_points)
+    >>> R, t = make_identity_rigid((2,))
+    >>> points = torch.randn(2, 5, 3)  # 5 atoms per residue
+    >>> R_exp, t_exp = _expand_rigid_to_points(R, t, points)
+    >>> R_exp.shape
+    torch.Size([2, 1, 3, 3])
+    >>> t_exp.shape
+    torch.Size([2, 1, 3])
     """
     extra_dims = points.dim() - translations.dim()
     if extra_dims < 0:
@@ -209,6 +243,8 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     apply_rigid, make_identity_rigid)
     >>> R, t = make_identity_rigid((2,))
     >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     >>> out = apply_rigid(R, t, pts)
@@ -245,6 +281,8 @@ def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     apply_inverse_rigid, make_identity_rigid)
     >>> R, t = make_identity_rigid((2,))
     >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
     >>> out = apply_inverse_rigid(R, t, pts)
@@ -279,6 +317,7 @@ def invert_rigid(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import invert_rigid
     >>> R = torch.eye(3)
     >>> t = torch.tensor([1.0, 2.0, 3.0])
     >>> inv_R, inv_t = invert_rigid(R, t)
@@ -314,6 +353,8 @@ def compose_rigids(
     Examples
     --------
     >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     compose_rigids, make_identity_rigid)
     >>> R1, t1 = make_identity_rigid(())
     >>> R2, t2 = make_identity_rigid(())
     >>> R_comp, t_comp = compose_rigids(R1, t1, R2, t2)
@@ -326,14 +367,42 @@ def compose_rigids(
 
 
 def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
-    """Return `sin(x) / x` with a stable Taylor branch near zero."""
+    """Return `sin(x) / x` with a stable Taylor branch near zero.
+
+    Used by `so3_exp_map` as the coefficient on the skew-symmetric term of
+    Rodrigues' formula, where `x` is the rotation angle `omega`.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor, typically a batch of rotation angles.
+
+    Returns
+    -------
+    torch.Tensor
+        Elementwise `sin(x) / x`, same shape as `x`.
+    """
     small = x.abs() < _SMALL_OMEGA
     safe_x = torch.where(small, torch.ones_like(x), x)
     return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
 
 
 def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
-    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch."""
+    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch.
+
+    Used by `so3_exp_map` as the coefficient on the squared skew-symmetric
+    term of Rodrigues' formula, where `x` is the rotation angle `omega`.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor, typically a batch of rotation angles.
+
+    Returns
+    -------
+    torch.Tensor
+        Elementwise `(1 - cos(x)) / x^2`, same shape as `x`.
+    """
     small = x.abs() < _SMALL_OMEGA
     safe_x = torch.where(small, torch.ones_like(x), x)
     closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)

--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -17,34 +17,35 @@ try:
 except ModuleNotFoundError:
     raise ImportError("rfdiffusion_frames requires PyTorch to be installed.")
 
-__all__ = [
-    "apply_inverse_rigid",
-    "apply_rigid",
-    "build_backbone_frames",
-    "compose_rigids",
-    "invert_rigid",
-    "make_identity_rigid",
-    "so3_exp_map",
-    "so3_log_map",
-]
-
+# Threshold for small-angle Taylor expansions.
+# For rotation angles theta < 1e-4, sin(theta)/theta ~ 1 - theta^2/6 and
+# (1 - cos(theta))/theta^2 ~ 1/2 - theta^2/24. This avoids division-by-zero
+# and float32 precision loss near the identity (Grassia, 1998).
 _SMALL_OMEGA: float = 1e-4
 
 
-def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
-    """Normalize vectors with epsilon stabilization.
+def _normalize(vector: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Normalize 3D vectors along the last dimension with epsilon stabilization.
 
     Parameters
     ----------
     vector : torch.Tensor
         Tensor of shape `(..., 3)`.
-    eps : float
-        Positive epsilon added to the norm.
+    eps : float, default 1e-8
+        Small positive constant added to the norm denominator.
 
     Returns
     -------
     torch.Tensor
-        Normalized vectors.
+        Normalized vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> v = torch.tensor([[3.0, 0.0, 0.0], [0.0, 4.0, 0.0]])
+    >>> _normalize(v)
+    tensor([[1., 0., 0.],
+            [0., 1., 0.]])
     """
     norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
     return vector / (norm + eps)
@@ -53,22 +54,47 @@ def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
 def build_backbone_frames(
         backbone: torch.Tensor,
         eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Build residue-local frames from `(N, CA, C)` backbone coordinates.
+    """Construct residue-local coordinate frames from protein backbone coordinates.
+
+    Builds an orthonormal right-handed reference frame for each residue
+    from N, CA, and C atom positions using Gram-Schmidt orthogonalization:
+    - The x-axis points along the CA -> C bond.
+    - The xy-plane contains the N, CA, and C atoms (with N in the positive y-half).
+    - The z-axis is the cross product x x y.
+    - The frame origin is positioned at the CA atom.
 
     Parameters
     ----------
     backbone : torch.Tensor
-        Backbone coordinates of shape `(..., 3, 3)` ordered as
-        `(N, CA, C)`.
+        Backbone coordinates of shape `(..., 3, 3)` ordered as `(N, CA, C)`
+        along the second-to-last dimension.
     eps : float, default 1e-8
-        Positive stabilization constant.
+        Small positive constant to avoid division by zero during normalization.
 
     Returns
     -------
     rotations : torch.Tensor
-        Rotation matrices of shape `(..., 3, 3)`.
+        Rotation matrices of shape `(..., 3, 3)` representing local frame orientations.
     translations : torch.Tensor
-        Frame origins of shape `(..., 3)`.
+        Frame origins of shape `(..., 3)` corresponding to CA coordinates.
+
+    Raises
+    ------
+    ValueError
+        If backbone does not have shape `(..., 3, 3)` or `eps <= 0`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> n = torch.tensor([0.0, 1.0, 0.0])
+    >>> ca = torch.tensor([0.0, 0.0, 0.0])
+    >>> c = torch.tensor([1.0, 0.0, 0.0])
+    >>> backbone = torch.stack([n, ca, c], dim=0)
+    >>> R, t = build_backbone_frames(backbone)
+    >>> R.shape
+    torch.Size([3, 3])
+    >>> t.shape
+    torch.Size([3])
     """
     if backbone.shape[-2:] != (3, 3):
         raise ValueError("backbone must have shape (..., 3, 3).")
@@ -95,23 +121,32 @@ def make_identity_rigid(
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Create identity rigid transforms `(I, 0)`.
+    """Create identity rigid transforms (identity rotation and zero translation).
 
     Parameters
     ----------
     shape : sequence of int
-        Batch shape.
+        Batch shape for the generated transforms.
     device : torch.device, optional
-        Device for returned tensors.
+        Target device for the returned tensors.
     dtype : torch.dtype, optional
-        Tensor dtype.
+        Target data type for the returned tensors.
 
     Returns
     -------
     rotations : torch.Tensor
-        Identity rotations of shape `(*shape, 3, 3)`.
+        Identity rotation matrices of shape `(*shape, 3, 3)`.
     translations : torch.Tensor
-        Zero translations of shape `(*shape, 3)`.
+        Zero translation vectors of shape `(*shape, 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2, 4))
+    >>> R.shape
+    torch.Size([2, 4, 3, 3])
+    >>> t.shape
+    torch.Size([2, 4, 3])
     """
     shape = tuple(shape)
     rotation = torch.eye(3, device=device, dtype=dtype)
@@ -123,7 +158,24 @@ def make_identity_rigid(
 def _expand_rigid_to_points(
         rotations: torch.Tensor, translations: torch.Tensor,
         points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Broadcast rigid transforms across extra point dimensions."""
+    """Broadcast rigid transform batch dimensions across extra point dimensions.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points tensor of shape `(..., *extra_dims, 3)`.
+
+    Returns
+    -------
+    expanded_rotations : torch.Tensor
+        Rotations with unsqueezed singleton dimensions matching points.
+    expanded_translations : torch.Tensor
+        Translations with unsqueezed singleton dimensions matching points.
+    """
     extra_dims = points.dim() - translations.dim()
     if extra_dims < 0:
         raise ValueError(
@@ -136,7 +188,9 @@ def _expand_rigid_to_points(
 
 def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
                 points: torch.Tensor) -> torch.Tensor:
-    """Apply rigid transforms `x -> x @ R.T + t`.
+    """Apply rigid transforms to 3D points: `y = points @ R.T + t`.
+
+    Transforms points from local coordinates to global coordinates.
 
     Parameters
     ----------
@@ -145,12 +199,21 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     translations : torch.Tensor
         Translation vectors of shape `(..., 3)`.
     points : torch.Tensor
-        Points of shape `(..., 3)` or with extra point axes.
+        Points tensor of shape `(..., 3)` or with extra point axes.
 
     Returns
     -------
     torch.Tensor
-        Transformed points.
+        Transformed points of the same shape as `points`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2,))
+    >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> out = apply_rigid(R, t, pts)
+    >>> torch.allclose(out, pts)
+    True
     """
     rotations, translations = _expand_rigid_to_points(rotations, translations,
                                                       points)
@@ -161,7 +224,33 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
 
 def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
                         points: torch.Tensor) -> torch.Tensor:
-    """Apply inverse rigid transforms `y -> (y - t) @ R`."""
+    """Apply inverse rigid transforms to 3D points: `x = (points - t) @ R`.
+
+    Transforms points from global coordinates back to local residue coordinates.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points tensor of shape `(..., 3)` or with extra point axes.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points of the same shape as `points`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2,))
+    >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> out = apply_inverse_rigid(R, t, pts)
+    >>> torch.allclose(out, pts)
+    True
+    """
     rotations, translations = _expand_rigid_to_points(rotations, translations,
                                                       points)
     centered = points - translations
@@ -171,7 +260,7 @@ def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
 def invert_rigid(
         rotations: torch.Tensor,
         translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Invert rigid transforms.
+    """Compute the inverse of rigid transforms `(R, t)^(-1) = (R.T, -t @ R)`.
 
     Parameters
     ----------
@@ -183,9 +272,18 @@ def invert_rigid(
     Returns
     -------
     inv_rotations : torch.Tensor
-        Transposed rotations.
+        Inverted rotation matrices of shape `(..., 3, 3)`.
     inv_translations : torch.Tensor
-        Inverse translations.
+        Inverted translation vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R = torch.eye(3)
+    >>> t = torch.tensor([1.0, 2.0, 3.0])
+    >>> inv_R, inv_t = invert_rigid(R, t)
+    >>> inv_t
+    tensor([-1., -2., -3.])
     """
     inv_rotations = rotations.transpose(-1, -2)
     inv_translations = -torch.matmul(translations.unsqueeze(-2),
@@ -197,7 +295,7 @@ def compose_rigids(
         rotations_a: torch.Tensor, translations_a: torch.Tensor,
         rotations_b: torch.Tensor,
         translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Compose two rigid transforms `T_a o T_b`.
+    """Compose two rigid transforms `T_a o T_b = (R_a @ R_b, apply_rigid(T_a, t_b))`.
 
     Parameters
     ----------
@@ -209,9 +307,18 @@ def compose_rigids(
     Returns
     -------
     rotations : torch.Tensor
-        Composite rotations.
+        Composed rotation matrices of shape `(..., 3, 3)`.
     translations : torch.Tensor
-        Composite translations.
+        Composed translation vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R1, t1 = make_identity_rigid(())
+    >>> R2, t2 = make_identity_rigid(())
+    >>> R_comp, t_comp = compose_rigids(R1, t1, R2, t2)
+    >>> R_comp.shape
+    torch.Size([3, 3])
     """
     rotations = torch.matmul(rotations_a, rotations_b)
     translations = apply_rigid(rotations_a, translations_a, translations_b)
@@ -235,17 +342,26 @@ def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
 
 
 def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
-    """Map tangent vectors in so(3) to rotation matrices.
+    """Map so(3) tangent vectors (axis-angle) to SO(3) rotation matrices via Rodrigues' formula.
 
     Parameters
     ----------
     tangent : torch.Tensor
-        Tangent vectors of shape `(..., 3)`.
+        Tangent vectors of shape `(..., 3)` where direction specifies the
+        rotation axis and norm specifies the rotation angle in radians.
 
     Returns
     -------
     torch.Tensor
         Rotation matrices of shape `(..., 3, 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> w = torch.zeros(3)
+    >>> R = so3_exp_map(w)
+    >>> torch.allclose(R, torch.eye(3))
+    True
     """
     omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)
     zeros = torch.zeros_like(tangent[..., 0])
@@ -264,12 +380,12 @@ def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
 
 
 def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
-    """Map rotation matrices to tangent vectors on the principal branch.
+    """Map SO(3) rotation matrices to so(3) tangent vectors on the principal branch.
 
-    The rotation is converted to a unit quaternion first and then to an
+    The rotation matrix is converted to a unit quaternion first and then to an
     axis-angle vector. Routing through the quaternion keeps the result stable
-    for rotations near ``pi``, where reading the angle straight from the trace
-    loses accuracy because ``sin(omega)`` goes to zero.
+    for rotations near pi, where reading the angle from the matrix trace
+    loses accuracy because sin(omega) goes to zero.
 
     Parameters
     ----------
@@ -279,7 +395,15 @@ def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
     Returns
     -------
     torch.Tensor
-        Tangent vectors of shape `(..., 3)` whose norm lies in ``[0, pi]``.
+        Tangent vectors of shape `(..., 3)` whose norm lies in `[0, pi]`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R = torch.eye(3)
+    >>> w = so3_log_map(R)
+    >>> torch.allclose(w, torch.zeros(3))
+    True
     """
     m00 = rotations[..., 0, 0]
     m11 = rotations[..., 1, 1]

--- a/deepchem/models/torch_models/rfdiffusion_ipa.py
+++ b/deepchem/models/torch_models/rfdiffusion_ipa.py
@@ -1,0 +1,328 @@
+"""Invariant Point Attention for SE(3)-equivariant protein structure models.
+
+This module adds :class:`InvariantPointAttention`, the core geometric
+attention block from AlphaFold2 (Algorithm 22).  The layer computes
+attention over residues using scalar features plus 3-D point features
+that live in each residue's local frame.  The key property is that the
+scalar output is exactly invariant to any global rigid transform of the
+input frames, so the network does not need to track absolute
+orientation.
+
+The three logit contributions are:
+
+* Scaled dot-product of the scalar Q/K projections.
+* Negative half-sum of squared point distances between query and key
+  points lifted to the global frame.
+* Optional per-head bias projected from a pairwise representation.
+
+This is PR 6 in the RFDiffusion integration.  It depends on the
+rigid-frame utilities in ``rfdiffusion_frames.py`` (PR 5 / #4982).
+
+References
+----------
+.. [Jumper2021] Jumper, J. et al. *Highly accurate protein structure
+   prediction with AlphaFold.* Nature 596, 583-589 (2021).
+.. [Watson2023] Watson, J. L. et al. *De novo design of protein
+   structure and function with RFdiffusion.* Nature 620, 1089-1100
+   (2023).
+"""
+
+import math
+from typing import Optional
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_ipa requires PyTorch to be installed.')
+
+from deepchem.models.torch_models.rfdiffusion_frames import (
+    apply_inverse_rigid,
+    apply_rigid,
+)
+
+
+class InvariantPointAttention(nn.Module):
+    """SE(3)-invariant attention over residue frames.
+
+    Computes per-residue attention logits using three additive terms
+    (scalar QK, point-distance, and optional pair bias) following
+    AlphaFold2 supplementary Algorithm 22.  The scalar output is
+    invariant to any global rigid motion of the input frames.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Scalar input / output channel width.  Must be a positive
+        multiple of ``num_heads``.
+    num_heads : int, default 8
+        Number of attention heads.
+    num_qk_points : int, default 4
+        Number of 3-D query / key points per head.
+    num_v_points : int, default 8
+        Number of 3-D value points per head.
+    pair_dim : int, optional
+        Width of an optional pairwise feature tensor ``z_{ij}``.  When
+        set, the layer accepts ``pair_repr`` in :meth:`forward` and uses
+        it both as a logit bias and as an additional output feature.
+    dropout : float, default 0.0
+        Dropout probability applied to attention weights.
+    eps : float, default 1e-8
+        Small constant added inside the point-norm sqrt to keep
+        gradients finite.
+
+    Raises
+    ------
+    ValueError
+        If any parameter is out of range or inconsistent.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_ipa import (
+    ...     InvariantPointAttention)
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     build_backbone_frames)
+    >>> _ = torch.manual_seed(0)
+    >>> backbone = torch.randn(2, 5, 3, 3)
+    >>> R, t = build_backbone_frames(backbone)
+    >>> layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+    >>> out = layer(torch.randn(2, 5, 16), R, t)
+    >>> tuple(out.shape)
+    (2, 5, 16)
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 num_heads: int = 8,
+                 num_qk_points: int = 4,
+                 num_v_points: int = 8,
+                 pair_dim: Optional[int] = None,
+                 dropout: float = 0.0,
+                 eps: float = 1e-8) -> None:
+        super().__init__()
+        if embed_dim <= 0:
+            raise ValueError('embed_dim must be positive.')
+        if num_heads <= 0:
+            raise ValueError('num_heads must be positive.')
+        if embed_dim % num_heads != 0:
+            raise ValueError('embed_dim must be divisible by num_heads.')
+        if num_qk_points <= 0:
+            raise ValueError('num_qk_points must be positive.')
+        if num_v_points <= 0:
+            raise ValueError('num_v_points must be positive.')
+        if pair_dim is not None and pair_dim <= 0:
+            raise ValueError('pair_dim must be positive when provided.')
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError('dropout must lie in [0, 1).')
+        if eps <= 0:
+            raise ValueError('eps must be positive.')
+
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.num_qk_points = num_qk_points
+        self.num_v_points = num_v_points
+        self.pair_dim = pair_dim
+        self.eps = eps
+
+        # Scalar Q / K / V projections.
+        self.query_scalar = nn.Linear(embed_dim, embed_dim)
+        self.key_scalar = nn.Linear(embed_dim, embed_dim)
+        self.value_scalar = nn.Linear(embed_dim, embed_dim)
+
+        # 3-D point projections.  Output is interpreted as
+        # (num_heads * num_points, 3) and reshaped accordingly.
+        self.query_points = nn.Linear(embed_dim, num_heads * num_qk_points * 3)
+        self.key_points = nn.Linear(embed_dim, num_heads * num_qk_points * 3)
+        self.value_points = nn.Linear(embed_dim, num_heads * num_v_points * 3)
+
+        # Optional pair-bias projection.
+        self.pair_bias: Optional[nn.Linear]
+        if pair_dim is not None:
+            self.pair_bias = nn.Linear(pair_dim, num_heads, bias=False)
+        else:
+            self.pair_bias = None
+
+        # Learnable per-head point-distance weight (scalar gamma^h). The raw
+        # value is initialised to log(e - 1) so that softplus(raw) = 1 at the
+        # start of training, matching the AlphaFold2 default.
+        self.point_weights = nn.Parameter(
+            torch.full((num_heads,), math.log(math.exp(1.0) - 1.0)))
+
+        # Output linear: concatenation of scalar + (pair) + point vectors +
+        # point norms.
+        point_features = num_heads * num_v_points * (3 + 1)
+        pair_features = num_heads * pair_dim if pair_dim is not None else 0
+        self.output = nn.Linear(embed_dim + pair_features + point_features,
+                                embed_dim)
+        self.dropout = nn.Dropout(dropout)
+
+        # AF2 weighting constants. Kept as plain floats so they broadcast
+        # over any dtype or device without extra handling.
+        self.w_c = math.sqrt(2.0 / (9.0 * num_qk_points))
+        num_sources = 3.0 if pair_dim is not None else 2.0
+        self.w_l = math.sqrt(1.0 / num_sources)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _reshape_scalar(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reshape ``(B, L, H*c)`` to ``(B, H, L, c)``."""
+        b, l, _ = tensor.shape
+        return tensor.view(b, l, self.num_heads,
+                           self.head_dim).permute(0, 2, 1, 3)
+
+    def _reshape_points(self, tensor: torch.Tensor,
+                        num_points: int) -> torch.Tensor:
+        """Reshape ``(B, L, H*P*3)`` to ``(B, L, H, P, 3)``."""
+        b, l, _ = tensor.shape
+        return tensor.view(b, l, self.num_heads, num_points, 3)
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+
+    def forward(self,
+                single_repr: torch.Tensor,
+                rotations: torch.Tensor,
+                translations: torch.Tensor,
+                pair_repr: Optional[torch.Tensor] = None,
+                mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Apply IPA to update per-residue scalar features.
+
+        Parameters
+        ----------
+        single_repr : torch.Tensor
+            Residue features, shape ``(batch, num_residues, embed_dim)``.
+        rotations : torch.Tensor
+            Residue frame rotations, shape
+            ``(batch, num_residues, 3, 3)``.
+        translations : torch.Tensor
+            Residue frame origins, shape ``(batch, num_residues, 3)``.
+        pair_repr : torch.Tensor, optional
+            Pairwise features, shape
+            ``(batch, num_residues, num_residues, pair_dim)``.  Required
+            when the layer was built with ``pair_dim`` set; forbidden
+            otherwise.
+        mask : torch.Tensor, optional
+            Boolean residue mask, shape ``(batch, num_residues)``.
+            Masked residues are excluded as attention keys and their
+            output rows are zeroed.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated residue features, shape
+            ``(batch, num_residues, embed_dim)``.
+
+        Raises
+        ------
+        ValueError
+            On shape or consistency mismatches.
+        """
+        if single_repr.dim() != 3:
+            raise ValueError(
+                'single_repr must have shape (batch, num_residues, embed_dim).')
+        b, l, _ = single_repr.shape
+        device = single_repr.device
+
+        if rotations.shape != (b, l, 3, 3):
+            raise ValueError(
+                'rotations must have shape (batch, num_residues, 3, 3).')
+        if translations.shape != (b, l, 3):
+            raise ValueError(
+                'translations must have shape (batch, num_residues, 3).')
+
+        if (pair_repr is None) != (self.pair_dim is None):
+            raise ValueError(
+                'pair_repr must be provided iff pair_dim was set at '
+                'construction.')
+        if pair_repr is not None and pair_repr.shape != (b, l, l,
+                                                         self.pair_dim):
+            raise ValueError('pair_repr must have shape '
+                             '(batch, num_residues, num_residues, pair_dim).')
+
+        if mask is not None and mask.shape != (b, l):
+            raise ValueError('mask must have shape (batch, num_residues).')
+        if mask is not None:
+            mask = mask.to(dtype=torch.bool, device=device)
+
+        # ---------- Scalar Q / K / V projections (B, H, L, c) --------
+        qs = self._reshape_scalar(self.query_scalar(single_repr))
+        ks = self._reshape_scalar(self.key_scalar(single_repr))
+        vs = self._reshape_scalar(self.value_scalar(single_repr))
+
+        # ---------- 3-D point projections in local frames (B, L, H, P, 3)
+        qp_local = self._reshape_points(self.query_points(single_repr),
+                                        self.num_qk_points)
+        kp_local = self._reshape_points(self.key_points(single_repr),
+                                        self.num_qk_points)
+        vp_local = self._reshape_points(self.value_points(single_repr),
+                                        self.num_v_points)
+
+        # Lift points from local residue frame to global frame using T_i.
+        qp = apply_rigid(rotations, translations,
+                         qp_local).permute(0, 2, 1, 3, 4)
+        kp = apply_rigid(rotations, translations,
+                         kp_local).permute(0, 2, 1, 3, 4)
+        vp = apply_rigid(rotations, translations,
+                         vp_local).permute(0, 2, 1, 3, 4)
+
+        # ---------- Logits --------------------------------------------
+        scalar_logits = torch.matmul(qs, ks.transpose(-1, -2))
+        scalar_logits = scalar_logits / math.sqrt(self.head_dim)
+
+        # Point-distance term: (B, H, L_q, L_k).
+        # qp: (B, H, L_q, P, 3), kp: (B, H, L_k, P, 3)
+        point_diff = qp.unsqueeze(3) - kp.unsqueeze(2)
+        point_dist2 = point_diff.pow(2).sum(dim=(-1, -2))
+
+        gamma = F.softplus(self.point_weights).view(1, self.num_heads, 1, 1)
+        point_logits = -0.5 * self.w_c * gamma * point_dist2
+
+        if self.pair_bias is not None:
+            assert pair_repr is not None
+            bias = self.pair_bias(pair_repr).permute(0, 3, 1, 2)  # (B, H, L, L)
+        else:
+            bias = torch.zeros_like(scalar_logits)
+
+        logits = self.w_l * (scalar_logits + point_logits + bias)
+
+        # ---------- Mask and attention --------------------------------
+        if mask is not None:
+            logits = logits.masked_fill(~mask.view(b, 1, 1, l),
+                                        torch.finfo(logits.dtype).min)
+
+        attn = torch.softmax(logits, dim=-1)
+        attn = self.dropout(attn)
+
+        # ---------- Outputs -------------------------------------------
+        # Scalar output (B, L, H*c).
+        scalar_out = torch.matmul(attn, vs)
+        scalar_out = scalar_out.permute(0, 2, 1,
+                                        3).reshape(b, l, self.embed_dim)
+
+        # Point output: weighted sum in global frame, then back to local.
+        # attn: (B, H, L, L), vp: (B, H, L, P, 3)
+        vp_out_global = torch.einsum('bhij,bhjpd->bhipd', attn, vp)
+        vp_out_global = vp_out_global.permute(0, 2, 1, 3, 4)
+        vp_out_local = apply_inverse_rigid(rotations, translations,
+                                           vp_out_global)
+        vp_norms = torch.sqrt(vp_out_local.pow(2).sum(-1) + self.eps)
+        vp_out_flat = vp_out_local.reshape(b, l, -1)
+        vp_norms_flat = vp_norms.reshape(b, l, -1)
+
+        parts = [scalar_out]
+        if self.pair_bias is not None:
+            assert pair_repr is not None
+            pair_out = torch.einsum('bhij,bijc->bihc', attn, pair_repr)
+            parts.append(pair_out.reshape(b, l, -1))
+        parts.extend([vp_out_flat, vp_norms_flat])
+
+        out = self.output(torch.cat(parts, dim=-1))
+        if mask is not None:
+            out = out * mask.unsqueeze(-1).to(dtype=out.dtype)
+        return out

--- a/deepchem/models/torch_models/rfdiffusion_ipa.py
+++ b/deepchem/models/torch_models/rfdiffusion_ipa.py
@@ -34,13 +34,14 @@ try:
     import torch
     import torch.nn as nn
     import torch.nn.functional as F
-except ModuleNotFoundError:
-    raise ImportError('rfdiffusion_ipa requires PyTorch to be installed.')
-
-from deepchem.models.torch_models.rfdiffusion_frames import (
-    apply_inverse_rigid,
-    apply_rigid,
-)
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        apply_inverse_rigid,
+        apply_rigid,
+    )
+except (ModuleNotFoundError, ImportError):
+    raise ImportError(
+        'rfdiffusion_ipa requires PyTorch and rfdiffusion_frames to be installed.'
+    )
 
 
 class InvariantPointAttention(nn.Module):

--- a/deepchem/models/torch_models/rfdiffusion_ipa.py
+++ b/deepchem/models/torch_models/rfdiffusion_ipa.py
@@ -223,6 +223,20 @@ class InvariantPointAttention(nn.Module):
         ------
         ValueError
             On shape or consistency mismatches.
+
+        Examples
+        --------
+        >>> import torch
+        >>> from deepchem.models.torch_models.rfdiffusion_ipa import (
+        ...     InvariantPointAttention)
+        >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+        ...     build_backbone_frames)
+        >>> backbone = torch.randn(2, 5, 3, 3)
+        >>> R, t = build_backbone_frames(backbone)
+        >>> layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        >>> out = layer.forward(torch.randn(2, 5, 16), R, t)
+        >>> tuple(out.shape)
+        (2, 5, 16)
         """
         if single_repr.dim() != 3:
             raise ValueError(

--- a/deepchem/models/torch_models/rfdiffusion_multitrack.py
+++ b/deepchem/models/torch_models/rfdiffusion_multitrack.py
@@ -223,6 +223,24 @@ class RFDiffusionMultiTrackDenoiser(nn.Module):
         pred_translations : torch.Tensor
             Predicted denoised translations, shape ``(batch, num_residues,
             3)``.
+
+        Examples
+        --------
+        >>> import torch
+        >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+        ...     RFDiffusionMultiTrackDenoiser)
+        >>> denoiser = RFDiffusionMultiTrackDenoiser(
+        ...     embed_dim=32, pair_dim=16, num_blocks=1, num_heads=4,
+        ...     pair_num_heads=2)
+        >>> noisy_coords = torch.randn(2, 6, 9)
+        >>> rotations = torch.eye(3).expand(2, 6, 3, 3).contiguous()
+        >>> translations = torch.zeros(2, 6, 3)
+        >>> t = torch.tensor([3, 7])
+        >>> mask = torch.ones(2, 6)
+        >>> pred_r, pred_t = denoiser.forward(
+        ...     [noisy_coords, rotations, translations, t, mask])
+        >>> pred_r.shape, pred_t.shape
+        (torch.Size([2, 6, 3, 3]), torch.Size([2, 6, 3]))
         """
         noisy_coords, rotations, translations, t, mask = inputs
         t = t.long()
@@ -283,6 +301,11 @@ def sample_noisy_frames(
         Shape ``(batch, num_residues, 3, 3)``.
     noisy_translations : torch.Tensor
         Shape ``(batch, num_residues, 3)``.
+
+    Raises
+    ------
+    ValueError
+        If `rotations0` and `t` do not share the same batch size.
 
     Examples
     --------
@@ -357,6 +380,11 @@ def translation_posterior_step(
     torch.Tensor
         Translations at timestep ``t - 1``, same shape as ``x_t``.
 
+    Raises
+    ------
+    ValueError
+        If `t` is negative.
+
     Examples
     --------
     >>> import torch
@@ -422,6 +450,11 @@ def so3_x0_reverse_step(
     -------
     torch.Tensor
         Rotations at timestep ``t - 1``, same shape as ``rotations_t``.
+
+    Raises
+    ------
+    ValueError
+        If `t` is not positive.
 
     Examples
     --------

--- a/deepchem/models/torch_models/rfdiffusion_multitrack.py
+++ b/deepchem/models/torch_models/rfdiffusion_multitrack.py
@@ -1,0 +1,522 @@
+"""Frame-based multi-track denoiser that connects RFDiffusion's
+RoseTTAFold-style network to combined SO(3) + translation diffusion.
+
+The pieces built in earlier PRs -- rigid frames (``rfdiffusion_frames``),
+Invariant Point Attention (``rfdiffusion_ipa``), the pair-track blocks
+(``rfdiffusion_pair_track``), the sequence/structure track and
+``RFDiffusionMultiTrackStack`` (``rfdiffusion_sequence_track``), and IGSO(3)
+rotational diffusion (``rfdiffusion_so3``) -- are all standalone modules.
+This module is the glue: it wraps ``RFDiffusionMultiTrackStack`` into a
+denoiser that predicts a full backbone frame (rotation + translation) per
+residue, and provides the forward-noising and reverse-sampling steps needed
+to actually run combined rotational/translational diffusion end to end.
+
+Unlike the coordinate-space baseline in
+:mod:`deepchem.models.torch_models.layers` (``BackboneDiffusion``), which
+predicts additive Gaussian noise on flat ``(N, CA, C)`` coordinates, this
+denoiser follows RFdiffusion's own parameterization: the network predicts
+the denoised structure ``x0`` (here, per-residue rigid frames) directly at
+every step, matching the original repository's ``px0`` convention.
+
+References
+----------
+.. [Watson2023] Watson, J. L., et al. "De novo design of protein structure
+   and function with RFdiffusion." Nature 620.7976 (2023): 1089-1100.
+.. [Yim2023] Yim, J., et al. "SE(3) diffusion model with application to
+   protein backbone generation." ICML 2023.
+.. [Jumper2021] Jumper, J., et al. "Highly accurate protein structure
+   prediction with AlphaFold." Nature 596 (2021): 583-589.
+
+Notes
+-----
+This module requires PyTorch to be installed.
+"""
+
+from typing import List, Optional, Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+except ModuleNotFoundError:
+    raise ImportError(
+        'rfdiffusion_multitrack requires PyTorch to be installed.')
+
+from deepchem.models.torch_models.layers import (
+    CosineSchedule,
+    PositionalEncoding,
+    ResidueEmbedding,
+    SinusoidalTimestepEmbedding,
+)
+from deepchem.models.torch_models.rfdiffusion_frames import apply_rigid
+from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    RFDiffusionMultiTrackStack,)
+from deepchem.models.torch_models.rfdiffusion_so3 import (
+    IGSO3,
+    so3_exp_map,
+    so3_log_map,
+)
+
+__all__ = [
+    'RFDiffusionMultiTrackDenoiser',
+    'backbone_coords_from_frames',
+    'multitrack_frame_loss',
+    'sample_noisy_frames',
+    'so3_x0_reverse_step',
+    'translation_posterior_step',
+]
+
+# Idealized backbone geometry (CA at the origin, C along +x), taken from
+# RFdiffusion's own ``chemical.py`` literature backbone coordinates. These
+# are the exact values ``build_backbone_frames`` implicitly inverts: they
+# let us turn a predicted (rotation, translation) frame back into
+# (N, CA, C) coordinates without needing predicted bond lengths/angles.
+_IDEAL_LOCAL_N: Tuple[float, float, float] = (-0.5272, 1.3593, 0.0)
+_IDEAL_LOCAL_CA: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+_IDEAL_LOCAL_C: Tuple[float, float, float] = (1.5233, 0.0, 0.0)
+
+
+def backbone_coords_from_frames(rotations: torch.Tensor,
+                                translations: torch.Tensor) -> torch.Tensor:
+    """Reconstruct idealized (N, CA, C) coordinates from rigid frames.
+
+    Applies each rigid transform to the fixed literature backbone geometry
+    used by RFdiffusion, giving the inverse of the frame construction done
+    by :func:`~deepchem.models.torch_models.rfdiffusion_frames.build_backbone_frames`
+    for perfectly idealized geometry.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+    translations : torch.Tensor
+        Frame origins (CA positions) of shape ``(..., 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Backbone coordinates of shape ``(..., 3, 3)`` ordered ``(N, CA, C)``
+        along the second-to-last dimension.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    ...     backbone_coords_from_frames)
+    >>> R = torch.eye(3).expand(2, 5, 3, 3)
+    >>> t = torch.zeros(2, 5, 3)
+    >>> coords = backbone_coords_from_frames(R, t)
+    >>> coords.shape
+    torch.Size([2, 5, 3, 3])
+    """
+    ideal_local = torch.tensor(
+        [_IDEAL_LOCAL_N, _IDEAL_LOCAL_CA, _IDEAL_LOCAL_C],
+        device=rotations.device,
+        dtype=rotations.dtype)
+    batch_shape = rotations.shape[:-2]
+    ideal_local = ideal_local.expand(*batch_shape, 3, 3)
+    return apply_rigid(rotations, translations, ideal_local)
+
+
+class RFDiffusionMultiTrackDenoiser(nn.Module):
+    """Frame-based denoiser built on ``RFDiffusionMultiTrackStack``.
+
+    Embeds noisy backbone coordinates and a diffusion timestep into a
+    single-residue representation, runs the RoseTTAFold-style multi-track
+    stack (pair track, sequence/structure track, Invariant Point
+    Attention), and returns the stack's predicted rigid frames directly as
+    the ``x0`` (denoised structure) prediction -- there is no separate
+    output head, since ``RFDiffusionMultiTrackStack.forward_tracks``
+    already returns updated ``(rotations, translations)``.
+
+    Parameters
+    ----------
+    embed_dim : int, default 128
+        Single-track channel size.
+    pair_dim : int, default 64
+        Pair-track channel size.
+    time_dim : int, default 128
+        Dimension of the sinusoidal timestep embedding.
+    num_blocks : int, default 2
+        Number of stacked multi-track blocks.
+    num_heads : int, default 8
+        Attention heads for the single track and IPA.
+    pair_num_heads : int, default 4
+        Attention heads for triangular self-attention.
+    max_seq_len : int, default 512
+        Maximum supported protein length in residues.
+    dropout : float, default 0.0
+        Shared dropout probability.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    ...     RFDiffusionMultiTrackDenoiser)
+    >>> denoiser = RFDiffusionMultiTrackDenoiser(
+    ...     embed_dim=32, pair_dim=16, num_blocks=1, num_heads=4,
+    ...     pair_num_heads=2)
+    >>> noisy_coords = torch.randn(2, 6, 9)
+    >>> rotations = torch.eye(3).expand(2, 6, 3, 3).contiguous()
+    >>> translations = torch.zeros(2, 6, 3)
+    >>> t = torch.tensor([3, 7])
+    >>> mask = torch.ones(2, 6)
+    >>> pred_r, pred_t = denoiser(
+    ...     [noisy_coords, rotations, translations, t, mask])
+    >>> pred_r.shape, pred_t.shape
+    (torch.Size([2, 6, 3, 3]), torch.Size([2, 6, 3]))
+    """
+
+    def __init__(self,
+                 embed_dim: int = 128,
+                 pair_dim: int = 64,
+                 time_dim: int = 128,
+                 num_blocks: int = 2,
+                 num_heads: int = 8,
+                 pair_num_heads: int = 4,
+                 max_seq_len: int = 512,
+                 dropout: float = 0.0) -> None:
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.time_embedding = SinusoidalTimestepEmbedding(time_dim)
+        self.time_mlp = nn.Sequential(
+            nn.Linear(time_dim, embed_dim),
+            nn.SiLU(),
+            nn.Linear(embed_dim, embed_dim),
+        )
+        self.coord_embed = ResidueEmbedding(9, embed_dim)
+        self.pos_encoding = PositionalEncoding(embed_dim, max_seq_len)
+        self.stack = RFDiffusionMultiTrackStack(
+            embed_dim=embed_dim,
+            pair_dim=pair_dim,
+            num_blocks=num_blocks,
+            num_heads=num_heads,
+            pair_num_heads=pair_num_heads,
+            dropout=dropout,
+        )
+
+    def forward(
+            self,
+            inputs: List[torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Predict denoised backbone frames from a noisy structure.
+
+        Parameters
+        ----------
+        inputs : list of torch.Tensor
+            ``[noisy_coords, rotations, translations, t, mask]`` where:
+
+            - ``noisy_coords``: noisy ``(N, CA, C)`` coordinates flattened
+              to shape ``(batch, num_residues, 9)``.
+            - ``rotations``: noisy rotation matrices, shape ``(batch,
+              num_residues, 3, 3)``.
+            - ``translations``: noisy CA translations, shape ``(batch,
+              num_residues, 3)``.
+            - ``t``: integer diffusion timesteps, shape ``(batch,)``.
+            - ``mask``: residue validity mask of shape ``(batch,
+              num_residues)``; 1 for real residues, 0 for padding. May be
+              ``None``.
+
+        Returns
+        -------
+        pred_rotations : torch.Tensor
+            Predicted denoised rotations, shape ``(batch, num_residues, 3,
+            3)``.
+        pred_translations : torch.Tensor
+            Predicted denoised translations, shape ``(batch, num_residues,
+            3)``.
+        """
+        noisy_coords, rotations, translations, t, mask = inputs
+        t = t.long()
+        t_emb = self.time_mlp(self.time_embedding(t))
+        single = self.pos_encoding(self.coord_embed(noisy_coords))
+        attn_mask = mask.bool() if mask is not None else None
+        _, _, pred_rotations, pred_translations = self.stack.forward_tracks(
+            single,
+            t_emb,
+            attention_mask=attn_mask,
+            rotations=rotations,
+            translations=translations,
+        )
+        return pred_rotations, pred_translations
+
+
+def sample_noisy_frames(
+    igso3: IGSO3,
+    schedule: CosineSchedule,
+    rotations0: torch.Tensor,
+    translations0: torch.Tensor,
+    t: torch.Tensor,
+    fixed_mask: Optional[torch.Tensor] = None,
+    generator: Optional[torch.Generator] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Diffuse ground-truth backbone frames forward to timestep ``t``.
+
+    Rotations are noised by left-composing an IGSO(3) perturbation sampled
+    at the timestep's noise level; translations are noised with the
+    standard Gaussian forward process from ``schedule.q_sample``. This
+    mirrors RFdiffusion's ``Diffuser.diffuse_pose``, which combines an
+    ``IGSO3`` rotation diffuser with a Euclidean translation diffuser.
+
+    Parameters
+    ----------
+    igso3 : IGSO3
+        Rotational noise distribution; ``igso3.sigmas`` must have at least
+        ``t.max() + 1`` entries.
+    schedule : CosineSchedule
+        Translation noise schedule.
+    rotations0 : torch.Tensor
+        Clean rotation matrices of shape ``(batch, num_residues, 3, 3)``.
+    translations0 : torch.Tensor
+        Clean CA translations of shape ``(batch, num_residues, 3)``.
+    t : torch.Tensor
+        Integer timesteps of shape ``(batch,)``, one per batch element.
+    fixed_mask : torch.Tensor, optional
+        Boolean mask of shape ``(batch, num_residues)``. Positions marked
+        ``True`` are motif/context residues that are held at their clean
+        value instead of being diffused, matching RFdiffusion's
+        ``diffusion_mask`` convention.
+    generator : torch.Generator, optional
+        PyTorch random generator for reproducibility.
+
+    Returns
+    -------
+    noisy_rotations : torch.Tensor
+        Shape ``(batch, num_residues, 3, 3)``.
+    noisy_translations : torch.Tensor
+        Shape ``(batch, num_residues, 3)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.layers import CosineSchedule
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     IGSO3, log_beta_schedule)
+    >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    ...     sample_noisy_frames)
+    >>> igso3 = IGSO3(log_beta_schedule(10), num_omega=256)
+    >>> schedule = CosineSchedule(num_timesteps=10)
+    >>> R0 = torch.eye(3).expand(2, 4, 3, 3).contiguous()
+    >>> T0 = torch.zeros(2, 4, 3)
+    >>> t = torch.tensor([1, 5])
+    >>> R_t, T_t = sample_noisy_frames(igso3, schedule, R0, T0, t)
+    >>> R_t.shape, T_t.shape
+    (torch.Size([2, 4, 3, 3]), torch.Size([2, 4, 3]))
+    """
+    if rotations0.shape[0] != t.shape[0]:
+        raise ValueError('rotations0 and t must share the same batch size.')
+    batch, length = rotations0.shape[:2]
+    device = rotations0.device
+    dtype = rotations0.dtype
+
+    perturbations = torch.stack([
+        igso3.sample(sigma_index=int(t[i].item()),
+                     shape=(length,),
+                     generator=generator).to(device=device, dtype=dtype)
+        for i in range(batch)
+    ],
+                                dim=0)
+    noisy_rotations = torch.matmul(perturbations, rotations0)
+    noisy_translations, _ = schedule.q_sample(translations0, t)
+
+    if fixed_mask is not None:
+        keep = fixed_mask.to(device=device, dtype=torch.bool)
+        noisy_rotations = torch.where(keep[..., None, None], rotations0,
+                                      noisy_rotations)
+        noisy_translations = torch.where(keep[..., None], translations0,
+                                         noisy_translations)
+    return noisy_rotations, noisy_translations
+
+
+def translation_posterior_step(
+        schedule: CosineSchedule,
+        pred_translations: torch.Tensor,
+        noisy_translations: torch.Tensor,
+        t: int,
+        generator: Optional[torch.Generator] = None) -> torch.Tensor:
+    """One ``x0``-conditioned DDPM reverse step for translations.
+
+    Implements the standard posterior mean ``q(x_{t-1} | x_t, x0)`` from
+    Ho et al. 2020, reusing the ``posterior_mean_coef1/2`` and
+    ``posterior_variance`` tensors already computed by ``CosineSchedule``.
+
+    Parameters
+    ----------
+    schedule : CosineSchedule
+        Translation noise schedule.
+    pred_translations : torch.Tensor
+        Model's predicted clean translations (``x0``), shape ``(batch,
+        num_residues, 3)``.
+    noisy_translations : torch.Tensor
+        Current noisy translations (``x_t``), same shape.
+    t : int
+        Current (shared) timestep for the whole batch.
+    generator : torch.Generator, optional
+        PyTorch random generator for reproducibility.
+
+    Returns
+    -------
+    torch.Tensor
+        Translations at timestep ``t - 1``, same shape as ``x_t``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.layers import CosineSchedule
+    >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    ...     translation_posterior_step)
+    >>> schedule = CosineSchedule(num_timesteps=10)
+    >>> x0 = torch.zeros(2, 4, 3)
+    >>> x_t = torch.randn(2, 4, 3)
+    >>> x_prev = translation_posterior_step(schedule, x0, x_t, t=5)
+    >>> x_prev.shape
+    torch.Size([2, 4, 3])
+    """
+    if t < 0:
+        raise ValueError('t must be non-negative.')
+    device = pred_translations.device
+    coef1 = schedule.posterior_mean_coef1.to(device)[t]
+    coef2 = schedule.posterior_mean_coef2.to(device)[t]
+    mean = coef1 * pred_translations + coef2 * noisy_translations
+    if t == 0:
+        return mean
+    variance = schedule.posterior_variance.to(device)[t]
+    noise = torch.randn(pred_translations.shape,
+                        device=device,
+                        dtype=pred_translations.dtype,
+                        generator=generator)
+    return mean + torch.sqrt(variance) * noise
+
+
+def so3_x0_reverse_step(
+        igso3: IGSO3,
+        rotations_t: torch.Tensor,
+        pred_rotations: torch.Tensor,
+        t: int,
+        noise_level: float = 1.0,
+        generator: Optional[torch.Generator] = None) -> torch.Tensor:
+    """One ``x0``-conditioned reverse step for IGSO(3) rotational diffusion.
+
+    Follows RFdiffusion's own ``IGSO3.reverse_sample_vectorized``: the
+    score at the current noise level is evaluated on the *relative*
+    rotation between the noisy frame and the network's predicted clean
+    frame, ``R_0t = R_t @ R_0_pred^T``, and used to take a small step from
+    ``R_t`` toward ``R_0_pred`` plus IGSO(3)-scaled noise.
+
+    Parameters
+    ----------
+    igso3 : IGSO3
+        Rotational noise distribution used for training; ``igso3.sigmas``
+        must have at least ``t + 1`` entries.
+    rotations_t : torch.Tensor
+        Current noisy rotations, shape ``(..., 3, 3)``.
+    pred_rotations : torch.Tensor
+        Model's predicted clean rotations, same shape.
+    t : int
+        Current (shared) timestep for the whole batch; must be positive
+        (there is nothing to reverse at ``t = 0``).
+    noise_level : float, default 1.0
+        Scale applied to the stochastic term of the step.
+    generator : torch.Generator, optional
+        PyTorch random generator for reproducibility.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotations at timestep ``t - 1``, same shape as ``rotations_t``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     IGSO3, log_beta_schedule)
+    >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    ...     so3_x0_reverse_step)
+    >>> igso3 = IGSO3(log_beta_schedule(10), num_omega=256)
+    >>> R_t = torch.eye(3).expand(2, 4, 3, 3).contiguous()
+    >>> R_0 = torch.eye(3).expand(2, 4, 3, 3).contiguous()
+    >>> R_prev = so3_x0_reverse_step(igso3, R_t, R_0, t=5)
+    >>> R_prev.shape
+    torch.Size([2, 4, 3, 3])
+    """
+    if t <= 0:
+        raise ValueError('t must be positive; there is no reverse step at '
+                         't = 0.')
+    sigma_t = float(igso3.sigmas[t].item())
+    sigma_prev = float(igso3.sigmas[t - 1].item())
+
+    relative = torch.matmul(rotations_t, pred_rotations.transpose(-1, -2))
+    tangent = so3_log_map(relative)
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+    direction = tangent / omega
+    score = igso3.score(omega.squeeze(-1), t)
+    score = score.to(device=tangent.device, dtype=tangent.dtype).unsqueeze(-1)
+
+    drift = (sigma_t**2 - sigma_prev**2) * score * direction
+    diffusion_var = max(0.0, sigma_prev**2 * (1.0 - sigma_prev**2 / sigma_t**2))
+    noise = torch.randn(tangent.shape,
+                        device=tangent.device,
+                        dtype=tangent.dtype,
+                        generator=generator)
+    perturb_tangent = drift + (diffusion_var**0.5) * noise_level * noise
+    perturb = so3_exp_map(perturb_tangent)
+    return torch.matmul(perturb, rotations_t)
+
+
+def multitrack_frame_loss(
+    outputs: List[torch.Tensor],
+    labels: List[torch.Tensor],
+    weights: List[torch.Tensor],
+    rotation_weight: float = 1.0,
+) -> torch.Tensor:
+    """Masked frame loss for the multi-track denoiser.
+
+    Combines a translation MSE term with an SO(3) geodesic rotation term,
+    matching the ``x0``-prediction parameterization of
+    ``RFDiffusionMultiTrackDenoiser``.
+
+    Parameters
+    ----------
+    outputs : list of torch.Tensor
+        ``[pred_rotations, pred_translations]`` from the denoiser.
+    labels : list of torch.Tensor
+        ``[true_rotations, true_translations]``, same shapes as
+        ``outputs``.
+    weights : list of torch.Tensor
+        ``[mask]``, a residue validity mask of shape ``(batch,
+        num_residues)``.
+    rotation_weight : float, default 1.0
+        Scale applied to the rotation term before summing with the
+        translation term.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar loss.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_multitrack import (
+    ...     multitrack_frame_loss)
+    >>> pred_r = torch.eye(3).expand(2, 4, 3, 3).contiguous()
+    >>> pred_t = torch.zeros(2, 4, 3)
+    >>> true_r = torch.eye(3).expand(2, 4, 3, 3).contiguous()
+    >>> true_t = torch.zeros(2, 4, 3)
+    >>> mask = torch.ones(2, 4)
+    >>> loss = multitrack_frame_loss([pred_r, pred_t], [true_r, true_t],
+    ...                              [mask])
+    >>> round(float(loss), 6)
+    0.0
+    """
+    pred_rotations, pred_translations = outputs
+    true_rotations, true_translations = labels
+    mask = weights[0]
+    denom = torch.clamp(mask.sum(), min=1.0)
+
+    translation_loss = (((pred_translations - true_translations)**2).sum(-1) *
+                        mask).sum() / denom
+
+    relative = torch.matmul(pred_rotations.transpose(-1, -2), true_rotations)
+    angle = so3_log_map(relative).norm(dim=-1)
+    rotation_loss = ((angle**2) * mask).sum() / denom
+
+    return translation_loss + rotation_weight * rotation_loss

--- a/deepchem/models/torch_models/rfdiffusion_pair_track.py
+++ b/deepchem/models/torch_models/rfdiffusion_pair_track.py
@@ -1,0 +1,483 @@
+"""Pair-track (2D) update blocks for the RFDiffusion multi-track network.
+
+RFDiffusion denoises protein backbones with a RoseTTAFold-style network
+that keeps three coupled representations in sync: a 1D single-residue
+track, a 2D pairwise track :math:`z_{ij}`, and a 3D rigid-frame track.
+This module holds the **2D pair-track** half of that stack — the blocks
+that build and refine the pairwise representation before it feeds back
+into the single and structure tracks.
+
+The blocks follow the AlphaFold2 / RoseTTAFold pair-stack recipe:
+
+* :class:`RelativePositionEmbedding` seeds the pair tensor from clipped
+  relative sequence offsets :math:`|i - j|`.
+* :class:`OuterProductMean` injects the 1D single track into the 2D
+  pair track through a symmetrised outer product.
+* :class:`TriangleMultiplicativeUpdate` (outgoing / incoming) and
+  :class:`TriangleAttention` (starting / ending node) are the two
+  triangle operations that mix pair edges while respecting the
+  triangle-inequality structure of a distance-like tensor.
+* :class:`PairTransition` is the position-wise feed-forward that closes
+  each pair-stack block.
+
+The seed embedding and the outer-product mean are symmetric by
+construction (:math:`z_{ij} = z_{ji}`); the triangle operations are the
+standard AlphaFold2 building blocks that the full track block later
+combines into a symmetry-preserving update. Each triangle operation
+costs :math:`\\mathcal{O}(L^3)` / :math:`\\mathcal{O}(L^2)`, so it takes
+an optional ``chunk_size`` that bounds peak memory without changing the
+numerics — the test suite checks the chunked path matches the dense one
+exactly.
+
+This is the 2D-track half of the multi-track stack. It sits alongside
+the SE(3) rigid-frame utilities (PR #4982) and the Invariant Point
+Attention block (PR #5028); the later track-integration PR wires the
+1D, 2D, and 3D tracks together into a full block. Nothing here imports
+those modules, so the pair stack stands on its own.
+
+References
+----------
+.. [Jumper2021] Jumper, J. *et al.* "Highly accurate protein structure
+   prediction with AlphaFold." *Nature* **596** (2021): 583–589.
+.. [Baek2021] Baek, M. *et al.* "Accurate prediction of protein
+   structures and interactions using a three-track neural network."
+   *Science* **373** (2021): 871–876.
+.. [Watson2023] Watson, J. L. *et al.* "De novo design of protein
+   structure and function with RFdiffusion." *Nature* **620** (2023):
+   1089–1100.
+"""
+
+import math
+from typing import Optional
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError(
+        'rfdiffusion_pair_track requires PyTorch to be installed.')
+
+# ---------------------------------------------------------------------------
+# Embedding utilities
+# ---------------------------------------------------------------------------
+
+
+class RelativePositionEmbedding(nn.Module):
+    """Symmetric clipped relative-position embedding for the pair track.
+
+    Given a sequence of length :math:`L` and a clip radius
+    :math:`r_{\\max}`, this module returns a tensor
+    :math:`p_{ij} \\in \\mathbb{R}^{L \\times L \\times C_z}` where each
+    entry is the embedding of :math:`\\min(|i - j|, r_{\\max})`. Because
+    the index depends on :math:`|i-j|` rather than :math:`i-j`, the
+    resulting embedding is exactly symmetric:
+    :math:`p_{ij} = p_{ji}`.
+
+    Parameters
+    ----------
+    pair_dim : int
+        Output channel size :math:`C_z`.
+    max_relative_position : int, default 32
+        Clip radius :math:`r_{\\max}`. Indices beyond this distance map
+        to the same embedding bucket.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_pair_track import (
+    ...     RelativePositionEmbedding)
+    >>> rel = RelativePositionEmbedding(pair_dim=16, max_relative_position=4)
+    >>> emb = rel(8)
+    >>> emb.shape
+    torch.Size([8, 8, 16])
+    """
+
+    def __init__(self, pair_dim: int, max_relative_position: int = 32) -> None:
+        super().__init__()
+        if pair_dim <= 0:
+            raise ValueError('pair_dim must be positive.')
+        if max_relative_position <= 0:
+            raise ValueError('max_relative_position must be positive.')
+        self.pair_dim = pair_dim
+        self.max_relative_position = max_relative_position
+        self.embedding = nn.Embedding(max_relative_position + 1, pair_dim)
+
+    def forward(self, seq_len: int, device=None) -> torch.Tensor:
+        """Build the :math:`(L, L, C_z)` symmetric relative-position tensor.
+
+        Parameters
+        ----------
+        seq_len : int
+            Sequence length :math:`L`.
+        device : torch.device, optional
+            Device on which to allocate the position index tensor.
+
+        Returns
+        -------
+        torch.Tensor
+            Relative-position embeddings of shape ``(L, L, pair_dim)``.
+        """
+        device = device or self.embedding.weight.device
+        idx = torch.arange(seq_len, device=device)
+        diff = (idx.unsqueeze(0) - idx.unsqueeze(1)).abs()
+        diff = diff.clamp(max=self.max_relative_position)
+        return self.embedding(diff)
+
+
+# ---------------------------------------------------------------------------
+# 1D → 2D update: outer-product mean
+# ---------------------------------------------------------------------------
+
+
+class OuterProductMean(nn.Module):
+    """Outer-product update from the single track to the pair track.
+
+    For each pair :math:`(i, j)`, computes the symmetrised flattened
+    outer product
+
+    .. math::
+
+        o_{ij} = W_{\\text{out}}\\,\\big(L_a(s_i) \\otimes L_b(s_j)\\big)
+        + W_{\\text{out}}\\,\\big(L_a(s_j) \\otimes L_b(s_i)\\big),
+
+    where :math:`L_a, L_b: \\mathbb{R}^{C_s} \\to \\mathbb{R}^{c_h}` are
+    linear projections and the symmetrisation enforces
+    :math:`o_{ij} = o_{ji}` exactly.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    hidden_dim : int, default 32
+        Projection size :math:`c_h` for the outer product.
+
+    Notes
+    -----
+    The pre-projection layer norm follows AlphaFold2's outer-product-mean
+    placement; only one residue context (the single representation
+    itself) participates because RFDiffusion does not use an MSA stack.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 hidden_dim: int = 32) -> None:
+        super().__init__()
+        if embed_dim <= 0 or pair_dim <= 0 or hidden_dim <= 0:
+            raise ValueError(
+                'embed_dim, pair_dim and hidden_dim must all be positive.')
+        self.layer_norm = nn.LayerNorm(embed_dim)
+        self.linear_a = nn.Linear(embed_dim, hidden_dim)
+        self.linear_b = nn.Linear(embed_dim, hidden_dim)
+        self.linear_out = nn.Linear(hidden_dim * hidden_dim, pair_dim)
+
+    def forward(self, single: torch.Tensor) -> torch.Tensor:
+        """Compute the outer-product mean.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Pair update of shape ``(B, L, L, C_z)`` (symmetric in i, j).
+        """
+        single = self.layer_norm(single)
+        a = self.linear_a(single)  # (B, L, c_h)
+        b = self.linear_b(single)  # (B, L, c_h)
+        # Outer product per pair: (B, L, L, c_h, c_h) → flatten last two.
+        outer_ab = torch.einsum('bic,bjd->bijcd', a, b)
+        outer_ba = torch.einsum('bjc,bid->bijcd', a, b)
+        outer = 0.5 * (outer_ab + outer_ba)
+        flat = outer.flatten(start_dim=-2)
+        return self.linear_out(flat)
+
+
+# ---------------------------------------------------------------------------
+# Triangular multiplicative update
+# ---------------------------------------------------------------------------
+
+
+class TriangleMultiplicativeUpdate(nn.Module):
+    """Triangle multiplicative update for the pair track.
+
+    Implements AlphaFold2 Algorithms 11 / 12 [Jumper2021]_. The
+    "outgoing" variant computes
+
+    .. math::
+
+        \\tilde z_{ij} = g_{ij} \\odot W_{\\text{out}}\\,
+        \\mathrm{LN}\\Big( \\sum_k a_{ik} \\odot b_{jk} \\Big),
+
+    and the "incoming" variant replaces the summation by
+    :math:`\\sum_k a_{ki} \\odot b_{kj}`. The values :math:`a, b, g`
+    are gated linear projections of the layer-normalised pair
+    representation.
+
+    A ``chunk_size`` argument controls the working-set size along the
+    :math:`i` axis when forming the cubic-cost contraction, bounding
+    peak memory to :math:`\\mathcal{O}(\\text{chunk\\_size} \\cdot L^2
+    \\cdot c_h)` independently of :math:`L`.
+
+    Parameters
+    ----------
+    pair_dim : int
+        Input/output channel size :math:`C_z`.
+    hidden_dim : int, default 128
+        Hidden channel size :math:`c_h` for the gated projections.
+    outgoing : bool, default True
+        If True, use the outgoing variant (sum over :math:`a_{ik}
+        b_{jk}`); otherwise use the incoming variant (sum over
+        :math:`a_{ki} b_{kj}`).
+    """
+
+    def __init__(self,
+                 pair_dim: int,
+                 hidden_dim: int = 128,
+                 outgoing: bool = True) -> None:
+        super().__init__()
+        if pair_dim <= 0 or hidden_dim <= 0:
+            raise ValueError('pair_dim and hidden_dim must be positive.')
+        self.outgoing = outgoing
+        self.layer_norm_in = nn.LayerNorm(pair_dim)
+        self.linear_a = nn.Linear(pair_dim, hidden_dim)
+        self.linear_a_gate = nn.Linear(pair_dim, hidden_dim)
+        self.linear_b = nn.Linear(pair_dim, hidden_dim)
+        self.linear_b_gate = nn.Linear(pair_dim, hidden_dim)
+        self.linear_g = nn.Linear(pair_dim, pair_dim)
+        self.layer_norm_out = nn.LayerNorm(hidden_dim)
+        self.linear_out = nn.Linear(hidden_dim, pair_dim)
+
+    def forward(self,
+                pair: torch.Tensor,
+                chunk_size: Optional[int] = None) -> torch.Tensor:
+        """Apply the triangular multiplicative update.
+
+        Parameters
+        ----------
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+        chunk_size : int, optional
+            If given, chunk the :math:`i` axis of the cubic contraction
+            into pieces of at most ``chunk_size`` rows. Must produce
+            the same output as the unchunked path (verified by tests).
+
+        Returns
+        -------
+        torch.Tensor
+            Updated pair representation, same shape as input.
+        """
+        if pair.dim() != 4:
+            raise ValueError(
+                'pair must have shape (batch, L, L, pair_dim), got '
+                f'{tuple(pair.shape)}.')
+        z = self.layer_norm_in(pair)
+        a = torch.sigmoid(self.linear_a_gate(z)) * self.linear_a(z)
+        b = torch.sigmoid(self.linear_b_gate(z)) * self.linear_b(z)
+        g = torch.sigmoid(self.linear_g(z))
+        contracted = self._chunked_contract(a, b, chunk_size)
+        contracted = self.layer_norm_out(contracted)
+        return g * self.linear_out(contracted)
+
+    def _chunked_contract(self, a: torch.Tensor, b: torch.Tensor,
+                          chunk_size: Optional[int]) -> torch.Tensor:
+        """Compute :math:`\\sum_k a_{*k} \\odot b_{*k}` chunked over ``i``."""
+        seq_len = a.size(1)
+        if chunk_size is None or chunk_size >= seq_len:
+            if self.outgoing:
+                return torch.einsum('bikc,bjkc->bijc', a, b)
+            return torch.einsum('bkic,bkjc->bijc', a, b)
+        results = []
+        for start in range(0, seq_len, chunk_size):
+            end = min(start + chunk_size, seq_len)
+            if self.outgoing:
+                # a_chunk: (B, chunk, L, c) — k dim is L.
+                a_chunk = a[:, start:end]
+                results.append(torch.einsum('bikc,bjkc->bijc', a_chunk, b))
+            else:
+                # Need a[k, i_chunk]: slice on i (axis 2) of bkic.
+                a_chunk = a[:, :, start:end]
+                results.append(torch.einsum('bkic,bkjc->bijc', a_chunk, b))
+        return torch.cat(results, dim=1)
+
+
+# ---------------------------------------------------------------------------
+# Triangular self-attention
+# ---------------------------------------------------------------------------
+
+
+class TriangleAttention(nn.Module):
+    """Triangular self-attention for the pair track.
+
+    Implements AlphaFold2 Algorithms 13 / 14 [Jumper2021]_. In the
+    *starting-node* variant the attention runs along columns of each
+    row of the pair representation: for each :math:`i`, queries
+    :math:`q_{ij}` attend to keys :math:`k_{ik}` with the bias term
+    :math:`b_{jk}` derived linearly from the pair representation at
+    rows shared with the row being attended over. The *ending-node*
+    variant operates symmetrically along columns.
+
+    Memory is bounded by chunking over the :math:`i` axis (rows for the
+    starting-node variant, columns for the ending-node variant).
+
+    Parameters
+    ----------
+    pair_dim : int
+        Input/output channel size :math:`C_z`.
+    num_heads : int, default 4
+        Number of attention heads :math:`H`.
+    head_dim : int, default 32
+        Per-head channel size :math:`d_h`.
+    starting_node : bool, default True
+        Selects the starting-node (True) or ending-node (False) variant.
+    """
+
+    def __init__(self,
+                 pair_dim: int,
+                 num_heads: int = 4,
+                 head_dim: int = 32,
+                 starting_node: bool = True) -> None:
+        super().__init__()
+        if pair_dim <= 0 or num_heads <= 0 or head_dim <= 0:
+            raise ValueError(
+                'pair_dim, num_heads and head_dim must be positive.')
+        self.pair_dim = pair_dim
+        self.num_heads = num_heads
+        self.head_dim = head_dim
+        self.starting_node = starting_node
+        self.layer_norm = nn.LayerNorm(pair_dim)
+        inner = num_heads * head_dim
+        self.linear_q = nn.Linear(pair_dim, inner, bias=False)
+        self.linear_k = nn.Linear(pair_dim, inner, bias=False)
+        self.linear_v = nn.Linear(pair_dim, inner, bias=False)
+        self.linear_bias = nn.Linear(pair_dim, num_heads, bias=False)
+        self.linear_gate = nn.Linear(pair_dim, inner)
+        self.linear_out = nn.Linear(inner, pair_dim)
+
+    def forward(self,
+                pair: torch.Tensor,
+                chunk_size: Optional[int] = None) -> torch.Tensor:
+        """Apply triangular self-attention.
+
+        Parameters
+        ----------
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+        chunk_size : int, optional
+            Chunk size for the row-index axis. Must produce identical
+            results to the unchunked path.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated pair representation, same shape as input.
+        """
+        if pair.dim() != 4:
+            raise ValueError('pair must be 4D (B, L, L, C_z).')
+        # For ending-node, swap i and j axes, run the starting-node
+        # kernel, then swap back. This guarantees identical numerics
+        # to a hand-written ending-node implementation.
+        z = pair if self.starting_node else pair.transpose(-2, -3)
+        z = self.layer_norm(z)
+        q = self._split_heads(self.linear_q(z))
+        k = self._split_heads(self.linear_k(z))
+        v = self._split_heads(self.linear_v(z))
+        bias = self.linear_bias(z)  # (B, L, L, H) — uses row-i context.
+        gate = torch.sigmoid(self.linear_gate(z))
+
+        out = self._chunked_attend(q, k, v, bias, chunk_size)
+        out = out * gate
+        out = self.linear_out(out)
+        if not self.starting_node:
+            out = out.transpose(-2, -3)
+        return out
+
+    def _split_heads(self, tensor: torch.Tensor) -> torch.Tensor:
+        """Reshape ``(B, L, L, H*d) -> (B, L, L, H, d)``."""
+        batch, n1, n2, _ = tensor.shape
+        return tensor.view(batch, n1, n2, self.num_heads, self.head_dim)
+
+    def _chunked_attend(self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                        bias: torch.Tensor,
+                        chunk_size: Optional[int]) -> torch.Tensor:
+        """Row-wise scaled-dot-product attention with an additive bias.
+
+        For each row :math:`i`, the attention is computed across columns
+        :math:`(j, k)`. The bias :math:`b_{jk} = W_b z_{jk}` depends
+        only on the *column* pair :math:`(j, k)` and is broadcast across
+        all rows :math:`i` — this is precisely the AlphaFold2 starting-
+        node triangle-attention formulation [Jumper2021]_. Because
+        logits and attention weights are formed independently for each
+        row :math:`i`, chunking along :math:`i` is exactly numerically
+        equivalent to the dense path.
+        """
+        seq_len = q.size(1)
+        if chunk_size is None or chunk_size >= seq_len:
+            return self._attend_block(q, k, v, bias)
+        outputs = []
+        for start in range(0, seq_len, chunk_size):
+            end = min(start + chunk_size, seq_len)
+            outputs.append(
+                self._attend_block(q[:, start:end], k[:, start:end],
+                                   v[:, start:end], bias))
+        return torch.cat(outputs, dim=1)
+
+    @staticmethod
+    def _attend_block(q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+                      bias: torch.Tensor) -> torch.Tensor:
+        """Compute attention for a (possibly chunked) block of rows.
+
+        Parameters
+        ----------
+        q, k, v : torch.Tensor
+            Per-row queries/keys/values of shape ``(B, L_i, L, H, d)``.
+        bias : torch.Tensor
+            Pair bias of shape ``(B, L, L, H)`` indexed by ``(j, k)``;
+            broadcast across the row axis :math:`i`.
+        """
+        scale = 1.0 / math.sqrt(q.size(-1))
+        logits = torch.einsum('bijhd,bikhd->bhijk', q, k) * scale
+        # bias: (B, L_j, L_k, H) → (B, H, 1, L_j, L_k) so it broadcasts
+        # across the row index i.
+        logits = logits + bias.permute(0, 3, 1, 2).unsqueeze(2)
+        attn = F.softmax(logits, dim=-1)
+        out = torch.einsum('bhijk,bikhd->bijhd', attn, v)
+        return out.flatten(start_dim=-2)
+
+
+# ---------------------------------------------------------------------------
+# Pair transition (feed-forward)
+# ---------------------------------------------------------------------------
+
+
+class PairTransition(nn.Module):
+    """Two-layer feed-forward block applied position-wise to the pair."""
+
+    def __init__(self, pair_dim: int, expansion: int = 4) -> None:
+        super().__init__()
+        if pair_dim <= 0 or expansion <= 0:
+            raise ValueError('pair_dim and expansion must be positive.')
+        self.layer_norm = nn.LayerNorm(pair_dim)
+        self.linear_1 = nn.Linear(pair_dim, pair_dim * expansion)
+        self.linear_2 = nn.Linear(pair_dim * expansion, pair_dim)
+
+    def forward(self, pair: torch.Tensor) -> torch.Tensor:
+        """Apply the pair transition.
+
+        Parameters
+        ----------
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Transformed pair representation, same shape as input.
+        """
+        z = self.layer_norm(pair)
+        return self.linear_2(F.relu(self.linear_1(z)))

--- a/deepchem/models/torch_models/rfdiffusion_pair_track.py
+++ b/deepchem/models/torch_models/rfdiffusion_pair_track.py
@@ -159,6 +159,17 @@ class OuterProductMean(nn.Module):
     The pre-projection layer norm follows AlphaFold2's outer-product-mean
     placement; only one residue context (the single representation
     itself) participates because RFDiffusion does not use an MSA stack.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_pair_track import (
+    ...     OuterProductMean)
+    >>> layer = OuterProductMean(embed_dim=16, pair_dim=32, hidden_dim=8)
+    >>> single = torch.randn(2, 6, 16)
+    >>> pair_update = layer(single)
+    >>> pair_update.shape
+    torch.Size([2, 6, 6, 32])
     """
 
     def __init__(self,
@@ -234,6 +245,18 @@ class TriangleMultiplicativeUpdate(nn.Module):
         If True, use the outgoing variant (sum over :math:`a_{ik}
         b_{jk}`); otherwise use the incoming variant (sum over
         :math:`a_{ki} b_{kj}`).
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_pair_track import (
+    ...     TriangleMultiplicativeUpdate)
+    >>> layer = TriangleMultiplicativeUpdate(
+    ...     pair_dim=16, hidden_dim=32, outgoing=True)
+    >>> pair = torch.randn(2, 5, 5, 16)
+    >>> out = layer(pair)
+    >>> out.shape
+    torch.Size([2, 5, 5, 16])
     """
 
     def __init__(self,
@@ -335,6 +358,18 @@ class TriangleAttention(nn.Module):
         Per-head channel size :math:`d_h`.
     starting_node : bool, default True
         Selects the starting-node (True) or ending-node (False) variant.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_pair_track import (
+    ...     TriangleAttention)
+    >>> layer = TriangleAttention(
+    ...     pair_dim=16, num_heads=4, head_dim=8, starting_node=True)
+    >>> pair = torch.randn(2, 5, 5, 16)
+    >>> out = layer(pair)
+    >>> out.shape
+    torch.Size([2, 5, 5, 16])
     """
 
     def __init__(self,
@@ -456,7 +491,26 @@ class TriangleAttention(nn.Module):
 
 
 class PairTransition(nn.Module):
-    """Two-layer feed-forward block applied position-wise to the pair."""
+    """Two-layer feed-forward block applied position-wise to the pair track.
+
+    Parameters
+    ----------
+    pair_dim : int
+        Pair channel dimension.
+    expansion : int, default 4
+        Hidden expansion factor.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_pair_track import (
+    ...     PairTransition)
+    >>> layer = PairTransition(pair_dim=16, expansion=2)
+    >>> pair = torch.randn(2, 4, 4, 16)
+    >>> out = layer(pair)
+    >>> out.shape
+    torch.Size([2, 4, 4, 16])
+    """
 
     def __init__(self, pair_dim: int, expansion: int = 4) -> None:
         super().__init__()

--- a/deepchem/models/torch_models/rfdiffusion_pair_track.py
+++ b/deepchem/models/torch_models/rfdiffusion_pair_track.py
@@ -82,6 +82,11 @@ class RelativePositionEmbedding(nn.Module):
         Clip radius :math:`r_{\\max}`. Indices beyond this distance map
         to the same embedding bucket.
 
+    Raises
+    ------
+    ValueError
+        If `pair_dim` or `max_relative_position` is not positive.
+
     Examples
     --------
     >>> import torch
@@ -153,6 +158,11 @@ class OuterProductMean(nn.Module):
         Pair-track channel size :math:`C_z`.
     hidden_dim : int, default 32
         Projection size :math:`c_h` for the outer product.
+
+    Raises
+    ------
+    ValueError
+        If `embed_dim`, `pair_dim`, or `hidden_dim` is not positive.
 
     Notes
     -----
@@ -246,6 +256,11 @@ class TriangleMultiplicativeUpdate(nn.Module):
         b_{jk}`); otherwise use the incoming variant (sum over
         :math:`a_{ki} b_{kj}`).
 
+    Raises
+    ------
+    ValueError
+        If `pair_dim` or `hidden_dim` is not positive.
+
     Examples
     --------
     >>> import torch
@@ -294,6 +309,11 @@ class TriangleMultiplicativeUpdate(nn.Module):
         -------
         torch.Tensor
             Updated pair representation, same shape as input.
+
+        Raises
+        ------
+        ValueError
+            If `pair` is not 4D.
         """
         if pair.dim() != 4:
             raise ValueError(
@@ -309,7 +329,21 @@ class TriangleMultiplicativeUpdate(nn.Module):
 
     def _chunked_contract(self, a: torch.Tensor, b: torch.Tensor,
                           chunk_size: Optional[int]) -> torch.Tensor:
-        """Compute :math:`\\sum_k a_{*k} \\odot b_{*k}` chunked over ``i``."""
+        """Compute :math:`\\sum_k a_{*k} \\odot b_{*k}` chunked over ``i``.
+
+        Parameters
+        ----------
+        a, b : torch.Tensor
+            Gated projections of shape ``(B, L, L, hidden_dim)``.
+        chunk_size : int, optional
+            Chunk size for the ``i`` axis. If None or `>= L`, runs the
+            dense contraction in one call.
+
+        Returns
+        -------
+        torch.Tensor
+            Contracted tensor of shape ``(B, L, L, hidden_dim)``.
+        """
         seq_len = a.size(1)
         if chunk_size is None or chunk_size >= seq_len:
             if self.outgoing:
@@ -358,6 +392,11 @@ class TriangleAttention(nn.Module):
         Per-head channel size :math:`d_h`.
     starting_node : bool, default True
         Selects the starting-node (True) or ending-node (False) variant.
+
+    Raises
+    ------
+    ValueError
+        If `pair_dim`, `num_heads`, or `head_dim` is not positive.
 
     Examples
     --------
@@ -411,6 +450,11 @@ class TriangleAttention(nn.Module):
         -------
         torch.Tensor
             Updated pair representation, same shape as input.
+
+        Raises
+        ------
+        ValueError
+            If `pair` is not 4D.
         """
         if pair.dim() != 4:
             raise ValueError('pair must be 4D (B, L, L, C_z).')
@@ -450,6 +494,21 @@ class TriangleAttention(nn.Module):
         logits and attention weights are formed independently for each
         row :math:`i`, chunking along :math:`i` is exactly numerically
         equivalent to the dense path.
+
+        Parameters
+        ----------
+        q, k, v : torch.Tensor
+            Per-head queries/keys/values of shape ``(B, L, L, H, d)``.
+        bias : torch.Tensor
+            Pair bias of shape ``(B, L, L, H)``, indexed by ``(j, k)``.
+        chunk_size : int, optional
+            Row-chunk size. If None or `>= L`, runs the dense path in
+            one call to `_attend_block`.
+
+        Returns
+        -------
+        torch.Tensor
+            Attention output of shape ``(B, L, L, H * d)``.
         """
         seq_len = q.size(1)
         if chunk_size is None or chunk_size >= seq_len:
@@ -474,6 +533,11 @@ class TriangleAttention(nn.Module):
         bias : torch.Tensor
             Pair bias of shape ``(B, L, L, H)`` indexed by ``(j, k)``;
             broadcast across the row axis :math:`i`.
+
+        Returns
+        -------
+        torch.Tensor
+            Attention output of shape ``(B, L_i, L, H * d)``.
         """
         scale = 1.0 / math.sqrt(q.size(-1))
         logits = torch.einsum('bijhd,bikhd->bhijk', q, k) * scale
@@ -499,6 +563,11 @@ class PairTransition(nn.Module):
         Pair channel dimension.
     expansion : int, default 4
         Hidden expansion factor.
+
+    Raises
+    ------
+    ValueError
+        If `pair_dim` or `expansion` is not positive.
 
     Examples
     --------

--- a/deepchem/models/torch_models/rfdiffusion_sequence_track.py
+++ b/deepchem/models/torch_models/rfdiffusion_sequence_track.py
@@ -1,0 +1,751 @@
+"""Sequence (1D) and structure (3D) track updates for RFDiffusion.
+
+This is the second half of RFDiffusion's RoseTTAFold-style multi-track
+network — the blocks that turn the pair representation back into
+single-residue features and rigid backbone frames, plus the block and
+stack that tie all three tracks together.
+
+* :class:`PairBiasedSingleAttention` — 2D -> 1D update: single-track
+  self-attention with a pair-derived logit bias.
+* :class:`SingleTransition` — position-wise feed-forward on the single
+  track with adaLN-style timestep conditioning.
+* :func:`quaternion_to_rotation_matrix` — quaternion -> rotation helper.
+* :class:`BackboneUpdate` — 3D head that predicts a per-residue rigid
+  frame update (quaternion rotation + local translation), composed so
+  the frames move equivariantly under any global rigid motion.
+* :class:`RFDiffusionTrackBlock` — one full single -> pair -> single ->
+  frames iteration.
+* :class:`RFDiffusionMultiTrackStack` — a stack of those blocks with a
+  ``forward(single, t_emb, attention_mask=None) -> single`` signature,
+  so it drops straight in for the baseline transformer stack in
+  :mod:`deepchem.models.torch_models.rfdiffusion`.
+
+It builds on the earlier RFDiffusion PRs: the pair-track blocks (PR 7,
+``rfdiffusion_pair_track``), the Invariant Point Attention block (PR 6,
+``rfdiffusion_ipa``), and the rigid-frame helpers (PR 5,
+``rfdiffusion_frames``). Every pair update stays symmetric
+(:math:`z_{ij} = z_{ji}`) and every frame update is equivariant — the
+test suite checks both.
+
+References
+----------
+.. [Jumper2021] Jumper, J. *et al.* "Highly accurate protein structure
+   prediction with AlphaFold." *Nature* **596** (2021): 583–589.
+.. [Baek2021] Baek, M. *et al.* "Accurate prediction of protein
+   structures and interactions using a three-track neural network."
+   *Science* **373** (2021): 871–876.
+.. [Watson2023] Watson, J. L. *et al.* "De novo design of protein
+   structure and function with RFdiffusion." *Nature* **620** (2023):
+   1089–1100.
+"""
+
+import math
+from typing import Optional, Tuple
+
+try:
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+except ModuleNotFoundError:
+    raise ImportError(
+        'rfdiffusion_sequence_track requires PyTorch to be installed.')
+
+from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
+from deepchem.models.torch_models.rfdiffusion_ipa import (
+    InvariantPointAttention)
+from deepchem.models.torch_models.rfdiffusion_pair_track import (
+    OuterProductMean,
+    PairTransition,
+    RelativePositionEmbedding,
+    TriangleAttention,
+    TriangleMultiplicativeUpdate,
+)
+
+# ---------------------------------------------------------------------------
+# 2D → 1D update: pair-biased self-attention
+# ---------------------------------------------------------------------------
+
+
+class PairBiasedSingleAttention(nn.Module):
+    """Multi-head self-attention on the single track biased by the pair.
+
+    The attention logits are augmented by a per-head linear projection
+    of the pair representation, giving the pair channel a direct
+    pathway to modulate the single track. This is the AlphaFold2
+    "MSA row-wise attention with pair bias" reduced to a single MSA
+    row.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    num_heads : int, default 8
+        Number of attention heads.
+    dropout : float, default 0.0
+        Dropout probability applied to attention weights.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 num_heads: int = 8,
+                 dropout: float = 0.0) -> None:
+        super().__init__()
+        if embed_dim <= 0 or pair_dim <= 0 or num_heads <= 0:
+            raise ValueError(
+                'embed_dim, pair_dim and num_heads must be positive.')
+        if embed_dim % num_heads != 0:
+            raise ValueError('embed_dim must be divisible by num_heads.')
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError('dropout must lie in [0, 1).')
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.head_dim = embed_dim // num_heads
+        self.norm_single = nn.LayerNorm(embed_dim)
+        self.norm_pair = nn.LayerNorm(pair_dim)
+        self.linear_q = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.linear_k = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.linear_v = nn.Linear(embed_dim, embed_dim, bias=False)
+        self.linear_bias = nn.Linear(pair_dim, num_heads, bias=False)
+        self.linear_out = nn.Linear(embed_dim, embed_dim)
+        self.dropout = nn.Dropout(dropout)
+        self.scale = 1.0 / math.sqrt(self.head_dim)
+
+    def forward(self,
+                single: torch.Tensor,
+                pair: torch.Tensor,
+                mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        pair : torch.Tensor
+            Pair representation of shape ``(B, L, L, C_z)``.
+        mask : torch.Tensor, optional
+            Boolean mask of shape ``(B, L)`` where True marks valid
+            residues. Masked keys are excluded from attention; masked
+            queries receive zero output.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated single representation, same shape as input.
+        """
+        if single.dim() != 3:
+            raise ValueError('single must be 3D (B, L, C_s).')
+        if pair.dim() != 4:
+            raise ValueError('pair must be 4D (B, L, L, C_z).')
+
+        s_norm = self.norm_single(single)
+        z_norm = self.norm_pair(pair)
+        batch, seq_len, _ = s_norm.shape
+        q = self.linear_q(s_norm).view(batch, seq_len, self.num_heads,
+                                       self.head_dim)
+        k = self.linear_k(s_norm).view(batch, seq_len, self.num_heads,
+                                       self.head_dim)
+        v = self.linear_v(s_norm).view(batch, seq_len, self.num_heads,
+                                       self.head_dim)
+        # logits: (B, H, L_q, L_k) = (1/√d) qᵢ · kⱼ + bᵢⱼ
+        logits = torch.einsum('bihd,bjhd->bhij', q, k) * self.scale
+        bias = self.linear_bias(z_norm).permute(0, 3, 1, 2)
+        logits = logits + bias
+        if mask is not None:
+            mask_bool = mask.to(dtype=torch.bool)
+            key_mask = mask_bool.view(batch, 1, 1, seq_len)
+            logits = logits.masked_fill(~key_mask,
+                                        torch.finfo(logits.dtype).min)
+        attn = F.softmax(logits, dim=-1)
+        attn = self.dropout(attn)
+        out = torch.einsum('bhij,bjhd->bihd', attn, v)
+        out = out.reshape(batch, seq_len, self.embed_dim)
+        out = self.linear_out(out)
+        if mask is not None:
+            out = out * mask.to(dtype=out.dtype).unsqueeze(-1)
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Single transition (feed-forward) with adaptive time conditioning
+# ---------------------------------------------------------------------------
+
+
+class SingleTransition(nn.Module):
+    """Position-wise feed-forward block on the single track with
+    adaLN-style timestep conditioning.
+
+    The block applies layer-norm, computes a time-dependent
+    :math:`(scale, shift)` pair from the timestep embedding, modulates
+    the normalised representation, then runs a two-layer MLP with GELU
+    activation.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    expansion : int, default 4
+        Hidden expansion of the MLP.
+    dropout : float, default 0.0
+        Dropout probability applied to the MLP hidden activations.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 expansion: int = 4,
+                 dropout: float = 0.0) -> None:
+        super().__init__()
+        if embed_dim <= 0 or expansion <= 0:
+            raise ValueError('embed_dim and expansion must be positive.')
+        if not 0.0 <= dropout < 1.0:
+            raise ValueError('dropout must lie in [0, 1).')
+        self.norm = nn.LayerNorm(embed_dim)
+        self.time_mlp = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(embed_dim, embed_dim * 2),
+        )
+        self.mlp = nn.Sequential(
+            nn.Linear(embed_dim, embed_dim * expansion),
+            nn.GELU(),
+            nn.Dropout(dropout),
+            nn.Linear(embed_dim * expansion, embed_dim),
+            nn.Dropout(dropout),
+        )
+
+    def forward(self, single: torch.Tensor,
+                t_emb: torch.Tensor) -> torch.Tensor:
+        """Forward pass.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(B, C_s)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated single representation, same shape as input.
+        """
+        time_cond = self.time_mlp(t_emb)
+        scale, shift = time_cond.chunk(2, dim=-1)
+        h = self.norm(single)
+        h = h * (1.0 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+        return self.mlp(h)
+
+
+# ---------------------------------------------------------------------------
+# Backbone update head
+# ---------------------------------------------------------------------------
+
+
+def quaternion_to_rotation_matrix(quat: torch.Tensor) -> torch.Tensor:
+    """Convert a (possibly unnormalised) quaternion to a rotation matrix.
+
+    Uses the standard formula for a unit quaternion :math:`q = (w, x,
+    y, z)`:
+
+    .. math::
+
+        R = \\begin{pmatrix}
+            1 - 2y^2 - 2z^2 & 2xy - 2wz & 2xz + 2wy \\\\
+            2xy + 2wz & 1 - 2x^2 - 2z^2 & 2yz - 2wx \\\\
+            2xz - 2wy & 2yz + 2wx & 1 - 2x^2 - 2y^2
+        \\end{pmatrix}.
+
+    The quaternion is normalised internally so callers do not need to
+    pre-normalise.
+
+    Parameters
+    ----------
+    quat : torch.Tensor
+        Quaternion of shape ``(..., 4)`` with components in the order
+        :math:`(w, x, y, z)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrix of shape ``(..., 3, 3)``.
+    """
+    norm = torch.linalg.norm(quat, dim=-1, keepdim=True).clamp(min=1e-12)
+    w, x, y, z = (quat / norm).unbind(dim=-1)
+    two = 2.0
+    r00 = 1.0 - two * (y * y + z * z)
+    r01 = two * (x * y - w * z)
+    r02 = two * (x * z + w * y)
+    r10 = two * (x * y + w * z)
+    r11 = 1.0 - two * (x * x + z * z)
+    r12 = two * (y * z - w * x)
+    r20 = two * (x * z - w * y)
+    r21 = two * (y * z + w * x)
+    r22 = 1.0 - two * (x * x + y * y)
+    row0 = torch.stack([r00, r01, r02], dim=-1)
+    row1 = torch.stack([r10, r11, r12], dim=-1)
+    row2 = torch.stack([r20, r21, r22], dim=-1)
+    return torch.stack([row0, row1, row2], dim=-2)
+
+
+class BackboneUpdate(nn.Module):
+    """Predicts a per-residue rigid-frame update from the single track.
+
+    The head linearly projects the (layer-normed) single representation
+    to six channels: three real components :math:`(b, c, d)` of a
+    quaternion with implicit :math:`w = 1`, and three local-frame
+    translation components :math:`\\Delta t_{\\text{local}}`.
+
+    The frame update is then composed as
+
+    .. math::
+
+        R_i^{\\text{new}} = R_i \\, R_{\\Delta},\\qquad
+        t_i^{\\text{new}} = R_i \\, \\Delta t_{\\text{local}} + t_i,
+
+    so that under any global rigid motion :math:`(R_g, t_g)` acting on
+    the input frames the output frames transform equivariantly.
+    Zero-initialisation of the head's final linear layer makes the
+    initial update an identity, a standard diffusion practice.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    """
+
+    def __init__(self, embed_dim: int) -> None:
+        super().__init__()
+        if embed_dim <= 0:
+            raise ValueError('embed_dim must be positive.')
+        self.norm = nn.LayerNorm(embed_dim)
+        self.linear = nn.Linear(embed_dim, 6)
+        # Zero-init so the initial update is the identity transform.
+        nn.init.zeros_(self.linear.weight)
+        nn.init.zeros_(self.linear.bias)
+
+    def forward(
+        self,
+        single: torch.Tensor,
+        rotations: torch.Tensor,
+        translations: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Apply the backbone update.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        rotations : torch.Tensor
+            Current frame rotations of shape ``(B, L, 3, 3)``.
+        translations : torch.Tensor
+            Current frame translations of shape ``(B, L, 3)``.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor]
+            Updated ``(rotations, translations)`` of shapes ``(B, L, 3,
+            3)`` and ``(B, L, 3)``.
+        """
+        update = self.linear(self.norm(single))
+        quat_imag = update[..., :3]
+        delta_t_local = update[..., 3:]
+        # Construct the quaternion (1, b, c, d). Using an implicit
+        # w=1 component biases the initial update toward identity.
+        ones = torch.ones_like(quat_imag[..., :1])
+        quat = torch.cat([ones, quat_imag], dim=-1)
+        r_update = quaternion_to_rotation_matrix(quat)
+        new_rotations = rotations @ r_update
+        # t_new = R · Δt_local + t. Use einsum to broadcast cleanly.
+        new_translations = (
+            torch.einsum('blij,blj->bli', rotations, delta_t_local) +
+            translations)
+        return new_rotations, new_translations
+
+
+# ---------------------------------------------------------------------------
+# Full multi-track block and stack
+# ---------------------------------------------------------------------------
+
+
+class RFDiffusionTrackBlock(nn.Module):
+    """One iteration of the three-track RFDiffusion architecture.
+
+    Each block executes, in order:
+
+    1. **Single → pair** via :class:`OuterProductMean`.
+    2. **Pair self-update** via outgoing and incoming
+       :class:`TriangleMultiplicativeUpdate`, starting- and ending-node
+       :class:`TriangleAttention`, and a :class:`PairTransition`. After
+       each update the pair is symmetrised, preserving
+       :math:`z_{ij} = z_{ji}`.
+    3. **Pair → single** via :class:`PairBiasedSingleAttention`,
+       followed by an adaLN-style :class:`SingleTransition` modulated
+       by the timestep embedding.
+    4. **Frame update** via :class:`InvariantPointAttention` (using the
+       updated single and pair) and :class:`BackboneUpdate`.
+
+    Every operation that touches the pair is symmetric in :math:`(i,
+    j)`, and every operation that touches the frames is built so that
+    composing a global rigid motion on the input frames yields the same
+    motion on the output frames.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    num_heads : int, default 8
+        Heads for the single-track and IPA attentions.
+    pair_num_heads : int, default 4
+        Heads for the triangular self-attention.
+    triangle_hidden_dim : int, default 64
+        Hidden dimension of the triangular multiplicative update.
+    triangle_head_dim : int, default 32
+        Per-head channel size for triangular attention.
+    opm_hidden_dim : int, default 16
+        Projection size of the outer-product mean.
+    num_qk_points : int, default 4
+        Number of query/key 3-D points for IPA.
+    num_v_points : int, default 8
+        Number of value 3-D points for IPA.
+    dropout : float, default 0.0
+        Dropout probability for attention paths and MLPs.
+    chunk_size : int, optional
+        Default chunk size applied to triangular operations. ``None``
+        means no chunking (dense path). Tests verify chunked and dense
+        outputs match to within ``atol=1e-5``.
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 num_heads: int = 8,
+                 pair_num_heads: int = 4,
+                 triangle_hidden_dim: int = 64,
+                 triangle_head_dim: int = 32,
+                 opm_hidden_dim: int = 16,
+                 num_qk_points: int = 4,
+                 num_v_points: int = 8,
+                 dropout: float = 0.0,
+                 chunk_size: Optional[int] = None) -> None:
+        super().__init__()
+        self.chunk_size = chunk_size
+        self.outer_product_mean = OuterProductMean(embed_dim, pair_dim,
+                                                   opm_hidden_dim)
+        self.tri_mul_out = TriangleMultiplicativeUpdate(pair_dim,
+                                                        triangle_hidden_dim,
+                                                        outgoing=True)
+        self.tri_mul_in = TriangleMultiplicativeUpdate(pair_dim,
+                                                       triangle_hidden_dim,
+                                                       outgoing=False)
+        self.tri_attn_start = TriangleAttention(pair_dim,
+                                                pair_num_heads,
+                                                triangle_head_dim,
+                                                starting_node=True)
+        self.tri_attn_end = TriangleAttention(pair_dim,
+                                              pair_num_heads,
+                                              triangle_head_dim,
+                                              starting_node=False)
+        self.pair_transition = PairTransition(pair_dim)
+        self.pair_to_single = PairBiasedSingleAttention(embed_dim,
+                                                        pair_dim,
+                                                        num_heads=num_heads,
+                                                        dropout=dropout)
+        self.single_transition = SingleTransition(embed_dim, dropout=dropout)
+        self.ipa = InvariantPointAttention(embed_dim,
+                                           num_heads=num_heads,
+                                           num_qk_points=num_qk_points,
+                                           num_v_points=num_v_points,
+                                           pair_dim=pair_dim,
+                                           dropout=dropout)
+        self.ipa_norm = nn.LayerNorm(embed_dim)
+        self.backbone_update = BackboneUpdate(embed_dim)
+
+    def forward(
+        self,
+        single: torch.Tensor,
+        pair: torch.Tensor,
+        rotations: torch.Tensor,
+        translations: torch.Tensor,
+        t_emb: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        chunk_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run one multi-track update.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Shape ``(B, L, C_s)``.
+        pair : torch.Tensor
+            Shape ``(B, L, L, C_z)``.
+        rotations : torch.Tensor
+            Shape ``(B, L, 3, 3)``.
+        translations : torch.Tensor
+            Shape ``(B, L, 3)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(B, C_s)``.
+        mask : torch.Tensor, optional
+            Residue mask of shape ``(B, L)``.
+        chunk_size : int, optional
+            Override the block-level default chunk size for this call.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+            Updated ``(single, pair, rotations, translations)``.
+        """
+        active_chunk = (chunk_size
+                        if chunk_size is not None else self.chunk_size)
+        # Single → pair (residual + symmetrise).
+        pair = pair + self.outer_product_mean(single)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        # Pair self-updates.
+        pair = pair + self.tri_mul_out(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.tri_mul_in(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.tri_attn_start(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.tri_attn_end(pair, chunk_size=active_chunk)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        pair = pair + self.pair_transition(pair)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        # Pair → single + transition.
+        single = single + self.pair_to_single(single, pair, mask=mask)
+        single = single + self.single_transition(single, t_emb)
+        # Frame update: IPA produces an invariant single increment.
+        ipa_out = self.ipa(self.ipa_norm(single),
+                           rotations,
+                           translations,
+                           pair_repr=pair,
+                           mask=mask)
+        single = single + ipa_out
+        rotations, translations = self.backbone_update(single, rotations,
+                                                       translations)
+        return single, pair, rotations, translations
+
+
+class RFDiffusionMultiTrackStack(nn.Module):
+    """Stacked multi-track architecture matching ``DiffusionTransformerBlock``.
+
+    Wraps a sequence of :class:`RFDiffusionTrackBlock` updates so that
+    the public :meth:`forward` signature ``forward(single, t_emb,
+    attention_mask=None) -> single`` is identical to the baseline
+    transformer block stack in
+    :mod:`deepchem.models.torch_models.rfdiffusion`. The pair
+    representation and rigid frames live entirely within the stack and
+    are initialised fresh on every forward pass.
+
+    Use :meth:`forward_tracks` from tests to retrieve the final
+    ``(single, pair, rotations, translations)`` tuple — this enables
+    direct equivariance checks on the frame outputs.
+
+    Parameters
+    ----------
+    embed_dim : int
+        Single-track channel size :math:`C_s`.
+    pair_dim : int
+        Pair-track channel size :math:`C_z`.
+    num_blocks : int, default 2
+        Number of stacked multi-track blocks.
+    num_heads : int, default 8
+        Heads for single-track and IPA attention.
+    pair_num_heads : int, default 4
+        Heads for triangular self-attention.
+    chunk_size : int, optional
+        Default chunk size for triangular operations.
+    dropout : float, default 0.0
+        Shared dropout probability.
+    max_relative_position : int, default 32
+        Clip radius for the relative-position embedding used to
+        initialise the pair representation.
+    opm_hidden_dim : int, default 16
+        Hidden size of the outer-product-mean projection used in each
+        block.
+    triangle_hidden_dim : int, default 64
+        Hidden size for the triangular multiplicative update.
+    triangle_head_dim : int, default 32
+        Per-head channel size for triangular attention.
+    num_qk_points : int, default 4
+        IPA query/key 3-D point count.
+    num_v_points : int, default 8
+        IPA value 3-D point count.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    ...     RFDiffusionMultiTrackStack)
+    >>> stack = RFDiffusionMultiTrackStack(
+    ...     embed_dim=32, pair_dim=16, num_blocks=2, num_heads=4,
+    ...     pair_num_heads=2, triangle_hidden_dim=16,
+    ...     triangle_head_dim=8, opm_hidden_dim=8)
+    >>> single = torch.randn(2, 6, 32)
+    >>> t_emb = torch.randn(2, 32)
+    >>> out = stack(single, t_emb)
+    >>> out.shape
+    torch.Size([2, 6, 32])
+    """
+
+    def __init__(self,
+                 embed_dim: int,
+                 pair_dim: int,
+                 num_blocks: int = 2,
+                 num_heads: int = 8,
+                 pair_num_heads: int = 4,
+                 chunk_size: Optional[int] = None,
+                 dropout: float = 0.0,
+                 max_relative_position: int = 32,
+                 opm_hidden_dim: int = 16,
+                 triangle_hidden_dim: int = 64,
+                 triangle_head_dim: int = 32,
+                 num_qk_points: int = 4,
+                 num_v_points: int = 8) -> None:
+        super().__init__()
+        if num_blocks <= 0:
+            raise ValueError('num_blocks must be positive.')
+        self.embed_dim = embed_dim
+        self.pair_dim = pair_dim
+        self.num_blocks = num_blocks
+        self.chunk_size = chunk_size
+        # Pair initialiser: relpos + initial OPM-style outer product
+        # mean of the input single representation.
+        self.rel_pos = RelativePositionEmbedding(pair_dim,
+                                                 max_relative_position)
+        self.initial_opm = OuterProductMean(embed_dim, pair_dim, opm_hidden_dim)
+        self.blocks = nn.ModuleList([
+            RFDiffusionTrackBlock(embed_dim,
+                                  pair_dim,
+                                  num_heads=num_heads,
+                                  pair_num_heads=pair_num_heads,
+                                  triangle_hidden_dim=triangle_hidden_dim,
+                                  triangle_head_dim=triangle_head_dim,
+                                  opm_hidden_dim=opm_hidden_dim,
+                                  num_qk_points=num_qk_points,
+                                  num_v_points=num_v_points,
+                                  dropout=dropout,
+                                  chunk_size=chunk_size)
+            for _ in range(num_blocks)
+        ])
+        self.final_norm = nn.LayerNorm(embed_dim)
+
+    # -- DropIn-compatible forward ------------------------------------
+
+    def forward(self,
+                single: torch.Tensor,
+                t_emb: torch.Tensor,
+                attention_mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Drop-in replacement for the baseline transformer block stack.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Single representation of shape ``(B, L, C_s)``.
+        t_emb : torch.Tensor
+            Timestep embedding of shape ``(B, C_s)``.
+        attention_mask : torch.Tensor, optional
+            Boolean mask of shape ``(B, L)``.
+
+        Returns
+        -------
+        torch.Tensor
+            Updated single representation, shape ``(B, L, C_s)``.
+        """
+        single_out, _, _, _ = self.forward_tracks(single, t_emb, attention_mask)
+        return single_out
+
+    # -- Full multi-track API (for tests and downstream consumers) ----
+
+    def forward_tracks(
+        self,
+        single: torch.Tensor,
+        t_emb: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        rotations: Optional[torch.Tensor] = None,
+        translations: Optional[torch.Tensor] = None,
+        chunk_size: Optional[int] = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Run all tracks and return
+        ``(single, pair, rotations, translations)``.
+
+        Parameters
+        ----------
+        single : torch.Tensor
+            Shape ``(B, L, C_s)``.
+        t_emb : torch.Tensor
+            Shape ``(B, C_s)``.
+        attention_mask : torch.Tensor, optional
+            Shape ``(B, L)``.
+        rotations : torch.Tensor, optional
+            Initial frame rotations of shape ``(B, L, 3, 3)``. If
+            ``None``, identity rotations are used.
+        translations : torch.Tensor, optional
+            Initial frame translations of shape ``(B, L, 3)``. If
+            ``None``, zero translations are used.
+        chunk_size : int, optional
+            Override the stack-level default chunk size for this call.
+
+        Returns
+        -------
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
+            Final ``(single, pair, rotations, translations)``.
+        """
+        if single.dim() != 3:
+            raise ValueError('single must be 3D (B, L, C_s).')
+        if single.size(-1) != self.embed_dim:
+            raise ValueError(
+                f'Expected embed_dim {self.embed_dim}, got {single.size(-1)}.')
+        if t_emb.dim() != 2 or t_emb.size(-1) != self.embed_dim:
+            raise ValueError('t_emb must have shape (B, embed_dim).')
+
+        batch, seq_len, _ = single.shape
+        device = single.device
+        dtype = single.dtype
+
+        # Mask coercion.
+        mask = None
+        if attention_mask is not None:
+            mask = attention_mask.to(device=device, dtype=torch.bool)
+            if mask.shape != (batch, seq_len):
+                raise ValueError('attention_mask must have shape (B, L).')
+
+        # Initial frames.  Use concrete Tensor-typed locals (R, T) so mypy
+        # can verify the Tuple[Tensor, Tensor, Tensor, Tensor] return type.
+        if rotations is None:
+            R, t_id = make_identity_rigid((batch, seq_len),
+                                          device=device,
+                                          dtype=dtype)
+            T: torch.Tensor = (translations
+                               if translations is not None else t_id)
+        else:
+            R = rotations
+            T = (translations if translations is not None else torch.zeros(
+                batch, seq_len, 3, device=device, dtype=dtype))
+
+        # Initial pair: symmetric relpos + symmetric OPM.
+        rel = self.rel_pos(seq_len, device=device).to(dtype)
+        pair = rel.unsqueeze(0).expand(batch, -1, -1, -1).contiguous()
+        pair = pair + self.initial_opm(single)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+
+        active_chunk = (chunk_size
+                        if chunk_size is not None else self.chunk_size)
+
+        for block in self.blocks:
+            single, pair, R, T = block(single,
+                                       pair,
+                                       R,
+                                       T,
+                                       t_emb,
+                                       mask=mask,
+                                       chunk_size=active_chunk)
+            # Re-mask single for masked residues so that downstream
+            # consumers see exactly zeros for padded entries.
+            if mask is not None:
+                single = single * mask.unsqueeze(-1).to(single.dtype)
+
+        single = self.final_norm(single)
+        return single, pair, R, T

--- a/deepchem/models/torch_models/rfdiffusion_sequence_track.py
+++ b/deepchem/models/torch_models/rfdiffusion_sequence_track.py
@@ -86,6 +86,13 @@ class PairBiasedSingleAttention(nn.Module):
     dropout : float, default 0.0
         Dropout probability applied to attention weights.
 
+    Raises
+    ------
+    ValueError
+        If `embed_dim`, `pair_dim`, or `num_heads` is not positive, if
+        `embed_dim` is not divisible by `num_heads`, or if `dropout` is
+        not in `[0, 1)`.
+
     Examples
     --------
     >>> import torch
@@ -146,6 +153,11 @@ class PairBiasedSingleAttention(nn.Module):
         -------
         torch.Tensor
             Updated single representation, same shape as input.
+
+        Raises
+        ------
+        ValueError
+            If `single` is not 3D or `pair` is not 4D.
         """
         if single.dim() != 3:
             raise ValueError('single must be 3D (B, L, C_s).')
@@ -202,6 +214,12 @@ class SingleTransition(nn.Module):
         Hidden expansion of the MLP.
     dropout : float, default 0.0
         Dropout probability applied to the MLP hidden activations.
+
+    Raises
+    ------
+    ValueError
+        If `embed_dim` or `expansion` is not positive, or if `dropout`
+        is not in `[0, 1)`.
 
     Examples
     --------
@@ -346,6 +364,11 @@ class BackboneUpdate(nn.Module):
     ----------
     embed_dim : int
         Single-track channel size :math:`C_s`.
+
+    Raises
+    ------
+    ValueError
+        If `embed_dim` is not positive.
 
     Examples
     --------
@@ -641,6 +664,11 @@ class RFDiffusionMultiTrackStack(nn.Module):
     num_v_points : int, default 8
         IPA value 3-D point count.
 
+    Raises
+    ------
+    ValueError
+        If `num_blocks` is not positive.
+
     Examples
     --------
     >>> import torch
@@ -759,6 +787,12 @@ class RFDiffusionMultiTrackStack(nn.Module):
         -------
         Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]
             Final ``(single, pair, rotations, translations)``.
+
+        Raises
+        ------
+        ValueError
+            If `single` is not 3D, its last dimension doesn't match
+            `embed_dim`, or `t_emb`/`attention_mask` have the wrong shape.
         """
         if single.dim() != 3:
             raise ValueError('single must be 3D (B, L, C_s).')

--- a/deepchem/models/torch_models/rfdiffusion_sequence_track.py
+++ b/deepchem/models/torch_models/rfdiffusion_sequence_track.py
@@ -46,20 +46,20 @@ try:
     import torch
     import torch.nn as nn
     import torch.nn.functional as F
-except ModuleNotFoundError:
+    from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
+    from deepchem.models.torch_models.rfdiffusion_ipa import (
+        InvariantPointAttention)
+    from deepchem.models.torch_models.rfdiffusion_pair_track import (
+        OuterProductMean,
+        PairTransition,
+        RelativePositionEmbedding,
+        TriangleAttention,
+        TriangleMultiplicativeUpdate,
+    )
+except (ModuleNotFoundError, ImportError):
     raise ImportError(
-        'rfdiffusion_sequence_track requires PyTorch to be installed.')
-
-from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
-from deepchem.models.torch_models.rfdiffusion_ipa import (
-    InvariantPointAttention)
-from deepchem.models.torch_models.rfdiffusion_pair_track import (
-    OuterProductMean,
-    PairTransition,
-    RelativePositionEmbedding,
-    TriangleAttention,
-    TriangleMultiplicativeUpdate,
-)
+        'rfdiffusion_sequence_track requires PyTorch and upstream RFDiffusion modules.'
+    )
 
 # ---------------------------------------------------------------------------
 # 2D → 1D update: pair-biased self-attention
@@ -85,6 +85,18 @@ class PairBiasedSingleAttention(nn.Module):
         Number of attention heads.
     dropout : float, default 0.0
         Dropout probability applied to attention weights.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    ...     PairBiasedSingleAttention)
+    >>> layer = PairBiasedSingleAttention(embed_dim=16, pair_dim=8, num_heads=4)
+    >>> single = torch.randn(2, 5, 16)
+    >>> pair = torch.randn(2, 5, 5, 8)
+    >>> out = layer(single, pair)
+    >>> out.shape
+    torch.Size([2, 5, 16])
     """
 
     def __init__(self,
@@ -190,6 +202,18 @@ class SingleTransition(nn.Module):
         Hidden expansion of the MLP.
     dropout : float, default 0.0
         Dropout probability applied to the MLP hidden activations.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    ...     SingleTransition)
+    >>> layer = SingleTransition(embed_dim=16, expansion=2)
+    >>> single = torch.randn(2, 5, 16)
+    >>> t_emb = torch.randn(2, 16)
+    >>> out = layer(single, t_emb)
+    >>> out.shape
+    torch.Size([2, 5, 16])
     """
 
     def __init__(self,
@@ -269,6 +293,16 @@ def quaternion_to_rotation_matrix(quat: torch.Tensor) -> torch.Tensor:
     -------
     torch.Tensor
         Rotation matrix of shape ``(..., 3, 3)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    ...     quaternion_to_rotation_matrix)
+    >>> q = torch.tensor([1.0, 0.0, 0.0, 0.0])
+    >>> R = quaternion_to_rotation_matrix(q)
+    >>> torch.allclose(R, torch.eye(3))
+    True
     """
     norm = torch.linalg.norm(quat, dim=-1, keepdim=True).clamp(min=1e-12)
     w, x, y, z = (quat / norm).unbind(dim=-1)
@@ -312,6 +346,21 @@ class BackboneUpdate(nn.Module):
     ----------
     embed_dim : int
         Single-track channel size :math:`C_s`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    ...     BackboneUpdate)
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
+    >>> head = BackboneUpdate(embed_dim=16)
+    >>> single = torch.randn(2, 5, 16)
+    >>> R, t = make_identity_rigid((2, 5))
+    >>> new_R, new_t = head(single, R, t)
+    >>> new_R.shape
+    torch.Size([2, 5, 3, 3])
+    >>> new_t.shape
+    torch.Size([2, 5, 3])
     """
 
     def __init__(self, embed_dim: int) -> None:
@@ -416,6 +465,24 @@ class RFDiffusionTrackBlock(nn.Module):
         Default chunk size applied to triangular operations. ``None``
         means no chunking (dense path). Tests verify chunked and dense
         outputs match to within ``atol=1e-5``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+    ...     RFDiffusionTrackBlock)
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import make_identity_rigid
+    >>> block = RFDiffusionTrackBlock(
+    ...     embed_dim=16, pair_dim=8, num_heads=2, pair_num_heads=2,
+    ...     triangle_hidden_dim=8, triangle_head_dim=4, opm_hidden_dim=4,
+    ...     num_qk_points=2, num_v_points=2)
+    >>> single = torch.randn(2, 4, 16)
+    >>> pair = torch.randn(2, 4, 4, 8)
+    >>> R, t = make_identity_rigid((2, 4))
+    >>> t_emb = torch.randn(2, 16)
+    >>> s_out, p_out, R_out, t_out = block(single, pair, R, t, t_emb)
+    >>> s_out.shape
+    torch.Size([2, 4, 16])
     """
 
     def __init__(self,

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -1,0 +1,610 @@
+"""SO(3) diffusion utilities for RFDiffusion.
+
+This module implements the rotational component of the RFDiffusion noise
+process [Watson2023]_: an IGSO(3) (Isotropic Gaussian on SO(3)) diffusion
+with a logarithmic variance schedule and a reverse-time Euler-Maruyama
+integrator on the so(3) tangent space [Leach2022]_, [Yim2023]_.
+
+Conventions
+-----------
+* Rotations are represented as ``(..., 3, 3)`` proper rotation matrices
+  R in SO(3) with det(R) = +1.
+* A rotation is parameterised on the tangent space so(3) =~ R^3 by a
+  rotation vector tau = omega * u where omega in [0, pi] is the rotation angle
+  (geodesic distance from the identity) and u in S^2 is the rotation axis.
+* The matrix exponential of a tangent vector uses Rodrigues' formula
+  R = I + sin(omega) [u]_x + (1 - cos(omega)) [u]_x^2 where [u]_x is the
+  skew-symmetric matrix associated with u.
+
+Mathematical reference
+----------------------
+The IGSO(3) density on the rotation angle omega is
+
+.. math::
+
+    f(\\omega; \\sigma) = \\sum_{l=0}^{\\infty}
+        (2l+1)\\,
+        \\exp\\!\\left(-\\tfrac{l(l+1)}{2}\\sigma^{2}\\right)\\,
+        \\frac{\\sin\\!\\big((l+\\tfrac{1}{2})\\omega\\big)}
+             {\\sin(\\omega/2)}
+
+and the marginal density on omega in [0, pi] is
+
+.. math::
+
+    p(\\omega; \\sigma) = \\frac{1 - \\cos \\omega}{\\pi}\\, f(\\omega; \\sigma).
+
+The score on the rotation angle is
+
+.. math::
+
+    s(\\omega; \\sigma) = \\partial_{\\omega}\\log f(\\omega; \\sigma)
+
+and the score on so(3) - used as the drift term in the reverse SDE -
+points along the geodesic from the identity to R with magnitude
+``s(omega; sigma)``.
+
+Developer-facing summary
+------------------------
+This file is the rotation-noise backend for RFDiffusion. Use
+``so3_exp_map`` and ``so3_log_map`` to move between tangent vectors and
+rotation matrices, build an ``IGSO3`` table once for cached score /
+sampling queries, and call ``so3_reverse_step`` during sampling to move
+one denoising step from ``R_t`` to ``R_{t-1}``.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+.. [Leach2022] Leach et al. "Denoising Diffusion Probabilistic Models on
+   SO(3) for Rotational Alignment." ICLR Workshop on Geometric and
+   Topological Representation Learning (2022).
+.. [Yim2023] Yim et al. "SE(3) Diffusion Model with Application to Protein
+   Backbone Generation." ICML (2023).
+"""
+
+import math
+from typing import Optional, Tuple
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_so3 requires PyTorch to be installed.')
+
+__all__ = [
+    'IGSO3',
+    'log_beta_schedule',
+    'so3_log_map',
+    'so3_exp_map',
+    'so3_reverse_step',
+]
+
+# Threshold below which series expansions are used instead of the closed
+# form to preserve numerical stability.
+_SMALL_OMEGA: float = 1e-4
+_SMALL_SIGMA: float = 5e-2
+
+
+def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
+    """Return ``sin(x) / x`` with a stable Taylor series near zero.
+
+    Computes the second-order Taylor expansion ``1 - x^2/6`` when
+    |x| < ``_SMALL_OMEGA`` and the closed-form expression elsewhere.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of arbitrary shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x`` containing ``sin(x) / x``.
+    """
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
+
+
+def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
+    """Return ``(1 - cos x) / x^2`` with a Taylor series near zero.
+
+    Computes ``1/2 - x^2/24`` when |x| < ``_SMALL_OMEGA`` and the closed
+    form ``(1 - cos x) / x^2`` elsewhere.
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        Input tensor of arbitrary shape.
+
+    Returns
+    -------
+    torch.Tensor
+        Tensor of the same shape as ``x``.
+    """
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)
+    series = 0.5 - x * x / 24.0
+    return torch.where(small, series, closed)
+
+
+def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
+    """Map a tangent vector in so(3) =~ R^3 to a rotation matrix.
+
+    Implements Rodrigues' rotation formula
+
+    .. math::
+
+        R = I + \\frac{\\sin\\omega}{\\omega}\\,[\\tau]_{\\times}
+            + \\frac{1 - \\cos\\omega}{\\omega^{2}}\\,[\\tau]_{\\times}^{2}
+
+    where omega = ||tau|| and [tau]_x is the skew-symmetric matrix of tau. Small-omega
+    Taylor expansions are used to maintain numerical stability.
+
+    Parameters
+    ----------
+    tangent : torch.Tensor
+        Tangent vector(s) of shape ``(..., 3)`` representing rotation
+        vectors tau = omega * u.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import so3_exp_map
+    >>> R = so3_exp_map(torch.zeros(1, 3))
+    >>> bool(torch.allclose(R, torch.eye(3).unsqueeze(0)))
+    True
+    """
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)  # (..., 1)
+    # Build the skew matrix [tau]_x.
+    zeros = torch.zeros_like(tangent[..., 0])
+    tx, ty, tz = tangent[..., 0], tangent[..., 1], tangent[..., 2]
+    skew = torch.stack([
+        torch.stack([zeros, -tz, ty], dim=-1),
+        torch.stack([tz, zeros, -tx], dim=-1),
+        torch.stack([-ty, tx, zeros], dim=-1),
+    ],
+                       dim=-2)  # (..., 3, 3)
+    eye = torch.eye(3, dtype=tangent.dtype, device=tangent.device)
+    sin_coeff = _safe_sin_div_x(omega).unsqueeze(-1)  # (..., 1, 1)
+    cos_coeff = _safe_one_minus_cos_div_x_sq(omega).unsqueeze(-1)
+    skew_sq = torch.matmul(skew, skew)
+    return eye + sin_coeff * skew + cos_coeff * skew_sq
+
+
+def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
+    """Map rotation matrices to tangent vectors on the principal branch.
+
+    The rotation is converted to a unit quaternion first and then to an
+    axis-angle vector. Routing through the quaternion keeps the result
+    stable for rotations near ``pi``, where reading the angle straight from
+    the trace loses accuracy because ``sin(omega)`` goes to zero.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape ``(..., 3, 3)``.
+
+    Returns
+    -------
+    torch.Tensor
+        Tangent vectors of shape ``(..., 3)`` whose norm lies in
+        ``[0, pi]``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     so3_exp_map, so3_log_map)
+    >>> tangent = torch.tensor([[0.3, -0.4, 1.2]])
+    >>> recovered = so3_log_map(so3_exp_map(tangent))
+    >>> bool(torch.allclose(recovered, tangent, atol=1e-5))
+    True
+    """
+    m00 = rotations[..., 0, 0]
+    m11 = rotations[..., 1, 1]
+    m22 = rotations[..., 2, 2]
+    trace = m00 + m11 + m22
+
+    # Read the unit quaternion from the rotation matrix. Each component
+    # magnitude comes from the diagonal and its sign from the skew part.
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
+    qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
+    qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
+
+    quat_vec = torch.stack([qx, qy, qz], dim=-1)
+    sin_half = quat_vec.norm(dim=-1)
+    cos_half = qw.clamp(-1.0, 1.0)
+    omega = 2.0 * torch.atan2(sin_half, cos_half)
+
+    small = sin_half < _SMALL_OMEGA
+    safe_sin_half = torch.where(small, torch.ones_like(sin_half), sin_half)
+    unit_axis = quat_vec / safe_sin_half.unsqueeze(-1)
+    # Near zero rotation the axis is ill-defined; there the tangent vector
+    # is approximately 2 * (qx, qy, qz).
+    return torch.where(small.unsqueeze(-1), 2.0 * quat_vec,
+                       omega.unsqueeze(-1) * unit_axis)
+
+
+def log_beta_schedule(num_steps: int,
+                      beta_min: float = 0.1,
+                      beta_max: float = 1.5) -> torch.Tensor:
+    """Logarithmic variance schedule for IGSO(3) diffusion.
+
+    Returns sigma_t = exp(linear(log beta_min, log beta_max)) for t = 1 .. T. This
+    is the schedule used by [Watson2023]_ and [Yim2023]_ for rotational
+    diffusion. The schedule is **monotonically increasing** in t.
+
+    Parameters
+    ----------
+    num_steps : int
+        Number of diffusion steps T (must be >= 2).
+    beta_min : float, default 0.1
+        Smallest sigma value (at t = 1).
+    beta_max : float, default 1.5
+        Largest sigma value (at t = T).
+
+    Returns
+    -------
+    torch.Tensor
+        Schedule tensor of shape ``(num_steps,)`` containing sigma_t values.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     log_beta_schedule)
+    >>> sigmas = log_beta_schedule(5, beta_min=0.1, beta_max=1.5)
+    >>> sigmas.shape
+    torch.Size([5])
+    >>> bool((sigmas[1:] > sigmas[:-1]).all())
+    True
+    """
+    if num_steps < 2:
+        raise ValueError('num_steps must be >= 2.')
+    if beta_min <= 0 or beta_max <= 0 or beta_max <= beta_min:
+        raise ValueError('Require 0 < beta_min < beta_max; got '
+                         f'beta_min={beta_min}, beta_max={beta_max}.')
+    log_min = math.log(beta_min)
+    log_max = math.log(beta_max)
+    return torch.exp(torch.linspace(log_min, log_max, num_steps))
+
+
+class IGSO3:
+    """Isotropic Gaussian distribution on SO(3).
+
+    The IGSO(3) density on the rotation angle omega in [0, pi] is the heat
+    kernel of the Laplace-Beltrami operator on SO(3) evaluated at
+    rotations whose geodesic distance from the identity is omega
+    [Nikolayev1997]_, [Leach2022]_.
+
+    The class caches a discretised PDF / CDF over a ``num_omega`` grid
+    for the supplied ``sigma`` values so that ``sample`` and ``score``
+    queries are fast.
+
+    Parameters
+    ----------
+    sigmas : torch.Tensor
+        1-D tensor of strictly positive sigma values (one per discrete
+        diffusion step).
+    num_omega : int, default 1024
+        Number of grid points used to discretise omega in (0, pi).
+    lmax : int, default 1999
+        Maximum degree retained in the infinite-series PDF. This gives
+        2000 terms, matching upstream RFdiffusion's default truncation
+        level.
+    cache : bool, default True
+        If ``True`` precompute and cache the discretised PDF / CDF for
+        each sigma in ``sigmas``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import IGSO3
+    >>> sigmas = torch.tensor([0.5])
+    >>> dist = IGSO3(sigmas, num_omega=256)
+    >>> samples = dist.sample(sigma_index=0, shape=(8,))
+    >>> samples.shape
+    torch.Size([8, 3, 3])
+
+    References
+    ----------
+    .. [Nikolayev1997] Nikolayev, D. I. & Savyolov, T. I. "Normal
+       distribution on the rotation group SO(3)." Textures and
+       Microstructures 29 (1997) 201-233.
+    """
+
+    def __init__(self,
+                 sigmas: torch.Tensor,
+                 num_omega: int = 1024,
+                 lmax: int = 1999,
+                 cache: bool = True) -> None:
+        if sigmas.ndim != 1:
+            raise ValueError('sigmas must be a 1-D tensor.')
+        if (sigmas <= 0).any():
+            raise ValueError('sigmas must be strictly positive.')
+        if num_omega < 64:
+            raise ValueError('num_omega must be at least 64.')
+        if lmax < 1:
+            raise ValueError('lmax must be at least 1.')
+        self.sigmas = sigmas.to(dtype=torch.float64)
+        self.num_omega = int(num_omega)
+        self.lmax = int(lmax)
+        # Upstream RFdiffusion discretises omega as linspace(0, pi, N+1)[1:]:
+        # zero is skipped, pi is included.
+        self.omegas = torch.linspace(0.0,
+                                     math.pi,
+                                     self.num_omega + 1,
+                                     dtype=torch.float64)[1:]
+        self.domega = float(self.omegas[1] - self.omegas[0])
+        self._pdf: Optional[torch.Tensor] = None
+        self._cdf: Optional[torch.Tensor] = None
+        self._score: Optional[torch.Tensor] = None
+        if cache:
+            self._compute_tables()
+
+    # ------------------------------------------------------------------
+    # PDF / CDF / score on the rotation angle omega
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _f_omega(omega: torch.Tensor, sigma: torch.Tensor,
+                 lmax: int) -> torch.Tensor:
+        """Evaluate the heat-kernel series f(omega; sigma).
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of shape ``(N,)`` containing rotation angles omega.
+        sigma : torch.Tensor
+            Tensor of shape ``(M,)`` containing sigma values.
+        lmax : int
+            Truncation degree of the series.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(M, N)`` with ``f(omega_n; sigma_m)``.
+        """
+        l_values = torch.arange(lmax + 1, device=omega.device)[None]
+        omega_col = omega[:, None]
+        rows = []
+        for sigma_i in sigma:
+            sigma_sq = float(sigma_i.detach().cpu().item()**2)
+            terms = ((2 * l_values + 1) *
+                     torch.exp(-l_values * (l_values + 1) * sigma_sq / 2) *
+                     torch.sin(omega_col *
+                               (l_values + 0.5)) / torch.sin(omega_col / 2))
+            rows.append(terms.sum(dim=-1))
+        return torch.stack(rows, dim=0)
+
+    @staticmethod
+    def _score_omega(omega: torch.Tensor, sigma: torch.Tensor,
+                     lmax: int) -> torch.Tensor:
+        """Evaluate domega log f(omega; sigma) using upstream-style autograd."""
+        with torch.enable_grad():
+            omega_var = omega.detach().clone().requires_grad_(True)
+            f = IGSO3._f_omega(omega_var, sigma.detach(), lmax)
+            scores = []
+            for row in f:
+                log_f = torch.log(row)
+                grad = torch.autograd.grad(log_f.sum(),
+                                           omega_var,
+                                           retain_graph=True)[0]
+                scores.append(grad.detach())
+        return torch.stack(scores, dim=0)
+
+    def _compute_tables(self) -> None:
+        """Populate the PDF / CDF / score caches."""
+        f = self._f_omega(self.omegas, self.sigmas, self.lmax)  # (M, N)
+        # Marginal density on omega: p(omega) = (1 - cos omega)/pi * f(omega).
+        prefactor = (1.0 - torch.cos(self.omegas)) / math.pi  # (N,)
+        pdf = prefactor[None, :] * f
+        cdf = torch.cumsum(pdf, dim=-1) * self.domega
+        # Score s(omega; sigma) = domega log f(omega; sigma), matching the upstream
+        # autograd derivative of the truncated heat-kernel series.
+        score = self._score_omega(self.omegas, self.sigmas, self.lmax)
+        self._pdf = pdf
+        self._cdf = cdf
+        self._score = score
+
+    def pdf(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached PDF at the supplied angles.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles omega in (0, pi) of arbitrary shape.
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` whose PDF to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            PDF evaluated at the supplied angles.
+        """
+        if self._pdf is None:
+            self._compute_tables()
+        assert self._pdf is not None
+        return self._interp(omega, self._pdf[sigma_index])
+
+    def cdf(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached CDF at the supplied angles."""
+        if self._cdf is None:
+            self._compute_tables()
+        assert self._cdf is not None
+        return self._interp(omega, self._cdf[sigma_index])
+
+    def score(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
+        """Interpolate the cached score s(omega; sigma) at the supplied angles.
+
+        For small sigma the IGSO(3) collapses to a wrapped Gaussian on
+        so(3); the score is then approximately -omega / sigma^2. The cached
+        table already encodes this limit, so no special branch is
+        required at query time.
+        """
+        if self._score is None:
+            self._compute_tables()
+        assert self._score is not None
+        return self._interp(omega, self._score[sigma_index])
+
+    def _interp(self, omega: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
+        """Linear interpolation of a 1-D cached table on the omega grid."""
+        omega = omega.to(dtype=torch.float64)
+        x = (omega - self.omegas[0]) / self.domega
+        x = x.clamp(0.0, float(self.num_omega - 1))
+        lo = x.floor().long()
+        hi = (lo + 1).clamp(max=self.num_omega - 1)
+        frac = (x - lo.to(x.dtype))
+        return (1.0 - frac) * table[lo] + frac * table[hi]
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+    def sample_angle(
+            self,
+            sigma_index: int,
+            shape: Tuple[int, ...],
+            generator: Optional[torch.Generator] = None) -> torch.Tensor:
+        """Sample rotation angles omega from IGSO(3) by inverse CDF."""
+        if self._cdf is None:
+            self._compute_tables()
+        assert self._cdf is not None
+        cdf = self._cdf[sigma_index]
+        u = torch.rand(shape, dtype=torch.float64, generator=generator)
+        idx = torch.searchsorted(cdf, u.flatten()).clamp(max=self.num_omega - 1)
+        return self.omegas[idx].reshape(shape)
+
+    def sample(self,
+               sigma_index: int,
+               shape: Tuple[int, ...],
+               generator: Optional[torch.Generator] = None) -> torch.Tensor:
+        """Sample rotation matrices from IGSO(3, sigma).
+
+        Sampling proceeds by:
+
+        1. drawing omega ~ p(omega; sigma) via inverse CDF;
+        2. drawing a uniform axis u in S^2 (rejection-free);
+        3. mapping tau = omega * u through Rodrigues' formula.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of sigma in ``self.sigmas``.
+        shape : tuple of int
+            Output batch shape; the returned tensor has shape
+            ``shape + (3, 3)``.
+        generator : torch.Generator, optional
+            PyTorch random generator for reproducibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Sampled rotation matrices of shape ``shape + (3, 3)`` in
+            ``torch.float32``.
+        """
+        omega = self.sample_angle(sigma_index, shape, generator=generator)
+        # Uniform axis on S^2 via standard normal normalisation.
+        axis = torch.randn(shape + (3,),
+                           dtype=torch.float64,
+                           generator=generator)
+        axis = axis / axis.norm(dim=-1, keepdim=True).clamp(min=1e-12)
+        tangent = (omega.unsqueeze(-1) * axis).to(dtype=torch.float32)
+        return so3_exp_map(tangent)
+
+    # ------------------------------------------------------------------
+    # Discrete normalisation check
+    # ------------------------------------------------------------------
+    def normalisation_error(self, sigma_index: int) -> float:
+        """Return |integralp(omega;sigma) domega - 1| on the cached grid.
+
+        This mirrors the upstream RFdiffusion Riemann-sum check; the
+        table is not renormalised after truncation.
+        """
+        if self._pdf is None:
+            self._compute_tables()
+        assert self._pdf is not None
+        total = float(self._pdf[sigma_index].sum() * self.domega)
+        return abs(total - 1.0)
+
+
+def so3_reverse_step(rotations: torch.Tensor,
+                     score: torch.Tensor,
+                     sigma_t: float,
+                     sigma_t_minus_1: float,
+                     noise: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """Single reverse-time Euler-Maruyama step on SO(3).
+
+    Implements the discretisation [Yim2023]_
+
+    .. math::
+
+        \\tau_{t-1} = (\\sigma_{t-1}^{2}/\\sigma_{t}^{2})\\,\\tau_{t}
+                    + (\\sigma_{t}^{2} - \\sigma_{t-1}^{2})\\,
+                      s(\\omega_t; \\sigma_t)\\,
+                      \\frac{\\tau_t}{\\omega_t}
+                    + \\sqrt{\\sigma_{t-1}^{2}\\,
+                            (1 - \\sigma_{t-1}^{2}/\\sigma_{t}^{2})}\\,
+                      \\xi
+
+    where xi ~ N(0, I3), tau_t = log(R_t) and the resulting tau_{t-1} is
+    re-exponentiated via Rodrigues' formula to give R_{t-1}.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Current rotation matrices of shape ``(..., 3, 3)``.
+    score : torch.Tensor
+        Score s(omega_t; sigma_t) evaluated at the current rotation angles,
+        broadcastable to the leading dimensions of ``rotations``.
+    sigma_t : float
+        Noise level at the current step.
+    sigma_t_minus_1 : float
+        Noise level at the previous step (must be < sigma_t).
+    noise : torch.Tensor, optional
+        Standard normal noise of shape ``rotations.shape[:-2] + (3,)``.
+        If ``None`` a fresh sample is drawn.
+
+    Returns
+    -------
+    torch.Tensor
+        Updated rotation matrices of shape ``(..., 3, 3)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_so3 import (
+    ...     so3_exp_map, so3_reverse_step)
+    >>> R_t = so3_exp_map(torch.tensor([[0.0, 0.0, 2.0]]))
+    >>> R_prev = so3_reverse_step(R_t, torch.tensor([-1.0]), sigma_t=1.0,
+    ...                           sigma_t_minus_1=0.9,
+    ...                           noise=torch.zeros(1, 3))
+    >>> R_prev.shape
+    torch.Size([1, 3, 3])
+    """
+    if sigma_t <= 0 or sigma_t_minus_1 <= 0:
+        raise ValueError('sigma values must be strictly positive.')
+    if sigma_t_minus_1 >= sigma_t:
+        raise ValueError('Reverse step requires sigma_t_minus_1 < sigma_t; got '
+                         f'{sigma_t_minus_1} >= {sigma_t}.')
+    tau_t = so3_log_map(rotations)
+    omega = tau_t.norm(dim=-1, keepdim=True).clamp(min=_SMALL_OMEGA)
+    direction = tau_t / omega
+    score = score.unsqueeze(-1) if score.dim() == tau_t.dim() - 1 else score
+    ratio = (sigma_t_minus_1 / sigma_t)**2
+    drift = ratio * tau_t + (sigma_t**2 - sigma_t_minus_1**2) * (score *
+                                                                 direction)
+    diffusion_std = math.sqrt(max(0.0, sigma_t_minus_1**2 * (1.0 - ratio)))
+    if noise is None:
+        noise = torch.randn_like(tau_t)
+    tau_prev = drift + diffusion_std * noise
+    return so3_exp_map(tau_prev)

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -208,10 +208,17 @@ def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
 
     # Read the unit quaternion from the rotation matrix. Each component
     # magnitude comes from the diagonal and its sign from the skew part.
-    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
-    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
-    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
-    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    # The clamp floor is a small positive epsilon rather than 0: torch.sqrt
+    # has an infinite gradient exactly at 0, which this component reaches
+    # whenever the corresponding quaternion axis is (near) zero -- e.g. for
+    # any rotation close to the identity. Training a model that predicts
+    # rotations close to their target hits this constantly, so a hard
+    # min=0.0 clamp turns into NaN gradients partway through optimization.
+    _sqrt_eps = 1e-12
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=_sqrt_eps))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=_sqrt_eps))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=_sqrt_eps))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=_sqrt_eps))
     qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
     qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
     qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
@@ -453,13 +460,24 @@ class IGSO3:
 
     def _interp(self, omega: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
         """Linear interpolation of a 1-D cached table on the omega grid."""
-        omega = omega.to(dtype=torch.float64)
+        original_device = omega.device
+        # The cached tables are float64 for interpolation accuracy, but
+        # some backends (e.g. Apple's MPS) do not support float64 tensors
+        # at all -- not even as a transient step of a combined device+dtype
+        # .to() call -- so the move to CPU and the cast to float64 have to
+        # happen as two separate steps.
+        omega = omega.to(device='cpu').to(dtype=torch.float64)
         x = (omega - self.omegas[0]) / self.domega
         x = x.clamp(0.0, float(self.num_omega - 1))
         lo = x.floor().long()
         hi = (lo + 1).clamp(max=self.num_omega - 1)
         frac = (x - lo.to(x.dtype))
-        return (1.0 - frac) * table[lo] + frac * table[hi]
+        result = (1.0 - frac) * table[lo] + frac * table[hi]
+        # MPS has no float64 support, so results headed back there are
+        # downcast to float32; other devices keep full precision.
+        result_dtype = (torch.float32
+                        if original_device.type == 'mps' else torch.float64)
+        return result.to(device=original_device, dtype=result_dtype)
 
     # ------------------------------------------------------------------
     # Sampling

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -260,6 +260,12 @@ def log_beta_schedule(num_steps: int,
     torch.Tensor
         Schedule tensor of shape ``(num_steps,)`` containing sigma_t values.
 
+    Raises
+    ------
+    ValueError
+        If `num_steps < 2` or `beta_min`/`beta_max` are not `0 < beta_min
+        < beta_max`.
+
     Examples
     --------
     >>> import torch
@@ -307,6 +313,12 @@ class IGSO3:
     cache : bool, default True
         If ``True`` precompute and cache the discretised PDF / CDF for
         each sigma in ``sigmas``.
+
+    Raises
+    ------
+    ValueError
+        If `sigmas` is not 1-D or not strictly positive, if `num_omega
+        < 64`, or if `lmax < 1`.
 
     Examples
     --------
@@ -408,6 +420,22 @@ class IGSO3:
         backward call, since independent leaves have no cross-row terms
         to sum over. This is the same closed-form formula as
         ``_f_omega``, just batched over sigma instead of looped.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of shape ``(N,)`` containing rotation angles omega.
+        sigma : torch.Tensor
+            Tensor of shape ``(M,)`` containing sigma values.
+        lmax : int
+            Truncation degree of the series.
+        chunk_size : int, default 32
+            Number of sigma rows processed per backward call.
+
+        Returns
+        -------
+        torch.Tensor
+            Tensor of shape ``(M, N)`` with domega log f(omega_n; sigma_m).
         """
         num_sigma = sigma.shape[0]
         l_values = torch.arange(lmax + 1, device=omega.device)[None, None, :]
@@ -465,7 +493,20 @@ class IGSO3:
         return self._interp(omega, self._pdf[sigma_index])
 
     def cdf(self, omega: torch.Tensor, sigma_index: int) -> torch.Tensor:
-        """Interpolate the cached CDF at the supplied angles."""
+        """Interpolate the cached CDF at the supplied angles.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles omega in (0, pi) of arbitrary shape.
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` whose CDF to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            CDF evaluated at the supplied angles.
+        """
         if self._cdf is None:
             self._compute_tables()
         assert self._cdf is not None
@@ -478,6 +519,18 @@ class IGSO3:
         so(3); the score is then approximately -omega / sigma^2. The cached
         table already encodes this limit, so no special branch is
         required at query time.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Tensor of angles omega in (0, pi) of arbitrary shape.
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` whose score to evaluate.
+
+        Returns
+        -------
+        torch.Tensor
+            Score s(omega; sigma) evaluated at the supplied angles.
         """
         if self._score is None:
             self._compute_tables()
@@ -485,7 +538,22 @@ class IGSO3:
         return self._interp(omega, self._score[sigma_index])
 
     def _interp(self, omega: torch.Tensor, table: torch.Tensor) -> torch.Tensor:
-        """Linear interpolation of a 1-D cached table on the omega grid."""
+        """Linear interpolation of a 1-D cached table on the omega grid.
+
+        Parameters
+        ----------
+        omega : torch.Tensor
+            Query angles, arbitrary shape, on any device/dtype.
+        table : torch.Tensor
+            1-D cached table of shape ``(num_omega,)`` (e.g. `self._pdf`,
+            `self._cdf`, or `self._score`, indexed by sigma) to interpolate.
+
+        Returns
+        -------
+        torch.Tensor
+            Interpolated values, same shape as `omega`, on `omega`'s
+            original device.
+        """
         original_device = omega.device
         # The cached tables are float64 for interpolation accuracy, but
         # some backends (e.g. Apple's MPS) do not support float64 tensors
@@ -513,7 +581,22 @@ class IGSO3:
             sigma_index: int,
             shape: Tuple[int, ...],
             generator: Optional[torch.Generator] = None) -> torch.Tensor:
-        """Sample rotation angles omega from IGSO(3) by inverse CDF."""
+        """Sample rotation angles omega from IGSO(3) by inverse CDF.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of sigma in ``self.sigmas``.
+        shape : tuple of int
+            Output batch shape for the sampled angles.
+        generator : torch.Generator, optional
+            PyTorch random generator for reproducibility.
+
+        Returns
+        -------
+        torch.Tensor
+            Sampled angles omega of shape ``shape``, in ``torch.float64``.
+        """
         if self._cdf is None:
             self._compute_tables()
         assert self._cdf is not None
@@ -567,6 +650,17 @@ class IGSO3:
 
         This mirrors the upstream RFdiffusion Riemann-sum check; the
         table is not renormalised after truncation.
+
+        Parameters
+        ----------
+        sigma_index : int
+            Index of sigma in ``self.sigmas`` to check.
+
+        Returns
+        -------
+        float
+            Absolute deviation of the cached PDF's Riemann sum from 1.
+            Should be small for a well-resolved grid (see `num_omega`).
         """
         if self._pdf is None:
             self._compute_tables()
@@ -616,6 +710,12 @@ def so3_reverse_step(rotations: torch.Tensor,
     -------
     torch.Tensor
         Updated rotation matrices of shape ``(..., 3, 3)``.
+
+    Raises
+    ------
+    ValueError
+        If `sigma_t` or `sigma_t_minus_1` is not strictly positive, or
+        if `sigma_t_minus_1 >= sigma_t`.
 
     Examples
     --------

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -389,20 +389,46 @@ class IGSO3:
         return torch.stack(rows, dim=0)
 
     @staticmethod
-    def _score_omega(omega: torch.Tensor, sigma: torch.Tensor,
-                     lmax: int) -> torch.Tensor:
-        """Evaluate domega log f(omega; sigma) using upstream-style autograd."""
-        with torch.enable_grad():
-            omega_var = omega.detach().clone().requires_grad_(True)
-            f = IGSO3._f_omega(omega_var, sigma.detach(), lmax)
-            scores = []
-            for row in f:
-                log_f = torch.log(row)
-                grad = torch.autograd.grad(log_f.sum(),
-                                           omega_var,
-                                           retain_graph=True)[0]
-                scores.append(grad.detach())
-        return torch.stack(scores, dim=0)
+    def _score_omega(omega: torch.Tensor,
+                     sigma: torch.Tensor,
+                     lmax: int,
+                     chunk_size: int = 32) -> torch.Tensor:
+        """Evaluate domega log f(omega; sigma) using batched autograd.
+
+        Calling ``torch.autograd.grad`` once per sigma row with
+        ``retain_graph=True`` (as a naive per-row loop would) keeps the
+        whole shared computation graph alive across every call, which
+        makes the cost grow quadratically in the number of sigmas --
+        completely impractical at the ``num_diffusion_steps`` ~ 1000
+        scale this class is normally used at. Instead, sigmas are
+        processed in chunks: within a chunk, every row gets its own
+        independent leaf tensor (via ``.clone()``), so ``f`` for the whole
+        chunk can be computed with one vectorized (chunk, N, L) batched
+        expression and its per-row gradients recovered with a *single*
+        backward call, since independent leaves have no cross-row terms
+        to sum over. This is the same closed-form formula as
+        ``_f_omega``, just batched over sigma instead of looped.
+        """
+        num_sigma = sigma.shape[0]
+        l_values = torch.arange(lmax + 1, device=omega.device)[None, None, :]
+        scores = []
+        for start in range(0, num_sigma, chunk_size):
+            sigma_chunk = sigma[start:start + chunk_size].detach()
+            chunk = sigma_chunk.shape[0]
+            with torch.enable_grad():
+                omega_var = omega[None, :].expand(chunk, omega.shape[0]).clone()
+                omega_var.requires_grad_(True)
+                sigma_sq = (sigma_chunk**2)[:, None, None]
+                omega_col = omega_var[:, :, None]
+                terms = ((2 * l_values + 1) *
+                         torch.exp(-l_values * (l_values + 1) * sigma_sq / 2) *
+                         torch.sin(omega_col *
+                                   (l_values + 0.5)) / torch.sin(omega_col / 2))
+                f_chunk = terms.sum(dim=-1)  # (chunk, N)
+                log_f = torch.log(f_chunk)
+                grad = torch.autograd.grad(log_f.sum(), omega_var)[0]
+            scores.append(grad.detach())
+        return torch.cat(scores, dim=0)
 
     def _compute_tables(self) -> None:
         """Populate the PDF / CDF / score caches."""

--- a/deepchem/models/torch_models/rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/rfdiffusion_so3.py
@@ -71,16 +71,10 @@ try:
 except ModuleNotFoundError:
     raise ImportError('rfdiffusion_so3 requires PyTorch to be installed.')
 
-__all__ = [
-    'IGSO3',
-    'log_beta_schedule',
-    'so3_log_map',
-    'so3_exp_map',
-    'so3_reverse_step',
-]
-
-# Threshold below which series expansions are used instead of the closed
-# form to preserve numerical stability.
+# Threshold for small-angle Taylor expansions.
+# For rotation angles theta < 1e-4, sin(theta)/theta ~ 1 - theta^2/6 and
+# (1 - cos(theta))/theta^2 ~ 1/2 - theta^2/24. This avoids division-by-zero
+# and float32 precision loss near the identity (Grassia, 1998).
 _SMALL_OMEGA: float = 1e-4
 _SMALL_SIGMA: float = 5e-2
 

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
@@ -1,0 +1,269 @@
+"""Tests for RFDiffusion rigid-frame math utilities."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        apply_inverse_rigid,
+        apply_rigid,
+        build_backbone_frames,
+        compose_rigids,
+        invert_rigid,
+        make_identity_rigid,
+        so3_exp_map,
+        so3_log_map,
+    )
+
+
+def _random_rotation(device=None, dtype=torch.float32, generator=None):
+    matrix = torch.randn(3, 3, device=device, dtype=dtype, generator=generator)
+    q_matrix, r_matrix = torch.linalg.qr(matrix)
+    signs = torch.sign(torch.diagonal(r_matrix))
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    q_matrix = q_matrix @ torch.diag(signs)
+    if torch.det(q_matrix) < 0:
+        q_matrix[:, -1] = -q_matrix[:, -1]
+    return q_matrix
+
+
+def _make_backbone(batch_size=2, seq_len=5, dtype=torch.float32, seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    base = torch.tensor([[-1.2, 1.1, 0.0], [0.0, 0.0, 0.0], [1.5, 0.0, 0.0]],
+                        dtype=dtype)
+    offsets = torch.randn(batch_size,
+                          seq_len,
+                          1,
+                          3,
+                          dtype=dtype,
+                          generator=generator)
+    return base.view(1, 1, 3, 3) + offsets
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestRigidFrameUtilities:
+
+    def test_frames_are_orthonormal_and_right_handed(self):
+        backbone = _make_backbone(batch_size=3, seq_len=7)
+        rotations, translations = build_backbone_frames(backbone)
+        assert rotations.shape == (3, 7, 3, 3)
+        assert translations.shape == (3, 7, 3)
+        gram = rotations.transpose(-1, -2) @ rotations
+        identity = torch.eye(3).expand_as(gram)
+        assert torch.allclose(gram, identity, atol=1e-5)
+        det = torch.det(rotations)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+
+    def test_translation_is_alpha_carbon(self):
+        backbone = _make_backbone()
+        _, translations = build_backbone_frames(backbone)
+        assert torch.allclose(translations, backbone[..., 1, :], atol=0.0)
+
+    def test_frames_match_canonical_residue(self):
+        backbone = torch.tensor([[[-1.0, 1.0, 0.0], [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        rotations, translations = build_backbone_frames(backbone)
+        assert torch.allclose(rotations, torch.eye(3).unsqueeze(0), atol=1e-6)
+        assert torch.allclose(translations, torch.zeros(1, 3), atol=0.0)
+
+    def test_frames_match_upstream_epsilon_normalization(self):
+        backbone = torch.tensor(
+            [[[[-1.1, 0.9, 0.2], [0.2, -0.3, 0.4], [1.4, 0.1, -0.2]]]],
+            dtype=torch.float64)
+        rotations, translations = build_backbone_frames(backbone, eps=1e-8)
+        n_atom = backbone[..., 0, :]
+        ca_atom = backbone[..., 1, :]
+        c_atom = backbone[..., 2, :]
+        e1 = c_atom - ca_atom
+        e1 = e1 / (torch.linalg.norm(e1, dim=-1, keepdim=True) + 1e-8)
+        v2 = n_atom - ca_atom
+        u2 = v2 - (e1 * v2).sum(dim=-1, keepdim=True) * e1
+        e2 = u2 / (torch.linalg.norm(u2, dim=-1, keepdim=True) + 1e-8)
+        e3 = torch.cross(e1, e2, dim=-1)
+        expected = torch.stack([e1, e2, e3], dim=-1)
+        assert torch.allclose(rotations, expected, atol=0.0, rtol=0.0)
+        assert torch.allclose(translations, ca_atom, atol=0.0, rtol=0.0)
+
+    def test_frames_handle_small_n_ca_c_angle(self):
+        backbone = torch.tensor([[[1.0, 1e-3, 0.0], [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        rotations, _ = build_backbone_frames(backbone)
+        gram = rotations.transpose(-1, -2) @ rotations
+        assert torch.isfinite(rotations).all()
+        assert torch.allclose(gram, torch.eye(3).unsqueeze(0), atol=3e-5)
+
+    def test_frames_se3_equivariance(self):
+        backbone = _make_backbone(seed=11)
+        rotations, translations = build_backbone_frames(backbone)
+        global_rotation = _random_rotation()
+        global_translation = torch.randn(3)
+        moved = apply_rigid(global_rotation, global_translation, backbone)
+        rotations_moved, translations_moved = build_backbone_frames(moved)
+        assert torch.allclose(rotations_moved,
+                              global_rotation @ rotations,
+                              atol=1e-5)
+        expected_t = apply_rigid(global_rotation, global_translation,
+                                 translations)
+        assert torch.allclose(translations_moved, expected_t, atol=1e-5)
+
+    def test_frames_raise_on_bad_shape(self):
+        with pytest.raises(ValueError, match=r"\(\.\.\., 3, 3\)"):
+            build_backbone_frames(torch.zeros(2, 5, 3))
+
+    def test_frames_raise_on_nonpositive_eps(self):
+        backbone = _make_backbone()
+        with pytest.raises(ValueError, match="eps"):
+            build_backbone_frames(backbone, eps=0.0)
+
+    def test_make_identity_rigid_shape_and_values(self):
+        rotations, translations = make_identity_rigid((4, 3))
+        assert rotations.shape == (4, 3, 3, 3)
+        assert translations.shape == (4, 3, 3)
+        identity = torch.eye(3).expand_as(rotations)
+        assert torch.equal(rotations, identity)
+        assert torch.equal(translations, torch.zeros_like(translations))
+
+    def test_make_identity_rigid_returns_writable_tensor(self):
+        rotations, _ = make_identity_rigid((4, 3))
+        rotations[0, 0, 0, 0] = 99.0
+        assert rotations[0, 0, 0, 0].item() == 99.0
+        assert rotations[0, 1, 0, 0].item() == 1.0
+
+    def test_apply_rigid_inverse_roundtrip(self):
+        backbone = _make_backbone()
+        rotations, translations = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(rotations, translations, backbone)
+        recovered = apply_rigid(rotations, translations, local)
+        assert torch.allclose(recovered, backbone, atol=1e-5)
+
+    def test_apply_rigid_broadcasts_over_extra_dims(self):
+        rotations, translations = make_identity_rigid((2, 3))
+        rotations = rotations.clone()
+        for batch_idx in range(2):
+            for seq_idx in range(3):
+                rotations[batch_idx, seq_idx] = _random_rotation()
+        translations = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 4, 5, 3)
+        moved = apply_rigid(rotations, translations, points)
+        expected = torch.einsum("blij,blkmj->blkmi", rotations, points)
+        expected = expected + translations.view(2, 3, 1, 1, 3)
+        assert moved.shape == points.shape
+        assert torch.allclose(moved, expected, atol=1e-5)
+
+    def test_apply_rigid_translation_only(self):
+        rotations, _ = make_identity_rigid((2, 5))
+        translations = torch.randn(2, 5, 3)
+        points = torch.randn(2, 5, 3)
+        assert torch.allclose(apply_rigid(rotations, translations, points),
+                              points + translations,
+                              atol=1e-6)
+
+    def test_apply_rigid_raises_on_too_few_point_dims(self):
+        rotations, translations = make_identity_rigid((2, 3))
+        bad = torch.randn(3)
+        with pytest.raises(ValueError, match="at least"):
+            apply_rigid(rotations, translations, bad)
+
+    def test_invert_rigid_is_left_and_right_inverse(self):
+        backbone = _make_backbone()
+        rotations, translations = build_backbone_frames(backbone)
+        inv_rotations, inv_translations = invert_rigid(rotations, translations)
+        left_r, left_t = compose_rigids(inv_rotations, inv_translations,
+                                        rotations, translations)
+        right_r, right_t = compose_rigids(rotations, translations,
+                                          inv_rotations, inv_translations)
+        assert torch.allclose(left_r, torch.eye(3).expand_as(left_r), atol=1e-5)
+        assert torch.allclose(left_t, torch.zeros_like(left_t), atol=1e-5)
+        assert torch.allclose(right_r,
+                              torch.eye(3).expand_as(right_r),
+                              atol=1e-5)
+        assert torch.allclose(right_t, torch.zeros_like(right_t), atol=1e-5)
+
+    def test_compose_matches_sequential_application(self):
+        rotations_a = torch.stack([_random_rotation() for _ in range(6)])
+        rotations_a = rotations_a.view(2, 3, 3, 3)
+        rotations_b = torch.stack([_random_rotation() for _ in range(6)])
+        rotations_b = rotations_b.view(2, 3, 3, 3)
+        translations_a = torch.randn(2, 3, 3)
+        translations_b = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 7, 3)
+
+        sequential = apply_rigid(
+            rotations_a, translations_a,
+            apply_rigid(rotations_b, translations_b, points))
+        rotations, translations = compose_rigids(rotations_a, translations_a,
+                                                 rotations_b, translations_b)
+        composed = apply_rigid(rotations, translations, points)
+        assert torch.allclose(composed, sequential, atol=1e-5)
+
+    def test_compose_is_associative(self):
+        rotations = [_random_rotation() for _ in range(3)]
+        translations = [torch.randn(3) for _ in range(3)]
+        rotation_a, rotation_b, rotation_c = rotations
+        translation_a, translation_b, translation_c = translations
+        left_r, left_t = compose_rigids(
+            *compose_rigids(rotation_a, translation_a, rotation_b,
+                            translation_b), rotation_c, translation_c)
+        right_r, right_t = compose_rigids(
+            rotation_a, translation_a,
+            *compose_rigids(rotation_b, translation_b, rotation_c,
+                            translation_c))
+        assert torch.allclose(left_r, right_r, atol=1e-5)
+        assert torch.allclose(left_t, right_t, atol=1e-5)
+
+    def test_apply_rigid_supports_fp64_precision(self):
+        backbone = _make_backbone(dtype=torch.float64, seed=3)
+        rotations, translations = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(rotations, translations, backbone)
+        recovered = apply_rigid(rotations, translations, local)
+        assert torch.allclose(recovered, backbone, atol=1e-12)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3Maps:
+
+    def test_exp_returns_proper_rotation(self):
+        torch.manual_seed(0)
+        tangent = torch.randn(32, 3) * 0.5
+        rotations = so3_exp_map(tangent)
+        det = torch.det(rotations)
+        ortho_err = (rotations @ rotations.transpose(-1, -2) -
+                     torch.eye(3)).abs().max()
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+        assert ortho_err < 1e-5
+
+    def test_exp_zero_tangent_gives_identity(self):
+        rotations = so3_exp_map(torch.zeros(4, 3))
+        identity = torch.eye(3).expand(4, 3, 3)
+        assert torch.allclose(rotations, identity, atol=1e-7)
+
+    def test_log_exp_roundtrip_principal_branch(self):
+        torch.manual_seed(1)
+        axis = torch.randn(50, 3)
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        omega = torch.rand(50) * (math.pi - 1e-3) + 1e-4
+        tangent = omega.unsqueeze(-1) * axis
+        recovered = so3_log_map(so3_exp_map(tangent))
+        assert (tangent - recovered).norm(dim=-1).max() < 1e-3
+
+    def test_log_map_stable_near_pi(self):
+        axis = torch.tensor([[0.6, -0.2, 0.7745967]])
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        tangent = (math.pi - 1e-4) * axis
+        recovered = so3_log_map(so3_exp_map(tangent))
+        assert torch.allclose(recovered, tangent, atol=1e-3)
+
+    def test_small_omega_taylor_branch(self):
+        tangent = torch.tensor([[1e-7, 0.0, 0.0], [0.0, 1e-7, 0.0]])
+        rotations = so3_exp_map(tangent)
+        identity = torch.eye(3).expand_as(rotations)
+        assert (rotations - identity).abs().max() < 1e-6

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_ipa.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_ipa.py
@@ -1,0 +1,289 @@
+"""Tests for InvariantPointAttention (PR 6 of the RFDiffusion integration)."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    from deepchem.models.torch_models.rfdiffusion_ipa import (
+        InvariantPointAttention,)
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        apply_rigid,
+        build_backbone_frames,
+    )
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+def _random_rotation(dtype=None, seed=None):
+    """Return a random proper rotation matrix via QR decomposition."""
+    if seed is not None:
+        torch.manual_seed(seed)
+    dtype = dtype or torch.float32
+    q, r = torch.linalg.qr(torch.randn(3, 3, dtype=dtype))
+    # Ensure det = +1.
+    sign = torch.sign(torch.det(q @ torch.diag(torch.sign(torch.diagonal(r)))))
+    return q * sign
+
+
+def _make_backbone(batch=2, seq=6, seed=0):
+    """Build a small synthetic backbone tensor for frame construction."""
+    torch.manual_seed(seed)
+    base = torch.tensor([[-1.2, 1.1, 0.0], [0.0, 0.0, 0.0], [1.5, 0.0, 0.0]])
+    return base.view(1, 1, 3, 3) + torch.randn(batch, seq, 1, 3)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestIPAConstruction:
+    """Tests for argument validation in __init__."""
+
+    @pytest.mark.parametrize(
+        'kwargs',
+        [
+            dict(embed_dim=0),
+            dict(embed_dim=16, num_heads=0),
+            dict(embed_dim=15, num_heads=4),  # not divisible
+            dict(embed_dim=16, num_heads=4, num_qk_points=0),
+            dict(embed_dim=16, num_heads=4, num_v_points=0),
+            dict(embed_dim=16, num_heads=4, pair_dim=0),
+            dict(embed_dim=16, num_heads=4, dropout=-0.1),
+            dict(embed_dim=16, num_heads=4, dropout=1.0),
+            dict(embed_dim=16, num_heads=4, eps=0.0),
+        ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            InvariantPointAttention(**kwargs)
+
+    def test_basic_construction(self):
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        assert layer.embed_dim == 32
+        assert layer.num_heads == 4
+        assert layer.head_dim == 8
+
+    def test_pair_dim_construction(self):
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4, pair_dim=16)
+        assert layer.pair_dim == 16
+        assert layer.pair_bias is not None
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestIPAOutputShape:
+    """Tests that the output shape is always ``(B, L, embed_dim)``."""
+
+    def test_no_pair_no_mask(self):
+        backbone = _make_backbone(batch=2, seq=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        out = layer(torch.randn(2, 6, 32), R, t)
+        assert out.shape == (2, 6, 32)
+
+    def test_with_pair_repr(self):
+        backbone = _make_backbone(batch=2, seq=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4, pair_dim=8)
+        pair = torch.randn(2, 6, 6, 8)
+        out = layer(torch.randn(2, 6, 32), R, t, pair_repr=pair)
+        assert out.shape == (2, 6, 32)
+
+    def test_with_mask(self):
+        backbone = _make_backbone(batch=2, seq=6)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        mask = torch.tensor([[1, 1, 1, 1, 0, 0], [1, 1, 1, 0, 0, 0]],
+                            dtype=torch.bool)
+        out = layer(torch.randn(2, 6, 32), R, t, mask=mask)
+        assert out.shape == (2, 6, 32)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestIPAMasking:
+    """Tests for the residue mask behaviour."""
+
+    def test_masked_outputs_are_zero(self):
+        backbone = _make_backbone(batch=1, seq=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        mask = torch.tensor([[1, 1, 1, 0, 0]], dtype=torch.bool)
+        out = layer(torch.randn(1, 5, 32), R, t, mask=mask)
+        assert torch.allclose(out[:, 3:],
+                              torch.zeros_like(out[:, 3:]),
+                              atol=0.0)
+
+    def test_masked_keys_do_not_affect_unmasked_queries(self):
+        torch.manual_seed(7)
+        backbone = _make_backbone(batch=1, seq=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4).eval()
+        single = torch.randn(1, 5, 32)
+        mask = torch.tensor([[1, 1, 1, 0, 0]], dtype=torch.bool)
+
+        out_a = layer(single, R, t, mask=mask)
+        # Replace masked rows with large random values.
+        perturbed = single.clone()
+        perturbed[:, 3:] = torch.randn(1, 2, 32) * 1000.0
+        out_b = layer(perturbed, R, t, mask=mask)
+        assert torch.allclose(out_a[:, :3], out_b[:, :3], atol=1e-4)
+
+    def test_wrong_mask_shape_raises(self):
+        backbone = _make_backbone(batch=1, seq=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        with pytest.raises(ValueError, match='mask'):
+            layer(torch.randn(1, 5, 16),
+                  R,
+                  t,
+                  mask=torch.ones(1, 5, 1, dtype=torch.bool))
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestIPAInvariance:
+    """SE(3) invariance checks — the core correctness property."""
+
+    @pytest.mark.parametrize('seed', [0, 1, 42, 2026])
+    def test_global_rotation_invariance(self, seed):
+        torch.manual_seed(seed)
+        backbone = _make_backbone(batch=2, seq=6, seed=seed)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32,
+                                        num_heads=4,
+                                        num_qk_points=3,
+                                        num_v_points=4).eval()
+        single = torch.randn(2, 6, 32)
+
+        out = layer(single, R, t)
+
+        # Apply a random global rigid transform to all frames.
+        g_R = _random_rotation(seed=seed)
+        g_t = torch.randn(3)
+        R_moved = torch.einsum('ij,...jk->...ik', g_R, R)
+        t_moved = apply_rigid(g_R, g_t, t)
+        out_moved = layer(single, R_moved, t_moved)
+
+        assert torch.allclose(out, out_moved, atol=1e-4)
+
+    def test_translation_only_invariance(self):
+        backbone = _make_backbone(batch=2, seq=6, seed=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4).eval()
+        single = torch.randn(2, 6, 32)
+
+        out = layer(single, R, t)
+        out_shifted = layer(single, R, t + torch.randn(3) * 100.0)
+        assert torch.allclose(out, out_shifted, atol=1e-4)
+
+    def test_pair_bias_does_not_break_invariance(self):
+        torch.manual_seed(3)
+        backbone = _make_backbone(batch=2, seq=6, seed=3)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4,
+                                        pair_dim=8).eval()
+        single = torch.randn(2, 6, 32)
+        pair = torch.randn(2, 6, 6, 8)
+
+        out = layer(single, R, t, pair_repr=pair)
+
+        g_R = _random_rotation(seed=3)
+        g_t = torch.randn(3)
+        R_moved = torch.einsum('ij,...jk->...ik', g_R, R)
+        t_moved = apply_rigid(g_R, g_t, t)
+        out_moved = layer(single, R_moved, t_moved, pair_repr=pair)
+
+        assert torch.allclose(out, out_moved, atol=1e-4)
+
+    def test_invariance_in_fp64(self):
+        backbone = _make_backbone(batch=1, seq=4, seed=9).double()
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4).eval()
+        layer = layer.double()
+        single = torch.randn(1, 4, 16, dtype=torch.float64)
+
+        out = layer(single, R, t)
+        g_R = _random_rotation(dtype=torch.float64, seed=9)
+        g_t = torch.randn(3, dtype=torch.float64)
+        R_moved = torch.einsum('ij,...jk->...ik', g_R, R)
+        t_moved = apply_rigid(g_R, g_t, t)
+        out_moved = layer(single, R_moved, t_moved)
+
+        assert torch.allclose(out, out_moved, atol=1e-7)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestIPAValidation:
+    """Tests that bad input shapes raise ValueError."""
+
+    def test_pair_repr_missing_raises(self):
+        backbone = _make_backbone(batch=1, seq=4)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4, pair_dim=8)
+        with pytest.raises(ValueError):
+            layer(torch.randn(1, 4, 16), R, t)  # pair_repr missing
+
+    def test_extra_pair_repr_raises(self):
+        backbone = _make_backbone(batch=1, seq=4)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)  # no pair
+        with pytest.raises(ValueError):
+            layer(torch.randn(1, 4, 16),
+                  R,
+                  t,
+                  pair_repr=torch.randn(1, 4, 4, 8))
+
+    def test_bad_single_repr_dims_raises(self):
+        backbone = _make_backbone(batch=1, seq=4)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        with pytest.raises(ValueError):
+            layer(torch.randn(1, 4), R, t)  # 2-D instead of 3-D
+
+    def test_bad_rotation_shape_raises(self):
+        layer = InvariantPointAttention(embed_dim=16, num_heads=4)
+        with pytest.raises(ValueError):
+            layer(
+                torch.randn(1, 4, 16),
+                torch.randn(1, 4, 3),  # wrong rotation shape
+                torch.zeros(1, 4, 3))
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestIPAGradients:
+    """Gradient-flow and parameter tests."""
+
+    def test_gradients_flow_to_inputs(self):
+        backbone = _make_backbone(batch=2, seq=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        single = torch.randn(2, 5, 32, requires_grad=True)
+        layer(single, R, t).sum().backward()
+        assert single.grad is not None
+
+    def test_point_weights_are_positive_after_softplus(self):
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4)
+        gamma = torch.nn.functional.softplus(layer.point_weights)
+        assert (gamma > 0).all()
+
+    def test_weighting_constants_have_expected_values(self):
+        layer = InvariantPointAttention(embed_dim=32,
+                                        num_heads=4,
+                                        num_qk_points=4)
+        expected_wc = math.sqrt(2.0 / (9.0 * 4))
+        expected_wl = math.sqrt(1.0 / 2.0)  # no pair → L=2
+        assert abs(float(layer.w_c) - expected_wc) < 1e-6
+        assert abs(float(layer.w_l) - expected_wl) < 1e-6
+
+    def test_dropout_eval_is_deterministic(self):
+        backbone = _make_backbone(batch=2, seq=5)
+        R, t = build_backbone_frames(backbone)
+        layer = InvariantPointAttention(embed_dim=32, num_heads=4,
+                                        dropout=0.5).eval()
+        single = torch.randn(2, 5, 32)
+        out_a = layer(single, R, t)
+        out_b = layer(single, R, t)
+        assert torch.allclose(out_a, out_b)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_model.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_model.py
@@ -26,11 +26,17 @@ def _make_dataset(n=6, length=20):
 
 
 def _small_model(**kw):
+    # embed_dim/num_layers keep the 'transformer' baseline cheap;
+    # pair_dim/num_blocks/pair_num_heads do the same for the default
+    # 'multitrack' architecture, so this helper stays fast either way.
     defaults = dict(embed_dim=32,
                     num_layers=1,
                     num_heads=4,
                     num_diffusion_steps=10,
-                    batch_size=2)
+                    batch_size=2,
+                    pair_dim=8,
+                    num_blocks=1,
+                    pair_num_heads=2)
     defaults.update(kw)
     return RFDiffusionModel(**defaults)
 
@@ -199,7 +205,7 @@ class TestRFDiffusionModelMultiTrack:
         assert np.isfinite(samples).all()
 
     def test_motif_conditioning_requires_multitrack(self):
-        model = _small_model()  # architecture='transformer'
+        model = _small_transformer_model()
         mask = np.zeros(10, dtype=bool)
         reference = np.zeros((10, 3, 3), dtype=np.float32)
         with pytest.raises(ValueError):
@@ -230,3 +236,33 @@ class TestRFDiffusionModelMultiTrack:
         model2 = _small_multitrack_model()
         model2.restore(model_dir=str(tmp_path))
         assert model2._train_std == model._train_std
+
+
+def _small_transformer_model(**kw):
+    defaults = dict(architecture='transformer',
+                    embed_dim=32,
+                    num_layers=1,
+                    num_heads=4,
+                    num_diffusion_steps=10,
+                    batch_size=2)
+    defaults.update(kw)
+    return RFDiffusionModel(**defaults)
+
+
+@pytest.mark.torch
+@requires_dc
+class TestRFDiffusionModelTransformerBaseline:
+    """Standalone coverage for architecture='transformer', now that it is
+    no longer the default exercised implicitly by _small_model()."""
+
+    def test_fit_returns_loss(self):
+        model = _small_transformer_model()
+        loss = model.fit(_make_dataset(), nb_epoch=1)
+        assert isinstance(loss, float)
+        assert np.isfinite(loss)
+
+    def test_generate_shape_and_finite(self):
+        model = _small_transformer_model()
+        samples = model.generate(num_samples=2, seq_length=10)
+        assert samples.shape == (2, 10, 9)
+        assert np.isfinite(samples).all()

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_model.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_model.py
@@ -128,3 +128,105 @@ class TestRFDiffusionModel:
         loss_before = model.fit(ds, nb_epoch=1)
         loss_after = model.fit(ds, nb_epoch=5)
         assert loss_after <= loss_before * 1.5  # some decrease expected
+
+    def test_invalid_architecture_raises(self):
+        with pytest.raises(ValueError):
+            RFDiffusionModel(architecture='not-a-real-architecture')
+
+
+def _small_multitrack_model(**kw):
+    defaults = dict(architecture='multitrack',
+                    embed_dim=16,
+                    pair_dim=8,
+                    num_blocks=1,
+                    num_heads=2,
+                    pair_num_heads=2,
+                    num_diffusion_steps=10,
+                    batch_size=2)
+    defaults.update(kw)
+    return RFDiffusionModel(**defaults)
+
+
+@pytest.mark.torch
+@requires_dc
+class TestRFDiffusionModelMultiTrack:
+    """Tests for architecture='multitrack', the real RFdiffusion network."""
+
+    def test_fit_returns_loss(self):
+        model = _small_multitrack_model()
+        ds = _make_dataset()
+        loss = model.fit(ds, nb_epoch=1)
+        assert isinstance(loss, float)
+        assert np.isfinite(loss)
+
+    def test_generate_shape_and_finite(self):
+        model = _small_multitrack_model()
+        samples = model.generate(num_samples=2, seq_length=10)
+        assert samples.shape == (2, 10, 9)
+        assert np.isfinite(samples).all()
+
+    def test_generate_after_fit(self):
+        model = _small_multitrack_model()
+        model.fit(_make_dataset(), nb_epoch=1)
+        samples = model.generate(num_samples=2, seq_length=12)
+        assert samples.shape == (2, 12, 9)
+        assert np.isfinite(samples).all()
+
+    def test_fit_variable_length(self):
+        model = _small_multitrack_model()
+        proteins = [
+            np.random.randn(np.random.randint(5, 15), 9).astype(np.float32)
+            for _ in range(4)
+        ]
+        X = np.empty(4, dtype=object)
+        for i, p in enumerate(proteins):
+            X[i] = p
+        ds = dc.data.NumpyDataset(X=X, y=np.zeros((4, 1), dtype=np.float32))
+        loss = model.fit(ds, nb_epoch=1)
+        assert np.isfinite(loss)
+
+    def test_motif_conditioning_holds_positions_fixed(self):
+        model = _small_multitrack_model()
+        seq_length = 12
+        mask = np.zeros(seq_length, dtype=bool)
+        mask[4:8] = True
+        reference = np.random.randn(seq_length, 3, 3).astype(np.float32)
+        samples = model.generate(num_samples=1,
+                                 seq_length=seq_length,
+                                 motif_mask=mask,
+                                 motif_coords=reference)
+        assert samples.shape == (1, seq_length, 9)
+        assert np.isfinite(samples).all()
+
+    def test_motif_conditioning_requires_multitrack(self):
+        model = _small_model()  # architecture='transformer'
+        mask = np.zeros(10, dtype=bool)
+        reference = np.zeros((10, 3, 3), dtype=np.float32)
+        with pytest.raises(ValueError):
+            model.generate(seq_length=10,
+                           motif_mask=mask,
+                           motif_coords=reference)
+
+    def test_motif_mask_without_coords_raises(self):
+        model = _small_multitrack_model()
+        mask = np.zeros(10, dtype=bool)
+        with pytest.raises(ValueError):
+            model.generate(seq_length=10, motif_mask=mask)
+
+    def test_motif_mask_shape_mismatch_raises(self):
+        model = _small_multitrack_model()
+        mask = np.zeros(5, dtype=bool)  # wrong length for seq_length=10
+        reference = np.zeros((10, 3, 3), dtype=np.float32)
+        with pytest.raises(ValueError):
+            model.generate(seq_length=10,
+                           motif_mask=mask,
+                           motif_coords=reference)
+
+    def test_save_and_reload(self, tmp_path):
+        model = _small_multitrack_model()
+        model.fit(_make_dataset(), nb_epoch=1)
+        model.save_checkpoint(model_dir=str(tmp_path))
+
+        model2 = _small_multitrack_model()
+        model2.restore(model_dir=str(tmp_path))
+        assert model2._train_std == model._train_std

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_multitrack.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_multitrack.py
@@ -1,0 +1,238 @@
+"""Tests for the RFDiffusion multi-track denoiser integration."""
+
+import pytest
+
+try:
+    import torch
+    from deepchem.models.torch_models.layers import CosineSchedule
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        build_backbone_frames, make_identity_rigid)
+    from deepchem.models.torch_models.rfdiffusion_multitrack import (
+        RFDiffusionMultiTrackDenoiser, backbone_coords_from_frames,
+        multitrack_frame_loss, sample_noisy_frames, so3_x0_reverse_step,
+        translation_posterior_step)
+    from deepchem.models.torch_models.rfdiffusion_so3 import (IGSO3,
+                                                              log_beta_schedule)
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+requires_torch = pytest.mark.skipif(not has_torch,
+                                    reason='PyTorch not installed')
+
+
+def _schedule_and_igso3(num_steps=10):
+    schedule = CosineSchedule(num_timesteps=num_steps)
+    igso3 = IGSO3(log_beta_schedule(num_steps), num_omega=256)
+    return schedule, igso3
+
+
+@pytest.mark.torch
+@requires_torch
+class TestBackboneCoordsFromFrames:
+
+    def test_identity_frame_gives_ideal_geometry(self):
+        R, t = make_identity_rigid((2, 3))
+        coords = backbone_coords_from_frames(R, t)
+        assert coords.shape == (2, 3, 3, 3)
+        # CA (middle atom) should sit exactly at the translation (origin).
+        assert torch.allclose(coords[:, :, 1, :], t)
+
+    def test_roundtrip_with_build_backbone_frames(self):
+        torch.manual_seed(0)
+        R, t = make_identity_rigid((4,))
+        # Perturb with a random valid rotation via so3-consistent frames
+        # built from random backbone coordinates, then reconstruct.
+        backbone = torch.randn(4, 3, 3)
+        R2, t2 = build_backbone_frames(backbone)
+        coords = backbone_coords_from_frames(R2, t2)
+        R3, t3 = build_backbone_frames(coords)
+        assert torch.allclose(R2, R3, atol=1e-4)
+        assert torch.allclose(t2, t3, atol=1e-4)
+
+    def test_output_shape(self):
+        R, t = make_identity_rigid((2, 5))
+        coords = backbone_coords_from_frames(R, t)
+        assert coords.shape == (2, 5, 3, 3)
+
+
+@pytest.mark.torch
+@requires_torch
+class TestSampleNoisyFrames:
+
+    def test_shapes_and_finite(self):
+        schedule, igso3 = _schedule_and_igso3()
+        R0, T0 = make_identity_rigid((2, 6))
+        t = torch.tensor([1, 5])
+        Rt, Tt = sample_noisy_frames(igso3, schedule, R0, T0, t)
+        assert Rt.shape == (2, 6, 3, 3)
+        assert Tt.shape == (2, 6, 3)
+        assert torch.isfinite(Rt).all()
+        assert torch.isfinite(Tt).all()
+
+    def test_rotations_stay_valid(self):
+        schedule, igso3 = _schedule_and_igso3()
+        R0, T0 = make_identity_rigid((3, 4))
+        t = torch.tensor([0, 4, 9])
+        Rt, _ = sample_noisy_frames(igso3, schedule, R0, T0, t)
+        det = torch.linalg.det(Rt)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-3)
+        orth = torch.matmul(Rt, Rt.transpose(-1, -2))
+        assert torch.allclose(orth, torch.eye(3).expand_as(orth), atol=1e-3)
+
+    def test_fixed_mask_holds_positions_clean(self):
+        schedule, igso3 = _schedule_and_igso3()
+        torch.manual_seed(0)
+        backbone = torch.randn(2, 5, 3, 3)
+        R0, T0 = build_backbone_frames(backbone)
+        t = torch.tensor([9, 9])
+        fixed = torch.zeros(2, 5, dtype=torch.bool)
+        fixed[:, :2] = True
+        Rt, Tt = sample_noisy_frames(igso3,
+                                     schedule,
+                                     R0,
+                                     T0,
+                                     t,
+                                     fixed_mask=fixed)
+        assert torch.allclose(Rt[:, :2], R0[:, :2])
+        assert torch.allclose(Tt[:, :2], T0[:, :2])
+
+    def test_batch_size_mismatch_raises(self):
+        schedule, igso3 = _schedule_and_igso3()
+        R0, T0 = make_identity_rigid((2, 4))
+        t = torch.tensor([1, 2, 3])
+        with pytest.raises(ValueError):
+            sample_noisy_frames(igso3, schedule, R0, T0, t)
+
+
+@pytest.mark.torch
+@requires_torch
+class TestReverseSteps:
+
+    def test_translation_posterior_step_shape(self):
+        schedule, _ = _schedule_and_igso3()
+        x0 = torch.zeros(2, 4, 3)
+        xt = torch.randn(2, 4, 3)
+        out = translation_posterior_step(schedule, x0, xt, t=5)
+        assert out.shape == (2, 4, 3)
+        assert torch.isfinite(out).all()
+
+    def test_translation_posterior_step_t0_is_deterministic(self):
+        schedule, _ = _schedule_and_igso3()
+        x0 = torch.randn(2, 4, 3)
+        xt = torch.randn(2, 4, 3)
+        out1 = translation_posterior_step(schedule, x0, xt, t=0)
+        out2 = translation_posterior_step(schedule, x0, xt, t=0)
+        assert torch.allclose(out1, out2)
+
+    def test_translation_posterior_step_negative_t_raises(self):
+        schedule, _ = _schedule_and_igso3()
+        x0 = torch.zeros(1, 2, 3)
+        xt = torch.zeros(1, 2, 3)
+        with pytest.raises(ValueError):
+            translation_posterior_step(schedule, x0, xt, t=-1)
+
+    def test_so3_reverse_step_output_is_valid_rotation(self):
+        _, igso3 = _schedule_and_igso3()
+        Rt, _ = make_identity_rigid((2, 3))
+        R0, _ = make_identity_rigid((2, 3))
+        out = so3_x0_reverse_step(igso3, Rt, R0, t=5)
+        det = torch.linalg.det(out)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-3)
+
+    def test_so3_reverse_step_t0_raises(self):
+        _, igso3 = _schedule_and_igso3()
+        Rt, _ = make_identity_rigid((1, 2))
+        R0, _ = make_identity_rigid((1, 2))
+        with pytest.raises(ValueError):
+            so3_x0_reverse_step(igso3, Rt, R0, t=0)
+
+
+@pytest.mark.torch
+@requires_torch
+class TestMultitrackFrameLoss:
+
+    def test_zero_loss_for_perfect_prediction(self):
+        R, t = make_identity_rigid((2, 4))
+        mask = torch.ones(2, 4)
+        loss = multitrack_frame_loss([R, t], [R, t], [mask])
+        assert round(float(loss), 5) == 0.0
+
+    def test_masked_positions_do_not_contribute(self):
+        torch.manual_seed(0)
+        R0, T0 = make_identity_rigid((1, 3))
+        R_pred = torch.randn(1, 3, 3, 3)  # garbage prediction
+        T_pred = torch.randn(1, 3, 3)
+        mask = torch.zeros(1, 3)  # everything masked out
+        loss = multitrack_frame_loss([R_pred, T_pred], [R0, T0], [mask])
+        assert round(float(loss), 5) == 0.0
+
+    def test_rotation_weight_scales_rotation_term(self):
+        torch.manual_seed(1)
+        backbone = torch.randn(1, 3, 3, 3)
+        R0, T0 = build_backbone_frames(backbone)
+        R_pred, _ = make_identity_rigid((1, 3))
+        mask = torch.ones(1, 3)
+        loss_low = multitrack_frame_loss([R_pred, T0], [R0, T0], [mask],
+                                         rotation_weight=0.1)
+        loss_high = multitrack_frame_loss([R_pred, T0], [R0, T0], [mask],
+                                          rotation_weight=10.0)
+        assert loss_high > loss_low
+
+    def test_gradients_do_not_explode_near_identity(self):
+        # Regression test for the so3_log_map sqrt(0)-gradient bug: a
+        # denoiser output that has converged very close to the target
+        # should not blow up into NaN gradients.
+        torch.manual_seed(0)
+        denoiser = RFDiffusionMultiTrackDenoiser(embed_dim=16,
+                                                 pair_dim=8,
+                                                 num_blocks=1,
+                                                 num_heads=2,
+                                                 pair_num_heads=2)
+        R0, T0 = make_identity_rigid((2, 4))
+        mask = torch.ones(2, 4)
+        noisy_coords = backbone_coords_from_frames(R0, T0).reshape(2, 4, 9)
+        t = torch.tensor([1, 1])
+        pred_R, pred_T = denoiser([noisy_coords, R0, T0, t, mask])
+        loss = multitrack_frame_loss([pred_R, pred_T], [R0, T0], [mask])
+        loss.backward()
+        for p in denoiser.parameters():
+            if p.grad is not None:
+                assert torch.isfinite(p.grad).all()
+
+
+@pytest.mark.torch
+@requires_torch
+class TestRFDiffusionMultiTrackDenoiser:
+
+    def _denoiser(self, **kw):
+        defaults = dict(embed_dim=16,
+                        pair_dim=8,
+                        num_blocks=1,
+                        num_heads=2,
+                        pair_num_heads=2)
+        defaults.update(kw)
+        return RFDiffusionMultiTrackDenoiser(**defaults)
+
+    def test_output_shapes(self):
+        denoiser = self._denoiser()
+        R, t_trans = make_identity_rigid((2, 5))
+        noisy_coords = backbone_coords_from_frames(R, t_trans).reshape(2, 5, 9)
+        t = torch.tensor([0, 3])
+        mask = torch.ones(2, 5)
+        pred_R, pred_T = denoiser([noisy_coords, R, t_trans, t, mask])
+        assert pred_R.shape == (2, 5, 3, 3)
+        assert pred_T.shape == (2, 5, 3)
+
+    def test_finite_without_mask(self):
+        denoiser = self._denoiser()
+        R, t_trans = make_identity_rigid((1, 4))
+        noisy_coords = backbone_coords_from_frames(R, t_trans).reshape(1, 4, 9)
+        t = torch.tensor([2])
+        pred_R, pred_T = denoiser([noisy_coords, R, t_trans, t, None])
+        assert torch.isfinite(pred_R).all()
+        assert torch.isfinite(pred_T).all()
+
+    def test_invalid_num_blocks_raises(self):
+        with pytest.raises(ValueError):
+            self._denoiser(num_blocks=0)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_pair_track.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_pair_track.py
@@ -1,0 +1,224 @@
+"""Tests for the RFDiffusion pair-track blocks (PR 7 of the RFDiffusion
+integration)."""
+
+import pytest
+
+try:
+    import torch
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion_pair_track import (
+        RelativePositionEmbedding,
+        OuterProductMean,
+        TriangleMultiplicativeUpdate,
+        TriangleAttention,
+        PairTransition,
+    )
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestRelativePositionEmbedding:
+    """Symmetric clipped relative-position embedding."""
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(pair_dim=0),
+        dict(pair_dim=16, max_relative_position=0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            RelativePositionEmbedding(**kwargs)
+
+    def test_output_shape(self):
+        rel = RelativePositionEmbedding(pair_dim=16, max_relative_position=8)
+        assert rel(10).shape == (10, 10, 16)
+
+    def test_symmetric(self):
+        rel = RelativePositionEmbedding(pair_dim=12, max_relative_position=8)
+        emb = rel(9)
+        assert torch.allclose(emb, emb.transpose(0, 1))
+
+    def test_clip_radius(self):
+        rel = RelativePositionEmbedding(pair_dim=8, max_relative_position=3)
+        emb = rel(12)
+        # Offsets beyond the clip radius collapse to the same bucket.
+        assert torch.allclose(emb[0, 4], emb[0, 11])
+        assert torch.allclose(emb[0, 5], emb[0, 4])
+        # Offsets within the radius use distinct buckets.
+        assert not torch.allclose(emb[0, 1], emb[0, 2])
+
+    def test_diagonal_is_constant(self):
+        rel = RelativePositionEmbedding(pair_dim=8, max_relative_position=4)
+        emb = rel(6)
+        diag = torch.stack([emb[i, i] for i in range(6)])
+        assert torch.allclose(diag, diag[:1].expand_as(diag))
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestOuterProductMean:
+    """Symmetrised 1D -> 2D outer-product injection."""
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(embed_dim=0, pair_dim=16),
+        dict(embed_dim=12, pair_dim=0),
+        dict(embed_dim=12, pair_dim=16, hidden_dim=0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            OuterProductMean(**kwargs)
+
+    def test_output_shape(self):
+        opm = OuterProductMean(embed_dim=12, pair_dim=16, hidden_dim=8)
+        out = opm(torch.randn(2, 7, 12))
+        assert out.shape == (2, 7, 7, 16)
+
+    def test_symmetric(self):
+        torch.manual_seed(0)
+        opm = OuterProductMean(embed_dim=10, pair_dim=14, hidden_dim=6)
+        out = opm(torch.randn(3, 5, 10))
+        assert torch.allclose(out, out.transpose(1, 2), atol=1e-6)
+
+    def test_gradient_flow(self):
+        opm = OuterProductMean(embed_dim=8, pair_dim=8, hidden_dim=4)
+        single = torch.randn(2, 4, 8, requires_grad=True)
+        opm(single).sum().backward()
+        assert single.grad is not None
+        assert torch.isfinite(single.grad).all()
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestTriangleMultiplicativeUpdate:
+    """Outgoing / incoming triangle multiplicative update."""
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(pair_dim=0),
+        dict(pair_dim=16, hidden_dim=0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            TriangleMultiplicativeUpdate(**kwargs)
+
+    @pytest.mark.parametrize('outgoing', [True, False])
+    def test_output_shape(self, outgoing):
+        tmu = TriangleMultiplicativeUpdate(pair_dim=16,
+                                           hidden_dim=32,
+                                           outgoing=outgoing)
+        assert tmu(torch.randn(2, 6, 6, 16)).shape == (2, 6, 6, 16)
+
+    def test_requires_4d(self):
+        tmu = TriangleMultiplicativeUpdate(pair_dim=16)
+        with pytest.raises(ValueError):
+            tmu(torch.randn(6, 6, 16))
+
+    @pytest.mark.parametrize('outgoing', [True, False])
+    def test_chunked_matches_dense(self, outgoing):
+        torch.manual_seed(0)
+        tmu = TriangleMultiplicativeUpdate(pair_dim=12,
+                                           hidden_dim=16,
+                                           outgoing=outgoing)
+        tmu.eval()
+        pair = torch.randn(2, 9, 9, 12)
+        with torch.no_grad():
+            dense = tmu(pair)
+            chunked = tmu(pair, chunk_size=3)
+        assert torch.allclose(dense, chunked, atol=1e-5)
+
+    def test_outgoing_differs_from_incoming(self):
+        torch.manual_seed(0)
+        pair = torch.randn(1, 5, 5, 8)
+        out_mod = TriangleMultiplicativeUpdate(pair_dim=8,
+                                               hidden_dim=8,
+                                               outgoing=True)
+        in_mod = TriangleMultiplicativeUpdate(pair_dim=8,
+                                              hidden_dim=8,
+                                              outgoing=False)
+        # Share weights so only the contraction direction differs.
+        in_mod.load_state_dict(out_mod.state_dict())
+        with torch.no_grad():
+            assert not torch.allclose(out_mod(pair), in_mod(pair))
+
+    def test_gradient_flow(self):
+        tmu = TriangleMultiplicativeUpdate(pair_dim=8, hidden_dim=8)
+        pair = torch.randn(2, 5, 5, 8, requires_grad=True)
+        tmu(pair).sum().backward()
+        assert pair.grad is not None
+        assert torch.isfinite(pair.grad).all()
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestTriangleAttention:
+    """Starting / ending-node triangle self-attention."""
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(pair_dim=0),
+        dict(pair_dim=16, num_heads=0),
+        dict(pair_dim=16, num_heads=4, head_dim=0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            TriangleAttention(**kwargs)
+
+    @pytest.mark.parametrize('starting_node', [True, False])
+    def test_output_shape(self, starting_node):
+        ta = TriangleAttention(pair_dim=16,
+                               num_heads=4,
+                               head_dim=8,
+                               starting_node=starting_node)
+        assert ta(torch.randn(2, 6, 6, 16)).shape == (2, 6, 6, 16)
+
+    def test_requires_4d(self):
+        ta = TriangleAttention(pair_dim=16)
+        with pytest.raises(ValueError):
+            ta(torch.randn(6, 6, 16))
+
+    @pytest.mark.parametrize('starting_node', [True, False])
+    def test_chunked_matches_dense(self, starting_node):
+        torch.manual_seed(0)
+        ta = TriangleAttention(pair_dim=12,
+                               num_heads=3,
+                               head_dim=8,
+                               starting_node=starting_node)
+        ta.eval()
+        pair = torch.randn(2, 8, 8, 12)
+        with torch.no_grad():
+            dense = ta(pair)
+            chunked = ta(pair, chunk_size=2)
+        assert torch.allclose(dense, chunked, atol=1e-5)
+
+    def test_gradient_flow(self):
+        ta = TriangleAttention(pair_dim=8, num_heads=2, head_dim=4)
+        pair = torch.randn(2, 5, 5, 8, requires_grad=True)
+        ta(pair).sum().backward()
+        assert pair.grad is not None
+        assert torch.isfinite(pair.grad).all()
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestPairTransition:
+    """Position-wise pair feed-forward."""
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(pair_dim=0),
+        dict(pair_dim=16, expansion=0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            PairTransition(**kwargs)
+
+    def test_output_shape(self):
+        pt = PairTransition(pair_dim=16, expansion=2)
+        assert pt(torch.randn(2, 6, 6, 16)).shape == (2, 6, 6, 16)
+
+    def test_gradient_flow(self):
+        pt = PairTransition(pair_dim=8)
+        pair = torch.randn(2, 4, 4, 8, requires_grad=True)
+        pt(pair).sum().backward()
+        assert pair.grad is not None
+        assert torch.isfinite(pair.grad).all()

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_sequence_track.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_sequence_track.py
@@ -1,0 +1,244 @@
+"""Tests for the RFDiffusion sequence/structure track (PR 8 of the
+RFDiffusion integration)."""
+
+import pytest
+
+try:
+    import torch
+    from deepchem.models.torch_models.rfdiffusion_sequence_track import (
+        PairBiasedSingleAttention,
+        SingleTransition,
+        quaternion_to_rotation_matrix,
+        BackboneUpdate,
+        RFDiffusionTrackBlock,
+        RFDiffusionMultiTrackStack,
+    )
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+def _rot(seed=0):
+    """Return a random proper rotation matrix via QR."""
+    torch.manual_seed(seed)
+    q, r = torch.linalg.qr(torch.randn(3, 3))
+    q = q * torch.sign(torch.diagonal(r))
+    if torch.det(q) < 0:
+        q[:, 0] = -q[:, 0]
+    return q
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestPairBiasedSingleAttention:
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(embed_dim=0, pair_dim=8),
+        dict(embed_dim=16, pair_dim=0),
+        dict(embed_dim=16, pair_dim=8, num_heads=0),
+        dict(embed_dim=15, pair_dim=8, num_heads=4),
+        dict(embed_dim=16, pair_dim=8, dropout=1.0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            PairBiasedSingleAttention(**kwargs)
+
+    def test_output_shape(self):
+        attn = PairBiasedSingleAttention(16, 8, num_heads=4)
+        single = torch.randn(2, 6, 16)
+        pair = torch.randn(2, 6, 6, 8)
+        assert attn(single, pair).shape == (2, 6, 16)
+
+    def test_mask_zeros_padded_queries(self):
+        attn = PairBiasedSingleAttention(16, 8, num_heads=4)
+        single = torch.randn(1, 5, 16)
+        pair = torch.randn(1, 5, 5, 8)
+        mask = torch.tensor([[True, True, True, False, False]])
+        out = attn(single, pair, mask=mask)
+        assert torch.allclose(out[0, 3:], torch.zeros(2, 16), atol=1e-6)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestSingleTransition:
+
+    @pytest.mark.parametrize('kwargs', [
+        dict(embed_dim=0),
+        dict(embed_dim=16, expansion=0),
+        dict(embed_dim=16, dropout=1.0),
+    ])
+    def test_bad_construction_raises(self, kwargs):
+        with pytest.raises(ValueError):
+            SingleTransition(**kwargs)
+
+    def test_output_shape(self):
+        tr = SingleTransition(16)
+        assert tr(torch.randn(2, 6, 16), torch.randn(2, 16)).shape == (2, 6, 16)
+
+    def test_time_conditioning_matters(self):
+        torch.manual_seed(0)
+        tr = SingleTransition(16)
+        single = torch.randn(2, 6, 16)
+        out_a = tr(single, torch.zeros(2, 16))
+        out_b = tr(single, torch.ones(2, 16))
+        assert not torch.allclose(out_a, out_b)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestQuaternionToRotationMatrix:
+
+    def test_identity_quaternion(self):
+        rot = quaternion_to_rotation_matrix(torch.tensor([1.0, 0.0, 0.0, 0.0]))
+        assert torch.allclose(rot, torch.eye(3), atol=1e-6)
+
+    def test_orthogonal_and_det_one(self):
+        torch.manual_seed(0)
+        quat = torch.randn(5, 4)
+        rot = quaternion_to_rotation_matrix(quat)
+        eye = torch.eye(3).expand(5, 3, 3)
+        assert torch.allclose(rot @ rot.transpose(-1, -2), eye, atol=1e-5)
+        assert torch.allclose(torch.linalg.det(rot), torch.ones(5), atol=1e-5)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestBackboneUpdate:
+
+    def test_bad_construction_raises(self):
+        with pytest.raises(ValueError):
+            BackboneUpdate(0)
+
+    def test_output_shapes(self):
+        upd = BackboneUpdate(16)
+        single = torch.randn(2, 5, 16)
+        rot = _rot().view(1, 1, 3, 3).expand(2, 5, 3, 3).contiguous()
+        trans = torch.randn(2, 5, 3)
+        new_rot, new_trans = upd(single, rot, trans)
+        assert new_rot.shape == (2, 5, 3, 3)
+        assert new_trans.shape == (2, 5, 3)
+
+    def test_zero_init_is_identity_update(self):
+        # Zero-initialised head -> update is the identity transform.
+        upd = BackboneUpdate(16)
+        single = torch.randn(2, 5, 16)
+        rot = torch.randn(2, 5, 3, 3)
+        trans = torch.randn(2, 5, 3)
+        new_rot, new_trans = upd(single, rot, trans)
+        assert torch.allclose(new_rot, rot, atol=1e-6)
+        assert torch.allclose(new_trans, trans, atol=1e-6)
+
+
+def _small_stack(seed=0, **over):
+    torch.manual_seed(seed)
+    cfg = dict(embed_dim=24,
+               pair_dim=12,
+               num_blocks=2,
+               num_heads=3,
+               pair_num_heads=2,
+               triangle_hidden_dim=16,
+               triangle_head_dim=8,
+               opm_hidden_dim=8)
+    cfg.update(over)
+    return RFDiffusionMultiTrackStack(**cfg)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestRFDiffusionTrackBlock:
+
+    def test_output_shapes(self):
+        block = RFDiffusionTrackBlock(24,
+                                      12,
+                                      num_heads=3,
+                                      pair_num_heads=2,
+                                      triangle_hidden_dim=16,
+                                      triangle_head_dim=8,
+                                      opm_hidden_dim=8)
+        single = torch.randn(2, 5, 24)
+        pair = torch.randn(2, 5, 5, 12)
+        rot = _rot().view(1, 1, 3, 3).expand(2, 5, 3, 3).contiguous()
+        trans = torch.randn(2, 5, 3)
+        t_emb = torch.randn(2, 24)
+        s, p, r, t = block(single, pair, rot, trans, t_emb)
+        assert s.shape == (2, 5, 24)
+        assert p.shape == (2, 5, 5, 12)
+        assert r.shape == (2, 5, 3, 3)
+        assert t.shape == (2, 5, 3)
+
+    def test_pair_stays_symmetric(self):
+        block = RFDiffusionTrackBlock(24,
+                                      12,
+                                      num_heads=3,
+                                      pair_num_heads=2,
+                                      triangle_hidden_dim=16,
+                                      triangle_head_dim=8,
+                                      opm_hidden_dim=8)
+        block.eval()
+        single = torch.randn(2, 5, 24)
+        pair = torch.randn(2, 5, 5, 12)
+        pair = 0.5 * (pair + pair.transpose(-2, -3))
+        rot = _rot().view(1, 1, 3, 3).expand(2, 5, 3, 3).contiguous()
+        trans = torch.randn(2, 5, 3)
+        with torch.no_grad():
+            _, p, _, _ = block(single, pair, rot, trans, torch.randn(2, 24))
+        assert torch.allclose(p, p.transpose(-2, -3), atol=1e-6)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason='PyTorch not installed')
+class TestRFDiffusionMultiTrackStack:
+
+    def test_bad_construction_raises(self):
+        with pytest.raises(ValueError):
+            _small_stack(num_blocks=0)
+
+    def test_forward_shape(self):
+        stack = _small_stack()
+        out = stack(torch.randn(2, 6, 24), torch.randn(2, 24))
+        assert out.shape == (2, 6, 24)
+
+    def test_forward_tracks_shapes(self):
+        stack = _small_stack()
+        s, p, r, t = stack.forward_tracks(torch.randn(2, 6, 24),
+                                          torch.randn(2, 24))
+        assert s.shape == (2, 6, 24)
+        assert p.shape == (2, 6, 6, 12)
+        assert r.shape == (2, 6, 3, 3)
+        assert t.shape == (2, 6, 3)
+
+    def test_mask_zeros_padding(self):
+        stack = _small_stack()
+        stack.eval()
+        mask = torch.tensor([[True, True, True, True, False, False]])
+        with torch.no_grad():
+            out = stack(torch.randn(1, 6, 24),
+                        torch.randn(1, 24),
+                        attention_mask=mask)
+        assert torch.allclose(out[0, 4:], torch.zeros(2, 24), atol=1e-6)
+
+    def test_global_rotation_leaves_single_invariant(self):
+        stack = _small_stack()
+        stack.eval()
+        single = torch.randn(2, 5, 24)
+        t_emb = torch.randn(2, 24)
+        rot = _rot(1).view(1, 1, 3, 3).expand(2, 5, 3, 3).contiguous()
+        trans = torch.zeros(2, 5, 3)
+        with torch.no_grad():
+            s1, _, _, _ = stack.forward_tracks(single, t_emb)
+            s2, _, _, _ = stack.forward_tracks(single,
+                                               t_emb,
+                                               rotations=rot,
+                                               translations=trans)
+        assert torch.allclose(s1, s2, atol=1e-5)
+
+    def test_chunked_matches_dense(self):
+        stack = _small_stack()
+        stack.eval()
+        single = torch.randn(2, 8, 24)
+        t_emb = torch.randn(2, 24)
+        with torch.no_grad():
+            dense = stack.forward_tracks(single, t_emb, chunk_size=None)
+            chunked = stack.forward_tracks(single, t_emb, chunk_size=3)
+        for a, b in zip(dense, chunked):
+            assert torch.allclose(a, b, atol=1e-5)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_so3.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_so3.py
@@ -1,0 +1,223 @@
+"""Tests for the RFDiffusion SO(3) diffusion utilities."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    from deepchem.models.torch_models.rfdiffusion_so3 import (
+        IGSO3,
+        log_beta_schedule,
+        so3_exp_map,
+        so3_log_map,
+        so3_reverse_step,
+    )
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3Maps:
+    """Exponential and logarithm maps between so(3) and SO(3)."""
+
+    def test_exp_zero_is_identity(self):
+        """A zero tangent vector maps to the identity rotation."""
+        rotations = so3_exp_map(torch.zeros(4, 3))
+        assert torch.allclose(rotations,
+                              torch.eye(3).expand(4, 3, 3),
+                              atol=1e-6)
+
+    def test_exp_is_valid_rotation(self):
+        """Exp-map outputs are orthogonal with determinant +1."""
+        torch.manual_seed(0)
+        rotations = so3_exp_map(torch.randn(16, 3))
+        eye = torch.eye(3).expand(16, 3, 3)
+        assert torch.allclose(rotations @ rotations.transpose(-1, -2),
+                              eye,
+                              atol=1e-5)
+        assert torch.allclose(torch.det(rotations), torch.ones(16), atol=1e-5)
+
+    def test_exp_known_rotation_about_z(self):
+        """A pi/2 rotation about z matches the closed-form matrix."""
+        rotation = so3_exp_map(torch.tensor([[0.0, 0.0, math.pi / 2]]))[0]
+        expected = torch.tensor([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0],
+                                 [0.0, 0.0, 1.0]])
+        assert torch.allclose(rotation, expected, atol=1e-6)
+
+    def test_log_is_inverse_of_exp(self):
+        """log(exp(tau)) recovers tau for angles across (0, pi)."""
+        torch.manual_seed(1)
+        axis = torch.randn(32, 3)
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        for angle in [0.05, 1.0, 2.5, math.pi - 0.05]:
+            tangent = angle * axis
+            recovered = so3_log_map(so3_exp_map(tangent))
+            assert torch.allclose(recovered, tangent, atol=1e-3)
+
+    def test_log_near_pi_is_stable(self):
+        """The log map stays accurate for rotations very close to pi.
+
+        The quaternion route keeps the error small where reading the angle
+        from the trace would lose precision (``sin(omega) -> 0``).
+        """
+        axis = torch.tensor([[0.3, -0.5, 0.8]])
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        rotation = so3_exp_map((math.pi - 1e-3) * axis)
+        # Compare rotations, avoiding the axis-sign ambiguity at pi.
+        recovered = so3_exp_map(so3_log_map(rotation))
+        assert torch.allclose(rotation, recovered, atol=1e-3)
+
+    def test_log_identity_is_zero(self):
+        """The log of the identity rotation is the zero tangent vector."""
+        identity = torch.eye(3).unsqueeze(0)
+        assert torch.allclose(so3_log_map(identity),
+                              torch.zeros(1, 3),
+                              atol=1e-6)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestLogBetaSchedule:
+    """Logarithmic sigma schedule for rotational diffusion."""
+
+    def test_shape_and_endpoints(self):
+        """The schedule has the requested length and hits both endpoints."""
+        sigmas = log_beta_schedule(10, beta_min=0.1, beta_max=1.5)
+        assert sigmas.shape == (10,)
+        assert math.isclose(sigmas[0].item(), 0.1, rel_tol=1e-6)
+        assert math.isclose(sigmas[-1].item(), 1.5, rel_tol=1e-6)
+
+    def test_monotonic_increasing(self):
+        """Sigma increases monotonically with the step index."""
+        sigmas = log_beta_schedule(50)
+        assert bool((sigmas[1:] > sigmas[:-1]).all())
+
+    def test_linear_in_log_space(self):
+        """Successive log-sigma differences are constant."""
+        sigmas = log_beta_schedule(7, beta_min=0.2, beta_max=2.0)
+        diffs = torch.log(sigmas)[1:] - torch.log(sigmas)[:-1]
+        assert torch.allclose(diffs, diffs[0].expand_as(diffs), atol=1e-6)
+
+    def test_invalid_args_raise(self):
+        """Bad step counts and beta ranges raise ValueError."""
+        with pytest.raises(ValueError):
+            log_beta_schedule(1)
+        with pytest.raises(ValueError):
+            log_beta_schedule(10, beta_min=1.0, beta_max=0.5)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestIGSO3:
+    """IGSO(3) density, score, and sampling."""
+
+    def test_pdf_normalised(self):
+        """The discretised marginal density integrates to approximately 1."""
+        dist = IGSO3(torch.tensor([0.3, 0.8, 1.5]), num_omega=512)
+        for index in range(3):
+            assert dist.normalisation_error(index) < 1e-2
+
+    def test_cdf_monotonic_and_bounded(self):
+        """The CDF increases monotonically and reaches ~1 at pi."""
+        dist = IGSO3(torch.tensor([0.7]), num_omega=512)
+        cdf = dist._cdf[0]
+        assert bool((cdf[1:] >= cdf[:-1] - 1e-9).all())
+        assert abs(cdf[-1].item() - 1.0) < 1e-2
+
+    def test_score_matches_finite_difference(self):
+        """The autograd score equals a finite-difference of log f(omega)."""
+        sigma = torch.tensor([0.9]).double()
+        lmax = 500
+        omega = torch.tensor([0.5, 1.0, 2.0], dtype=torch.float64)
+        analytic = IGSO3._score_omega(omega, sigma, lmax)[0]
+        eps = 1e-4
+        fp = torch.log(IGSO3._f_omega(omega + eps, sigma, lmax))[0]
+        fm = torch.log(IGSO3._f_omega(omega - eps, sigma, lmax))[0]
+        finite_diff = (fp - fm) / (2 * eps)
+        assert torch.allclose(analytic, finite_diff, atol=1e-3)
+
+    def test_sample_shape_and_valid(self):
+        """Samples have the requested batch shape and are valid rotations."""
+        dist = IGSO3(torch.tensor([0.6]), num_omega=256)
+        generator = torch.Generator().manual_seed(0)
+        rotations = dist.sample(0, (5, 4), generator=generator)
+        assert rotations.shape == (5, 4, 3, 3)
+        eye = torch.eye(3).expand(5, 4, 3, 3)
+        assert torch.allclose(rotations @ rotations.transpose(-1, -2),
+                              eye,
+                              atol=1e-4)
+
+    def test_sample_angle_in_range(self):
+        """Sampled rotation angles lie within (0, pi]."""
+        dist = IGSO3(torch.tensor([1.0]), num_omega=256)
+        generator = torch.Generator().manual_seed(0)
+        angles = dist.sample_angle(0, (1000,), generator=generator)
+        assert bool((angles > 0).all())
+        assert bool((angles <= math.pi + 1e-6).all())
+
+    def test_larger_sigma_gives_larger_mean_angle(self):
+        """A larger sigma produces a larger mean sampled angle."""
+        dist = IGSO3(torch.tensor([0.3, 1.5]), num_omega=512)
+        generator = torch.Generator().manual_seed(0)
+        small = dist.sample_angle(0, (4000,), generator=generator).mean()
+        large = dist.sample_angle(1, (4000,), generator=generator).mean()
+        assert large > small
+
+    def test_invalid_construction_raises(self):
+        """Invalid sigmas or grid sizes raise ValueError."""
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([[0.5]]))
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([-0.5]))
+        with pytest.raises(ValueError):
+            IGSO3(torch.tensor([0.5]), num_omega=8)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3ReverseStep:
+    """Reverse-time Euler-Maruyama integrator on SO(3)."""
+
+    def test_output_shape_and_valid(self):
+        """A reverse step returns valid rotations of the input shape."""
+        torch.manual_seed(0)
+        rotations = so3_exp_map(torch.randn(6, 3))
+        score = torch.full((6,), -0.5)
+        updated = so3_reverse_step(rotations,
+                                   score,
+                                   1.0,
+                                   0.9,
+                                   noise=torch.zeros(6, 3))
+        assert updated.shape == (6, 3, 3)
+        eye = torch.eye(3).expand(6, 3, 3)
+        assert torch.allclose(updated @ updated.transpose(-1, -2),
+                              eye,
+                              atol=1e-5)
+
+    def test_deterministic_without_noise(self):
+        """With zero noise the reverse step is deterministic."""
+        rotations = so3_exp_map(torch.tensor([[0.0, 0.0, 2.0]]))
+        score = torch.tensor([-1.0])
+        first = so3_reverse_step(rotations,
+                                 score,
+                                 1.0,
+                                 0.8,
+                                 noise=torch.zeros(1, 3))
+        second = so3_reverse_step(rotations,
+                                  score,
+                                  1.0,
+                                  0.8,
+                                  noise=torch.zeros(1, 3))
+        assert torch.allclose(first, second)
+
+    def test_invalid_sigmas_raise(self):
+        """Non-decreasing or non-positive sigma values raise ValueError."""
+        rotations = so3_exp_map(torch.zeros(1, 3))
+        score = torch.tensor([0.0])
+        with pytest.raises(ValueError):
+            so3_reverse_step(rotations, score, 1.0, 1.0)
+        with pytest.raises(ValueError):
+            so3_reverse_step(rotations, score, -1.0, 0.5)

--- a/deepchem/utils/rfdiffusion_contigs.py
+++ b/deepchem/utils/rfdiffusion_contigs.py
@@ -47,16 +47,6 @@ try:
 except ModuleNotFoundError:
     raise ImportError('rfdiffusion_contigs requires NumPy to be installed.')
 
-__all__ = [
-    'LinkerSegment',
-    'MotifSegment',
-    'ContigMap',
-    'RealisedContig',
-    'parse_contig_string',
-    'build_motif_mask',
-    'freeze_motif_coords',
-]
-
 _MOTIF_RE = re.compile(r'^([A-Za-z])(-?\d+)-(-?\d+)$')
 _LINKER_RE = re.compile(r'^(\d+)-(\d+)$')
 _FIXED_LINKER_RE = re.compile(r'^(\d+)$')
@@ -330,6 +320,20 @@ def build_motif_mask(realised: RealisedContig,
         If a motif refers to a chain not present in ``reference_coords``.
     IndexError
         If a motif residue index is out of range for its chain.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from deepchem.utils.rfdiffusion_contigs import (
+    ...     parse_contig_string, build_motif_mask)
+    >>> cm = parse_contig_string('2-2/A1-2/2-2')
+    >>> realised = cm.realise()
+    >>> ref_coords = {'A': np.ones((5, 3, 3), dtype=np.float32)}
+    >>> coords, mask = build_motif_mask(realised, ref_coords)
+    >>> coords.shape
+    (6, 3, 3)
+    >>> mask.tolist()
+    [False, False, True, True, False, False]
     """
     if reference_offset is None:
         reference_offset = {c: 1 for c in reference_coords}
@@ -407,7 +411,31 @@ def freeze_motif_coords(generated: np.ndarray, reference: np.ndarray,
 
 def realised_to_index_arrays(
         realised: RealisedContig) -> Tuple[np.ndarray, np.ndarray]:
-    """Return (motif_indices, linker_indices) arrays of int positions."""
+    """Return (motif_indices, linker_indices) arrays of int positions.
+
+    Parameters
+    ----------
+    realised : RealisedContig
+        Realised contig plan with concrete lengths.
+
+    Returns
+    -------
+    motif_indices : numpy.ndarray
+        1D array of int indices corresponding to motif residues.
+    linker_indices : numpy.ndarray
+        1D array of int indices corresponding to linker residues.
+
+    Examples
+    --------
+    >>> from deepchem.utils.rfdiffusion_contigs import (
+    ...     parse_contig_string, realised_to_index_arrays)
+    >>> cm = parse_contig_string('2-2/A1-2/2-2')
+    >>> motif_idx, linker_idx = realised_to_index_arrays(cm.realise())
+    >>> motif_idx.tolist()
+    [2, 3]
+    >>> linker_idx.tolist()
+    [0, 1, 4, 5]
+    """
     mask = realised.motif_mask()
     idx = np.arange(realised.total_length, dtype=np.int64)
     return idx[mask], idx[~mask]

--- a/deepchem/utils/rfdiffusion_contigs.py
+++ b/deepchem/utils/rfdiffusion_contigs.py
@@ -1,0 +1,456 @@
+"""Contig-map parsing and motif scaffolding utilities for RFDiffusion.
+
+RFDiffusion's inpainting / motif-scaffolding pipeline [Watson2023]_ uses a
+*contig string* to describe an output protein in terms of fixed motif
+segments copied from a reference structure interspersed with sampled
+linkers of variable length. This module implements a self-contained
+parser and a coordinate-masking helper that the diffusion sampler can
+use to keep motif atoms frozen at the reference geometry while the
+remainder of the chain is denoised.
+
+The contig grammar is the same dialect accepted by the official
+RFDiffusion CLI:
+
+* ``"10-20"`` - a sampled linker of between 10 and 20 residues.
+* ``"A12-30"`` - copy residues 12-30 of chain ``A`` from the reference.
+* ``"A12-30/0 5-10"`` - chain-break after the motif then 5-10 linker.
+* ``"/"`` - separator between segments.
+
+Each contig segment is one of two types:
+
+``MotifSegment``
+    Fixed-coordinate residues sourced from the reference.
+``LinkerSegment``
+    Variable-length sampled residues with an inclusive ``[lo, hi]``
+    range.
+
+Developer-facing summary
+------------------------
+Call ``parse_contig_string`` first to turn a CLI-style contig string
+into a :class:`ContigMap`. Then call ``realise()`` to sample concrete
+linker lengths, ``build_motif_mask`` to align the realised layout with
+reference coordinates, and ``freeze_motif_coords`` inside the sampling
+loop to keep motif residues fixed.
+
+References
+----------
+.. [Watson2023] Watson et al. "De novo design of protein structure and
+   function with RFdiffusion." Nature 620 (2023) 1089-1100.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Tuple, Union
+
+try:
+    import numpy as np
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_contigs requires NumPy to be installed.')
+
+__all__ = [
+    'LinkerSegment',
+    'MotifSegment',
+    'ContigMap',
+    'RealisedContig',
+    'parse_contig_string',
+    'build_motif_mask',
+    'freeze_motif_coords',
+]
+
+_MOTIF_RE = re.compile(r'^([A-Za-z])(-?\d+)-(-?\d+)$')
+_LINKER_RE = re.compile(r'^(\d+)-(\d+)$')
+_FIXED_LINKER_RE = re.compile(r'^(\d+)$')
+
+
+@dataclass(frozen=True)
+class LinkerSegment:
+    """Variable-length sampled linker segment.
+
+    Parameters
+    ----------
+    lo : int
+        Inclusive lower bound on the linker length.
+    hi : int
+        Inclusive upper bound on the linker length (``hi >= lo``).
+    """
+
+    lo: int
+    hi: int
+
+    def sample_length(self, rng: Optional[np.random.Generator] = None) -> int:
+        """Draw a length uniformly from [lo, hi]."""
+        if rng is None:
+            rng = np.random.default_rng()
+        return int(rng.integers(self.lo, self.hi + 1))
+
+    def __post_init__(self) -> None:
+        if self.lo < 0 or self.hi < self.lo:
+            raise ValueError(f'Invalid linker range [{self.lo}, {self.hi}].')
+
+
+@dataclass(frozen=True)
+class MotifSegment:
+    """Fixed motif segment copied from a reference structure.
+
+    Parameters
+    ----------
+    chain : str
+        Single-letter chain identifier in the reference.
+    start : int
+        Inclusive start residue index (PDB numbering) in the reference.
+    end : int
+        Inclusive end residue index (PDB numbering) in the reference.
+    """
+
+    chain: str
+    start: int
+    end: int
+
+    def __post_init__(self) -> None:
+        if len(self.chain) != 1 or not self.chain.isalpha():
+            raise ValueError(
+                f'Motif chain must be a single letter; got {self.chain!r}.')
+        if self.end < self.start:
+            raise ValueError(f'Motif end {self.end} < start {self.start}.')
+
+    @property
+    def length(self) -> int:
+        """Number of residues in the motif (end - start + 1)."""
+        return self.end - self.start + 1
+
+
+Segment = Union[LinkerSegment, MotifSegment]
+
+
+@dataclass
+class ContigMap:
+    """Parsed contig map describing a generated chain.
+
+    Parameters
+    ----------
+    segments : list of Segment
+        Ordered list of motif and linker segments.
+    """
+
+    segments: List[Segment]
+
+    def total_length_range(self) -> Tuple[int, int]:
+        """Return ``(min_total, max_total)`` for the chain length."""
+        lo = 0
+        hi = 0
+        for seg in self.segments:
+            if isinstance(seg, MotifSegment):
+                lo += seg.length
+                hi += seg.length
+            else:
+                lo += seg.lo
+                hi += seg.hi
+        return lo, hi
+
+    def realise(self,
+                rng: Optional[np.random.Generator] = None) -> 'RealisedContig':
+        """Sample concrete linker lengths and produce a ``RealisedContig``.
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator, optional
+            Random number generator.
+
+        Returns
+        -------
+        RealisedContig
+            Concrete plan with sampled linker lengths and the implied
+            mapping from generated positions to motif source residues.
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+        layout: List[Tuple[Segment, int]] = []
+        for seg in self.segments:
+            if isinstance(seg, MotifSegment):
+                layout.append((seg, seg.length))
+            else:
+                layout.append((seg, seg.sample_length(rng)))
+        return RealisedContig(layout=layout)
+
+
+@dataclass
+class RealisedContig:
+    """Concrete chain layout with sampled linker lengths.
+
+    Attributes
+    ----------
+    layout : list of (Segment, int)
+        Ordered list of ``(segment, realised_length)`` pairs.
+    """
+
+    layout: List[Tuple[Segment, int]]
+
+    @property
+    def total_length(self) -> int:
+        """Realised chain length (sum of motif + sampled linker lengths)."""
+        return sum(length for _, length in self.layout)
+
+    def motif_mask(self) -> np.ndarray:
+        """Boolean mask of shape ``(L,)`` flagging fixed motif positions.
+
+        Returns
+        -------
+        numpy.ndarray
+            Array of ``bool`` with ``True`` at motif residues.
+        """
+        mask = np.zeros(self.total_length, dtype=bool)
+        cursor = 0
+        for seg, length in self.layout:
+            if isinstance(seg, MotifSegment):
+                mask[cursor:cursor + length] = True
+            cursor += length
+        return mask
+
+    def motif_source_index(self) -> List[Optional[Tuple[str, int]]]:
+        """Per-position list of source ``(chain, residue_index)`` tuples.
+
+        Returns
+        -------
+        list of (str, int) or None
+            ``None`` for sampled-linker residues; ``(chain, idx)`` for
+            motif residues. Length matches ``total_length``.
+        """
+        sources: List[Optional[Tuple[str, int]]] = []
+        for seg, length in self.layout:
+            if isinstance(seg, MotifSegment):
+                for offset in range(length):
+                    sources.append((seg.chain, seg.start + offset))
+            else:
+                sources.extend([None] * length)
+        return sources
+
+
+def parse_contig_string(text: str) -> ContigMap:
+    """Parse a contig specification string into a :class:`ContigMap`.
+
+    Tokens are separated by '/' or whitespace. Each token is one of:
+
+    * ``<chain><start>-<end>`` - motif segment.
+    * ``<lo>-<hi>`` - variable linker.
+    * ``<n>`` - fixed-length linker of exactly ``n`` residues.
+
+    Parameters
+    ----------
+    text : str
+        Contig string in the RFDiffusion CLI dialect.
+
+    Returns
+    -------
+    ContigMap
+        Parsed contig map.
+
+    Raises
+    ------
+    ValueError
+        If a token does not match any of the accepted patterns.
+
+    Examples
+    --------
+    >>> cm = parse_contig_string('5-10/A12-30/5-10')
+    >>> cm.total_length_range()
+    (29, 39)
+    """
+    if not text or not text.strip():
+        raise ValueError('Empty contig string.')
+    tokens = [tok for tok in re.split(r'[/\s]+', text.strip()) if tok]
+    segments: List[Segment] = []
+    for tok in tokens:
+        m_motif = _MOTIF_RE.match(tok)
+        if m_motif is not None:
+            chain = m_motif.group(1)
+            start = int(m_motif.group(2))
+            end = int(m_motif.group(3))
+            segments.append(MotifSegment(chain=chain, start=start, end=end))
+            continue
+        m_linker = _LINKER_RE.match(tok)
+        if m_linker is not None:
+            lo = int(m_linker.group(1))
+            hi = int(m_linker.group(2))
+            segments.append(LinkerSegment(lo=lo, hi=hi))
+            continue
+        m_fixed = _FIXED_LINKER_RE.match(tok)
+        if m_fixed is not None:
+            n = int(m_fixed.group(1))
+            segments.append(LinkerSegment(lo=n, hi=n))
+            continue
+        raise ValueError(f'Unrecognised contig token: {tok!r}')
+    if not segments:
+        raise ValueError('Contig string produced no segments.')
+    return ContigMap(segments=segments)
+
+
+def build_motif_mask(realised: RealisedContig,
+                     reference_coords: Dict[str, np.ndarray],
+                     reference_offset: Optional[Dict[str, int]] = None,
+                     atoms_per_residue: int = 3,
+                     atom_dim: int = 3) -> Tuple[np.ndarray, np.ndarray]:
+    """Build aligned ``(reference_coords, motif_mask)`` arrays.
+
+    Iterates over a :class:`RealisedContig` and, for every position whose
+    source is a motif residue, copies the corresponding atom coordinates
+    from ``reference_coords[chain]`` into the output array. Linker
+    positions receive zeros and the mask flags them as not fixed.
+
+    Parameters
+    ----------
+    realised : RealisedContig
+        Realised contig with concrete linker lengths.
+    reference_coords : dict
+        Mapping from chain id to ``(N_chain, atoms_per_residue, atom_dim)``
+        array of reference coordinates. PDB residue indices map to
+        array rows via ``reference_offset[chain]`` (default 0 - i.e.
+        residue 1 lives at array index ``1 - offset``).
+    reference_offset : dict, optional
+        Mapping from chain id to the PDB residue index that lives at
+        row 0 of the reference array. Defaults to ``{c: 1 for c in
+        reference_coords}`` matching the most common PDB convention.
+    atoms_per_residue : int, default 3
+        Number of atoms stored per residue (3 for N/CA/C backbones,
+        14 for AlphaFold2 atom14).
+    atom_dim : int, default 3
+        Atom coordinate dimensionality (3 for R^3).
+
+    Returns
+    -------
+    coords : numpy.ndarray
+        Array of shape ``(L, atoms_per_residue, atom_dim)`` with motif
+        coordinates filled in.
+    motif_mask : numpy.ndarray
+        Boolean array of shape ``(L,)`` - ``True`` for fixed motif
+        positions.
+
+    Raises
+    ------
+    KeyError
+        If a motif refers to a chain not present in ``reference_coords``.
+    IndexError
+        If a motif residue index is out of range for its chain.
+    """
+    if reference_offset is None:
+        reference_offset = {c: 1 for c in reference_coords}
+    total_length = realised.total_length
+    coords = np.zeros((total_length, atoms_per_residue, atom_dim),
+                      dtype=np.float32)
+    mask = realised.motif_mask()
+    sources = realised.motif_source_index()
+    for out_idx, src in enumerate(sources):
+        if src is None:
+            continue
+        chain, res = src
+        if chain not in reference_coords:
+            raise KeyError(f'Reference does not contain chain {chain!r}.')
+        offset = reference_offset.get(chain, 1)
+        row = res - offset
+        ref = reference_coords[chain]
+        if row < 0 or row >= ref.shape[0]:
+            raise IndexError(
+                f'Motif residue {chain}{res} is out of range; '
+                f'reference chain {chain} has {ref.shape[0]} residues '
+                f'starting at PDB index {offset}.')
+        coords[out_idx] = ref[row, :atoms_per_residue, :atom_dim]
+    return coords, mask
+
+
+def freeze_motif_coords(generated: np.ndarray, reference: np.ndarray,
+                        motif_mask: np.ndarray) -> np.ndarray:
+    """Overwrite motif positions of ``generated`` with ``reference``.
+
+    Parameters
+    ----------
+    generated : numpy.ndarray
+        Array of shape ``(L, ...)`` containing the current generated
+        coordinates.
+    reference : numpy.ndarray
+        Array of shape ``(L, ...)`` with the same suffix dims as
+        ``generated`` containing the frozen reference coordinates.
+    motif_mask : numpy.ndarray
+        Boolean array of shape ``(L,)`` flagging motif positions.
+
+    Returns
+    -------
+    numpy.ndarray
+        New array equal to ``reference`` at motif positions and
+        ``generated`` elsewhere. The input arrays are not modified.
+
+    Raises
+    ------
+    ValueError
+        If the shapes are inconsistent.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from deepchem.utils.rfdiffusion_contigs import freeze_motif_coords
+    >>> generated = np.zeros((3, 3))
+    >>> reference = np.ones((3, 3))
+    >>> mask = np.array([True, False, True])
+    >>> out = freeze_motif_coords(generated, reference, mask)
+    >>> out[:, 0].tolist()
+    [1.0, 0.0, 1.0]
+    """
+    if generated.shape != reference.shape:
+        raise ValueError(f'Shape mismatch: generated {generated.shape} vs '
+                         f'reference {reference.shape}.')
+    if motif_mask.shape[0] != generated.shape[0]:
+        raise ValueError(
+            f'motif_mask length {motif_mask.shape[0]} does not match '
+            f'coordinate length {generated.shape[0]}.')
+    out = generated.copy()
+    out[motif_mask] = reference[motif_mask]
+    return out
+
+
+def realised_to_index_arrays(
+        realised: RealisedContig) -> Tuple[np.ndarray, np.ndarray]:
+    """Return (motif_indices, linker_indices) arrays of int positions."""
+    mask = realised.motif_mask()
+    idx = np.arange(realised.total_length, dtype=np.int64)
+    return idx[mask], idx[~mask]
+
+
+def fixed_layout(motif_lengths: Sequence[int],
+                 linker_lengths: Sequence[int],
+                 chain: str = 'A',
+                 motif_start: int = 1) -> RealisedContig:
+    """Build a deterministic ``RealisedContig`` from explicit lengths.
+
+    Convenience constructor used in tests where we want a deterministic
+    motif placement without invoking the random sampler.
+
+    Parameters
+    ----------
+    motif_lengths : sequence of int
+        Length of each motif block.
+    linker_lengths : sequence of int
+        Length of each linker block. Must satisfy
+        ``len(linker_lengths) == len(motif_lengths) + 1``: layout is
+        linker-motif-linker-motif-...-linker.
+    chain : str, default 'A'
+        Reference chain id assigned to every motif.
+    motif_start : int, default 1
+        Starting PDB residue index assigned to the first motif.
+
+    Returns
+    -------
+    RealisedContig
+        Deterministic realised contig.
+    """
+    if len(linker_lengths) != len(motif_lengths) + 1:
+        raise ValueError(
+            'linker_lengths must have one more entry than motif_lengths.')
+    layout: List[Tuple[Segment, int]] = []
+    cursor = motif_start
+    for i, lin_len in enumerate(linker_lengths):
+        layout.append((LinkerSegment(lo=lin_len, hi=lin_len), lin_len))
+        if i < len(motif_lengths):
+            m = MotifSegment(chain=chain,
+                             start=cursor,
+                             end=cursor + motif_lengths[i] - 1)
+            layout.append((m, motif_lengths[i]))
+            cursor += motif_lengths[i]
+    return RealisedContig(layout=layout)

--- a/deepchem/utils/rfdiffusion_contigs.py
+++ b/deepchem/utils/rfdiffusion_contigs.py
@@ -62,13 +62,37 @@ class LinkerSegment:
         Inclusive lower bound on the linker length.
     hi : int
         Inclusive upper bound on the linker length (``hi >= lo``).
+
+    Raises
+    ------
+    ValueError
+        If `lo` is negative or `hi < lo`.
+
+    Examples
+    --------
+    >>> from deepchem.utils.rfdiffusion_contigs import LinkerSegment
+    >>> seg = LinkerSegment(lo=5, hi=10)
+    >>> seg.lo, seg.hi
+    (5, 10)
     """
 
     lo: int
     hi: int
 
     def sample_length(self, rng: Optional[np.random.Generator] = None) -> int:
-        """Draw a length uniformly from [lo, hi]."""
+        """Draw a length uniformly from [lo, hi].
+
+        Parameters
+        ----------
+        rng : numpy.random.Generator, optional
+            Random number generator. A fresh default generator is used
+            if not given.
+
+        Returns
+        -------
+        int
+            Sampled length in `[lo, hi]` inclusive.
+        """
         if rng is None:
             rng = np.random.default_rng()
         return int(rng.integers(self.lo, self.hi + 1))
@@ -90,6 +114,18 @@ class MotifSegment:
         Inclusive start residue index (PDB numbering) in the reference.
     end : int
         Inclusive end residue index (PDB numbering) in the reference.
+
+    Raises
+    ------
+    ValueError
+        If `chain` is not a single letter, or if `end < start`.
+
+    Examples
+    --------
+    >>> from deepchem.utils.rfdiffusion_contigs import MotifSegment
+    >>> seg = MotifSegment(chain='A', start=12, end=30)
+    >>> seg.length
+    19
     """
 
     chain: str
@@ -120,12 +156,35 @@ class ContigMap:
     ----------
     segments : list of Segment
         Ordered list of motif and linker segments.
+
+    Examples
+    --------
+    >>> from deepchem.utils.rfdiffusion_contigs import (
+    ...     ContigMap, LinkerSegment, MotifSegment)
+    >>> cmap = ContigMap(segments=[
+    ...     LinkerSegment(lo=5, hi=10), MotifSegment(chain='A', start=12, end=30)])
+    >>> cmap.total_length_range()
+    (24, 29)
     """
 
     segments: List[Segment]
 
     def total_length_range(self) -> Tuple[int, int]:
-        """Return ``(min_total, max_total)`` for the chain length."""
+        """Return ``(min_total, max_total)`` for the chain length.
+
+        Returns
+        -------
+        tuple of int
+            ``(min_total, max_total)`` inclusive length bounds implied
+            by the segments' linker ranges and motif lengths.
+
+        Examples
+        --------
+        >>> from deepchem.utils.rfdiffusion_contigs import parse_contig_string
+        >>> cm = parse_contig_string('5-10/A12-30/5-10')
+        >>> cm.total_length_range()
+        (29, 39)
+        """
         lo = 0
         hi = 0
         for seg in self.segments:
@@ -151,6 +210,13 @@ class ContigMap:
         RealisedContig
             Concrete plan with sampled linker lengths and the implied
             mapping from generated positions to motif source residues.
+
+        Examples
+        --------
+        >>> from deepchem.utils.rfdiffusion_contigs import parse_contig_string
+        >>> cm = parse_contig_string('2-2/A1-2/2-2')
+        >>> cm.realise().total_length
+        6
         """
         if rng is None:
             rng = np.random.default_rng()
@@ -171,6 +237,14 @@ class RealisedContig:
     ----------
     layout : list of (Segment, int)
         Ordered list of ``(segment, realised_length)`` pairs.
+
+    Examples
+    --------
+    >>> from deepchem.utils.rfdiffusion_contigs import parse_contig_string
+    >>> cm = parse_contig_string('2-2/A1-2/2-2')
+    >>> realised = cm.realise()
+    >>> realised.total_length
+    6
     """
 
     layout: List[Tuple[Segment, int]]
@@ -187,6 +261,13 @@ class RealisedContig:
         -------
         numpy.ndarray
             Array of ``bool`` with ``True`` at motif residues.
+
+        Examples
+        --------
+        >>> from deepchem.utils.rfdiffusion_contigs import parse_contig_string
+        >>> cm = parse_contig_string('2-2/A1-2/2-2')
+        >>> cm.realise().motif_mask().tolist()
+        [False, False, True, True, False, False]
         """
         mask = np.zeros(self.total_length, dtype=bool)
         cursor = 0
@@ -204,6 +285,13 @@ class RealisedContig:
         list of (str, int) or None
             ``None`` for sampled-linker residues; ``(chain, idx)`` for
             motif residues. Length matches ``total_length``.
+
+        Examples
+        --------
+        >>> from deepchem.utils.rfdiffusion_contigs import parse_contig_string
+        >>> cm = parse_contig_string('2-2/A1-2/2-2')
+        >>> cm.realise().motif_source_index()
+        [None, None, ('A', 1), ('A', 2), None, None]
         """
         sources: List[Optional[Tuple[str, int]]] = []
         for seg, length in self.layout:
@@ -241,6 +329,7 @@ def parse_contig_string(text: str) -> ContigMap:
 
     Examples
     --------
+    >>> from deepchem.utils.rfdiffusion_contigs import parse_contig_string
     >>> cm = parse_contig_string('5-10/A12-30/5-10')
     >>> cm.total_length_range()
     (29, 39)
@@ -467,6 +556,15 @@ def fixed_layout(motif_lengths: Sequence[int],
     -------
     RealisedContig
         Deterministic realised contig.
+
+    Examples
+    --------
+    >>> from deepchem.utils.rfdiffusion_contigs import fixed_layout
+    >>> realised = fixed_layout(motif_lengths=[5], linker_lengths=[3, 3])
+    >>> realised.total_length
+    11
+    >>> realised.motif_mask().tolist()
+    [False, False, False, True, True, True, True, True, False, False, False]
     """
     if len(linker_lengths) != len(motif_lengths) + 1:
         raise ValueError(

--- a/deepchem/utils/test/test_rfdiffusion_contigs.py
+++ b/deepchem/utils/test/test_rfdiffusion_contigs.py
@@ -1,0 +1,160 @@
+"""Tests for the RFDiffusion contig parser and motif scaffolding utilities."""
+
+import numpy as np
+import pytest
+
+from deepchem.utils.rfdiffusion_contigs import (
+    LinkerSegment,
+    MotifSegment,
+    parse_contig_string,
+    build_motif_mask,
+    freeze_motif_coords,
+    fixed_layout,
+)
+
+
+class TestSegments:
+    """Linker and motif segment dataclasses."""
+
+    def test_linker_sample_length_in_range(self):
+        """A sampled linker length stays within its inclusive bounds."""
+        seg = LinkerSegment(lo=5, hi=10)
+        rng = np.random.default_rng(0)
+        for _ in range(50):
+            assert 5 <= seg.sample_length(rng) <= 10
+
+    def test_linker_fixed_length(self):
+        """A linker with lo == hi always samples that exact length."""
+        seg = LinkerSegment(lo=7, hi=7)
+        assert seg.sample_length(np.random.default_rng(0)) == 7
+
+    def test_linker_invalid_range_raises(self):
+        """A reversed or negative linker range is rejected."""
+        with pytest.raises(ValueError):
+            LinkerSegment(lo=10, hi=5)
+        with pytest.raises(ValueError):
+            LinkerSegment(lo=-1, hi=5)
+
+    def test_motif_length(self):
+        """Motif length counts residues inclusively."""
+        assert MotifSegment(chain='A', start=12, end=30).length == 19
+
+    def test_motif_invalid_raises(self):
+        """A bad chain id or reversed range is rejected."""
+        with pytest.raises(ValueError):
+            MotifSegment(chain='AB', start=1, end=5)
+        with pytest.raises(ValueError):
+            MotifSegment(chain='A', start=10, end=5)
+
+
+class TestParseContigString:
+    """Parsing CLI-style contig strings."""
+
+    def test_parse_mixed(self):
+        """A mixed string yields the right segment types, order and range."""
+        cm = parse_contig_string('5-10/A12-30/5-10')
+        assert isinstance(cm.segments[0], LinkerSegment)
+        assert isinstance(cm.segments[1], MotifSegment)
+        assert isinstance(cm.segments[2], LinkerSegment)
+        assert cm.segments[1].chain == 'A'
+        assert cm.total_length_range() == (29, 39)
+
+    def test_parse_fixed_linker(self):
+        """A bare integer token is a fixed-length linker."""
+        cm = parse_contig_string('8')
+        assert cm.segments[0].lo == 8
+        assert cm.segments[0].hi == 8
+
+    def test_parse_whitespace_or_slash(self):
+        """Tokens may be separated by slashes or whitespace."""
+        a = parse_contig_string('A1-5/10-20')
+        b = parse_contig_string('A1-5 10-20')
+        assert len(a.segments) == len(b.segments) == 2
+
+    def test_parse_empty_raises(self):
+        """An empty or whitespace-only string is rejected."""
+        with pytest.raises(ValueError):
+            parse_contig_string('')
+        with pytest.raises(ValueError):
+            parse_contig_string('   ')
+
+    def test_parse_bad_token_raises(self):
+        """An unrecognised token is rejected."""
+        with pytest.raises(ValueError):
+            parse_contig_string('A1-5/xyz')
+
+
+class TestContigMap:
+    """Length ranges and realisation."""
+
+    def test_total_length_range(self):
+        """Length range sums motif lengths and linker bounds."""
+        cm = parse_contig_string('5-10/A1-20/5-10')
+        assert cm.total_length_range() == (30, 40)
+
+    def test_realise_length_within_range(self):
+        """A realised total length falls inside the declared range."""
+        cm = parse_contig_string('5-10/A1-20/5-10')
+        rng = np.random.default_rng(0)
+        lo, hi = cm.total_length_range()
+        for _ in range(20):
+            assert lo <= cm.realise(rng).total_length <= hi
+
+    def test_motif_mask_and_sources(self):
+        """The mask and source map flag motif residues consistently."""
+        r = fixed_layout(motif_lengths=[3],
+                         linker_lengths=[2, 2],
+                         chain='A',
+                         motif_start=5)
+        assert r.motif_mask().tolist() == [
+            False, False, True, True, True, False, False
+        ]
+        sources = r.motif_source_index()
+        assert sources[2] == ('A', 5)
+        assert sources[4] == ('A', 7)
+        assert sources[0] is None
+
+
+class TestMotifMasking:
+    """Building and applying motif masks against reference coordinates."""
+
+    def test_build_motif_mask_copies_reference(self):
+        """Motif rows copy reference coordinates; linkers stay zero."""
+        r = fixed_layout(motif_lengths=[2],
+                         linker_lengths=[1, 1],
+                         chain='A',
+                         motif_start=1)
+        ref = {'A': np.arange(2 * 3 * 3).reshape(2, 3, 3).astype(np.float32)}
+        coords, mask = build_motif_mask(r, ref)
+        assert coords.shape == (4, 3, 3)
+        assert mask.tolist() == [False, True, True, False]
+        assert np.allclose(coords[1], ref['A'][0])
+        assert np.allclose(coords[2], ref['A'][1])
+        assert np.allclose(coords[0], 0.0)
+
+    def test_build_motif_mask_missing_chain_raises(self):
+        """A motif on an absent reference chain raises KeyError."""
+        r = fixed_layout([1], [0, 0], chain='B')
+        with pytest.raises(KeyError):
+            build_motif_mask(r, {'A': np.zeros((5, 3, 3))})
+
+    def test_build_motif_mask_out_of_range_raises(self):
+        """A motif residue past the reference length raises IndexError."""
+        r = fixed_layout([3], [0, 0], chain='A', motif_start=1)
+        with pytest.raises(IndexError):
+            build_motif_mask(r, {'A': np.zeros((2, 3, 3))})
+
+    def test_freeze_motif_coords(self):
+        """Freezing overwrites only masked rows and leaves the input alone."""
+        gen = np.zeros((3, 3))
+        ref = np.ones((3, 3))
+        mask = np.array([True, False, True])
+        out = freeze_motif_coords(gen, ref, mask)
+        assert out[:, 0].tolist() == [1.0, 0.0, 1.0]
+        assert np.allclose(gen, 0.0)
+
+    def test_freeze_shape_mismatch_raises(self):
+        """Mismatched coordinate shapes raise ValueError."""
+        with pytest.raises(ValueError):
+            freeze_motif_coords(np.zeros((3, 3)), np.zeros((4, 3)),
+                                np.array([True, False, True]))

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -546,3 +546,16 @@ RFDiffusion Layers
 
 .. autoclass:: deepchem.models.torch_models.layers.BackboneDiffusion
    :members:
+
+.. autoclass:: deepchem.models.torch_models.rfdiffusion_multitrack.RFDiffusionMultiTrackDenoiser
+   :members:
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_multitrack.backbone_coords_from_frames
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_multitrack.sample_noisy_frames
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_multitrack.translation_posterior_step
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_multitrack.so3_x0_reverse_step
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_multitrack.multitrack_frame_loss


### PR DESCRIPTION
## Description

Connects the RFDiffusion modules from the earlier PRs (frames, IPA, pair track, sequence/structure track, SO(3) diffusion, contigs) into `RFDiffusionModel`. Before this, `RFDiffusionModel` only ever used the simple Transformer baseline — none of those modules were actually wired up.

Adds `rfdiffusion_multitrack.py` with `RFDiffusionMultiTrackDenoiser`, wrapping `RFDiffusionMultiTrackStack` into a full frame-based denoiser, plus the forward-noising and reverse-sampling helpers to run combined IGSO(3) rotational + translational diffusion end to end. The denoiser predicts the denoised frame directly at every step, the way RFdiffusion itself does, instead of predicting noise like the coordinate-space baseline.

`RFDiffusionModel` now takes an `architecture` argument: `'multitrack'` is the real network above and is now the default, `'transformer'` is the old baseline kept as a fallback. Only `'multitrack'` supports motif conditioning in `generate()`.

Also fixed two real bugs found in the SO(3) module (#5073) while wiring this up, pushed there directly too:
- `so3_log_map` clamped a `sqrt()` at exactly 0, which has an infinite gradient there, so training reliably went to NaN.
- `IGSO3._score_omega` was roughly O(n²) in the number of diffusion steps from a `retain_graph=True` loop. At the default 1000 steps this took hours. Rewrote it batched, verified bit-identical output, now takes about a minute.

Depends on #4997, #4982, #5028, #5036, #5041, #5073, #5076.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version 0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings