### PR TITLE
Add RFDiffusion All-Atom ligand parser and all-atom losses

### DIFF
--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -1,0 +1,310 @@
+"""SE(3) rigid-frame math utilities for RFDiffusion.
+
+This module contains the non-learned geometric primitives used by the
+RFDiffusion stack:
+
+* residue-local frame construction from backbone atoms `(N, CA, C)`
+* rigid transform apply / inverse / invert / compose helpers
+* Rodrigues exp/log maps between so(3) vectors and SO(3) rotations
+
+The module is intentionally self-contained and depends only on PyTorch.
+"""
+
+from typing import Optional, Sequence, Tuple
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError("rfdiffusion_frames requires PyTorch to be installed.")
+
+__all__ = [
+    "apply_inverse_rigid",
+    "apply_rigid",
+    "build_backbone_frames",
+    "compose_rigids",
+    "invert_rigid",
+    "make_identity_rigid",
+    "so3_exp_map",
+    "so3_log_map",
+]
+
+_SMALL_OMEGA: float = 1e-4
+
+
+def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
+    """Normalize vectors with epsilon stabilization.
+
+    Parameters
+    ----------
+    vector : torch.Tensor
+        Tensor of shape `(..., 3)`.
+    eps : float
+        Positive epsilon added to the norm.
+
+    Returns
+    -------
+    torch.Tensor
+        Normalized vectors.
+    """
+    norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
+    return vector / (norm + eps)
+
+
+def build_backbone_frames(
+        backbone: torch.Tensor,
+        eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Build residue-local frames from `(N, CA, C)` backbone coordinates.
+
+    Parameters
+    ----------
+    backbone : torch.Tensor
+        Backbone coordinates of shape `(..., 3, 3)` ordered as
+        `(N, CA, C)`.
+    eps : float, default 1e-8
+        Positive stabilization constant.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Frame origins of shape `(..., 3)`.
+    """
+    if backbone.shape[-2:] != (3, 3):
+        raise ValueError("backbone must have shape (..., 3, 3).")
+    if eps <= 0:
+        raise ValueError("eps must be positive.")
+
+    n_atom = backbone[..., 0, :]
+    ca_atom = backbone[..., 1, :]
+    c_atom = backbone[..., 2, :]
+
+    x_axis = _normalize(c_atom - ca_atom, eps)
+    n_direction = n_atom - ca_atom
+    y_axis = n_direction - (n_direction * x_axis).sum(dim=-1,
+                                                      keepdim=True) * x_axis
+    y_axis = _normalize(y_axis, eps)
+    z_axis = torch.linalg.cross(x_axis, y_axis, dim=-1)
+
+    rotations = torch.stack((x_axis, y_axis, z_axis), dim=-1)
+    return rotations, ca_atom
+
+
+def make_identity_rigid(
+        shape: Sequence[int],
+        device: Optional[torch.device] = None,
+        dtype: Optional[torch.dtype] = None
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Create identity rigid transforms `(I, 0)`.
+
+    Parameters
+    ----------
+    shape : sequence of int
+        Batch shape.
+    device : torch.device, optional
+        Device for returned tensors.
+    dtype : torch.dtype, optional
+        Tensor dtype.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Identity rotations of shape `(*shape, 3, 3)`.
+    translations : torch.Tensor
+        Zero translations of shape `(*shape, 3)`.
+    """
+    shape = tuple(shape)
+    rotation = torch.eye(3, device=device, dtype=dtype)
+    rotation = rotation.expand(*shape, 3, 3).contiguous().clone()
+    translation = torch.zeros(*shape, 3, device=device, dtype=dtype)
+    return rotation, translation
+
+
+def _expand_rigid_to_points(
+        rotations: torch.Tensor, translations: torch.Tensor,
+        points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Broadcast rigid transforms across extra point dimensions."""
+    extra_dims = points.dim() - translations.dim()
+    if extra_dims < 0:
+        raise ValueError(
+            "points must have at least the transform batch dimensions.")
+    for _ in range(extra_dims):
+        rotations = rotations.unsqueeze(-3)
+        translations = translations.unsqueeze(-2)
+    return rotations, translations
+
+
+def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                points: torch.Tensor) -> torch.Tensor:
+    """Apply rigid transforms `x -> x @ R.T + t`.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points of shape `(..., 3)` or with extra point axes.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points.
+    """
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    rotated = torch.matmul(points.unsqueeze(-2),
+                           rotations.transpose(-1, -2)).squeeze(-2)
+    return rotated + translations
+
+
+def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
+                        points: torch.Tensor) -> torch.Tensor:
+    """Apply inverse rigid transforms `y -> (y - t) @ R`."""
+    rotations, translations = _expand_rigid_to_points(rotations, translations,
+                                                      points)
+    centered = points - translations
+    return torch.matmul(centered.unsqueeze(-2), rotations).squeeze(-2)
+
+
+def invert_rigid(
+        rotations: torch.Tensor,
+        translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Invert rigid transforms.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    inv_rotations : torch.Tensor
+        Transposed rotations.
+    inv_translations : torch.Tensor
+        Inverse translations.
+    """
+    inv_rotations = rotations.transpose(-1, -2)
+    inv_translations = -torch.matmul(translations.unsqueeze(-2),
+                                     rotations).squeeze(-2)
+    return inv_rotations, inv_translations
+
+
+def compose_rigids(
+        rotations_a: torch.Tensor, translations_a: torch.Tensor,
+        rotations_b: torch.Tensor,
+        translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compose two rigid transforms `T_a o T_b`.
+
+    Parameters
+    ----------
+    rotations_a, rotations_b : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations_a, translations_b : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    rotations : torch.Tensor
+        Composite rotations.
+    translations : torch.Tensor
+        Composite translations.
+    """
+    rotations = torch.matmul(rotations_a, rotations_b)
+    translations = apply_rigid(rotations_a, translations_a, translations_b)
+    return rotations, translations
+
+
+def _safe_sin_div_x(x: torch.Tensor) -> torch.Tensor:
+    """Return `sin(x) / x` with a stable Taylor branch near zero."""
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    return torch.where(small, 1.0 - x * x / 6.0, torch.sin(safe_x) / safe_x)
+
+
+def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
+    """Return `(1 - cos(x)) / x^2` with a stable Taylor branch."""
+    small = x.abs() < _SMALL_OMEGA
+    safe_x = torch.where(small, torch.ones_like(x), x)
+    closed = (1.0 - torch.cos(safe_x)) / (safe_x * safe_x)
+    series = 0.5 - x * x / 24.0
+    return torch.where(small, series, closed)
+
+
+def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
+    """Map tangent vectors in so(3) to rotation matrices.
+
+    Parameters
+    ----------
+    tangent : torch.Tensor
+        Tangent vectors of shape `(..., 3)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    """
+    omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)
+    zeros = torch.zeros_like(tangent[..., 0])
+    tx, ty, tz = tangent[..., 0], tangent[..., 1], tangent[..., 2]
+    skew = torch.stack([
+        torch.stack([zeros, -tz, ty], dim=-1),
+        torch.stack([tz, zeros, -tx], dim=-1),
+        torch.stack([-ty, tx, zeros], dim=-1),
+    ],
+                       dim=-2)
+    eye = torch.eye(3, dtype=tangent.dtype, device=tangent.device)
+    sin_coeff = _safe_sin_div_x(omega).unsqueeze(-1)
+    cos_coeff = _safe_one_minus_cos_div_x_sq(omega).unsqueeze(-1)
+    skew_sq = torch.matmul(skew, skew)
+    return eye + sin_coeff * skew + cos_coeff * skew_sq
+
+
+def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
+    """Map rotation matrices to tangent vectors on the principal branch.
+
+    The rotation is converted to a unit quaternion first and then to an
+    axis-angle vector. Routing through the quaternion keeps the result stable
+    for rotations near ``pi``, where reading the angle straight from the trace
+    loses accuracy because ``sin(omega)`` goes to zero.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+
+    Returns
+    -------
+    torch.Tensor
+        Tangent vectors of shape `(..., 3)` whose norm lies in ``[0, pi]``.
+    """
+    m00 = rotations[..., 0, 0]
+    m11 = rotations[..., 1, 1]
+    m22 = rotations[..., 2, 2]
+    trace = m00 + m11 + m22
+
+    # Read the unit quaternion from the rotation matrix. Each component
+    # magnitude comes from the diagonal and its sign from the skew part.
+    qw = 0.5 * torch.sqrt(torch.clamp(1.0 + trace, min=0.0))
+    qx = 0.5 * torch.sqrt(torch.clamp(1.0 + m00 - m11 - m22, min=0.0))
+    qy = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 + m11 - m22, min=0.0))
+    qz = 0.5 * torch.sqrt(torch.clamp(1.0 - m00 - m11 + m22, min=0.0))
+    qx = torch.copysign(qx, rotations[..., 2, 1] - rotations[..., 1, 2])
+    qy = torch.copysign(qy, rotations[..., 0, 2] - rotations[..., 2, 0])
+    qz = torch.copysign(qz, rotations[..., 1, 0] - rotations[..., 0, 1])
+
+    quat_vec = torch.stack([qx, qy, qz], dim=-1)
+    sin_half = quat_vec.norm(dim=-1)
+    cos_half = qw.clamp(-1.0, 1.0)
+    omega = 2.0 * torch.atan2(sin_half, cos_half)
+
+    small = sin_half < _SMALL_OMEGA
+    safe_sin_half = torch.where(small, torch.ones_like(sin_half), sin_half)
+    unit_axis = quat_vec / safe_sin_half.unsqueeze(-1)
+    # Near zero rotation the axis is ill-defined; there the tangent vector
+    # is approximately 2 * (qx, qy, qz).
+    return torch.where(small.unsqueeze(-1), 2.0 * quat_vec,
+                       omega.unsqueeze(-1) * unit_axis)

--- a/deepchem/models/torch_models/rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/rfdiffusion_frames.py
@@ -17,34 +17,35 @@ try:
 except ModuleNotFoundError:
     raise ImportError("rfdiffusion_frames requires PyTorch to be installed.")
 
-__all__ = [
-    "apply_inverse_rigid",
-    "apply_rigid",
-    "build_backbone_frames",
-    "compose_rigids",
-    "invert_rigid",
-    "make_identity_rigid",
-    "so3_exp_map",
-    "so3_log_map",
-]
-
+# Threshold for small-angle Taylor expansions.
+# For rotation angles theta < 1e-4, sin(theta)/theta ~ 1 - theta^2/6 and
+# (1 - cos(theta))/theta^2 ~ 1/2 - theta^2/24. This avoids division-by-zero
+# and float32 precision loss near the identity (Grassia, 1998).
 _SMALL_OMEGA: float = 1e-4
 
 
-def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
-    """Normalize vectors with epsilon stabilization.
+def _normalize(vector: torch.Tensor, eps: float = 1e-8) -> torch.Tensor:
+    """Normalize 3D vectors along the last dimension with epsilon stabilization.
 
     Parameters
     ----------
     vector : torch.Tensor
         Tensor of shape `(..., 3)`.
-    eps : float
-        Positive epsilon added to the norm.
+    eps : float, default 1e-8
+        Small positive constant added to the norm denominator.
 
     Returns
     -------
     torch.Tensor
-        Normalized vectors.
+        Normalized vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> v = torch.tensor([[3.0, 0.0, 0.0], [0.0, 4.0, 0.0]])
+    >>> _normalize(v)
+    tensor([[1., 0., 0.],
+            [0., 1., 0.]])
     """
     norm = torch.linalg.norm(vector, dim=-1, keepdim=True)
     return vector / (norm + eps)
@@ -53,22 +54,47 @@ def _normalize(vector: torch.Tensor, eps: float) -> torch.Tensor:
 def build_backbone_frames(
         backbone: torch.Tensor,
         eps: float = 1e-8) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Build residue-local frames from `(N, CA, C)` backbone coordinates.
+    """Construct residue-local coordinate frames from protein backbone coordinates.
+
+    Builds an orthonormal right-handed reference frame for each residue
+    from N, CA, and C atom positions using Gram-Schmidt orthogonalization:
+    - The x-axis points along the CA -> C bond.
+    - The xy-plane contains the N, CA, and C atoms (with N in the positive y-half).
+    - The z-axis is the cross product x x y.
+    - The frame origin is positioned at the CA atom.
 
     Parameters
     ----------
     backbone : torch.Tensor
-        Backbone coordinates of shape `(..., 3, 3)` ordered as
-        `(N, CA, C)`.
+        Backbone coordinates of shape `(..., 3, 3)` ordered as `(N, CA, C)`
+        along the second-to-last dimension.
     eps : float, default 1e-8
-        Positive stabilization constant.
+        Small positive constant to avoid division by zero during normalization.
 
     Returns
     -------
     rotations : torch.Tensor
-        Rotation matrices of shape `(..., 3, 3)`.
+        Rotation matrices of shape `(..., 3, 3)` representing local frame orientations.
     translations : torch.Tensor
-        Frame origins of shape `(..., 3)`.
+        Frame origins of shape `(..., 3)` corresponding to CA coordinates.
+
+    Raises
+    ------
+    ValueError
+        If backbone does not have shape `(..., 3, 3)` or `eps <= 0`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> n = torch.tensor([0.0, 1.0, 0.0])
+    >>> ca = torch.tensor([0.0, 0.0, 0.0])
+    >>> c = torch.tensor([1.0, 0.0, 0.0])
+    >>> backbone = torch.stack([n, ca, c], dim=0)
+    >>> R, t = build_backbone_frames(backbone)
+    >>> R.shape
+    torch.Size([3, 3])
+    >>> t.shape
+    torch.Size([3])
     """
     if backbone.shape[-2:] != (3, 3):
         raise ValueError("backbone must have shape (..., 3, 3).")
@@ -95,23 +121,32 @@ def make_identity_rigid(
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Create identity rigid transforms `(I, 0)`.
+    """Create identity rigid transforms (identity rotation and zero translation).
 
     Parameters
     ----------
     shape : sequence of int
-        Batch shape.
+        Batch shape for the generated transforms.
     device : torch.device, optional
-        Device for returned tensors.
+        Target device for the returned tensors.
     dtype : torch.dtype, optional
-        Tensor dtype.
+        Target data type for the returned tensors.
 
     Returns
     -------
     rotations : torch.Tensor
-        Identity rotations of shape `(*shape, 3, 3)`.
+        Identity rotation matrices of shape `(*shape, 3, 3)`.
     translations : torch.Tensor
-        Zero translations of shape `(*shape, 3)`.
+        Zero translation vectors of shape `(*shape, 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2, 4))
+    >>> R.shape
+    torch.Size([2, 4, 3, 3])
+    >>> t.shape
+    torch.Size([2, 4, 3])
     """
     shape = tuple(shape)
     rotation = torch.eye(3, device=device, dtype=dtype)
@@ -123,7 +158,24 @@ def make_identity_rigid(
 def _expand_rigid_to_points(
         rotations: torch.Tensor, translations: torch.Tensor,
         points: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Broadcast rigid transforms across extra point dimensions."""
+    """Broadcast rigid transform batch dimensions across extra point dimensions.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points tensor of shape `(..., *extra_dims, 3)`.
+
+    Returns
+    -------
+    expanded_rotations : torch.Tensor
+        Rotations with unsqueezed singleton dimensions matching points.
+    expanded_translations : torch.Tensor
+        Translations with unsqueezed singleton dimensions matching points.
+    """
     extra_dims = points.dim() - translations.dim()
     if extra_dims < 0:
         raise ValueError(
@@ -136,7 +188,9 @@ def _expand_rigid_to_points(
 
 def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
                 points: torch.Tensor) -> torch.Tensor:
-    """Apply rigid transforms `x -> x @ R.T + t`.
+    """Apply rigid transforms to 3D points: `y = points @ R.T + t`.
+
+    Transforms points from local coordinates to global coordinates.
 
     Parameters
     ----------
@@ -145,12 +199,21 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
     translations : torch.Tensor
         Translation vectors of shape `(..., 3)`.
     points : torch.Tensor
-        Points of shape `(..., 3)` or with extra point axes.
+        Points tensor of shape `(..., 3)` or with extra point axes.
 
     Returns
     -------
     torch.Tensor
-        Transformed points.
+        Transformed points of the same shape as `points`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2,))
+    >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> out = apply_rigid(R, t, pts)
+    >>> torch.allclose(out, pts)
+    True
     """
     rotations, translations = _expand_rigid_to_points(rotations, translations,
                                                       points)
@@ -161,7 +224,33 @@ def apply_rigid(rotations: torch.Tensor, translations: torch.Tensor,
 
 def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
                         points: torch.Tensor) -> torch.Tensor:
-    """Apply inverse rigid transforms `y -> (y - t) @ R`."""
+    """Apply inverse rigid transforms to 3D points: `x = (points - t) @ R`.
+
+    Transforms points from global coordinates back to local residue coordinates.
+
+    Parameters
+    ----------
+    rotations : torch.Tensor
+        Rotation matrices of shape `(..., 3, 3)`.
+    translations : torch.Tensor
+        Translation vectors of shape `(..., 3)`.
+    points : torch.Tensor
+        Points tensor of shape `(..., 3)` or with extra point axes.
+
+    Returns
+    -------
+    torch.Tensor
+        Transformed points of the same shape as `points`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R, t = make_identity_rigid((2,))
+    >>> pts = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    >>> out = apply_inverse_rigid(R, t, pts)
+    >>> torch.allclose(out, pts)
+    True
+    """
     rotations, translations = _expand_rigid_to_points(rotations, translations,
                                                       points)
     centered = points - translations
@@ -171,7 +260,7 @@ def apply_inverse_rigid(rotations: torch.Tensor, translations: torch.Tensor,
 def invert_rigid(
         rotations: torch.Tensor,
         translations: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Invert rigid transforms.
+    """Compute the inverse of rigid transforms `(R, t)^(-1) = (R.T, -t @ R)`.
 
     Parameters
     ----------
@@ -183,9 +272,18 @@ def invert_rigid(
     Returns
     -------
     inv_rotations : torch.Tensor
-        Transposed rotations.
+        Inverted rotation matrices of shape `(..., 3, 3)`.
     inv_translations : torch.Tensor
-        Inverse translations.
+        Inverted translation vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R = torch.eye(3)
+    >>> t = torch.tensor([1.0, 2.0, 3.0])
+    >>> inv_R, inv_t = invert_rigid(R, t)
+    >>> inv_t
+    tensor([-1., -2., -3.])
     """
     inv_rotations = rotations.transpose(-1, -2)
     inv_translations = -torch.matmul(translations.unsqueeze(-2),
@@ -197,7 +295,7 @@ def compose_rigids(
         rotations_a: torch.Tensor, translations_a: torch.Tensor,
         rotations_b: torch.Tensor,
         translations_b: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Compose two rigid transforms `T_a o T_b`.
+    """Compose two rigid transforms `T_a o T_b = (R_a @ R_b, apply_rigid(T_a, t_b))`.
 
     Parameters
     ----------
@@ -209,9 +307,18 @@ def compose_rigids(
     Returns
     -------
     rotations : torch.Tensor
-        Composite rotations.
+        Composed rotation matrices of shape `(..., 3, 3)`.
     translations : torch.Tensor
-        Composite translations.
+        Composed translation vectors of shape `(..., 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R1, t1 = make_identity_rigid(())
+    >>> R2, t2 = make_identity_rigid(())
+    >>> R_comp, t_comp = compose_rigids(R1, t1, R2, t2)
+    >>> R_comp.shape
+    torch.Size([3, 3])
     """
     rotations = torch.matmul(rotations_a, rotations_b)
     translations = apply_rigid(rotations_a, translations_a, translations_b)
@@ -235,17 +342,26 @@ def _safe_one_minus_cos_div_x_sq(x: torch.Tensor) -> torch.Tensor:
 
 
 def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
-    """Map tangent vectors in so(3) to rotation matrices.
+    """Map so(3) tangent vectors (axis-angle) to SO(3) rotation matrices via Rodrigues' formula.
 
     Parameters
     ----------
     tangent : torch.Tensor
-        Tangent vectors of shape `(..., 3)`.
+        Tangent vectors of shape `(..., 3)` where direction specifies the
+        rotation axis and norm specifies the rotation angle in radians.
 
     Returns
     -------
     torch.Tensor
         Rotation matrices of shape `(..., 3, 3)`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> w = torch.zeros(3)
+    >>> R = so3_exp_map(w)
+    >>> torch.allclose(R, torch.eye(3))
+    True
     """
     omega = tangent.norm(dim=-1, keepdim=True).clamp(min=0.0)
     zeros = torch.zeros_like(tangent[..., 0])
@@ -264,12 +380,12 @@ def so3_exp_map(tangent: torch.Tensor) -> torch.Tensor:
 
 
 def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
-    """Map rotation matrices to tangent vectors on the principal branch.
+    """Map SO(3) rotation matrices to so(3) tangent vectors on the principal branch.
 
-    The rotation is converted to a unit quaternion first and then to an
+    The rotation matrix is converted to a unit quaternion first and then to an
     axis-angle vector. Routing through the quaternion keeps the result stable
-    for rotations near ``pi``, where reading the angle straight from the trace
-    loses accuracy because ``sin(omega)`` goes to zero.
+    for rotations near pi, where reading the angle from the matrix trace
+    loses accuracy because sin(omega) goes to zero.
 
     Parameters
     ----------
@@ -279,7 +395,15 @@ def so3_log_map(rotations: torch.Tensor) -> torch.Tensor:
     Returns
     -------
     torch.Tensor
-        Tangent vectors of shape `(..., 3)` whose norm lies in ``[0, pi]``.
+        Tangent vectors of shape `(..., 3)` whose norm lies in `[0, pi]`.
+
+    Examples
+    --------
+    >>> import torch
+    >>> R = torch.eye(3)
+    >>> w = so3_log_map(R)
+    >>> torch.allclose(w, torch.zeros(3))
+    True
     """
     m00 = rotations[..., 0, 0]
     m11 = rotations[..., 1, 1]

--- a/deepchem/models/torch_models/rfdiffusion_losses.py
+++ b/deepchem/models/torch_models/rfdiffusion_losses.py
@@ -1,0 +1,399 @@
+"""All-atom loss functions for RFDiffusion All-Atom.
+
+These are the loss terms RFdiffusion All-Atom-style training adds on top
+of the backbone-only diffusion objective once side-chain and/or ligand
+atoms are involved [Krishna2024]_, [Watson2023]_:
+
+- :func:`frame_aligned_point_error` -- the FAPE loss from AlphaFold2
+  [Jumper2021]_ (Algorithm 21): compares predicted and true atom
+  positions after expressing both in every local residue/ligand frame,
+  so the loss is invariant to any global rigid motion.
+- :func:`dihedral_angle` / :func:`chi_angle_loss` -- a generic 4-atom
+  dihedral angle and a masked loss between predicted and true dihedrals,
+  usable for side-chain chi angles once 4 atom positions defining that
+  angle are available.
+- :func:`ligand_clash_loss` -- a soft steric-clash penalty between atom
+  pairs that are closer than the sum of their van der Waals radii.
+- :func:`masked_all_atom_l2_loss` -- a plain masked coordinate loss for
+  supervising individual atom positions directly.
+
+These functions take frames/coordinates as plain tensors rather than
+assuming a specific atom14-style per-residue-type atom ordering. RFdiffusion
+All-Atom's own reference implementation hardcodes chi-angle atom indices
+per amino acid against its internal atom ordering; DeepChem's RFdiffusion
+stack does not yet have a full-atom (side-chain) protein representation to
+match that ordering against; see [Krishna2024]_ for how that mapping
+would need to be sourced once one exists. Every function here is
+otherwise the same closed-form math as the reference.
+
+References
+----------
+.. [Jumper2021] Jumper, J., et al. "Highly accurate protein structure
+   prediction with AlphaFold." Nature 596 (2021) 583-589.
+.. [Krishna2024] Krishna, R., et al. "Generalized biomolecular modeling
+   and design with RoseTTAFold All-Atom." Science 384 (2024) eadl2528.
+.. [Watson2023] Watson, J. L., et al. "De novo design of protein
+   structure and function with RFdiffusion." Nature 620 (2023) 1089-1100.
+
+Notes
+-----
+This module requires PyTorch to be installed.
+"""
+
+from typing import Dict, Optional
+
+try:
+    import torch
+except ModuleNotFoundError:
+    raise ImportError('rfdiffusion_losses requires PyTorch to be installed.')
+
+__all__ = [
+    'DEFAULT_VDW_RADII',
+    'chi_angle_loss',
+    'dihedral_angle',
+    'frame_aligned_point_error',
+    'ligand_clash_loss',
+    'masked_all_atom_l2_loss',
+    'vdw_radii_from_symbols',
+]
+
+# Bondi van der Waals radii (Angstrom) for elements common in proteins
+# and drug-like ligands [Bondi1964]_. Anything not listed falls back to
+# the carbon radius, a reasonable default for an unlisted heavy atom.
+#
+# .. [Bondi1964] Bondi, A. "van der Waals Volumes and Radii." J. Phys.
+#    Chem. 68 (1964) 441-451.
+DEFAULT_VDW_RADII: Dict[str, float] = {
+    'H': 1.20,
+    'C': 1.70,
+    'N': 1.55,
+    'O': 1.52,
+    'F': 1.47,
+    'P': 1.80,
+    'S': 1.80,
+    'Cl': 1.75,
+    'Br': 1.85,
+    'I': 1.98,
+}
+_DEFAULT_FALLBACK_RADIUS = DEFAULT_VDW_RADII['C']
+
+
+def vdw_radii_from_symbols(symbols) -> torch.Tensor:
+    """Look up Bondi van der Waals radii for a sequence of element symbols.
+
+    Parameters
+    ----------
+    symbols : sequence of str
+        Element symbols, e.g. ``['C', 'C', 'O', 'N']``.
+
+    Returns
+    -------
+    torch.Tensor
+        Float tensor of shape ``(len(symbols),)`` with each atom's van
+        der Waals radius in Angstrom. Unrecognized symbols fall back to
+        the carbon radius.
+
+    Examples
+    --------
+    >>> from deepchem.models.torch_models.rfdiffusion_losses import (
+    ...     vdw_radii_from_symbols)
+    >>> [round(r, 2) for r in vdw_radii_from_symbols(['C', 'O', 'H']).tolist()]
+    [1.7, 1.52, 1.2]
+    """
+    return torch.tensor(
+        [DEFAULT_VDW_RADII.get(s, _DEFAULT_FALLBACK_RADIUS) for s in symbols],
+        dtype=torch.float32)
+
+
+def frame_aligned_point_error(pred_rotations: torch.Tensor,
+                              pred_translations: torch.Tensor,
+                              true_rotations: torch.Tensor,
+                              true_translations: torch.Tensor,
+                              pred_positions: torch.Tensor,
+                              true_positions: torch.Tensor,
+                              frame_mask: Optional[torch.Tensor] = None,
+                              position_mask: Optional[torch.Tensor] = None,
+                              length_scale: float = 10.0,
+                              clamp_distance: Optional[float] = 10.0,
+                              eps: float = 1e-8) -> torch.Tensor:
+    """Frame Aligned Point Error (FAPE) [Jumper2021]_ Algorithm 21.
+
+    For every (frame, point) pair, both the predicted and the true point
+    are expressed in that frame's local coordinates -- ``R^T (x - t)``,
+    the same convention as
+    :func:`~deepchem.models.torch_models.rfdiffusion_frames.apply_inverse_rigid`
+    -- and the Euclidean distance between the two local positions is
+    averaged over every unmasked (frame, point) pair. Expressing points
+    locally before comparing them makes the loss invariant to any global
+    rigid motion applied equally to the predicted and true structures.
+
+    Parameters
+    ----------
+    pred_rotations : torch.Tensor
+        Predicted frame rotations, shape ``(..., F, 3, 3)``.
+    pred_translations : torch.Tensor
+        Predicted frame origins, shape ``(..., F, 3)``.
+    true_rotations : torch.Tensor
+        Ground-truth frame rotations, shape ``(..., F, 3, 3)``.
+    true_translations : torch.Tensor
+        Ground-truth frame origins, shape ``(..., F, 3)``.
+    pred_positions : torch.Tensor
+        Predicted atom positions, shape ``(..., P, 3)``.
+    true_positions : torch.Tensor
+        Ground-truth atom positions, shape ``(..., P, 3)``.
+    frame_mask : torch.Tensor, optional
+        Validity mask over frames, shape ``(..., F)``.
+    position_mask : torch.Tensor, optional
+        Validity mask over points, shape ``(..., P)``.
+    length_scale : float, default 10.0
+        Distances are divided by this value (Angstrom) before averaging,
+        matching AlphaFold2's ``Z = 10`` normalization.
+    clamp_distance : float, optional, default 10.0
+        If given, per-pair distances are clamped to this value
+        (Angstrom) before normalization, so a handful of very wrong
+        points cannot dominate the loss. Pass ``None`` to disable
+        clamping.
+    eps : float, default 1e-8
+        Numerical stability constant for the mask normalization.
+
+    Returns
+    -------
+    torch.Tensor
+        FAPE loss, shape equal to the leading batch shape of the inputs
+        (scalar if there is no batch dimension).
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_frames import (
+    ...     make_identity_rigid)
+    >>> from deepchem.models.torch_models.rfdiffusion_losses import (
+    ...     frame_aligned_point_error)
+    >>> R, t = make_identity_rigid((2,))
+    >>> points = torch.randn(5, 3)
+    >>> loss = frame_aligned_point_error(R, t, R, t, points, points)
+    >>> round(float(loss), 6)
+    0.0
+    """
+    pred_rel = pred_positions.unsqueeze(-3) - pred_translations.unsqueeze(-2)
+    pred_local = torch.matmul(pred_rel.unsqueeze(-2),
+                              pred_rotations.unsqueeze(-3)).squeeze(-2)
+    true_rel = true_positions.unsqueeze(-3) - true_translations.unsqueeze(-2)
+    true_local = torch.matmul(true_rel.unsqueeze(-2),
+                              true_rotations.unsqueeze(-3)).squeeze(-2)
+
+    distances = (pred_local - true_local).norm(dim=-1)  # (..., F, P)
+    if clamp_distance is not None:
+        distances = distances.clamp(max=clamp_distance)
+    distances = distances / length_scale
+
+    mask = torch.ones_like(distances)
+    if frame_mask is not None:
+        mask = mask * frame_mask.unsqueeze(-1)
+    if position_mask is not None:
+        mask = mask * position_mask.unsqueeze(-2)
+
+    denom = mask.sum(dim=(-2, -1)).clamp(min=eps)
+    return (distances * mask).sum(dim=(-2, -1)) / denom
+
+
+def dihedral_angle(p0: torch.Tensor,
+                   p1: torch.Tensor,
+                   p2: torch.Tensor,
+                   p3: torch.Tensor,
+                   eps: float = 1e-8) -> torch.Tensor:
+    """Signed dihedral angle defined by four points.
+
+    Parameters
+    ----------
+    p0, p1, p2, p3 : torch.Tensor
+        Points of shape ``(..., 3)``, in order along the dihedral bond
+        p1-p2 (p0 and p3 are the outer substituents).
+    eps : float, default 1e-8
+        Numerical stability constant.
+
+    Returns
+    -------
+    torch.Tensor
+        Signed angle in radians, shape ``(...,)``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_losses import (
+    ...     dihedral_angle)
+    >>> p0 = torch.tensor([1.0, 0.0, 0.0])
+    >>> p1 = torch.tensor([0.0, 0.0, 0.0])
+    >>> p2 = torch.tensor([0.0, 1.0, 0.0])
+    >>> p3 = torch.tensor([1.0, 1.0, 0.0])
+    >>> round(float(dihedral_angle(p0, p1, p2, p3)), 4)
+    0.0
+    """
+    b0 = p0 - p1
+    b1 = p2 - p1
+    b2 = p3 - p2
+    b1n = b1 / b1.norm(dim=-1, keepdim=True).clamp(min=eps)
+    v = b0 - (b0 * b1n).sum(dim=-1, keepdim=True) * b1n
+    w = b2 - (b2 * b1n).sum(dim=-1, keepdim=True) * b1n
+    x = (v * w).sum(dim=-1)
+    y = (torch.linalg.cross(b1n, v, dim=-1) * w).sum(dim=-1)
+    return torch.atan2(y, x)
+
+
+def chi_angle_loss(pred_atoms: torch.Tensor,
+                   true_atoms: torch.Tensor,
+                   mask: Optional[torch.Tensor] = None,
+                   eps: float = 1e-8) -> torch.Tensor:
+    """Masked loss between predicted and true dihedral angles.
+
+    Uses ``1 - cos(delta)`` rather than a squared angle difference so the
+    loss is smooth across the +-pi wraparound: two angles that differ by
+    a full turn contribute zero loss either way, without the usual "which
+    branch of the angle" bookkeeping.
+
+    Parameters
+    ----------
+    pred_atoms : torch.Tensor
+        Four atom positions defining the predicted dihedral, shape
+        ``(..., 4, 3)``.
+    true_atoms : torch.Tensor
+        Four atom positions defining the true dihedral, shape
+        ``(..., 4, 3)``.
+    mask : torch.Tensor, optional
+        Validity mask, shape matching the leading (batch) dims of
+        ``pred_atoms`` / ``true_atoms`` (everything but the last two
+        axes).
+    eps : float, default 1e-8
+        Numerical stability constant for the mask normalization.
+
+    Returns
+    -------
+    torch.Tensor
+        Scalar masked-mean loss (or plain mean if ``mask`` is ``None``).
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_losses import (
+    ...     chi_angle_loss)
+    >>> atoms = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0],
+    ...                       [0.0, 1.0, 0.0], [-1.0, 1.0, 0.0]])
+    >>> loss = chi_angle_loss(atoms.unsqueeze(0), atoms.unsqueeze(0))
+    >>> round(float(loss), 6)
+    0.0
+    """
+    pred_angle = dihedral_angle(pred_atoms[..., 0, :], pred_atoms[..., 1, :],
+                                pred_atoms[..., 2, :], pred_atoms[...,
+                                                                  3, :], eps)
+    true_angle = dihedral_angle(true_atoms[..., 0, :], true_atoms[..., 1, :],
+                                true_atoms[..., 2, :], true_atoms[...,
+                                                                  3, :], eps)
+    loss = 1.0 - torch.cos(pred_angle - true_angle)
+    if mask is not None:
+        denom = mask.sum().clamp(min=eps)
+        return (loss * mask).sum() / denom
+    return loss.mean()
+
+
+def ligand_clash_loss(coords: torch.Tensor,
+                      radii: torch.Tensor,
+                      mask: Optional[torch.Tensor] = None,
+                      tolerance: float = 0.4,
+                      eps: float = 1e-8) -> torch.Tensor:
+    """Soft steric-clash penalty between atom pairs.
+
+    Penalizes atom pairs whose distance is smaller than the sum of their
+    van der Waals radii minus a small tolerance, with a squared penalty
+    on the amount of overlap. This is a simplified, directly
+    differentiable stand-in for the full Lennard-Jones potential
+    RFdiffusion All-Atom uses internally [Krishna2024]_ -- it captures
+    the same "penalize atoms that are too close" idea without the
+    attractive well or custom backward pass of a full LJ term.
+
+    Parameters
+    ----------
+    coords : torch.Tensor
+        Atom coordinates, shape ``(..., N, 3)``.
+    radii : torch.Tensor
+        Per-atom van der Waals radii in the same units as ``coords``
+        (Angstrom), shape ``(..., N)`` or broadcastable to it. See
+        :func:`vdw_radii_from_symbols` for a convenience lookup.
+    mask : torch.Tensor, optional
+        Atom validity mask, shape ``(..., N)``.
+    tolerance : float, default 0.4
+        Overlap (Angstrom) allowed before a pair starts being penalized.
+    eps : float, default 1e-8
+        Numerical stability constant.
+
+    Returns
+    -------
+    torch.Tensor
+        Mean squared clash penalty over unmasked, non-self atom pairs,
+        shape equal to the leading batch shape of ``coords``.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_losses import (
+    ...     ligand_clash_loss)
+    >>> coords = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+    >>> radii = torch.tensor([1.7, 1.7])
+    >>> loss = ligand_clash_loss(coords, radii)
+    >>> round(float(loss), 6)
+    0.0
+    """
+    n = coords.shape[-2]
+    diff = coords.unsqueeze(-2) - coords.unsqueeze(-3)  # (..., N, N, 3)
+    dist = diff.norm(dim=-1).clamp(min=eps)
+
+    radii_sum = radii.unsqueeze(-1) + radii.unsqueeze(-2)
+    violation = (radii_sum - tolerance - dist).clamp(min=0.0)
+
+    not_self = ~torch.eye(n, dtype=torch.bool, device=coords.device)
+    pair_mask = not_self.to(dist.dtype).expand_as(dist).clone()
+    if mask is not None:
+        pair_mask = pair_mask * mask.unsqueeze(-1) * mask.unsqueeze(-2)
+
+    denom = pair_mask.sum(dim=(-2, -1)).clamp(min=eps)
+    return ((violation**2) * pair_mask).sum(dim=(-2, -1)) / denom
+
+
+def masked_all_atom_l2_loss(pred_coords: torch.Tensor,
+                            true_coords: torch.Tensor,
+                            mask: Optional[torch.Tensor] = None,
+                            eps: float = 1e-8) -> torch.Tensor:
+    """Masked mean squared distance between predicted and true atoms.
+
+    Parameters
+    ----------
+    pred_coords : torch.Tensor
+        Predicted atom coordinates, shape ``(..., N, 3)``.
+    true_coords : torch.Tensor
+        True atom coordinates, shape ``(..., N, 3)``.
+    mask : torch.Tensor, optional
+        Atom validity mask, shape ``(..., N)``.
+    eps : float, default 1e-8
+        Numerical stability constant for the mask normalization.
+
+    Returns
+    -------
+    torch.Tensor
+        Masked-mean squared error, shape equal to the leading batch
+        shape of the inputs.
+
+    Examples
+    --------
+    >>> import torch
+    >>> from deepchem.models.torch_models.rfdiffusion_losses import (
+    ...     masked_all_atom_l2_loss)
+    >>> pred = torch.zeros(4, 3)
+    >>> true = torch.ones(4, 3)
+    >>> mask = torch.tensor([1.0, 1.0, 0.0, 0.0])
+    >>> float(masked_all_atom_l2_loss(pred, true, mask))
+    3.0
+    """
+    squared_error = ((pred_coords - true_coords)**2).sum(dim=-1)  # (..., N)
+    if mask is not None:
+        denom = mask.sum(dim=-1).clamp(min=eps)
+        return (squared_error * mask).sum(dim=-1) / denom
+    return squared_error.mean(dim=-1)

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_frames.py
@@ -1,0 +1,269 @@
+"""Tests for RFDiffusion rigid-frame math utilities."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+if has_torch:
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        apply_inverse_rigid,
+        apply_rigid,
+        build_backbone_frames,
+        compose_rigids,
+        invert_rigid,
+        make_identity_rigid,
+        so3_exp_map,
+        so3_log_map,
+    )
+
+
+def _random_rotation(device=None, dtype=torch.float32, generator=None):
+    matrix = torch.randn(3, 3, device=device, dtype=dtype, generator=generator)
+    q_matrix, r_matrix = torch.linalg.qr(matrix)
+    signs = torch.sign(torch.diagonal(r_matrix))
+    signs = torch.where(signs == 0, torch.ones_like(signs), signs)
+    q_matrix = q_matrix @ torch.diag(signs)
+    if torch.det(q_matrix) < 0:
+        q_matrix[:, -1] = -q_matrix[:, -1]
+    return q_matrix
+
+
+def _make_backbone(batch_size=2, seq_len=5, dtype=torch.float32, seed=0):
+    generator = torch.Generator().manual_seed(seed)
+    base = torch.tensor([[-1.2, 1.1, 0.0], [0.0, 0.0, 0.0], [1.5, 0.0, 0.0]],
+                        dtype=dtype)
+    offsets = torch.randn(batch_size,
+                          seq_len,
+                          1,
+                          3,
+                          dtype=dtype,
+                          generator=generator)
+    return base.view(1, 1, 3, 3) + offsets
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestRigidFrameUtilities:
+
+    def test_frames_are_orthonormal_and_right_handed(self):
+        backbone = _make_backbone(batch_size=3, seq_len=7)
+        rotations, translations = build_backbone_frames(backbone)
+        assert rotations.shape == (3, 7, 3, 3)
+        assert translations.shape == (3, 7, 3)
+        gram = rotations.transpose(-1, -2) @ rotations
+        identity = torch.eye(3).expand_as(gram)
+        assert torch.allclose(gram, identity, atol=1e-5)
+        det = torch.det(rotations)
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+
+    def test_translation_is_alpha_carbon(self):
+        backbone = _make_backbone()
+        _, translations = build_backbone_frames(backbone)
+        assert torch.allclose(translations, backbone[..., 1, :], atol=0.0)
+
+    def test_frames_match_canonical_residue(self):
+        backbone = torch.tensor([[[-1.0, 1.0, 0.0], [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        rotations, translations = build_backbone_frames(backbone)
+        assert torch.allclose(rotations, torch.eye(3).unsqueeze(0), atol=1e-6)
+        assert torch.allclose(translations, torch.zeros(1, 3), atol=0.0)
+
+    def test_frames_match_upstream_epsilon_normalization(self):
+        backbone = torch.tensor(
+            [[[[-1.1, 0.9, 0.2], [0.2, -0.3, 0.4], [1.4, 0.1, -0.2]]]],
+            dtype=torch.float64)
+        rotations, translations = build_backbone_frames(backbone, eps=1e-8)
+        n_atom = backbone[..., 0, :]
+        ca_atom = backbone[..., 1, :]
+        c_atom = backbone[..., 2, :]
+        e1 = c_atom - ca_atom
+        e1 = e1 / (torch.linalg.norm(e1, dim=-1, keepdim=True) + 1e-8)
+        v2 = n_atom - ca_atom
+        u2 = v2 - (e1 * v2).sum(dim=-1, keepdim=True) * e1
+        e2 = u2 / (torch.linalg.norm(u2, dim=-1, keepdim=True) + 1e-8)
+        e3 = torch.cross(e1, e2, dim=-1)
+        expected = torch.stack([e1, e2, e3], dim=-1)
+        assert torch.allclose(rotations, expected, atol=0.0, rtol=0.0)
+        assert torch.allclose(translations, ca_atom, atol=0.0, rtol=0.0)
+
+    def test_frames_handle_small_n_ca_c_angle(self):
+        backbone = torch.tensor([[[1.0, 1e-3, 0.0], [0.0, 0.0, 0.0],
+                                  [1.0, 0.0, 0.0]]])
+        rotations, _ = build_backbone_frames(backbone)
+        gram = rotations.transpose(-1, -2) @ rotations
+        assert torch.isfinite(rotations).all()
+        assert torch.allclose(gram, torch.eye(3).unsqueeze(0), atol=3e-5)
+
+    def test_frames_se3_equivariance(self):
+        backbone = _make_backbone(seed=11)
+        rotations, translations = build_backbone_frames(backbone)
+        global_rotation = _random_rotation()
+        global_translation = torch.randn(3)
+        moved = apply_rigid(global_rotation, global_translation, backbone)
+        rotations_moved, translations_moved = build_backbone_frames(moved)
+        assert torch.allclose(rotations_moved,
+                              global_rotation @ rotations,
+                              atol=1e-5)
+        expected_t = apply_rigid(global_rotation, global_translation,
+                                 translations)
+        assert torch.allclose(translations_moved, expected_t, atol=1e-5)
+
+    def test_frames_raise_on_bad_shape(self):
+        with pytest.raises(ValueError, match=r"\(\.\.\., 3, 3\)"):
+            build_backbone_frames(torch.zeros(2, 5, 3))
+
+    def test_frames_raise_on_nonpositive_eps(self):
+        backbone = _make_backbone()
+        with pytest.raises(ValueError, match="eps"):
+            build_backbone_frames(backbone, eps=0.0)
+
+    def test_make_identity_rigid_shape_and_values(self):
+        rotations, translations = make_identity_rigid((4, 3))
+        assert rotations.shape == (4, 3, 3, 3)
+        assert translations.shape == (4, 3, 3)
+        identity = torch.eye(3).expand_as(rotations)
+        assert torch.equal(rotations, identity)
+        assert torch.equal(translations, torch.zeros_like(translations))
+
+    def test_make_identity_rigid_returns_writable_tensor(self):
+        rotations, _ = make_identity_rigid((4, 3))
+        rotations[0, 0, 0, 0] = 99.0
+        assert rotations[0, 0, 0, 0].item() == 99.0
+        assert rotations[0, 1, 0, 0].item() == 1.0
+
+    def test_apply_rigid_inverse_roundtrip(self):
+        backbone = _make_backbone()
+        rotations, translations = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(rotations, translations, backbone)
+        recovered = apply_rigid(rotations, translations, local)
+        assert torch.allclose(recovered, backbone, atol=1e-5)
+
+    def test_apply_rigid_broadcasts_over_extra_dims(self):
+        rotations, translations = make_identity_rigid((2, 3))
+        rotations = rotations.clone()
+        for batch_idx in range(2):
+            for seq_idx in range(3):
+                rotations[batch_idx, seq_idx] = _random_rotation()
+        translations = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 4, 5, 3)
+        moved = apply_rigid(rotations, translations, points)
+        expected = torch.einsum("blij,blkmj->blkmi", rotations, points)
+        expected = expected + translations.view(2, 3, 1, 1, 3)
+        assert moved.shape == points.shape
+        assert torch.allclose(moved, expected, atol=1e-5)
+
+    def test_apply_rigid_translation_only(self):
+        rotations, _ = make_identity_rigid((2, 5))
+        translations = torch.randn(2, 5, 3)
+        points = torch.randn(2, 5, 3)
+        assert torch.allclose(apply_rigid(rotations, translations, points),
+                              points + translations,
+                              atol=1e-6)
+
+    def test_apply_rigid_raises_on_too_few_point_dims(self):
+        rotations, translations = make_identity_rigid((2, 3))
+        bad = torch.randn(3)
+        with pytest.raises(ValueError, match="at least"):
+            apply_rigid(rotations, translations, bad)
+
+    def test_invert_rigid_is_left_and_right_inverse(self):
+        backbone = _make_backbone()
+        rotations, translations = build_backbone_frames(backbone)
+        inv_rotations, inv_translations = invert_rigid(rotations, translations)
+        left_r, left_t = compose_rigids(inv_rotations, inv_translations,
+                                        rotations, translations)
+        right_r, right_t = compose_rigids(rotations, translations,
+                                          inv_rotations, inv_translations)
+        assert torch.allclose(left_r, torch.eye(3).expand_as(left_r), atol=1e-5)
+        assert torch.allclose(left_t, torch.zeros_like(left_t), atol=1e-5)
+        assert torch.allclose(right_r,
+                              torch.eye(3).expand_as(right_r),
+                              atol=1e-5)
+        assert torch.allclose(right_t, torch.zeros_like(right_t), atol=1e-5)
+
+    def test_compose_matches_sequential_application(self):
+        rotations_a = torch.stack([_random_rotation() for _ in range(6)])
+        rotations_a = rotations_a.view(2, 3, 3, 3)
+        rotations_b = torch.stack([_random_rotation() for _ in range(6)])
+        rotations_b = rotations_b.view(2, 3, 3, 3)
+        translations_a = torch.randn(2, 3, 3)
+        translations_b = torch.randn(2, 3, 3)
+        points = torch.randn(2, 3, 7, 3)
+
+        sequential = apply_rigid(
+            rotations_a, translations_a,
+            apply_rigid(rotations_b, translations_b, points))
+        rotations, translations = compose_rigids(rotations_a, translations_a,
+                                                 rotations_b, translations_b)
+        composed = apply_rigid(rotations, translations, points)
+        assert torch.allclose(composed, sequential, atol=1e-5)
+
+    def test_compose_is_associative(self):
+        rotations = [_random_rotation() for _ in range(3)]
+        translations = [torch.randn(3) for _ in range(3)]
+        rotation_a, rotation_b, rotation_c = rotations
+        translation_a, translation_b, translation_c = translations
+        left_r, left_t = compose_rigids(
+            *compose_rigids(rotation_a, translation_a, rotation_b,
+                            translation_b), rotation_c, translation_c)
+        right_r, right_t = compose_rigids(
+            rotation_a, translation_a,
+            *compose_rigids(rotation_b, translation_b, rotation_c,
+                            translation_c))
+        assert torch.allclose(left_r, right_r, atol=1e-5)
+        assert torch.allclose(left_t, right_t, atol=1e-5)
+
+    def test_apply_rigid_supports_fp64_precision(self):
+        backbone = _make_backbone(dtype=torch.float64, seed=3)
+        rotations, translations = build_backbone_frames(backbone)
+        local = apply_inverse_rigid(rotations, translations, backbone)
+        recovered = apply_rigid(rotations, translations, local)
+        assert torch.allclose(recovered, backbone, atol=1e-12)
+
+
+@pytest.mark.torch
+@pytest.mark.skipif(not has_torch, reason="PyTorch not installed")
+class TestSO3Maps:
+
+    def test_exp_returns_proper_rotation(self):
+        torch.manual_seed(0)
+        tangent = torch.randn(32, 3) * 0.5
+        rotations = so3_exp_map(tangent)
+        det = torch.det(rotations)
+        ortho_err = (rotations @ rotations.transpose(-1, -2) -
+                     torch.eye(3)).abs().max()
+        assert torch.allclose(det, torch.ones_like(det), atol=1e-5)
+        assert ortho_err < 1e-5
+
+    def test_exp_zero_tangent_gives_identity(self):
+        rotations = so3_exp_map(torch.zeros(4, 3))
+        identity = torch.eye(3).expand(4, 3, 3)
+        assert torch.allclose(rotations, identity, atol=1e-7)
+
+    def test_log_exp_roundtrip_principal_branch(self):
+        torch.manual_seed(1)
+        axis = torch.randn(50, 3)
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        omega = torch.rand(50) * (math.pi - 1e-3) + 1e-4
+        tangent = omega.unsqueeze(-1) * axis
+        recovered = so3_log_map(so3_exp_map(tangent))
+        assert (tangent - recovered).norm(dim=-1).max() < 1e-3
+
+    def test_log_map_stable_near_pi(self):
+        axis = torch.tensor([[0.6, -0.2, 0.7745967]])
+        axis = axis / axis.norm(dim=-1, keepdim=True)
+        tangent = (math.pi - 1e-4) * axis
+        recovered = so3_log_map(so3_exp_map(tangent))
+        assert torch.allclose(recovered, tangent, atol=1e-3)
+
+    def test_small_omega_taylor_branch(self):
+        tangent = torch.tensor([[1e-7, 0.0, 0.0], [0.0, 1e-7, 0.0]])
+        rotations = so3_exp_map(tangent)
+        identity = torch.eye(3).expand_as(rotations)
+        assert (rotations - identity).abs().max() < 1e-6

--- a/deepchem/models/torch_models/tests/test_rfdiffusion_losses.py
+++ b/deepchem/models/torch_models/tests/test_rfdiffusion_losses.py
@@ -1,0 +1,236 @@
+"""Tests for RFDiffusion All-Atom loss functions."""
+
+import math
+
+import pytest
+
+try:
+    import torch
+    from deepchem.models.torch_models.rfdiffusion_frames import (
+        build_backbone_frames, make_identity_rigid)
+    from deepchem.models.torch_models.rfdiffusion_losses import (
+        DEFAULT_VDW_RADII, chi_angle_loss, dihedral_angle,
+        frame_aligned_point_error, ligand_clash_loss, masked_all_atom_l2_loss,
+        vdw_radii_from_symbols)
+    has_torch = True
+except ImportError:
+    has_torch = False
+
+requires_torch = pytest.mark.skipif(not has_torch,
+                                    reason='PyTorch not installed')
+
+
+@pytest.mark.torch
+@requires_torch
+class TestFrameAlignedPointError:
+
+    def test_zero_for_perfect_prediction(self):
+        R, t = make_identity_rigid((3,))
+        points = torch.randn(7, 3)
+        loss = frame_aligned_point_error(R, t, R, t, points, points)
+        assert round(float(loss), 5) == 0.0
+
+    def test_positive_for_wrong_prediction(self):
+        R, t = make_identity_rigid((2,))
+        true_points = torch.zeros(4, 3)
+        pred_points = torch.ones(4, 3)
+        loss = frame_aligned_point_error(R, t, R, t, pred_points, true_points)
+        assert float(loss) > 0.0
+
+    def test_invariant_to_global_rotation(self):
+        torch.manual_seed(0)
+        backbone = torch.randn(1, 3, 3, 3)
+        R, t = build_backbone_frames(backbone)
+        points = torch.randn(1, 5, 3)
+        loss_before = frame_aligned_point_error(R, t, R, t, points, points)
+
+        # Apply the same global rigid motion to everything.
+        rot = build_backbone_frames(torch.randn(1, 1, 3, 3))[0][:,
+                                                                0]  # (1, 3, 3)
+        shift = torch.randn(1, 1, 3)
+        R2 = torch.matmul(rot.unsqueeze(1), R)
+        t2 = torch.matmul(t.unsqueeze(-2), rot.transpose(
+            -1, -2)).squeeze(-2) + shift
+        points2 = torch.matmul(points, rot.transpose(-1, -2)) + shift
+        loss_after = frame_aligned_point_error(R2, t2, R2, t2, points2, points2)
+        assert round(float(loss_before), 4) == round(float(loss_after), 4)
+
+    def test_clamping_bounds_large_errors(self):
+        R, t = make_identity_rigid((1,))
+        true_points = torch.zeros(1, 3)
+        pred_points = torch.tensor([[1000.0, 0.0, 0.0]])
+        clamped = frame_aligned_point_error(R,
+                                            t,
+                                            R,
+                                            t,
+                                            pred_points,
+                                            true_points,
+                                            clamp_distance=5.0)
+        unclamped = frame_aligned_point_error(R,
+                                              t,
+                                              R,
+                                              t,
+                                              pred_points,
+                                              true_points,
+                                              clamp_distance=None)
+        assert float(clamped) < float(unclamped)
+
+    def test_masked_positions_ignored(self):
+        R, t = make_identity_rigid((1,))
+        true_points = torch.zeros(3, 3)
+        pred_points = torch.tensor([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0],
+                                    [50.0, 0.0, 0.0]])
+        mask = torch.tensor([1.0, 1.0, 0.0])
+        loss = frame_aligned_point_error(R,
+                                         t,
+                                         R,
+                                         t,
+                                         pred_points,
+                                         true_points,
+                                         position_mask=mask)
+        assert round(float(loss), 5) == 0.0
+
+
+@pytest.mark.torch
+@requires_torch
+class TestDihedralAngle:
+
+    def test_cis_configuration_is_zero(self):
+        p0 = torch.tensor([1.0, 0.0, 0.0])
+        p1 = torch.tensor([0.0, 0.0, 0.0])
+        p2 = torch.tensor([0.0, 1.0, 0.0])
+        p3 = torch.tensor([1.0, 1.0, 0.0])
+        angle = dihedral_angle(p0, p1, p2, p3)
+        assert round(float(angle), 4) == 0.0
+
+    def test_trans_configuration_is_pi(self):
+        p0 = torch.tensor([1.0, 0.0, 0.0])
+        p1 = torch.tensor([0.0, 0.0, 0.0])
+        p2 = torch.tensor([0.0, 1.0, 0.0])
+        p3 = torch.tensor([-1.0, 1.0, 0.0])
+        angle = dihedral_angle(p0, p1, p2, p3)
+        assert round(abs(float(angle)), 4) == round(math.pi, 4)
+
+    def test_batched_shape(self):
+        p = torch.randn(4, 3)
+        angle = dihedral_angle(p[0], p[1], p[2], p[3])
+        assert angle.shape == ()
+        p_batched = torch.randn(5, 4, 3)
+        angle_batched = dihedral_angle(p_batched[:, 0], p_batched[:, 1],
+                                       p_batched[:, 2], p_batched[:, 3])
+        assert angle_batched.shape == (5,)
+
+
+@pytest.mark.torch
+@requires_torch
+class TestChiAngleLoss:
+
+    def test_zero_for_identical_dihedral(self):
+        atoms = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                              [1.0, 1.0, 0.0]])
+        loss = chi_angle_loss(atoms.unsqueeze(0), atoms.unsqueeze(0))
+        assert round(float(loss), 6) == 0.0
+
+    def test_max_loss_for_opposite_dihedral(self):
+        cis = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                            [1.0, 1.0, 0.0]])
+        trans = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                              [-1.0, 1.0, 0.0]])
+        loss = chi_angle_loss(cis.unsqueeze(0), trans.unsqueeze(0))
+        # 1 - cos(pi) == 2, the maximum of this loss.
+        assert round(float(loss), 4) == 2.0
+
+    def test_mask_zeroes_out_excluded_entries(self):
+        cis = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                            [1.0, 1.0, 0.0]])
+        trans = torch.tensor([[1.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 1.0, 0.0],
+                              [-1.0, 1.0, 0.0]])
+        pred = torch.stack([cis, cis])
+        true = torch.stack([cis, trans])
+        mask = torch.tensor([1.0, 0.0])
+        loss = chi_angle_loss(pred, true, mask=mask)
+        assert round(float(loss), 6) == 0.0
+
+
+@pytest.mark.torch
+@requires_torch
+class TestLigandClashLoss:
+
+    def test_zero_when_far_apart(self):
+        coords = torch.tensor([[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]])
+        radii = torch.tensor([1.7, 1.7])
+        loss = ligand_clash_loss(coords, radii)
+        assert round(float(loss), 6) == 0.0
+
+    def test_positive_when_overlapping(self):
+        coords = torch.tensor([[0.0, 0.0, 0.0], [0.5, 0.0, 0.0]])
+        radii = torch.tensor([1.7, 1.7])
+        loss = ligand_clash_loss(coords, radii)
+        assert float(loss) > 0.0
+
+    def test_self_pairs_excluded(self):
+        # A single atom can never clash with itself.
+        coords = torch.zeros(1, 3)
+        radii = torch.tensor([1.7])
+        loss = ligand_clash_loss(coords, radii)
+        assert round(float(loss), 6) == 0.0
+
+    def test_masked_atoms_excluded(self):
+        coords = torch.tensor([[0.0, 0.0, 0.0], [0.1, 0.0, 0.0],
+                               [20.0, 0.0, 0.0]])
+        radii = torch.tensor([1.7, 1.7, 1.7])
+        mask = torch.tensor([1.0, 0.0, 1.0])  # clashing pair masked out
+        loss = ligand_clash_loss(coords, radii, mask=mask)
+        assert round(float(loss), 6) == 0.0
+
+    def test_tolerance_allows_small_overlap(self):
+        coords = torch.tensor([[0.0, 0.0, 0.0], [3.39, 0.0, 0.0]])
+        radii = torch.tensor([1.7, 1.7])  # sum = 3.4
+        loose = ligand_clash_loss(coords, radii, tolerance=0.4)
+        tight = ligand_clash_loss(coords, radii, tolerance=0.0)
+        assert float(loose) == 0.0
+        assert float(tight) > 0.0
+
+
+@pytest.mark.torch
+@requires_torch
+class TestMaskedAllAtomL2Loss:
+
+    def test_zero_for_perfect_prediction(self):
+        coords = torch.randn(6, 3)
+        loss = masked_all_atom_l2_loss(coords, coords)
+        assert round(float(loss), 6) == 0.0
+
+    def test_known_answer(self):
+        pred = torch.zeros(4, 3)
+        true = torch.ones(4, 3)
+        mask = torch.tensor([1.0, 1.0, 0.0, 0.0])
+        # each unmasked atom contributes ||[-1,-1,-1]||^2 = 3
+        loss = masked_all_atom_l2_loss(pred, true, mask)
+        assert float(loss) == 3.0
+
+    def test_unmasked_matches_plain_mean(self):
+        pred = torch.randn(5, 3)
+        true = torch.randn(5, 3)
+        masked = masked_all_atom_l2_loss(pred, true, torch.ones(5)).item()
+        unmasked = masked_all_atom_l2_loss(pred, true).item()
+        assert round(masked, 5) == round(unmasked, 5)
+
+
+@pytest.mark.torch
+@requires_torch
+class TestVdwRadiiFromSymbols:
+
+    def test_known_elements(self):
+        radii = vdw_radii_from_symbols(['C', 'O', 'N'])
+        assert round(radii[0].item(), 2) == DEFAULT_VDW_RADII['C']
+        assert round(radii[1].item(), 2) == DEFAULT_VDW_RADII['O']
+        assert round(radii[2].item(), 2) == DEFAULT_VDW_RADII['N']
+
+    def test_unknown_element_falls_back_to_carbon(self):
+        radii = vdw_radii_from_symbols(['Xx'])
+        assert round(radii[0].item(), 2) == DEFAULT_VDW_RADII['C']
+
+    def test_empty_list(self):
+        radii = vdw_radii_from_symbols([])
+        assert radii.shape == (0,)

--- a/deepchem/utils/rfdiffusion_ligand.py
+++ b/deepchem/utils/rfdiffusion_ligand.py
@@ -1,0 +1,310 @@
+"""Ligand parsing utilities for RFDiffusion All-Atom conditioning.
+
+Turns an on-disk ligand file (SDF, MOL2, or PDB) into a point cloud of
+atom coordinates plus the per-atom and per-atom-pair features the
+RFdiffusion All-Atom network needs: an element-based atom type, the raw
+atomic number, and a bond-order feature matrix. RDKit is imported lazily
+so the rest of the diffusion stack stays usable without it; parsing
+itself is delegated to :func:`deepchem.utils.rdkit_utils.load_molecule`
+rather than reimplementing file-format handling.
+
+The atom type vocabulary and bond feature convention (bond order 1-3,
+aromatic bonds coded as 4) follow RFdiffusion All-Atom's own
+``rf2aa.chemical.ChemData.frame_priority2atom`` / ``get_bond_feats``
+[Krishna2024]_, so a model trained against these features sees the same
+atom typing scheme the reference implementation uses. Automorphism
+enumeration (:func:`find_ligand_automorphisms`) mirrors
+``rf2aa.util.get_automorphs``: it lists every atom-index permutation that
+maps the ligand onto itself, so a loss can be evaluated against every
+permutation and take the best match instead of penalizing a model for
+correctly generating a symmetric ligand (e.g. a fluorinated ring) with a
+different, but equally valid, atom-index labeling than the reference.
+
+References
+----------
+.. [Krishna2024] Krishna, R., et al. "Generalized biomolecular modeling
+   and design with RoseTTAFold All-Atom." Science 384 (2024) eadl2528.
+"""
+
+from typing import List, Optional
+
+import numpy as np
+
+__all__ = [
+    'LIGAND_ATOM_TYPES',
+    'LigandPointCloud',
+    'parse_ligand_file',
+    'find_ligand_automorphisms',
+]
+
+# Element vocabulary, ordered by RFdiffusion All-Atom's atom "frame
+# priority" list (rf2aa/chemical.py: ChemData.frame_priority2atom), plus
+# the catch-all 'ATM' bucket it uses for anything else. The specific
+# order does not matter for a point-cloud featurization (it is only used
+# as a fixed embedding-table index), but keeping it identical to the
+# reference makes it easy to line features up against upstream code.
+LIGAND_ATOM_TYPES: List[str] = [
+    'F', 'Cl', 'Br', 'I', 'O', 'S', 'Se', 'Te', 'N', 'P', 'As', 'Sb', 'C', 'Si',
+    'Sn', 'Pb', 'B', 'Al', 'Zn', 'Hg', 'Cu', 'Au', 'Ni', 'Pd', 'Pt', 'Co', 'Rh',
+    'Ir', 'Pr', 'Fe', 'Ru', 'Os', 'Mn', 'Re', 'Cr', 'Mo', 'W', 'V', 'U', 'Tb',
+    'Y', 'Be', 'Mg', 'Ca', 'Li', 'K', 'ATM'
+]
+_ATOM_TYPE_TO_INDEX = {t: i for i, t in enumerate(LIGAND_ATOM_TYPES)}
+_UNKNOWN_ATOM_TYPE_INDEX = _ATOM_TYPE_TO_INDEX['ATM']
+
+
+class LigandPointCloud:
+    """Point-cloud representation of a parsed ligand.
+
+    Parameters
+    ----------
+    coords : numpy.ndarray
+        Atom Cartesian coordinates, shape ``(N, 3)``.
+    atom_types : numpy.ndarray
+        Integer index into :data:`LIGAND_ATOM_TYPES` for each atom, shape
+        ``(N,)``.
+    atomic_numbers : numpy.ndarray
+        Raw atomic number for each atom, shape ``(N,)``.
+    bond_features : numpy.ndarray
+        Symmetric integer bond-order matrix, shape ``(N, N)``: 0 for no
+        bond, 1/2/3 for single/double/triple, 4 for aromatic.
+    name : str, optional
+        Optional identifier (e.g. the source file path) kept for
+        bookkeeping only.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from deepchem.utils.rfdiffusion_ligand import LigandPointCloud
+    >>> coords = np.zeros((2, 3), dtype=np.float32)
+    >>> atom_types = np.array([4, 12])  # O, C
+    >>> atomic_numbers = np.array([8, 6])
+    >>> bonds = np.array([[0, 1], [1, 0]])
+    >>> ligand = LigandPointCloud(coords, atom_types, atomic_numbers, bonds)
+    >>> ligand.num_atoms
+    2
+    """
+
+    def __init__(self,
+                 coords: np.ndarray,
+                 atom_types: np.ndarray,
+                 atomic_numbers: np.ndarray,
+                 bond_features: np.ndarray,
+                 name: Optional[str] = None) -> None:
+        coords = np.asarray(coords, dtype=np.float32)
+        atom_types = np.asarray(atom_types, dtype=np.int64)
+        atomic_numbers = np.asarray(atomic_numbers, dtype=np.int64)
+        bond_features = np.asarray(bond_features, dtype=np.int64)
+
+        if coords.ndim != 2 or coords.shape[1] != 3:
+            raise ValueError(f'coords must have shape (N, 3), got '
+                             f'{coords.shape}.')
+        n = coords.shape[0]
+        if atom_types.shape != (n,):
+            raise ValueError(f'atom_types must have shape ({n},), got '
+                             f'{atom_types.shape}.')
+        if atomic_numbers.shape != (n,):
+            raise ValueError(f'atomic_numbers must have shape ({n},), got '
+                             f'{atomic_numbers.shape}.')
+        if bond_features.shape != (n, n):
+            raise ValueError(f'bond_features must have shape ({n}, {n}), '
+                             f'got {bond_features.shape}.')
+
+        self.coords = coords
+        self.atom_types = atom_types
+        self.atomic_numbers = atomic_numbers
+        self.bond_features = bond_features
+        self.name = name
+
+    @property
+    def num_atoms(self) -> int:
+        """Number of atoms in the point cloud."""
+        return self.coords.shape[0]
+
+
+def _element_to_type_index(symbol: str) -> int:
+    """Map an element symbol to its :data:`LIGAND_ATOM_TYPES` index."""
+    return _ATOM_TYPE_TO_INDEX.get(symbol, _UNKNOWN_ATOM_TYPE_INDEX)
+
+
+def _bond_feature_matrix(mol) -> np.ndarray:
+    """Build the ``(N, N)`` bond-order feature matrix for an RDKit mol."""
+    n = mol.GetNumAtoms()
+    feats = np.zeros((n, n), dtype=np.int64)
+    for bond in mol.GetBonds():
+        i, j = bond.GetBeginAtomIdx(), bond.GetEndAtomIdx()
+        order = 4 if bond.GetIsAromatic() else int(bond.GetBondTypeAsDouble())
+        feats[i, j] = order
+        feats[j, i] = order
+    return feats
+
+
+def parse_ligand_file(molecule_file: str,
+                      remove_hydrogens: bool = True) -> LigandPointCloud:
+    """Parse a ligand file into a :class:`LigandPointCloud`.
+
+    Supports the same file types as
+    :func:`deepchem.utils.rdkit_utils.load_molecule` (SDF, MOL2, PDB,
+    PDBQT), which this function calls to do the actual file parsing.
+
+    Parameters
+    ----------
+    molecule_file : str
+        Path to a ligand file. The format is inferred from the file
+        extension.
+    remove_hydrogens : bool, default True
+        Whether to strip explicit hydrogens before building the point
+        cloud, matching RFdiffusion All-Atom's default ligand
+        preprocessing.
+
+    Returns
+    -------
+    LigandPointCloud
+        Parsed atom coordinates, types, atomic numbers, and bond
+        features.
+
+    Raises
+    ------
+    ImportError
+        If RDKit is not installed.
+    ValueError
+        If the file cannot be parsed, or the parsed molecule has no 3-D
+        conformer.
+
+    Examples
+    --------
+    >>> from rdkit import Chem
+    >>> from rdkit.Chem import AllChem
+    >>> import tempfile, os
+    >>> from deepchem.utils.rfdiffusion_ligand import parse_ligand_file
+    >>> mol = Chem.AddHs(Chem.MolFromSmiles('CCO'))
+    >>> _ = AllChem.EmbedMolecule(mol, randomSeed=0)
+    >>> path = os.path.join(tempfile.mkdtemp(), 'ethanol.sdf')
+    >>> writer = Chem.SDWriter(path)
+    >>> writer.write(mol)
+    >>> writer.close()
+    >>> ligand = parse_ligand_file(path)
+    >>> ligand.num_atoms
+    3
+    >>> sorted(ligand.atomic_numbers.tolist())
+    [6, 6, 8]
+    """
+    try:
+        from rdkit import Chem
+    except ImportError:
+        raise ImportError('parse_ligand_file requires RDKit to be '
+                          'installed (pip install rdkit).')
+
+    from deepchem.utils.rdkit_utils import load_molecule
+
+    _, mol = load_molecule(molecule_file,
+                           add_hydrogens=False,
+                           calc_charges=False,
+                           sanitize=True)
+    if mol is None:
+        raise ValueError(f'Could not parse ligand file: {molecule_file}')
+    if remove_hydrogens:
+        mol = Chem.RemoveHs(mol)
+    if mol.GetNumConformers() == 0:
+        raise ValueError(
+            f'Parsed molecule from {molecule_file} has no 3-D conformer.')
+
+    conf = mol.GetConformer()
+    coords = np.array(
+        [conf.GetAtomPosition(i) for i in range(mol.GetNumAtoms())],
+        dtype=np.float32)
+    atomic_numbers = np.array([a.GetAtomicNum() for a in mol.GetAtoms()],
+                              dtype=np.int64)
+    atom_types = np.array(
+        [_element_to_type_index(a.GetSymbol()) for a in mol.GetAtoms()],
+        dtype=np.int64)
+    bond_features = _bond_feature_matrix(mol)
+
+    return LigandPointCloud(coords,
+                            atom_types,
+                            atomic_numbers,
+                            bond_features,
+                            name=molecule_file)
+
+
+def find_ligand_automorphisms(molecule_file: str,
+                              remove_hydrogens: bool = True,
+                              max_matches: int = 1000) -> np.ndarray:
+    """Enumerate graph-automorphism atom permutations for a ligand.
+
+    Two atoms are interchangeable under a permutation exactly when
+    swapping them maps the molecular graph onto itself (e.g. the two
+    fluorines of a -CF2- group, or the six carbons of an unsubstituted
+    benzene ring). Comparing a generated ligand against every such
+    permutation and keeping the best-matching one, instead of a single
+    fixed atom ordering, is what
+    :func:`~deepchem.models.torch_models.rfdiffusion_losses.masked_all_atom_l2_loss`
+    and the other losses in this module are meant to be combined with
+    for symmetric ligands. Mirrors ``rf2aa.util.get_automorphs``.
+
+    Parameters
+    ----------
+    molecule_file : str
+        Path to a ligand file, as accepted by :func:`parse_ligand_file`.
+    remove_hydrogens : bool, default True
+        Whether to strip explicit hydrogens before enumerating
+        automorphisms, matching :func:`parse_ligand_file`.
+    max_matches : int, default 1000
+        Upper bound on the number of automorphisms to enumerate, to keep
+        highly symmetric ligands (e.g. long unsubstituted chains) from
+        producing combinatorially many permutations.
+
+    Returns
+    -------
+    numpy.ndarray
+        Integer array of shape ``(num_automorphisms, num_atoms)``. Row 0
+        is always the identity permutation.
+
+    Raises
+    ------
+    ImportError
+        If RDKit is not installed.
+
+    Examples
+    --------
+    >>> from rdkit import Chem
+    >>> from rdkit.Chem import AllChem
+    >>> import tempfile, os
+    >>> from deepchem.utils.rfdiffusion_ligand import (
+    ...     find_ligand_automorphisms)
+    >>> mol = Chem.AddHs(Chem.MolFromSmiles('c1ccccc1'))  # benzene
+    >>> _ = AllChem.EmbedMolecule(mol, randomSeed=0)
+    >>> path = os.path.join(tempfile.mkdtemp(), 'benzene.sdf')
+    >>> writer = Chem.SDWriter(path)
+    >>> writer.write(mol)
+    >>> writer.close()
+    >>> perms = find_ligand_automorphisms(path)
+    >>> perms.shape[1]
+    6
+    >>> perms.shape[0] > 1
+    True
+    """
+    try:
+        from rdkit import Chem
+    except ImportError:
+        raise ImportError('find_ligand_automorphisms requires RDKit to be '
+                          'installed (pip install rdkit).')
+
+    from deepchem.utils.rdkit_utils import load_molecule
+
+    _, mol = load_molecule(molecule_file,
+                           add_hydrogens=False,
+                           calc_charges=False,
+                           sanitize=True)
+    if mol is None:
+        raise ValueError(f'Could not parse ligand file: {molecule_file}')
+    if remove_hydrogens:
+        mol = Chem.RemoveHs(mol)
+
+    matches = mol.GetSubstructMatches(mol,
+                                      uniquify=False,
+                                      useChirality=True,
+                                      maxMatches=max_matches)
+    if not matches:
+        matches = (tuple(range(mol.GetNumAtoms())),)
+    return np.array(matches, dtype=np.int64)

--- a/deepchem/utils/test/test_rfdiffusion_ligand.py
+++ b/deepchem/utils/test/test_rfdiffusion_ligand.py
@@ -1,0 +1,171 @@
+"""Tests for RFDiffusion All-Atom ligand parsing utilities."""
+
+import numpy as np
+import pytest
+
+try:
+    from rdkit import Chem
+    from rdkit.Chem import AllChem
+    has_rdkit = True
+except ImportError:
+    has_rdkit = False
+
+from deepchem.utils.rfdiffusion_ligand import (LIGAND_ATOM_TYPES,
+                                               LigandPointCloud,
+                                               find_ligand_automorphisms,
+                                               parse_ligand_file)
+
+requires_rdkit = pytest.mark.skipif(not has_rdkit, reason='RDKit not installed')
+
+
+def _write_sdf(smiles, path, seed=0):
+    mol = Chem.AddHs(Chem.MolFromSmiles(smiles))
+    AllChem.EmbedMolecule(mol, randomSeed=seed)
+    writer = Chem.SDWriter(path)
+    writer.write(mol)
+    writer.close()
+    return mol
+
+
+class TestLigandPointCloud:
+
+    def test_valid_construction(self):
+        coords = np.zeros((3, 3), dtype=np.float32)
+        atom_types = np.array([0, 1, 2])
+        atomic_numbers = np.array([6, 7, 8])
+        bonds = np.zeros((3, 3), dtype=np.int64)
+        ligand = LigandPointCloud(coords, atom_types, atomic_numbers, bonds)
+        assert ligand.num_atoms == 3
+
+    def test_name_stored(self):
+        coords = np.zeros((1, 3), dtype=np.float32)
+        ligand = LigandPointCloud(coords,
+                                  np.array([0]),
+                                  np.array([6]),
+                                  np.zeros((1, 1)),
+                                  name='foo.sdf')
+        assert ligand.name == 'foo.sdf'
+
+    def test_bad_coords_shape_raises(self):
+        with pytest.raises(ValueError):
+            LigandPointCloud(np.zeros((3, 2)), np.zeros(3), np.zeros(3),
+                             np.zeros((3, 3)))
+
+    def test_atom_types_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            LigandPointCloud(np.zeros((3, 3)), np.zeros(2), np.zeros(3),
+                             np.zeros((3, 3)))
+
+    def test_atomic_numbers_length_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            LigandPointCloud(np.zeros((3, 3)), np.zeros(3), np.zeros(2),
+                             np.zeros((3, 3)))
+
+    def test_bond_features_shape_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            LigandPointCloud(np.zeros((3, 3)), np.zeros(3), np.zeros(3),
+                             np.zeros((2, 2)))
+
+
+@pytest.mark.torch
+@requires_rdkit
+class TestParseLigandFile:
+
+    def test_ethanol_atom_count_and_types(self, tmp_path):
+        path = str(tmp_path / 'ethanol.sdf')
+        _write_sdf('CCO', path)
+        ligand = parse_ligand_file(path)
+        assert ligand.num_atoms == 3  # C, C, O (Hs removed by default)
+        assert sorted(ligand.atomic_numbers.tolist()) == [6, 6, 8]
+        # Oxygen's LIGAND_ATOM_TYPES index.
+        o_index = LIGAND_ATOM_TYPES.index('O')
+        assert o_index in ligand.atom_types.tolist()
+
+    def test_keep_hydrogens(self, tmp_path):
+        path = str(tmp_path / 'ethanol_h.sdf')
+        _write_sdf('CCO', path)
+        with_h = parse_ligand_file(path, remove_hydrogens=False)
+        without_h = parse_ligand_file(path, remove_hydrogens=True)
+        assert with_h.num_atoms > without_h.num_atoms
+
+    def test_bond_features_symmetric(self, tmp_path):
+        path = str(tmp_path / 'ethanol2.sdf')
+        _write_sdf('CCO', path)
+        ligand = parse_ligand_file(path)
+        assert np.array_equal(ligand.bond_features, ligand.bond_features.T)
+
+    def test_aromatic_bond_coded_as_four(self, tmp_path):
+        path = str(tmp_path / 'benzene.sdf')
+        _write_sdf('c1ccccc1', path)
+        ligand = parse_ligand_file(path)
+        # every ring bond should be coded as aromatic (4)
+        nonzero = ligand.bond_features[ligand.bond_features != 0]
+        assert set(nonzero.tolist()) == {4}
+
+    def test_double_bond_order(self, tmp_path):
+        path = str(tmp_path / 'ethene.sdf')
+        _write_sdf('C=C', path)
+        ligand = parse_ligand_file(path)
+        assert ligand.bond_features[0, 1] == 2
+
+    def test_missing_file_raises(self):
+        with pytest.raises((ValueError, OSError)):
+            parse_ligand_file('/nonexistent/path/to/ligand.sdf')
+
+    def test_unsupported_extension_raises(self, tmp_path):
+        path = str(tmp_path / 'ligand.xyz')
+        with open(path, 'w') as f:
+            f.write('not a real file')
+        with pytest.raises(ValueError):
+            parse_ligand_file(path)
+
+
+@pytest.mark.torch
+@requires_rdkit
+class TestFindLigandAutomorphisms:
+
+    def test_identity_is_first_row(self, tmp_path):
+        path = str(tmp_path / 'ethanol3.sdf')
+        _write_sdf('CCO', path)
+        perms = find_ligand_automorphisms(path)
+        assert perms.shape[0] >= 1
+        assert perms[0].tolist() == list(range(perms.shape[1]))
+
+    def test_benzene_has_multiple_symmetries(self, tmp_path):
+        path = str(tmp_path / 'benzene2.sdf')
+        _write_sdf('c1ccccc1', path)
+        perms = find_ligand_automorphisms(path)
+        assert perms.shape[1] == 6
+        # benzene's automorphism group (D6h restricted to atom
+        # permutations) has more than just the identity permutation
+        assert perms.shape[0] > 1
+
+    def test_asymmetric_molecule_has_only_identity(self, tmp_path):
+        # 2-chlorobutane: no two heavy atoms are topologically
+        # equivalent, so the only automorphism is the identity.
+        path = str(tmp_path / 'asym.sdf')
+        _write_sdf('CC(Cl)CC', path)
+        perms = find_ligand_automorphisms(path)
+        assert perms.shape[0] == 1
+
+    def test_max_matches_respected(self, tmp_path):
+        path = str(tmp_path / 'benzene3.sdf')
+        _write_sdf('c1ccccc1', path)
+        perms = find_ligand_automorphisms(path, max_matches=1)
+        assert perms.shape[0] == 1
+
+
+class TestOptionalDependencyBehavior:
+
+    def test_missing_rdkit_raises_importerror(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == 'rdkit' or name.startswith('rdkit.'):
+                raise ImportError('simulated missing rdkit')
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, '__import__', fake_import)
+        with pytest.raises(ImportError):
+            parse_ligand_file('does_not_matter.sdf')

--- a/docs/source/api_reference/layers.rst
+++ b/docs/source/api_reference/layers.rst
@@ -546,3 +546,23 @@ RFDiffusion Layers
 
 .. autoclass:: deepchem.models.torch_models.layers.BackboneDiffusion
    :members:
+
+RFDiffusion All-Atom Losses
+----------------------------
+
+Loss functions for RFDiffusion All-Atom training once side-chain and/or
+ligand atoms are involved: Frame Aligned Point Error (FAPE), a generic
+dihedral-angle loss usable for side-chain chi angles, a soft ligand
+steric-clash penalty, and a masked all-atom coordinate loss.
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_losses.frame_aligned_point_error
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_losses.dihedral_angle
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_losses.chi_angle_loss
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_losses.ligand_clash_loss
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_losses.masked_all_atom_l2_loss
+
+.. autofunction:: deepchem.models.torch_models.rfdiffusion_losses.vdw_radii_from_symbols

--- a/docs/source/api_reference/utils.rst
+++ b/docs/source/api_reference/utils.rst
@@ -962,3 +962,18 @@ node features for message-passing layers.
 .. autofunction:: deepchem.utils.ProteinMPNN_utils.gather_edges
 .. autofunction:: deepchem.utils.ProteinMPNN_utils.gather_nodes
 .. autofunction:: deepchem.utils.ProteinMPNN_utils.cat_neighbors_nodes
+
+RFDiffusion Ligand Utils
+------------------------
+
+Ligand parsing utilities for RFDiffusion All-Atom conditioning: turns an
+on-disk ligand file into a point cloud plus the atom-type and bond
+features the all-atom network needs, and enumerates graph-automorphism
+atom permutations for symmetric ligands.
+
+.. autoclass:: deepchem.utils.rfdiffusion_ligand.LigandPointCloud
+   :members:
+
+.. autofunction:: deepchem.utils.rfdiffusion_ligand.parse_ligand_file
+
+.. autofunction:: deepchem.utils.rfdiffusion_ligand.find_ligand_automorphisms


### PR DESCRIPTION
## Description

Adds ligand parsing and loss functions for RFDiffusion All-Atom. Draft for now since it's part of a larger stack that isn't finished yet.

`rfdiffusion_ligand.py` adds:
- `parse_ligand_file` — turns an SDF/MOL2/PDB ligand file into a `LigandPointCloud` (coordinates, element-based atom types, atomic numbers, bond-order matrix). Reuses the existing `deepchem.utils.rdkit_utils.load_molecule` instead of reimplementing file handling.
- `find_ligand_automorphisms` — lists atom-index permutations that map a symmetric ligand onto itself, so a loss can check against every valid labeling instead of penalizing a correct prediction just because the atoms got numbered differently.

`rfdiffusion_losses.py` adds:
- `frame_aligned_point_error` — the standard AlphaFold2 FAPE loss.
- `dihedral_angle` / `chi_angle_loss` — a generic 4-atom dihedral and a masked loss between predicted/true dihedrals.
- `ligand_clash_loss` — a soft steric-clash penalty between atoms that are too close.
- `masked_all_atom_l2_loss` — a plain masked coordinate loss.

FAPE and the dihedral loss take frames/atoms as plain tensors rather than hardcoding specific per-residue atom ordering, since DeepChem doesn't have a full side-chain atom representation yet to match that against. Same math either way, just generic over whatever atoms get passed in.

Depends on #4982 (frames) for the test suite only — the two new modules don't import it themselves.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version 0.32.0**)
  - [x] Run `mypy -p deepchem` and check no errors
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings