### PR TITLE
Add NequIP architecture

### DIFF
--- a/deepchem/models/torch_models/__init__.py
+++ b/deepchem/models/torch_models/__init__.py
@@ -58,6 +58,7 @@ from deepchem.models.torch_models.layers import PositionalEncoding
 from deepchem.models.torch_models.layers import CosineSchedule
 from deepchem.models.torch_models.layers import BackboneDiffusion
 from deepchem.models.torch_models.rfdiffusion import RFDiffusionModel
+from deepchem.models.torch_models.nequip import NequIP, NequIPInteractionBlock
 
 try:
     from deepchem.models.torch_models.dmpnn import DMPNN, DMPNNModel

--- a/deepchem/models/torch_models/nequip.py
+++ b/deepchem/models/torch_models/nequip.py
@@ -1,0 +1,800 @@
+"""Native PyTorch implementation of the original NequIP backbone.
+
+The architecture follows Batzner et al., *E(3)-Equivariant Graph Neural
+Networks for Data-Efficient and Accurate Interatomic Potentials*, in
+particular equations 4--8 and the interaction block in Figure 2.
+
+The implementation is organized in the same order as the model computation:
+
+1. represent node features by O(3) irreducible representations;
+2. expand edge distances with a Bessel basis and polynomial cutoff;
+3. build equivariant messages from spherical harmonics and tensor products;
+4. apply interaction blocks, scalar readout, and graph-wise energy summation;
+5. differentiate total energy with respect to positions when forces are needed.
+
+For an irrep ``(l, parity)``, features have shape
+``(num_atoms, multiplicity, 2*l + 1)``.  Parity is ``+1`` for even irreps and
+``-1`` for odd irreps.  This explicit parity bookkeeping complements
+DeepChem's :class:`Fiber`, which records angular degree but not parity.
+"""
+
+import math
+from dataclasses import dataclass
+from typing import cast, Dict, List, Mapping, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from deepchem.feat.graph_data import BatchGraphData, GraphData
+from deepchem.models.torch_models.layers import Fiber, SE3SelfInteraction
+from deepchem.utils.equivariance_utils import (basis_transformation_Q_J,
+                                               get_spherical_from_cartesian,
+                                               precompute_sh)
+
+# O(3) representations and selection rules
+# -----------------------------------------
+
+# An O(3) irrep is identified by angular degree l and parity (+1 even, -1 odd).
+_Irrep = Tuple[int, int]
+_Features = Dict[_Irrep, torch.Tensor]
+
+# Unit-second-moment factors used by the paper-era NequIP gate.
+_SILU_NORMALIZATION = 1.6791767923989418
+_TANH_NORMALIZATION = 1.5937334472592695
+
+
+def _normalized_silu(x: torch.Tensor) -> torch.Tensor:
+    """Apply SiLU normalized to unit second moment."""
+    return F.silu(x) * _SILU_NORMALIZATION
+
+
+def _normalized_tanh(x: torch.Tensor) -> torch.Tensor:
+    """Apply tanh normalized to unit second moment."""
+    return torch.tanh(x) * _TANH_NORMALIZATION
+
+
+def _irrep_name(irrep: _Irrep) -> str:
+    """Return a stable module key for an ``(l, parity)`` pair."""
+    return f"l{irrep[0]}_{'e' if irrep[1] == 1 else 'o'}"
+
+
+def _filter_parity(filter_degree: int) -> int:
+    """Return the natural O(3) parity of a spherical harmonic."""
+    return 1 if filter_degree % 2 == 0 else -1
+
+
+def _tensor_product_path_allowed(input_irrep: _Irrep, filter_degree: int,
+                                 output_irrep: _Irrep) -> bool:
+    """Test the triangle and parity selection rules from NequIP equation 7."""
+    l_in, parity_in = input_irrep
+    l_out, parity_out = output_irrep
+    return (abs(l_in - filter_degree) <= l_out <= l_in + filter_degree and
+            parity_out == parity_in * _filter_parity(filter_degree))
+
+
+def _path_exists(input_irreps: Mapping[_Irrep, int], output_irrep: _Irrep,
+                 l_max: int) -> bool:
+    """Return whether any input and edge irrep can produce ``output_irrep``."""
+    return any(
+        _tensor_product_path_allowed(input_irrep, filter_degree, output_irrep)
+        for input_irrep in input_irreps
+        for filter_degree in range(l_max + 1))
+
+
+def _reachable_hidden_irreps(input_irreps: Mapping[_Irrep, int], l_max: int,
+                             hidden_channels: int) -> Dict[_Irrep, int]:
+    """Return outputs reachable using edge harmonics through degree ``l_max``."""
+    candidates = [
+        (degree, parity) for degree in range(l_max + 1) for parity in (1, -1)
+    ]
+    return {
+        irrep: hidden_channels
+        for irrep in candidates
+        if _path_exists(input_irreps, irrep, l_max)
+    }
+
+
+# Radial representation
+# ---------------------
+
+
+class _BesselBasis(nn.Module):
+    """Trainable Bessel basis from NequIP equation 6.
+
+    Distances of shape ``(num_edges,)`` map to ``(num_edges, num_bessel)``.
+    """
+
+    def __init__(self, cutoff: float, num_bessel: int) -> None:
+        super().__init__()
+        self.cutoff = float(cutoff)
+        frequencies = torch.arange(
+            1, num_bessel + 1, dtype=torch.get_default_dtype()) * math.pi
+        self.frequencies = nn.Parameter(frequencies)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        # sin(w r / rc) / r = (w / rc) sinc(w r / (pi rc)); the latter is
+        # finite and differentiable at r=0.
+        scaled = distances.unsqueeze(-1) * self.frequencies / self.cutoff
+        sin_over_r = (self.frequencies / self.cutoff) * torch.sinc(
+            scaled / math.pi)
+        return (2.0 / self.cutoff) * sin_over_r
+
+
+class _PolynomialCutoff(nn.Module):
+    """Polynomial cutoff envelope used by the original NequIP model.
+
+    The envelope and its first two derivatives vanish at the cutoff; values at
+    and beyond the cutoff are set to zero.
+    """
+
+    def __init__(self, cutoff: float, p: int = 6) -> None:
+        super().__init__()
+        self.cutoff = float(cutoff)
+        self.p = int(p)
+
+    def forward(self, distances: torch.Tensor) -> torch.Tensor:
+        x = distances / self.cutoff
+        p = self.p
+        envelope = (1.0 - ((p + 1) * (p + 2) / 2.0) * x.pow(p) + p *
+                    (p + 2) * x.pow(p + 1) - (p * (p + 1) / 2.0) * x.pow(p + 2))
+        return envelope * (distances < self.cutoff).to(distances.dtype)
+
+
+class _RadialMLP(nn.Module):
+    """Map radial bases to independent tensor-product path weights."""
+
+    def __init__(self, input_size: int, output_size: int, hidden_width: int,
+                 hidden_depth: int) -> None:
+        super().__init__()
+        layers: List[nn.Module] = []
+        in_features = input_size
+        for _ in range(hidden_depth):
+            layers.append(_VarianceScaledLinear(in_features, hidden_width))
+            layers.append(_NormalizedSiLU())
+            in_features = hidden_width
+        layers.append(_VarianceScaledLinear(in_features, output_size))
+        self.layers = nn.Sequential(*layers)
+
+    def forward(self, radial_basis: torch.Tensor) -> torch.Tensor:
+        return self.layers(radial_basis)
+
+
+class _NormalizedSiLU(nn.Module):
+    """Module form of the normalized SiLU used by radial networks."""
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return _normalized_silu(x)
+
+
+class _VarianceScaledLinear(nn.Linear):
+    """Bias-free linear map with NequIP's unit-variance initialization.
+
+    Parameters are sampled from a standard normal distribution and divided by
+    ``sqrt(in_features)`` during evaluation, matching the paper-era radial
+    network parameterization.
+    """
+
+    def __init__(self, input_size: int, output_size: int) -> None:
+        super().__init__(input_size, output_size, bias=False)
+        nn.init.normal_(self.weight)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return F.linear(x, self.weight / math.sqrt(self.in_features))
+
+
+# Equivariant feature operations
+# ------------------------------
+
+
+class _ParitySelfInteraction(nn.Module):
+    """Mix channels within each ``(l, parity)`` using DeepChem's linear map.
+
+    :class:`SE3SelfInteraction` performs the required channel transformation,
+    shared across the ``2*l + 1`` components.  Separate modules for even and
+    odd features preserve parity without changing DeepChem's ``Fiber`` API.
+    """
+
+    def __init__(self, input_irreps: Mapping[_Irrep, int],
+                 output_irreps: Mapping[_Irrep, int]) -> None:
+        super().__init__()
+        self.input_irreps = dict(input_irreps)
+        self.interactions = nn.ModuleDict()
+
+        for parity in (1, -1):
+            input_degrees = {
+                degree: channels
+                for (degree, irrep_parity), channels in input_irreps.items()
+                if irrep_parity == parity
+            }
+            output_degrees = {
+                degree: channels
+                for (degree, irrep_parity), channels in output_irreps.items()
+                if irrep_parity == parity
+            }
+            if not output_degrees:
+                continue
+            missing = set(output_degrees).difference(input_degrees)
+            if missing:
+                raise ValueError(
+                    "An equivariant self-interaction cannot create a new irrep")
+            self.interactions[str(parity)] = SE3SelfInteraction(
+                Fiber(dictionary=input_degrees),
+                Fiber(dictionary=output_degrees))
+
+    def forward(self, features: _Features) -> _Features:
+        output: _Features = {}
+        for parity in (1, -1):
+            key = str(parity)
+            if key not in self.interactions:
+                continue
+            parity_features = {
+                str(degree): features[(degree, parity)]
+                for degree, irrep_parity in self.input_irreps
+                if irrep_parity == parity and (degree, parity) in features
+            }
+            transformed = self.interactions[key](parity_features)
+            output.update({(int(degree), parity): value
+                           for degree, value in transformed.items()})
+        return output
+
+
+class _SpeciesSelfConnection(nn.Module):
+    """Species-conditioned equivariant residual used by NequIP.
+
+    A one-hot species attribute is a collection of even scalars.  Its fully
+    connected tensor product with an irrep is therefore exactly a
+    species-indexed channel matrix applied identically to every m component.
+    """
+
+    def __init__(self, input_irreps: Mapping[_Irrep, int],
+                 output_irreps: Mapping[_Irrep, int], num_species: int) -> None:
+        super().__init__()
+        self.num_species = num_species
+        self.weights = nn.ParameterDict()
+        for irrep, output_channels in output_irreps.items():
+            if irrep not in input_irreps:
+                continue
+            input_channels = input_irreps[irrep]
+            weight = torch.randn(num_species, output_channels, input_channels)
+            self.weights[_irrep_name(irrep)] = nn.Parameter(weight)
+
+    def forward(self, features: _Features, species: torch.Tensor) -> _Features:
+        output: _Features = {}
+        for irrep, feature in features.items():
+            key = _irrep_name(irrep)
+            if key not in self.weights:
+                continue
+            # The one-hot species axis contributes to the tensor-product fan-in.
+            normalization = math.sqrt(feature.shape[1] * self.num_species)
+            weight = self.weights[key][species] / normalization
+            output[irrep] = torch.einsum("noi,nim->nom", weight, feature)
+        return output
+
+
+@dataclass(frozen=True)
+class _TensorProductPath:
+    """Metadata for one input, edge-filter, and output irrep coupling."""
+
+    input_irrep: _Irrep
+    filter_degree: int
+    output_irrep: _Irrep
+    weight_start: int
+    weight_stop: int
+    basis_name: str
+
+
+class _TensorProductConvolution(nn.Module):
+    """Evaluate NequIP equation 8 with distinct channels for each path.
+
+    Each feature tensor has shape ``(num_atoms, multiplicity, 2*l + 1)``.
+    Radial weights are generated per edge, and compatible paths remain
+    separate until the post-convolution self-interaction.
+    """
+
+    def __init__(self, input_irreps: Mapping[_Irrep, int],
+                 output_irreps: Mapping[_Irrep, int], l_max: int,
+                 num_bessel: int, radial_hidden_width: int,
+                 radial_hidden_depth: int, avg_num_neighbors: float) -> None:
+        super().__init__()
+        self.output_irreps = dict(output_irreps)
+        self.avg_num_neighbors = float(avg_num_neighbors)
+        self.paths: List[_TensorProductPath] = []
+        basis_names: Dict[Tuple[int, int, int], str] = {}
+        mid_irreps: Dict[_Irrep, int] = {irrep: 0 for irrep in output_irreps}
+        weight_offset = 0
+
+        # One path corresponds to one e3nn ``uvu`` instruction: the input
+        # multiplicity is preserved, while the edge harmonic has multiplicity
+        # one.  It therefore consumes one radial weight per input channel.
+        # Paths with the same output irrep remain separate in ``mid_irreps``.
+        for input_irrep, input_channels in input_irreps.items():
+            l_in, _ = input_irrep
+            for filter_degree in range(l_max + 1):
+                for output_irrep in output_irreps:
+                    if not _tensor_product_path_allowed(
+                            input_irrep, filter_degree, output_irrep):
+                        continue
+                    l_out, _ = output_irrep
+                    basis_key = (filter_degree, l_in, l_out)
+                    if basis_key not in basis_names:
+                        basis_name = f"q_{filter_degree}_{l_in}_{l_out}"
+                        q_matrix = basis_transformation_Q_J(
+                            filter_degree, l_in, l_out).to(
+                                dtype=torch.get_default_dtype()).T.contiguous()
+                        self.register_buffer(basis_name, q_matrix)
+                        basis_names[basis_key] = basis_name
+                    self.paths.append(
+                        _TensorProductPath(input_irrep=input_irrep,
+                                           filter_degree=filter_degree,
+                                           output_irrep=output_irrep,
+                                           weight_start=weight_offset,
+                                           weight_stop=weight_offset +
+                                           input_channels,
+                                           basis_name=basis_names[basis_key]))
+                    weight_offset += input_channels
+                    mid_irreps[output_irrep] += input_channels
+
+        if weight_offset == 0:
+            raise ValueError(
+                "The requested irreps have no tensor-product paths")
+        self.radial_mlp = _RadialMLP(num_bessel, weight_offset,
+                                     radial_hidden_width, radial_hidden_depth)
+        self.post_self_interaction = _ParitySelfInteraction(
+            mid_irreps, output_irreps)
+
+    def forward(self, features: _Features, radial_basis: torch.Tensor,
+                spherical_harmonics: Mapping[int, torch.Tensor],
+                center: torch.Tensor, neighbor: torch.Tensor,
+                num_nodes: int) -> _Features:
+        """Convolve neighbor features along all allowed tensor-product paths.
+
+        For each edge and path, the contraction implements
+
+        ``neighbor feature x Y_l(edge direction) x radial weight``.
+
+        The Clebsch--Gordan basis maps the input components to output
+        components.  Messages are summed into central atoms, divided by
+        ``sqrt(avg_num_neighbors)``, concatenated by output irrep, and mixed by
+        the post-convolution self-interaction.
+
+        ``features[(l, p)]`` has shape ``(N, C, 2*l + 1)``;
+        ``radial_basis`` has shape ``(E, num_bessel)``; and each spherical
+        harmonic tensor is indexed by the same ``E`` directed edges.
+        """
+        weights = self.radial_mlp(radial_basis)
+        path_outputs: Dict[_Irrep, List[torch.Tensor]] = {
+            irrep: [] for irrep in self.output_irreps
+        }
+
+        for path in self.paths:
+            l_in, _ = path.input_irrep
+            l_out, _ = path.output_irrep
+            q_matrix = getattr(self, path.basis_name)
+            angular = torch.matmul(spherical_harmonics[path.filter_degree],
+                                   q_matrix)
+            # Convert DeepChem's integral-normalized SH and unit-norm Q_J to
+            # the component normalization used by the original NequIP model.
+            angular = angular * math.sqrt(4 * math.pi * (2 * l_out + 1))
+            angular = angular.view(-1, 2 * l_out + 1, 2 * l_in + 1)
+            neighbor_features = features[path.input_irrep][neighbor]
+            message = torch.einsum("eoi,eui->euo", angular, neighbor_features)
+            path_weight = weights[:, path.weight_start:path.weight_stop]
+            message = message * path_weight.unsqueeze(-1)
+            aggregated = message.new_zeros(
+                (num_nodes, message.shape[1], message.shape[2]))
+            aggregated.index_add_(0, center, message)
+            path_outputs[path.output_irrep].append(aggregated)
+
+        normalization = math.sqrt(self.avg_num_neighbors)
+        concatenated = {
+            irrep: torch.cat(outputs, dim=1) / normalization
+            for irrep, outputs in path_outputs.items()
+        }
+        return self.post_self_interaction(concatenated)
+
+
+class _EquivariantGate(nn.Module):
+    """Apply parity-aware scalar activations and higher-irrep gates.
+
+    Even and odd scalars use normalized SiLU and tanh, respectively.  Each
+    higher-irrep channel is multiplied by one normalized even scalar gate.
+    """
+
+    def __init__(self, output_irreps: Mapping[_Irrep, int]) -> None:
+        super().__init__()
+        self.output_irreps = dict(output_irreps)
+        self.scalar_irreps = {
+            irrep: channels
+            for irrep, channels in output_irreps.items()
+            if irrep[0] == 0
+        }
+        self.gated_irreps = {
+            irrep: channels
+            for irrep, channels in output_irreps.items()
+            if irrep[0] > 0
+        }
+        self.num_even_scalars = self.scalar_irreps.get((0, 1), 0)
+        self.num_gates = sum(self.gated_irreps.values())
+
+    @property
+    def input_irreps(self) -> Dict[_Irrep, int]:
+        """Return convolution outputs, including scalar gate channels."""
+        irreps = dict(self.output_irreps)
+        irreps[(0, 1)] = self.num_even_scalars + self.num_gates
+        return irreps
+
+    def forward(self, features: _Features) -> _Features:
+        output: _Features = {}
+        even_and_gates = features[(0, 1)]
+        if self.num_even_scalars:
+            output[(0, 1)] = _normalized_silu(
+                even_and_gates[:, :self.num_even_scalars])
+        if (0, -1) in self.scalar_irreps:
+            output[(0, -1)] = _normalized_tanh(features[(0, -1)])
+
+        gates = _normalized_silu(even_and_gates[:, self.num_even_scalars:, 0])
+        offset = 0
+        for irrep, channels in self.gated_irreps.items():
+            gate = gates[:, offset:offset + channels].unsqueeze(-1)
+            output[irrep] = features[irrep] * gate
+            offset += channels
+        return output
+
+
+# Interaction block and energy model
+# ----------------------------------
+
+
+class NequIPInteractionBlock(nn.Module):
+    """One interaction block from the original NequIP architecture.
+
+    The operation order follows Figure 2 of the paper::
+
+        residual = species self connection(x)
+        x = pre self-interaction(x)
+        x = tensor-product convolution(x)  # includes post self-interaction
+        output = gate(x + residual)
+
+    The convolution includes the post self-interaction that mixes distinct
+    tensor-product paths.  Paths satisfy the angular-momentum triangle and
+    parity selection rules.
+
+    Feature tensors are keyed by ``(l, parity)`` and have shape
+    ``(num_atoms, multiplicity, 2*l + 1)``.  Messages read features from the
+    neighbor endpoint and are summed into the center endpoint before division
+    by ``sqrt(avg_num_neighbors)``.
+
+    Parameters
+    ----------
+    input_irreps : mapping
+        Multiplicity of each input ``(l, parity)`` irrep.
+    hidden_channels : int
+        Multiplicity assigned to each reachable output irrep.
+    num_species : int
+        Size of the atomic-number embedding table.
+    l_max : int
+        Maximum degree of node and edge spherical harmonics.
+    num_bessel : int
+        Number of radial Bessel functions.
+    radial_hidden_width : int
+        Width of each radial MLP hidden layer.
+    radial_hidden_depth : int
+        Number of radial MLP hidden layers.
+    avg_num_neighbors : float
+        Neighbor statistic used to normalize aggregated messages.
+
+    References
+    ----------
+    .. [1] Batzner, S. et al. E(3)-equivariant graph neural networks for
+       data-efficient and accurate interatomic potentials. Nat Commun 13,
+       2453 (2022). https://doi.org/10.1038/s41467-022-29939-5
+    """
+
+    def __init__(self, input_irreps: Mapping[_Irrep, int], hidden_channels: int,
+                 num_species: int, l_max: int, num_bessel: int,
+                 radial_hidden_width: int, radial_hidden_depth: int,
+                 avg_num_neighbors: float) -> None:
+        super().__init__()
+        if avg_num_neighbors <= 0:
+            raise ValueError("avg_num_neighbors must be positive")
+        self.output_irreps = _reachable_hidden_irreps(input_irreps, l_max,
+                                                      hidden_channels)
+        self.gate = _EquivariantGate(self.output_irreps)
+        # The convolution must also emit one even scalar for every gated
+        # higher-irrep channel; the gate removes these auxiliary scalars.
+        convolution_irreps = self.gate.input_irreps
+        self.pre_self_interaction = _ParitySelfInteraction(
+            input_irreps, input_irreps)
+        self.convolution = _TensorProductConvolution(
+            input_irreps=input_irreps,
+            output_irreps=convolution_irreps,
+            l_max=l_max,
+            num_bessel=num_bessel,
+            radial_hidden_width=radial_hidden_width,
+            radial_hidden_depth=radial_hidden_depth,
+            avg_num_neighbors=avg_num_neighbors)
+        self.self_connection = _SpeciesSelfConnection(input_irreps,
+                                                      convolution_irreps,
+                                                      num_species)
+
+    def forward(self, features: _Features, radial_basis: torch.Tensor,
+                spherical_harmonics: Mapping[int, torch.Tensor],
+                edge_index: torch.Tensor, species: torch.Tensor) -> _Features:
+        """Apply one interaction block.
+
+        Parameters
+        ----------
+        features : dict
+            Input tensors keyed by ``(l, parity)``.
+        radial_basis : torch.Tensor
+            Cutoff-weighted radial basis, shape ``(num_edges, num_bessel)``.
+        spherical_harmonics : mapping
+            Edge spherical harmonics keyed by degree.
+        edge_index : torch.Tensor
+            Directed edges with shape ``(2, num_edges)``.
+        species : torch.Tensor
+            Atomic-number indices with shape ``(num_atoms,)``.
+
+        Returns
+        -------
+        dict
+            Gated output tensors keyed by ``(l, parity)``.
+        """
+        # Row 0 indexes receiving centers; row 1 indexes source neighbors.
+        center, neighbor = edge_index
+        residual = self.self_connection(features, species)
+        convolved = self.convolution(self.pre_self_interaction(features),
+                                     radial_basis, spherical_harmonics, center,
+                                     neighbor, species.shape[0])
+        for irrep, value in residual.items():
+            convolved[irrep] = convolved[irrep] + value
+        return self.gate(convolved)
+
+
+class NequIP(nn.Module):
+    """Native nonperiodic NequIP energy backbone.
+
+    Interaction blocks predict even scalar atomic energies, which are summed
+    for each structure using ``GraphData.graph_index``.
+
+    Parameters
+    ----------
+    cutoff : float
+        Radius cutoff used by equation 6.  Input topology must use the same
+        cutoff.
+    num_species : int
+        Atomic-number embedding size.  Atomic numbers are used directly as
+        indices, so this must be larger than the largest supported atomic
+        number.
+    hidden_channels : int
+        Multiplicity of every hidden ``(l, parity)`` feature type.
+    num_interaction_blocks : int
+        Number of NequIP interaction blocks.
+    l_max : int
+        Maximum node and edge spherical-harmonic degree.  Edge filters use
+        degrees ``0..l_max`` with natural parity ``(-1)**l``.
+    num_bessel : int
+        Number of trainable Bessel frequencies.
+    radial_hidden_width : int
+        Width of each radial MLP hidden layer.
+    radial_hidden_depth : int
+        Number of SiLU hidden layers in each radial MLP.
+    avg_num_neighbors : float
+        Training-set neighbor statistic used for ``sqrt(avg)`` normalization.
+    readout_hidden_channels : int
+        Number of even scalar channels in the first output self-interaction.
+    compute_forces : bool, optional
+        If ``True``, return forces obtained from the energy gradient by default.
+
+    Notes
+    -----
+    ``forward`` accepts a torch-converted :class:`GraphData` or
+    :class:`BatchGraphData`.  Static edge vectors and distances are ignored:
+    for an edge ``center -> neighbor`` geometry is recomputed as
+    ``pos[neighbor] - pos[center]`` so forces remain connected to positions.
+    ``node_features`` must contain one integer-valued atomic number per node;
+    values are cast to integer indices before embedding because graph tensor
+    conversion may produce floating-point features.
+
+    References
+    ----------
+    .. [1] Batzner, S. et al. E(3)-equivariant graph neural networks for
+       data-efficient and accurate interatomic potentials. Nat Commun 13,
+       2453 (2022). https://doi.org/10.1038/s41467-022-29939-5
+    """
+
+    def __init__(self,
+                 cutoff: float,
+                 num_species: int = 119,
+                 hidden_channels: int = 32,
+                 num_interaction_blocks: int = 3,
+                 l_max: int = 2,
+                 num_bessel: int = 8,
+                 radial_hidden_width: int = 64,
+                 radial_hidden_depth: int = 2,
+                 avg_num_neighbors: float = 1.0,
+                 readout_hidden_channels: int = 16,
+                 compute_forces: bool = False) -> None:
+        super().__init__()
+        integer_parameters = {
+            "num_species": num_species,
+            "hidden_channels": hidden_channels,
+            "num_interaction_blocks": num_interaction_blocks,
+            "num_bessel": num_bessel,
+            "radial_hidden_width": radial_hidden_width,
+            "radial_hidden_depth": radial_hidden_depth,
+            "readout_hidden_channels": readout_hidden_channels,
+        }
+        if cutoff <= 0:
+            raise ValueError("cutoff must be positive")
+        if l_max < 0:
+            raise ValueError("l_max must be nonnegative")
+        if avg_num_neighbors <= 0:
+            raise ValueError("avg_num_neighbors must be positive")
+        if any(value <= 0 for value in integer_parameters.values()):
+            raise ValueError("NequIP size parameters must be positive")
+
+        self.cutoff = float(cutoff)
+        self.num_species = int(num_species)
+        self.l_max = int(l_max)
+        self.compute_forces = bool(compute_forces)
+        self.embedding = nn.Embedding(num_species, hidden_channels)
+        self.bessel_basis = _BesselBasis(cutoff, num_bessel)
+        self.cutoff_envelope = _PolynomialCutoff(cutoff, p=6)
+
+        input_irreps: Dict[_Irrep, int] = {(0, 1): hidden_channels}
+        blocks: List[NequIPInteractionBlock] = []
+        for _ in range(num_interaction_blocks):
+            block = NequIPInteractionBlock(
+                input_irreps=input_irreps,
+                hidden_channels=hidden_channels,
+                num_species=num_species,
+                l_max=l_max,
+                num_bessel=num_bessel,
+                radial_hidden_width=radial_hidden_width,
+                radial_hidden_depth=radial_hidden_depth,
+                avg_num_neighbors=avg_num_neighbors)
+            blocks.append(block)
+            input_irreps = block.output_irreps
+        self.interaction_blocks = nn.ModuleList(blocks)
+
+        scalar_input = {(0, 1): input_irreps[(0, 1)]}
+        scalar_hidden = {(0, 1): readout_hidden_channels}
+        scalar_output = {(0, 1): 1}
+        self.output_hidden = _ParitySelfInteraction(scalar_input, scalar_hidden)
+        self.output_energy = _ParitySelfInteraction(scalar_hidden,
+                                                    scalar_output)
+
+    def _validate_graph(
+        self, graph: Union[GraphData, BatchGraphData]
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Validate and return species, edges, and graph membership."""
+        node_features = graph.node_features
+        positions = graph.node_pos_features
+        edge_index = graph.edge_index
+        graph_index = getattr(graph, "graph_index", None)
+        if not all(
+                isinstance(value, torch.Tensor)
+                for value in (node_features, positions, edge_index)):
+            raise TypeError("NequIP requires a torch-converted GraphData")
+        node_features = cast(torch.Tensor, node_features)
+        positions = cast(torch.Tensor, positions)
+        edge_index = cast(torch.Tensor, edge_index)
+        if node_features.ndim != 2 or node_features.shape[1] != 1:
+            raise ValueError("node_features must have shape (num_atoms, 1)")
+        if positions.ndim != 2 or positions.shape[1] != 3:
+            raise ValueError("node_pos_features must have shape (num_atoms, 3)")
+        if not positions.is_floating_point():
+            raise TypeError("node positions must be floating point")
+        if edge_index.ndim != 2 or edge_index.shape[0] != 2:
+            raise ValueError("edge_index must have shape (2, num_edges)")
+
+        species_values = node_features[:, 0]
+        if species_values.is_floating_point() and not torch.equal(
+                species_values, species_values.round()):
+            raise ValueError("atomic numbers must be integer-valued")
+        species = species_values.long()
+        if torch.any(species < 0) or torch.any(species >= self.num_species):
+            raise ValueError("atomic number is outside the embedding range")
+
+        if graph_index is None:
+            graph_index = torch.zeros(species.shape[0],
+                                      dtype=torch.long,
+                                      device=species.device)
+        elif not isinstance(graph_index, torch.Tensor):
+            raise TypeError("graph_index must be a torch tensor")
+        else:
+            graph_index = graph_index.long()
+        if graph_index.shape != species.shape:
+            raise ValueError("graph_index must have shape (num_atoms,)")
+        edge_index = edge_index.long()
+        if edge_index.numel() and torch.any(
+                graph_index[edge_index[0]] != graph_index[edge_index[1]]):
+            raise ValueError("edges may not connect different batch graphs")
+        return species, edge_index, graph_index
+
+    def _energy(self, graph: Union[GraphData, BatchGraphData],
+                positions: torch.Tensor) -> torch.Tensor:
+        """Run embedding, edge encoding, interaction blocks, and readout."""
+        species, edge_index, graph_index = self._validate_graph(graph)
+        center, neighbor = edge_index
+        # Reuse topology but rebuild all geometry from differentiable positions.
+        edge_vectors = positions[neighbor] - positions[center]
+        distances = torch.linalg.vector_norm(edge_vectors, dim=-1)
+        if distances.numel() and torch.any(distances <= 0):
+            raise ValueError("NequIP does not support zero-length edges")
+        directions = edge_vectors / distances.clamp_min(
+            torch.finfo(positions.dtype).eps).unsqueeze(-1)
+
+        radial_basis = self.bessel_basis(distances)
+        radial_basis = radial_basis * self.cutoff_envelope(distances).unsqueeze(
+            -1)
+        spherical = get_spherical_from_cartesian(directions)
+        spherical_harmonics = precompute_sh(spherical, self.l_max)
+
+        # Atomic numbers enter the network as even scalar (0e) features.
+        features: _Features = {
+            (0, 1): (self.embedding(species) /
+                     math.sqrt(self.num_species)).unsqueeze(-1)
+        }
+        for block in self.interaction_blocks:
+            features = block(features, radial_basis, spherical_harmonics,
+                             edge_index, species)
+
+        # Equivariant projection selects 0e features for atomic energies.
+        scalar_features = {(0, 1): features[(0, 1)]}
+        atomic_energies = self.output_energy(
+            self.output_hidden(scalar_features))[(0, 1)][:, 0, 0]
+        batch_size = int(graph_index.max().item()) + 1
+        total_energy = atomic_energies.new_zeros(batch_size)
+        # graph_index assigns each atomic contribution to its structure.
+        total_energy.index_add_(0, graph_index, atomic_energies)
+        return total_energy.unsqueeze(-1)
+
+    def forward(
+        self,
+        graph: Union[GraphData, BatchGraphData],
+        compute_forces: Optional[bool] = None,
+        create_graph: bool = False
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
+        """Predict total energies and optionally conservative forces.
+
+        Parameters
+        ----------
+        graph : GraphData or BatchGraphData
+            Torch-converted graph containing atomic numbers, positions,
+            directed edges, and optional graph membership.
+        compute_forces : bool, optional
+            Override the constructor setting for this call.
+        create_graph : bool, default False
+            Preserve the force derivative graph for force-loss backpropagation.
+
+        Returns
+        -------
+        torch.Tensor or tuple of torch.Tensor
+            Graph energies with shape ``(batch_size, 1)``.  When forces are
+            requested, also returns ``-dE/dR`` with shape ``(num_atoms, 3)``.
+
+        Notes
+        -----
+        Force calls create a differentiable position tensor when needed;
+        caller-owned graph tensors are not modified.
+        """
+        do_forces = self.compute_forces if compute_forces is None else compute_forces
+        positions = graph.node_pos_features
+        if not isinstance(positions, torch.Tensor):
+            raise TypeError("NequIP requires a torch-converted GraphData")
+        if not do_forces:
+            return self._energy(graph, positions)
+
+        with torch.enable_grad():
+            if not positions.requires_grad:
+                # Avoid setting requires_grad on the caller-owned graph tensor.
+                positions = positions.detach().requires_grad_(True)
+            total_energy = self._energy(graph, positions)
+            forces = -torch.autograd.grad(total_energy.sum(),
+                                          positions,
+                                          create_graph=create_graph,
+                                          retain_graph=create_graph)[0]
+        return total_energy, forces

--- a/deepchem/models/torch_models/tests/test_nequip.py
+++ b/deepchem/models/torch_models/tests/test_nequip.py
@@ -1,0 +1,313 @@
+"""Tests for the native NequIP backbone."""
+
+import copy
+import math
+
+import numpy as np
+import pytest
+import torch
+
+from deepchem.feat.graph_data import BatchGraphData, GraphData
+from deepchem.models.torch_models.nequip import (NequIP,
+                                                 _TensorProductConvolution)
+from deepchem.utils.equivariance_utils import (get_spherical_from_cartesian,
+                                               precompute_sh)
+
+
+def _graph(positions, atomic_numbers):
+    positions = np.asarray(positions, dtype=np.float32)
+    num_atoms = len(positions)
+    center = []
+    neighbor = []
+    for i in range(num_atoms):
+        for j in range(num_atoms):
+            if i != j:
+                center.append(i)
+                neighbor.append(j)
+    edge_index = np.asarray([center, neighbor], dtype=np.int64)
+    edge_vectors = positions[edge_index[1]] - positions[edge_index[0]]
+    edge_distances = np.linalg.norm(edge_vectors, axis=1, keepdims=True)
+    return GraphData(node_features=np.asarray(atomic_numbers,
+                                              dtype=np.int64).reshape(-1, 1),
+                     edge_index=edge_index,
+                     edge_features=edge_vectors.copy(),
+                     node_pos_features=positions,
+                     edge_distances=edge_distances)
+
+
+def _graphs():
+    first = _graph([[0.1, 0.2, -0.1], [1.0, -0.3, 0.4]], [1, 8])
+    second = _graph([[0.2, -0.4, 0.3], [1.1, 0.1, -0.2], [-0.5, 0.8, 0.7]],
+                    [6, 1, 8])
+    return first, second
+
+
+def _batch(*graphs):
+    return BatchGraphData(list(graphs)).numpy_to_torch()
+
+
+@pytest.fixture
+def model():
+    torch.manual_seed(13)
+    return NequIP(cutoff=4.0,
+                  num_species=10,
+                  hidden_channels=3,
+                  num_interaction_blocks=3,
+                  l_max=1,
+                  num_bessel=4,
+                  radial_hidden_width=8,
+                  radial_hidden_depth=1,
+                  avg_num_neighbors=2.0,
+                  readout_hidden_channels=3)
+
+
+def _transformed_batch(graphs, matrix=None, translation=None):
+    transformed = []
+    for graph in graphs:
+        graph = copy.deepcopy(graph)
+        positions = graph.node_pos_features
+        if matrix is not None:
+            positions = positions @ matrix.T
+        if translation is not None:
+            positions = positions + translation
+        graph.node_pos_features = positions
+        transformed.append(graph)
+    return _batch(*transformed)
+
+
+def test_tensor_product_paths_and_multiplicities():
+    e, o = 1, -1
+    expected = {
+        ((0, e), 0): {(0, e)},
+        ((0, e), 1): {(1, o)},
+        ((0, e), 2): {(2, e)},
+        ((0, o), 0): {(0, o)},
+        ((0, o), 1): {(1, e)},
+        ((0, o), 2): {(2, o)},
+        ((1, e), 0): {(1, e)},
+        ((1, e), 1): {(0, o), (1, o), (2, o)},
+        ((1, e), 2): {(1, e), (2, e)},
+        ((1, o), 0): {(1, o)},
+        ((1, o), 1): {(0, e), (1, e), (2, e)},
+        ((1, o), 2): {(1, o), (2, o)},
+        ((2, e), 0): {(2, e)},
+        ((2, e), 1): {(1, o), (2, o)},
+        ((2, e), 2): {(0, e), (1, e), (2, e)},
+        ((2, o), 0): {(2, o)},
+        ((2, o), 1): {(1, e), (2, e)},
+        ((2, o), 2): {(0, o), (1, o), (2, o)},
+    }
+    input_irreps = {
+        (0, e): 2,
+        (0, o): 3,
+        (1, e): 4,
+        (1, o): 5,
+        (2, e): 6,
+        (2, o): 7,
+    }
+    convolution = _TensorProductConvolution(
+        input_irreps=input_irreps,
+        output_irreps={irrep: 2 for irrep in input_irreps},
+        l_max=2,
+        num_bessel=3,
+        radial_hidden_width=4,
+        radial_hidden_depth=1,
+        avg_num_neighbors=1.0)
+    actual = {}
+    expected_mid = {irrep: 0 for irrep in input_irreps}
+    for path in convolution.paths:
+        actual.setdefault((path.input_irrep, path.filter_degree),
+                          set()).add(path.output_irrep)
+        path_channels = path.weight_stop - path.weight_start
+        assert path_channels == input_irreps[path.input_irrep]
+        expected_mid[path.output_irrep] += path_channels
+    assert actual == expected
+    assert convolution.post_self_interaction.input_irreps == expected_mid
+    expected_weights = sum(input_irreps[input_irrep] * len(outputs)
+                           for (input_irrep, _), outputs in expected.items())
+    assert convolution.paths[-1].weight_stop == expected_weights
+    assert convolution.radial_mlp.layers[-1].out_features == expected_weights
+
+
+def test_tensor_product_component_normalization():
+    direction = torch.tensor([[0.3, -0.4, 0.5]])
+    direction = direction / torch.linalg.vector_norm(direction, dim=-1)
+    spherical_harmonics = precompute_sh(get_spherical_from_cartesian(direction),
+                                        2)
+    radial_basis = torch.ones(1, 3)
+    features = {(0, 1): torch.ones(2, 1, 1)}
+
+    for output_degree in range(3):
+        output_irrep = (output_degree, 1 if output_degree % 2 == 0 else -1)
+        convolution = _TensorProductConvolution(input_irreps={(0, 1): 1},
+                                                output_irreps={output_irrep: 1},
+                                                l_max=2,
+                                                num_bessel=3,
+                                                radial_hidden_width=4,
+                                                radial_hidden_depth=1,
+                                                avg_num_neighbors=1.0)
+        interaction = convolution.post_self_interaction.interactions[str(
+            output_irrep[1])]
+        with torch.no_grad():
+            interaction.transform[str(output_degree)].fill_(1.0)
+        radial_weight = convolution.radial_mlp(radial_basis)[0, 0]
+        output = convolution(features,
+                             radial_basis,
+                             spherical_harmonics,
+                             center=torch.tensor([0]),
+                             neighbor=torch.tensor([1]),
+                             num_nodes=2)[output_irrep][0, 0]
+        expected_norm = radial_weight.abs() * math.sqrt(2 * output_degree + 1)
+        torch.testing.assert_close(torch.linalg.vector_norm(output),
+                                   expected_norm)
+
+
+def test_unequal_batch_matches_individual_graphs(model):
+    first, second = _graphs()
+    with torch.no_grad():
+        batched_energy = model(_batch(first, second))
+        first_energy = model(_batch(first))
+        second_energy = model(_batch(second))
+    assert batched_energy.shape == (2, 1)
+    torch.testing.assert_close(batched_energy,
+                               torch.cat([first_energy, second_energy]))
+
+
+def test_translation_invariance_and_force_invariance(model):
+    graphs = _graphs()
+    original_energy, original_forces = model(_batch(*graphs),
+                                             compute_forces=True)
+    translated = _transformed_batch(graphs,
+                                    translation=np.asarray([2.1, -0.7, 1.3],
+                                                           dtype=np.float32))
+    translated_energy, translated_forces = model(translated,
+                                                 compute_forces=True)
+    torch.testing.assert_close(translated_energy,
+                               original_energy,
+                               atol=2e-5,
+                               rtol=2e-5)
+    torch.testing.assert_close(translated_forces,
+                               original_forces,
+                               atol=3e-5,
+                               rtol=3e-5)
+
+
+def test_rotation_invariance_and_force_equivariance(model):
+    graphs = _graphs()
+    angle = 0.73
+    axis = torch.tensor([0.3, -0.5, 0.8])
+    axis = axis / torch.linalg.vector_norm(axis)
+    cross = torch.tensor([[0.0, -axis[2], axis[1]], [axis[2], 0.0, -axis[0]],
+                          [-axis[1], axis[0], 0.0]])
+    rotation = (
+        torch.eye(3) * torch.cos(torch.tensor(angle)) +
+        (1.0 - torch.cos(torch.tensor(angle))) * torch.outer(axis, axis) +
+        torch.sin(torch.tensor(angle)) * cross)
+
+    original_energy, original_forces = model(_batch(*graphs),
+                                             compute_forces=True)
+    rotated_energy, rotated_forces = model(_transformed_batch(
+        graphs, matrix=rotation.numpy()),
+                                           compute_forces=True)
+    torch.testing.assert_close(rotated_energy,
+                               original_energy,
+                               atol=3e-4,
+                               rtol=3e-4)
+    torch.testing.assert_close(rotated_forces,
+                               original_forces @ rotation.T,
+                               atol=5e-4,
+                               rtol=5e-4)
+
+
+def test_inversion_invariance_and_force_equivariance(model):
+    graphs = _graphs()
+    inversion = -np.eye(3, dtype=np.float32)
+    original_energy, original_forces = model(_batch(*graphs),
+                                             compute_forces=True)
+    inverted_energy, inverted_forces = model(_transformed_batch(
+        graphs, matrix=inversion),
+                                             compute_forces=True)
+    torch.testing.assert_close(inverted_energy,
+                               original_energy,
+                               atol=3e-5,
+                               rtol=3e-5)
+    torch.testing.assert_close(inverted_forces,
+                               -original_forces,
+                               atol=5e-5,
+                               rtol=5e-5)
+
+
+def test_force_is_negative_energy_gradient(model):
+    graphs = _graphs()
+    returned_energy, returned_force = model(_batch(*graphs),
+                                            compute_forces=True)
+    independent_batch = _batch(*graphs)
+    independent_batch.node_pos_features.requires_grad_(True)
+    independent_energy = model(independent_batch)
+    independent_force = -torch.autograd.grad(
+        independent_energy.sum(), independent_batch.node_pos_features)[0]
+    torch.testing.assert_close(returned_energy, independent_energy)
+    torch.testing.assert_close(returned_force, independent_force)
+
+
+def test_force_matches_finite_difference(model):
+    first, _ = _graphs()
+    model = copy.deepcopy(model).double()
+    batch = _batch(first)
+    batch.node_pos_features = batch.node_pos_features.double()
+    _, forces = model(batch, compute_forces=True)
+
+    epsilon = 1e-5
+    displaced_energies = []
+    for displacement in (epsilon, -epsilon):
+        displaced = _batch(first)
+        displaced.node_pos_features = displaced.node_pos_features.double()
+        displaced.node_pos_features[0, 1] += displacement
+        displaced_energies.append(model(displaced))
+    finite_difference = -(displaced_energies[0] - displaced_energies[1]) / (
+        2 * epsilon)
+    torch.testing.assert_close(forces[0, 1],
+                               finite_difference[0, 0],
+                               atol=1e-6,
+                               rtol=1e-4)
+
+
+def test_isolated_atom_has_finite_energy_and_zero_force(model):
+    isolated = GraphData(node_features=np.asarray([[1]], dtype=np.int64),
+                         edge_index=np.empty((2, 0), dtype=np.int64),
+                         edge_features=np.empty((0, 3), dtype=np.float32),
+                         node_pos_features=np.asarray([[0.2, -0.1, 0.7]],
+                                                      dtype=np.float32),
+                         edge_distances=np.empty((0, 1), dtype=np.float32))
+    batch = _batch(isolated)
+    energy, force = model(batch, compute_forces=True)
+    assert energy.shape == (1, 1)
+    assert force.shape == (1, 3)
+    assert torch.isfinite(energy).all()
+    assert torch.isfinite(force).all()
+    torch.testing.assert_close(force, torch.zeros_like(force))
+    assert not batch.node_pos_features.requires_grad
+
+
+def test_force_loss_is_differentiable(model):
+    _, forces = model(_batch(*_graphs()),
+                      compute_forces=True,
+                      create_graph=True)
+    forces.square().mean().backward()
+    gradients = [
+        model.embedding.weight.grad, model.bessel_basis.frequencies.grad,
+        model.interaction_blocks[0].convolution.radial_mlp.layers[0].weight.grad
+    ]
+    assert all(gradient is not None for gradient in gradients)
+    assert all(torch.isfinite(gradient).all() for gradient in gradients)
+
+
+def test_static_geometry_is_ignored(model):
+    batch = _batch(*_graphs())
+    changed = copy.deepcopy(batch)
+    changed.edge_features = torch.randn_like(changed.edge_features) * 1000
+    changed.edge_distances = torch.randn_like(changed.edge_distances) * 1000
+    with torch.no_grad():
+        expected = model(batch)
+        actual = model(changed)
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Description

This draft PR proposes the implementation of the NequIP model.

The PR focuses only on the main model architecture. It does not add the
`TorchModel` training wrapper, energy-force loss, loader integration, etc.

The implementation accepts torch-converted DeepChem `GraphData` or
`BatchGraphData` and returns structure-level energies. Conservative forces can
optionally be computed as the negative gradient of total energy with respect
to atomic positions.

### Motivation

DeepChem already contains useful equivariant building blocks, but its existing
`Fiber` and `SE3GraphConv` abstractions do not directly represent the complete
original NequIP architecture:

- `Fiber` records angular degree `l` but not O(3) parity;
- `SE3GraphConv` uses different radial, path-mixing, aggregation, and residual
  semantics;
- NequIP requires parity-aware gated nonlinearities and a
  species-conditioned self connection;
- NequIP keeps compatible tensor-product paths separate until a subsequent
  atom-wise linear transformation.

This implementation reuses DeepChem primitives where their mathematics match
while adding only the NequIP-specific bookkeeping and operations required by
the paper.

No new external dependency is introduced. In particular, the implementation
does not require e3nn, DGL, or torch-geometric.

## Architecture

The backbone follows this data flow:

```text
GraphData / BatchGraphData
        |
atomic numbers + positions + edge_index + graph_index
        |
atomic-number embedding into even scalar (0e) features
        |
differentiable edge geometry reconstructed from positions
        |
Bessel radial basis × polynomial cutoff
        |
real spherical harmonics
        |
NequIPInteractionBlock × num_interaction_blocks
        |
even-scalar atom-wise readout
        |
per-atom energies
        |
graph_index sum
        |
structure energies
        |
optional -dE/dR
        |
conservative forces
```

### O(3) feature representation

Node features are stored internally as:

```python
(l, parity) -> tensor
```

where:

- `l` is the angular degree;
- parity is `+1` for even irreps and `-1` for odd irreps;
- each tensor has shape
  `(num_atoms, multiplicity, 2*l + 1)`.

This small internal representation adds the parity information absent from
DeepChem's existing `Fiber` class without introducing a new general-purpose
irreps framework.

### Differentiable geometry

The graph topology is treated as fixed, but all geometric quantities used by
the energy calculation are reconstructed inside `forward()`:

```python
center = edge_index[0]
neighbor = edge_index[1]
r_ij = positions[neighbor] - positions[center]
```

Distances, directions, radial features, and spherical harmonics therefore
remain connected to `node_pos_features` through autograd.

Stored `edge_features` and `edge_distances` are intentionally ignored by the
backbone. This prevents NumPy-derived static geometry from breaking force
gradients.

### Radial representation

The edge-distance representation follows NequIP equation 6:

- trainable Bessel frequencies initialized to `n*pi`;
- prefactor `2 / cutoff`;
- polynomial cutoff with `p=6`;
- numerically safe sinc evaluation of the `r -> 0` limit;
- per-interaction radial MLPs;
- normalized SiLU hidden activations;
- no output activation.

The radial MLP produces independent per-edge weights for every allowed
tensor-product path.

### Tensor-product convolution

For each input irrep, spherical-harmonic filter degree, and requested output
irrep, the implementation enforces:

```text
abs(l_in - l_filter) <= l_out <= l_in + l_filter
p_out = p_in * (-1)^l_filter
```

The convolution follows the `uvu` multiplicity semantics used by the
paper-era NequIP implementation:

- input multiplicity is preserved within a path;
- edge spherical harmonics have multiplicity one;
- one radial weight is generated per input channel and path;
- paths producing the same output irrep remain separate;
- paths are concatenated only before the post-convolution atom-wise linear
  transformation.

Messages read the neighbor feature from `edge_index[1]`, aggregate into the
central atom at `edge_index[0]`, use SUM aggregation, and are normalized by:

```text
sqrt(avg_num_neighbors)
```

`avg_num_neighbors` is an explicit model parameter. The model does not replace
it with node degree or a batch-derived statistic.

### DeepChem spherical-harmonic and CG reuse

The implementation reuses:

- `get_spherical_from_cartesian`;
- `precompute_sh`;
- `basis_transformation_Q_J`.

DeepChem's spherical harmonics are integral-normalized and its `Q_J` basis is
unit-normalized. The tensor-product contraction applies:

```text
sqrt(4*pi*(2*l_out + 1))
```

to convert this basis to the component normalization used by the paper-era
NequIP/e3nn tensor product.

The allowed paths and normalization were checked for all angular couplings
through `l_max=2`.

### Interaction block

Each `NequIPInteractionBlock` applies the paper ordering:

```text
residual = species_self_connection(x)
x = pre_self_interaction(x)
x = tensor_product_convolution(x)
x = post_self_interaction(x)  # part of the convolution module
x = x + residual
x = equivariant_gate(x)
```

The species-conditioned self connection is represented by one channel matrix
per atomic species and compatible `(l, parity)` irrep. Each matrix acts
identically over the irrep's `m` components, which is equivalent to contracting
the input features with one-hot species attributes.

The gate uses the paper-era nonlinearities:

- even scalar features: normalized SiLU;
- odd scalar features: normalized tanh;
- higher-order features: one normalized even scalar gate per channel.

### Energy readout and forces

Only even `l=0` features enter the output block. Two atom-wise equivariant
linear layers produce one scalar atomic energy per atom, with no activation
between them.

Atomic energies are summed by `BatchGraphData.graph_index`, producing:

```text
(batch_size, 1)
```

When requested, forces are calculated without a direct-force head:

```python
forces = -torch.autograd.grad(total_energy.sum(), positions)
```

`create_graph=True` is supported so a later `TorchModel` integration can train
against force targets.

## Existing DeepChem components reused

This PR reuses the following existing components rather than duplicating them:

- `GraphData`
- `BatchGraphData`
- `BatchGraphData.graph_index`
- `Fiber`
- `SE3SelfInteraction`
- `get_spherical_from_cartesian`
- `precompute_sh`
- `basis_transformation_Q_J`
- standard PyTorch embedding, tensor operations, and autograd

`SE3SelfInteraction` is applied separately to even and odd feature groups
because `Fiber` itself does not track parity.

## New NequIP-specific components

The new code is limited to the operations not already represented faithfully
by existing DeepChem abstractions:

- lightweight `(l, parity)` bookkeeping;
- NequIP Bessel basis and polynomial cutoff;
- radial MLP with paper-era variance scaling;
- explicit parity-aware tensor-product path construction;
- NequIP tensor-product aggregation and normalization;
- species-conditioned self connection;
- parity-aware equivariant gate;
- interaction-block composition;
- scalar energy readout and optional conservative-force calculation.

## Type of change

Please check the option that is related to your PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - In this case, we recommend to discuss your modification on GitHub issues before creating the PR
- [ ] Documentations (modification for documents)

## Checklist

- [x] My code follows [the style guidelines of this project](https://deepchem.readthedocs.io/en/latest/development_guide/coding.html)
  - [x] Run `yapf -i <modified file>` and check no errors (**yapf version must be 0.32.0**)
  - [x] Run `mypy -p deepchem` and check no 
  - [x] Run `flake8 <modified file> --count` and check no errors
  - [x] Run `python -m doctest <modified file>` and check no errors
    - The new module contains API documentation but no executable doctest
      examples.
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
  - Public class and method documentation is included in `nequip.py`.
- [x] I have added tests that prove my feature works
- [x] New unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings