### PR TITLE
fix(imports): use explicit relative imports for Pylance/Pyright namespace recognition — Closes #5117

### DIFF
--- a/deepchem/__init__.py
+++ b/deepchem/__init__.py
@@ -5,15 +5,30 @@ Imports all submodules
 # If you push the tag, please remove `.dev`
 __version__ = '2.8.1.dev'
 
-import deepchem.data
-import deepchem.feat
-import deepchem.hyper
-import deepchem.metalearning
-import deepchem.metrics
-import deepchem.models
-import deepchem.splits
-import deepchem.trans
-import deepchem.utils
-import deepchem.dock
-import deepchem.molnet
-import deepchem.rl
+from . import data as data
+from . import feat as feat
+from . import hyper as hyper
+from . import metalearning as metalearning
+from . import metrics as metrics
+from . import models as models
+from . import splits as splits
+from . import trans as trans
+from . import utils as utils
+from . import dock as dock
+from . import molnet as molnet
+from . import rl as rl
+
+__all__ = [
+    "data",
+    "feat",
+    "hyper",
+    "metalearning",
+    "metrics",
+    "models",
+    "splits",
+    "trans",
+    "utils",
+    "dock",
+    "molnet",
+    "rl",
+]


### PR DESCRIPTION
## Summary
Fixes Pylance/Pyright not recognizing top-level namespaces such as \dc.feat\, \dc.models\, \dc.data\, etc. when using \import deepchem as dc\.

## Related Issue
Closes #5117

## Changes
- \deepchem/__init__.py\: Changed absolute imports (e.g., \import deepchem.feat\) to explicit relative imports with aliases (e.g., \rom . import feat as feat\). Added explicit \__all__\ declaration listing all public submodules.

## How to Test
1. Install the package in development mode: \pip install -e .\
2. In VS Code with Pylance, open a Python file and type:
   \\\python
   import deepchem as dc
   dc.feat.MolGraphConvFeaturizer(
   \\\
3. Verify autocomplete, hover documentation, and go-to-definition work for \dc.feat\, \dc.models\, \dc.data\, etc.

## Checklist
- [x] Code follows the project's style guidelines
- [x] DCO sign-off on all commits (\git commit -s\)
- [x] Runtime imports work correctly (verified locally)
- [x] Existing tests pass (ran featurizer tests)
- [x] Lint passes (\uff check\)